### PR TITLE
Add MVP planning specs and project configuration

### DIFF
--- a/.claude/specs/backlog-mvp.md
+++ b/.claude/specs/backlog-mvp.md
@@ -1,0 +1,1467 @@
+# AgentFluent MVP Backlog
+
+Full epic and story breakdown for the MVP. Each section below is a GitHub issue body ready for creation via `gh issue create`.
+
+**Label conventions:**
+- Epic labels: `epic:scaffolding`, `epic:parser`, `epic:agent-extraction`, `epic:analytics`, `epic:config-assessment`, `epic:diagnostics`, `epic:cli-output`
+- Type labels: `enhancement`, `documentation`, `testing`, `infrastructure`
+- Priority labels: `priority:high`, `priority:medium`, `priority:low`
+
+**Create labels first:**
+```bash
+gh label create "epic:scaffolding" --color "0E8A16" --description "E1: Project scaffolding and infrastructure"
+gh label create "epic:parser" --color "1D76DB" --description "E2: JSONL parser and session discovery"
+gh label create "epic:agent-extraction" --color "5319E7" --description "E3: Agent invocation extraction"
+gh label create "epic:analytics" --color "D93F0B" --description "E4: Execution analytics"
+gh label create "epic:config-assessment" --color "FBCA04" --description "E5: Agent configuration assessment"
+gh label create "epic:diagnostics" --color "B60205" --description "E6: Diagnostics preview"
+gh label create "epic:cli-output" --color "006B75" --description "E7: CLI output and formatting"
+gh label create "enhancement" --color "A2EEEF" --description "New feature or request"
+gh label create "documentation" --color "0075CA" --description "Documentation improvements"
+gh label create "testing" --color "D4C5F9" --description "Test coverage and infrastructure"
+gh label create "infrastructure" --color "E4E669" --description "CI/CD, tooling, project setup"
+gh label create "priority:high" --color "B60205" --description "Must have for MVP"
+gh label create "priority:medium" --color "FBCA04" --description "Should have for MVP"
+gh label create "priority:low" --color "0E8A16" --description "Nice to have"
+```
+
+---
+
+## E1: Project Scaffolding
+
+**Issue title:** Epic: Project scaffolding and infrastructure
+**Labels:** `epic:scaffolding`, `infrastructure`
+
+**Body:**
+
+### Summary
+
+Set up the Python project structure, dependency management, testing infrastructure, and CI/CD pipeline. This is the foundation everything else builds on.
+
+### Success Criteria
+
+- [ ] Python package with `pyproject.toml` managed by uv
+- [ ] CLI entry point (`agentfluent`) is installable and responds to `--help`
+- [ ] pytest runs with coverage reporting
+- [ ] Linting (ruff) and type checking configured
+- [ ] GitHub Actions CI runs tests on every PR
+- [ ] CLAUDE.md updated to reflect Python-only stack and uv tooling
+
+### Stories
+
+- [ ] #N -- Initialize Python package with uv and pyproject.toml
+- [ ] #N -- Create CLI skeleton with Typer
+- [ ] #N -- Set up pytest infrastructure with fixtures directory
+- [ ] #N -- Configure GitHub Actions CI pipeline
+- [ ] #N -- Update CLAUDE.md for Python-only MVP
+
+---
+
+### E1-S1: Initialize Python package with uv and pyproject.toml
+
+**Issue title:** Initialize Python package with uv and pyproject.toml
+**Labels:** `epic:scaffolding`, `infrastructure`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Initialize the AgentFluent Python project using `uv` with a proper package structure.
+
+### Acceptance Criteria
+
+- Given a fresh clone, when `uv sync` is run, then all dependencies are installed and the virtual environment is created
+- The `pyproject.toml` defines:
+  - Package name: `agentfluent`
+  - Python version: >=3.11
+  - CLI entry point: `agentfluent = "agentfluent.cli.main:app"`
+  - Dev dependencies: pytest, pytest-cov, ruff, mypy (or pyright)
+  - Runtime dependencies: typer, rich, pydantic
+- Package structure matches the layout in the PRD (Section 4)
+- `__init__.py` files exist in all package directories
+- `.python-version` file is present
+- `uv.lock` is committed
+
+### Implementation Notes
+
+- Use `uv init` as the starting point
+- See PRD Section 4 for the full package tree
+- Developer chooses between mypy and pyright for type checking
+- All `__init__.py` files can be empty initially
+
+### Dependencies
+
+None -- this is the first story.
+
+---
+
+### E1-S2: Create CLI skeleton with Typer
+
+**Issue title:** Create CLI skeleton with Typer
+**Labels:** `epic:scaffolding`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Create the CLI entry point with Typer, registering stub commands that will be implemented in later epics.
+
+### Acceptance Criteria
+
+- Given the package is installed, when `agentfluent --help` is run, then help text is displayed listing all commands
+- Given `agentfluent list --help`, then help text for the list command is shown
+- Given `agentfluent analyze --help`, then help text for the analyze command is shown
+- Given `agentfluent config-check --help`, then help text for the config-check command is shown
+- Stub commands print "Not yet implemented" and exit with code 0
+- Global options `--format` (json/table) and `--verbose`/`--quiet` flags are defined
+- Version flag (`--version`) prints the package version
+
+### Implementation Notes
+
+- `cli/main.py` creates the Typer app and registers command groups
+- `cli/commands/` contains one module per command (analyze.py, list.py, config_check.py)
+- Stubs should accept the flags they'll eventually need (e.g., `--project`, `--session`) even though they don't use them yet
+- See PRD Section 5.7 for output mode specs
+
+### Dependencies
+
+- E1-S1 (package structure must exist)
+
+---
+
+### E1-S3: Set up pytest infrastructure with fixtures directory
+
+**Issue title:** Set up pytest infrastructure with fixtures directory
+**Labels:** `epic:scaffolding`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Configure pytest with coverage reporting and create the test directory structure with initial fixture files.
+
+### Acceptance Criteria
+
+- Given the project is set up, when `uv run pytest` is run, then pytest discovers and runs tests
+- Given `uv run pytest --cov=agentfluent`, then coverage report is generated
+- Test directory structure exists: `tests/unit/`, `tests/integration/`, `tests/fixtures/`
+- `tests/conftest.py` exists with shared fixtures (e.g., paths to fixture files)
+- At least one placeholder test exists and passes
+- `pyproject.toml` contains pytest configuration (testpaths, coverage settings)
+- Fixture directory contains at least one anonymized JSONL snippet (can be minimal -- a single valid session message)
+
+### Implementation Notes
+
+- Integration tests should be marked with `@pytest.mark.integration` so they can be run separately
+- Fixture JSONL files should be anonymized versions of real session data, covering the key message types documented in CLAUDE.md
+- See PRD Section 7 for the full test strategy
+
+### Dependencies
+
+- E1-S1 (package structure must exist)
+
+---
+
+### E1-S4: Configure GitHub Actions CI pipeline
+
+**Issue title:** Configure GitHub Actions CI pipeline
+**Labels:** `epic:scaffolding`, `infrastructure`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Set up GitHub Actions to run tests, linting, and type checking on every PR to main.
+
+### Acceptance Criteria
+
+- Given a PR is opened against main, then the CI workflow runs automatically
+- CI runs: `uv run ruff check`, `uv run mypy agentfluent` (or pyright), `uv run pytest --cov=agentfluent`
+- CI uses uv for dependency installation (not pip)
+- Integration tests are excluded from CI (they require real session data on `~/.claude/projects/`)
+- CI fails if: any test fails, ruff reports errors, type checker reports errors
+- Workflow file: `.github/workflows/ci.yml`
+
+### Implementation Notes
+
+- Use `astral-sh/setup-uv` GitHub Action for uv installation
+- Python version should match `.python-version`
+- Consider caching uv's package cache for faster runs
+- Integration tests excluded via: `pytest -m "not integration"`
+
+### Dependencies
+
+- E1-S1 (package structure), E1-S3 (pytest infrastructure)
+
+---
+
+### E1-S5: Update CLAUDE.md for Python-only MVP
+
+**Issue title:** Update CLAUDE.md for Python-only MVP
+**Labels:** `epic:scaffolding`, `documentation`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+Update CLAUDE.md to reflect the decisions made during MVP planning: Python-only stack, uv for dependency management, updated code reuse references.
+
+### Acceptance Criteria
+
+- "Architecture Context > Code Reuse from CodeFluent" section references Python module names (not .ts files)
+- "Tech Stack" section states Python-only for MVP, uv for dependency management
+- Package structure is documented or referenced (link to PRD)
+- Testing conventions are documented (pytest, unit vs integration marks)
+- Branching workflow section is verified accurate
+
+### Implementation Notes
+
+- See decisions D001 and D007 in `.claude/specs/decisions.md`
+- Keep CLAUDE.md as the authoritative developer reference -- don't duplicate PRD content, link to it
+
+### Dependencies
+
+- E1-S1 (to confirm final package structure)
+
+---
+
+## E2: JSONL Parser + Session Discovery
+
+**Issue title:** Epic: JSONL parser and session discovery
+**Labels:** `epic:parser`, `enhancement`
+
+**Body:**
+
+### Summary
+
+Build the core data layer: discover projects and sessions from `~/.claude/projects/`, parse JSONL session files into typed data models. Everything downstream depends on this.
+
+### Success Criteria
+
+- [ ] Project discovery scans `~/.claude/projects/` and lists projects with metadata
+- [ ] Session discovery lists sessions within a project with timestamps and sizes
+- [ ] JSONL parser handles all message types documented in CLAUDE.md
+- [ ] Parser handles `message.content` as both string and array-of-blocks
+- [ ] Malformed lines are skipped gracefully
+- [ ] `agentfluent list` command is functional
+- [ ] Unit tests cover all message types and edge cases
+- [ ] Integration tests validate against real session data
+
+### Stories
+
+- [ ] #N -- Define core data models for parsed sessions
+- [ ] #N -- Implement project and session discovery
+- [ ] #N -- Implement JSONL session parser
+- [ ] #N -- Wire up `agentfluent list` command
+- [ ] #N -- Add parser unit tests with JSONL fixtures
+- [ ] #N -- Add discovery and parser integration tests
+
+---
+
+### E2-S1: Define core data models for parsed sessions
+
+**Issue title:** Define core data models for parsed sessions
+**Labels:** `epic:parser`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Define Pydantic (or dataclass) models for parsed JSONL data. These models are the contract between the parser and all downstream consumers (analytics, extraction, diagnostics).
+
+### Acceptance Criteria
+
+- Models defined for: `SessionMessage`, `ToolUseBlock`, `ToolResult`, `Usage`, `MessageContent`
+- `SessionMessage` captures: type, timestamp, content (normalized to text), tool_use blocks, usage stats, metadata
+- `ToolUseBlock` captures: id, name, input (dict)
+- `ToolResult` captures: tool_use_id, content, is_error, metadata (optional dict with total_tokens, tool_uses, duration_ms, agentId)
+- `Usage` captures: input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens
+- Models handle optional fields gracefully (metadata may be absent)
+- Models are importable from `agentfluent.core.session`
+
+### Implementation Notes
+
+- See PRD Section 6 for model guidance
+- See CLAUDE.md "JSONL Data Format" for exact field names and types
+- `message.content` can be string or list -- the model should normalize to a consistent representation
+- Developer decides Pydantic v2 vs dataclasses
+
+### Dependencies
+
+- E1-S1 (package structure)
+
+---
+
+### E2-S2: Implement project and session discovery
+
+**Issue title:** Implement project and session discovery
+**Labels:** `epic:parser`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Scan `~/.claude/projects/` to discover available projects and their sessions. Provide metadata (session count, file sizes, date ranges) without parsing full file contents.
+
+### Acceptance Criteria
+
+- Given `~/.claude/projects/` contains project directories, when `discover_projects()` is called, then all projects are returned with: slug, path, session count, total size bytes, earliest/latest session timestamps
+- Given a project path, when `discover_sessions(project_path)` is called, then all `.jsonl` files are returned with: filename, file size, modified timestamp
+- Project slugs are derived from directory names (e.g., `-home-fdpearce-project` -> display-friendly name)
+- Empty project directories are included with session_count=0
+- Non-existent `~/.claude/projects/` path produces a clear error message
+- Functions are in `agentfluent.core.discovery`
+
+### Implementation Notes
+
+- Session timestamps can be derived from file modification time for the discovery listing (full parsing happens later)
+- The slug-to-friendly-name conversion should handle the dash-encoded path format (e.g., `-home-fdpearce-Documents-Projects-git-codefluent` -> `codefluent` or the full path)
+- Consider making the base path configurable (env var or CLI flag) for testing
+
+### Dependencies
+
+- E1-S1 (package structure)
+
+---
+
+### E2-S3: Implement JSONL session parser
+
+**Issue title:** Implement JSONL session parser
+**Labels:** `epic:parser`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Parse JSONL session files into typed data models. This is the core data ingestion component.
+
+### Acceptance Criteria
+
+- Given a JSONL file path, when `parse_session(path)` is called, then a list of `SessionMessage` objects is returned
+- Given `message.content` as a plain string, then text is correctly extracted
+- Given `message.content` as an array of content blocks, then text is correctly extracted from each block
+- Given message types to skip (`file-history-snapshot`, `progress`, `hook_progress`, `bash_progress`, `system`, `create`), then they are excluded from results
+- Given a line with invalid JSON, then parsing continues with remaining lines (warning logged)
+- Given a line with valid JSON but missing expected fields, then it is handled gracefully
+- Given an empty file, then an empty list is returned
+- `tool_use` blocks within assistant messages are extracted into `ToolUseBlock` models
+- `tool_result` messages preserve metadata dict when present
+- `usage` data on assistant messages is captured
+- Parser is in `agentfluent.core.parser`
+
+### Implementation Notes
+
+- Read line by line (not load entire file) -- session files can be large
+- Use Python's `json` module for parsing
+- Log malformed lines with line number for debugging
+- See CLAUDE.md "JSONL Data Format" for exact schemas and "Types to skip" for exclusion list
+
+### Dependencies
+
+- E2-S1 (data models must be defined)
+
+---
+
+### E2-S4: Wire up agentfluent list command
+
+**Issue title:** Wire up agentfluent list command
+**Labels:** `epic:parser`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Connect the discovery module to the CLI `list` command, replacing the stub from E1.
+
+### Acceptance Criteria
+
+- Given `agentfluent list`, then all projects are displayed in a Rich table with: name, session count, size, date range
+- Given `agentfluent list --project SLUG`, then sessions in that project are listed with: filename, size, modified date, message count (requires parsing)
+- Given `agentfluent list --project INVALID`, then an error message is shown and exit code is 1
+- Given `agentfluent list --format json`, then output is valid JSON with the same data
+- Given no projects exist, then a helpful message is shown
+
+### Implementation Notes
+
+- The `--project` flag triggers session-level listing which requires parsing each file (at least partially for message count)
+- Consider a "quick mode" that shows file metadata only vs "full mode" that parses for message counts
+- See PRD Section 5.1 for full spec
+
+### Dependencies
+
+- E1-S2 (CLI skeleton), E2-S2 (discovery), E2-S3 (parser for message counts)
+
+---
+
+### E2-S5: Add parser unit tests with JSONL fixtures
+
+**Issue title:** Add parser unit tests with JSONL fixtures
+**Labels:** `epic:parser`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Create comprehensive unit tests for the JSONL parser using anonymized fixture files.
+
+### Acceptance Criteria
+
+- Fixture files in `tests/fixtures/` cover:
+  - Session with plain string content
+  - Session with array-of-blocks content
+  - Session with assistant message containing tool_use blocks
+  - Session with tool_result containing metadata block
+  - Session with types that should be skipped (progress, system, etc.)
+  - File with malformed JSON line(s)
+  - Empty file
+  - Session with Agent tool_use block (name="Agent" with subagent fields)
+- Tests validate:
+  - Correct number of messages returned after filtering
+  - Content text correctly extracted for both string and array formats
+  - tool_use blocks correctly parsed
+  - Metadata correctly captured from tool_result
+  - Usage data correctly captured from assistant messages
+  - Malformed lines don't crash parser
+  - Skip types are excluded
+- All tests pass and provide >90% coverage of parser module
+
+### Implementation Notes
+
+- Anonymize real session data to create fixtures -- change file paths, user names, project names
+- Keep fixture files small (5-20 lines each) for readability
+- One fixture file per scenario where possible
+
+### Dependencies
+
+- E1-S3 (test infrastructure), E2-S1 (models), E2-S3 (parser)
+
+---
+
+### E2-S6: Add discovery and parser integration tests
+
+**Issue title:** Add discovery and parser integration tests
+**Labels:** `epic:parser`, `testing`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+Integration tests that run against real session data from `~/.claude/projects/`.
+
+### Acceptance Criteria
+
+- Tests marked with `@pytest.mark.integration`
+- Tests validate:
+  - `discover_projects()` returns at least one project when real data exists
+  - `discover_sessions()` returns sessions for a known project
+  - `parse_session()` successfully parses a real session file without errors
+  - Parsed messages have valid timestamps, non-empty content where expected
+- Tests skip gracefully if `~/.claude/projects/` doesn't exist (CI environment)
+- Tests do not depend on specific project names or session contents (data may change)
+
+### Implementation Notes
+
+- Use `pytest.mark.skipif` for environment detection
+- These tests validate that the parser handles real-world JSONL variations, not just the fixtures
+
+### Dependencies
+
+- E2-S2 (discovery), E2-S3 (parser), E1-S3 (test infrastructure)
+
+---
+
+## E3: Agent Invocation Extraction
+
+**Issue title:** Epic: Agent invocation extraction
+**Labels:** `epic:agent-extraction`, `enhancement`
+
+**Body:**
+
+### Summary
+
+Extract agent invocation data from parsed sessions -- identify which agents were called, their metadata, and per-invocation metrics. This layer sits between the raw parser and the analytics/diagnostics consumers.
+
+### Success Criteria
+
+- [ ] Agent tool_use blocks (name="Agent") are identified in parsed sessions
+- [ ] Subagent metadata extracted: type, description, prompt, tokens, tool_uses, duration, agentId
+- [ ] tool_use blocks matched to their corresponding tool_result
+- [ ] Built-in vs custom agents distinguished
+- [ ] Per-invocation efficiency metrics computed
+- [ ] Unit and integration tests cover extraction logic
+
+### Stories
+
+- [ ] #N -- Define agent invocation data models
+- [ ] #N -- Implement agent invocation extractor
+- [ ] #N -- Add agent extraction tests
+
+---
+
+### E3-S1: Define agent invocation data models
+
+**Issue title:** Define agent invocation data models
+**Labels:** `epic:agent-extraction`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Define data models for agent invocations extracted from session data.
+
+### Acceptance Criteria
+
+- `AgentInvocation` model captures: agent_type, is_builtin, description, prompt, total_tokens, tool_uses, duration_ms, agent_id, output_text, tokens_per_tool_use, duration_per_tool_use
+- `is_builtin` correctly classifies known built-in agents: "explore", "plan", "general-purpose" (and any variations)
+- `tokens_per_tool_use` and `duration_per_tool_use` are computed properties
+- Model handles missing metadata gracefully (tool_result may lack metadata block)
+- Models are in `agentfluent.agents.models`
+
+### Implementation Notes
+
+- See CLAUDE.md "Key signals for agent analysis" for field sources
+- See research doc "Custom Agent Data: PM Agent Analysis" for real-world examples of metadata values
+- Built-in agent classification may need updating as Anthropic adds new built-in agents -- make the list configurable or at least easy to update
+
+### Dependencies
+
+- E2-S1 (base session models)
+
+---
+
+### E3-S2: Implement agent invocation extractor
+
+**Issue title:** Implement agent invocation extractor
+**Labels:** `epic:agent-extraction`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Extract agent invocations from a list of parsed session messages by matching Agent tool_use blocks with their corresponding tool_result blocks.
+
+### Acceptance Criteria
+
+- Given parsed session messages, when `extract_agent_invocations(messages)` is called, then all Agent invocations are returned as `AgentInvocation` objects
+- Agent tool_use blocks are identified by `name == "Agent"` in assistant message content
+- Each tool_use is matched to its subsequent tool_result by `tool_use_id`
+- When tool_result has metadata, then total_tokens, tool_uses, duration_ms, agentId are captured
+- When tool_result lacks metadata, then those fields are None
+- Output text is extracted from tool_result content
+- Efficiency metrics (tokens_per_tool_use, duration_per_tool_use) are computed when data is available
+- Sessions with no agent invocations return an empty list
+- Extractor is in `agentfluent.agents.extractor`
+
+### Implementation Notes
+
+- The tool_use `input` dict contains: `subagent_type`, `description`, `prompt` (and possibly other fields)
+- tool_result matching: the tool_result following an Agent tool_use has a `tool_use_id` field that matches the tool_use `id`
+- Handle edge case: tool_use without a matching tool_result (agent was interrupted)
+- See CLAUDE.md examples for exact JSON structure
+
+### Dependencies
+
+- E2-S1 (session models), E2-S3 (parser), E3-S1 (agent models)
+
+---
+
+### E3-S3: Add agent extraction tests
+
+**Issue title:** Add agent extraction tests
+**Labels:** `epic:agent-extraction`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Unit and integration tests for the agent invocation extractor.
+
+### Acceptance Criteria
+
+- Unit tests with fixtures covering:
+  - Session with a single built-in agent invocation (Explore)
+  - Session with a custom agent invocation (e.g., PM agent) including full metadata
+  - Session with multiple agent invocations of different types
+  - Session with agent tool_use but missing tool_result (interrupted)
+  - Session with tool_result lacking metadata block
+  - Session with no agent invocations
+- Integration test: extract agent invocations from a real session known to contain them
+- Tests validate correct field values, correct built-in classification, correct efficiency metric computation
+
+### Implementation Notes
+
+- Fixture files can extend those from E2-S5 or create new ones specific to agent extraction
+- The CodeFluent project sessions contain real PM agent invocations for integration testing
+
+### Dependencies
+
+- E1-S3 (test infrastructure), E3-S1 (models), E3-S2 (extractor)
+
+---
+
+## E4: Execution Analytics
+
+**Issue title:** Epic: Execution analytics
+**Labels:** `epic:analytics`, `enhancement`
+
+**Body:**
+
+### Summary
+
+Compute execution metrics from parsed sessions: token usage, cost, cache efficiency, tool patterns, and per-agent attribution. Powers the `agentfluent analyze` command.
+
+### Success Criteria
+
+- [ ] Token usage totals computed (input, output, cache_creation, cache_read)
+- [ ] Cost computed using model pricing lookup
+- [ ] Cache efficiency ratio calculated
+- [ ] Tool call frequency and diversity metrics
+- [ ] Per-agent type cost attribution and efficiency metrics
+- [ ] `agentfluent analyze` command functional
+- [ ] Tests cover all metric computations
+
+### Stories
+
+- [ ] #N -- Implement model pricing lookup
+- [ ] #N -- Implement token and cost analytics
+- [ ] #N -- Implement tool pattern analytics
+- [ ] #N -- Implement per-agent execution metrics
+- [ ] #N -- Wire up agentfluent analyze command
+- [ ] #N -- Add analytics unit and integration tests
+
+---
+
+### E4-S1: Implement model pricing lookup
+
+**Issue title:** Implement model pricing lookup
+**Labels:** `epic:analytics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Pricing table mapping model names to per-token costs for input, output, cache_creation, and cache_read.
+
+### Acceptance Criteria
+
+- Given a model name (e.g., "claude-opus-4-6", "claude-sonnet-4-20250514", "claude-haiku-3-5-20241022"), when pricing is looked up, then correct per-token rates are returned
+- Pricing handles: input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens
+- Unknown model names return a sensible default or None with a warning
+- Pricing data is in a single, easily-updatable location (dict, JSON file, or similar)
+- Module is at `agentfluent.analytics.pricing`
+
+### Implementation Notes
+
+- Port from CodeFluent's Python pricing module
+- Current Anthropic pricing as of April 2026 should be the starting point
+- Consider a configuration file for pricing data so users can update without code changes
+
+### Dependencies
+
+- E1-S1 (package structure)
+
+---
+
+### E4-S2: Implement token and cost analytics
+
+**Issue title:** Implement token and cost analytics
+**Labels:** `epic:analytics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Compute token usage totals and dollar costs from parsed session messages.
+
+### Acceptance Criteria
+
+- Given parsed session messages with usage data, when `compute_token_metrics(messages)` is called, then totals for input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens are correct
+- Given token totals and model name, when cost is computed, then dollar amount uses correct pricing
+- Cache efficiency ratio = cache_read / (cache_read + input_tokens), returned as a percentage
+- Handles sessions with mixed models (sum costs across models)
+- Handles messages missing usage data gracefully
+- Module is at `agentfluent.analytics.tokens`
+
+### Implementation Notes
+
+- Port and adapt from CodeFluent's Python analytics module
+- Return a structured result object (not just a dict) -- see PRD Section 6 `ExecutionMetrics`
+
+### Dependencies
+
+- E2-S1 (session models), E2-S3 (parser), E4-S1 (pricing)
+
+---
+
+### E4-S3: Implement tool pattern analytics
+
+**Issue title:** Implement tool pattern analytics
+**Labels:** `epic:analytics`, `enhancement`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+Analyze tool call patterns across a session: frequency by tool name, unique tool count, tool diversity metrics.
+
+### Acceptance Criteria
+
+- Given parsed session messages, when `compute_tool_metrics(messages)` is called, then tool call frequency by name is returned (sorted by frequency)
+- Unique tool count is computed
+- Top N tools account for what percentage of total calls (concentration metric)
+- Handles sessions with no tool calls
+- Module is at `agentfluent.analytics.tools`
+
+### Implementation Notes
+
+- Tool calls are in assistant message content blocks where `type == "tool_use"`
+- This counts ALL tool calls in the session, not just Agent calls
+- The concentration metric ("4 of 12 tools account for 95% of calls") is useful for config assessment recommendations later
+
+### Dependencies
+
+- E2-S1 (session models), E2-S3 (parser)
+
+---
+
+### E4-S4: Implement per-agent execution metrics
+
+**Issue title:** Implement per-agent execution metrics
+**Labels:** `epic:analytics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Compute execution metrics grouped by agent type: cost attribution, invocation count, efficiency metrics.
+
+### Acceptance Criteria
+
+- Given a list of `AgentInvocation` objects, when `compute_agent_metrics(invocations)` is called, then per-agent-type metrics are returned:
+  - Invocation count
+  - Total tokens and cost per agent type
+  - Average tokens_per_tool_use per agent type
+  - Average duration_per_tool_use per agent type
+  - Total duration per agent type
+- Metrics are computed separately for built-in vs custom agents
+- Summary includes: total agent cost as percentage of session cost
+- Handles invocations with missing metadata (excluded from averages, counted in invocation count)
+- Module is at `agentfluent.analytics.efficiency`
+
+### Implementation Notes
+
+- This consumes output from E3 (agent extraction) combined with E4-S1 (pricing)
+- The "agent cost as percentage of session cost" requires both session-level and agent-level cost data
+
+### Dependencies
+
+- E3-S2 (agent extractor), E4-S1 (pricing), E4-S2 (token analytics)
+
+---
+
+### E4-S5: Wire up agentfluent analyze command
+
+**Issue title:** Wire up agentfluent analyze command
+**Labels:** `epic:analytics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Connect analytics modules to the CLI `analyze` command, replacing the stub from E1.
+
+### Acceptance Criteria
+
+- Given `agentfluent analyze --project SLUG`, then analytics are computed across all sessions in the project and displayed
+- Given `agentfluent analyze --project SLUG --session FILE`, then analytics for a single session are displayed
+- Given `agentfluent analyze --project SLUG --agent pm`, then only PM agent metrics are shown
+- Output includes: token totals, cost, cache efficiency, tool patterns, agent-specific metrics
+- `--format json` produces valid JSON with all metrics
+- `--format table` produces Rich-formatted tables
+- `--quiet` produces a one-line summary (total cost, total tokens, agent invocation count)
+- Given no sessions match, then a helpful message is shown with exit code 2
+
+### Implementation Notes
+
+- This is the main analytical command -- it pulls together parser, extractor, and all analytics modules
+- See PRD Section 5.4 for full spec
+- Consider a `--latest N` flag to analyze only the N most recent sessions (useful for large projects)
+
+### Dependencies
+
+- E1-S2 (CLI skeleton), E2-S2 (discovery), E2-S3 (parser), E3-S2 (extractor), E4-S2 (token analytics), E4-S3 (tool analytics), E4-S4 (agent metrics)
+
+---
+
+### E4-S6: Add analytics unit and integration tests
+
+**Issue title:** Add analytics unit and integration tests
+**Labels:** `epic:analytics`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Tests for all analytics computations: pricing, tokens, cost, tools, and per-agent metrics.
+
+### Acceptance Criteria
+
+- Unit tests with known input values verify:
+  - Pricing lookup returns correct rates for known models
+  - Token totals are summed correctly
+  - Cost computation uses correct pricing per model
+  - Cache efficiency ratio is computed correctly
+  - Tool frequency counts are correct
+  - Per-agent metrics (averages, totals) are correct
+  - Edge cases: missing usage data, unknown models, empty sessions, invocations without metadata
+- Integration test: run full analytics pipeline on a real session and validate output structure (not exact values, since data changes)
+- >90% coverage on analytics modules
+
+### Dependencies
+
+- E1-S3 (test infrastructure), E4-S1 through E4-S4
+
+---
+
+## E5: Agent Configuration Assessment
+
+**Issue title:** Epic: Agent configuration assessment
+**Labels:** `epic:config-assessment`, `enhancement`
+
+**Body:**
+
+### Summary
+
+Scan agent definition files (`.claude/agents/*.md` at both user and project level), parse their YAML frontmatter and prompt body, and score them against a best-practices rubric. This epic is independent of session data and can be developed in parallel with E3/E4.
+
+### Success Criteria
+
+- [ ] Scanner discovers agent definition files at both `~/.claude/agents/` and `.claude/agents/`
+- [ ] YAML frontmatter correctly parsed for all config fields
+- [ ] Prompt body (markdown below frontmatter) extracted
+- [ ] Scoring rubric evaluates: description quality, tool restrictions, model selection, prompt body quality
+- [ ] Per-agent scores and specific recommendations generated
+- [ ] `agentfluent config-check` command functional
+- [ ] Tests cover scanning, parsing, and scoring
+
+### Stories
+
+- [ ] #N -- Define config assessment data models
+- [ ] #N -- Implement agent definition scanner and parser
+- [ ] #N -- Implement config scoring rubric
+- [ ] #N -- Wire up agentfluent config-check command
+- [ ] #N -- Add config assessment tests
+
+---
+
+### E5-S1: Define config assessment data models
+
+**Issue title:** Define config assessment data models
+**Labels:** `epic:config-assessment`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Data models for agent configuration data and scoring results.
+
+### Acceptance Criteria
+
+- `AgentConfig` model captures: name, file_path, scope (user/project), model, tools, disallowed_tools, description, prompt_body, raw_frontmatter (dict for unknown fields)
+- `ConfigScore` model captures: agent_name, overall_score (0-100), dimension_scores (dict of dimension -> score), recommendations (list)
+- `ConfigRecommendation` model captures: dimension, severity (info/warning/critical), message, current_value (what was found), suggested_action
+- Models are in `agentfluent.config.models`
+
+### Implementation Notes
+
+- `raw_frontmatter` preserves any fields not explicitly modeled, for forward compatibility
+- Severity levels: info (suggestion), warning (should fix), critical (likely causing issues)
+
+### Dependencies
+
+- E1-S1 (package structure)
+
+---
+
+### E5-S2: Implement agent definition scanner and parser
+
+**Issue title:** Implement agent definition scanner and parser
+**Labels:** `epic:config-assessment`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Discover and parse agent definition `.md` files from user and project scopes.
+
+### Acceptance Criteria
+
+- Given `~/.claude/agents/` contains `.md` files, when `scan_agents(scope="user")` is called, then all agent definitions are returned as `AgentConfig` objects
+- Given `.claude/agents/` (cwd) contains `.md` files, when `scan_agents(scope="project")` is called, then all are returned
+- Given `scope="all"`, then both locations are scanned
+- YAML frontmatter is parsed for: model, tools, disallowedTools, description, memory, isolation, color, and any other fields
+- Prompt body (everything after the YAML frontmatter closing `---`) is captured as a string
+- Files without valid YAML frontmatter are reported with a warning but don't crash the scanner
+- Module is at `agentfluent.config.scanner`
+
+### Implementation Notes
+
+- Use PyYAML or ruamel.yaml for YAML parsing
+- Frontmatter format: `---\n...yaml...\n---\nmarkdown body`
+- The `tools` field can be a list of strings; `disallowedTools` similarly
+- Consider making the project path configurable for testing (not hardcoded to cwd)
+
+### Dependencies
+
+- E5-S1 (config models)
+
+---
+
+### E5-S3: Implement config scoring rubric
+
+**Issue title:** Implement config scoring rubric
+**Labels:** `epic:config-assessment`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Score agent configurations against a best-practices rubric with specific, actionable recommendations.
+
+### Acceptance Criteria
+
+- Scoring dimensions and criteria:
+  - **Description quality (0-25):** present (5), length >= 20 chars (5), contains action verbs (5), specific to task (5), distinguishes from other agents (5)
+  - **Tool restrictions (0-25):** has `tools` OR `disallowedTools` (15), list is minimal/appropriate (10)
+  - **Model selection (0-25):** model is specified (10), model matches task complexity (15) -- e.g., Haiku for read-only tasks, Sonnet/Opus for complex tasks
+  - **Prompt body quality (0-25):** present and non-empty (5), length >= 100 chars (5), has structured sections (5), mentions error handling (5), defines success criteria (5)
+- Overall score is the sum of dimension scores (0-100)
+- Each dimension that scores below threshold generates a specific recommendation
+- Recommendations include: what was found, why it matters, what to change
+- Module is at `agentfluent.config.scoring`
+
+### Implementation Notes
+
+- Scoring is rule-based (no LLM) for MVP
+- "Contains action verbs" could be a simple keyword check (e.g., "analyze", "create", "review", "check")
+- "Model matches task complexity" is heuristic -- if tools are read-only (Read, Glob, Grep) and model is Opus, suggest Haiku/Sonnet
+- The rubric weights and thresholds should be in a configuration dict, not hardcoded throughout the code, so they're easy to tune
+
+### Dependencies
+
+- E5-S1 (config models), E5-S2 (scanner)
+
+---
+
+### E5-S4: Wire up agentfluent config-check command
+
+**Issue title:** Wire up agentfluent config-check command
+**Labels:** `epic:config-assessment`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Connect config scanner and scoring to the CLI `config-check` command.
+
+### Acceptance Criteria
+
+- Given `agentfluent config-check`, then all agents (user + project scope) are scanned, scored, and displayed
+- Given `--scope user`, then only `~/.claude/agents/` is scanned
+- Given `--scope project`, then only `.claude/agents/` is scanned
+- Given `--agent pm`, then only the PM agent is scored
+- Output shows per-agent: name, scope, overall score, dimension scores, recommendations
+- Recommendations are color-coded by severity (Rich formatting)
+- `--format json` produces valid JSON with scores and recommendations
+- Given no agent definition files found, then a helpful message is shown
+
+### Implementation Notes
+
+- See PRD Section 5.5 for full spec
+- Consider showing a summary line: "3 agents scanned, average score 62/100, 7 recommendations"
+
+### Dependencies
+
+- E1-S2 (CLI skeleton), E5-S2 (scanner), E5-S3 (scoring)
+
+---
+
+### E5-S5: Add config assessment tests
+
+**Issue title:** Add config assessment tests
+**Labels:** `epic:config-assessment`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Tests for agent definition scanning, parsing, and scoring.
+
+### Acceptance Criteria
+
+- Fixture files in `tests/fixtures/agents/` with sample agent .md files:
+  - Well-configured agent (high score expected)
+  - Agent with no tools restriction
+  - Agent with vague 1-word description
+  - Agent with empty prompt body
+  - Agent with no frontmatter
+  - Agent with all fields populated
+- Unit tests validate:
+  - Scanner discovers files in both user and project paths (use temp directories)
+  - Parser correctly extracts all frontmatter fields
+  - Parser correctly extracts prompt body
+  - Each scoring dimension produces expected scores for fixture agents
+  - Recommendations are generated for low-scoring dimensions
+  - Overall score computation is correct
+- Integration test: scan real agent definitions from `~/.claude/agents/` (if they exist)
+
+### Dependencies
+
+- E1-S3 (test infrastructure), E5-S1 through E5-S3
+
+---
+
+## E6: Diagnostics Preview
+
+**Issue title:** Epic: Diagnostics preview
+**Labels:** `epic:diagnostics`, `enhancement`
+
+**Body:**
+
+### Summary
+
+The stretch MVP feature: correlate observable behavior signals (from session analytics) with agent configuration data (from config assessment) to generate specific improvement recommendations. This is the differentiator -- "tells you what to change."
+
+Limited to three signal types for MVP: error patterns in output text, token consumption outliers, and duration outliers.
+
+### Success Criteria
+
+- [ ] Error patterns detected in agent output text via keyword/regex matching
+- [ ] Token consumption outliers identified (per-agent-type comparison)
+- [ ] Duration outliers identified
+- [ ] Signals correlated to specific config surfaces (prompt, tools, model)
+- [ ] Actionable recommendations generated with evidence
+- [ ] Diagnostics output integrated into `agentfluent analyze --diagnostics`
+- [ ] Tests cover signal detection and recommendation generation
+
+### Stories
+
+- [ ] #N -- Implement behavior signal extraction
+- [ ] #N -- Implement signal-to-config correlation engine
+- [ ] #N -- Implement recommendation templates
+- [ ] #N -- Integrate diagnostics into analyze command
+- [ ] #N -- Add diagnostics tests
+
+---
+
+### E6-S1: Implement behavior signal extraction
+
+**Issue title:** Implement behavior signal extraction
+**Labels:** `epic:diagnostics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Extract behavior signals from agent invocation data: error patterns in output text, token consumption outliers, duration outliers.
+
+### Acceptance Criteria
+
+- Given agent invocations, when `extract_signals(invocations)` is called, then detected signals are returned as `DiagnosticSignal` objects
+- **Error pattern detection:** regex/keyword matching in agent output_text for: "blocked", "unable to", "don't have access", "failed", "error", "retry", "permission denied", "not found", "timed out"
+  - Each match produces a signal with: signal_type="error_pattern", severity, matched keyword, text snippet (context around match)
+- **Token outlier detection:** invocations where tokens_per_tool_use is > 2x the mean for that agent type
+  - Signal with: signal_type="token_outlier", severity="warning", actual value, mean value
+- **Duration outlier detection:** invocations where duration_per_tool_use is > 2x the mean for that agent type
+  - Signal with: signal_type="duration_outlier", severity="warning", actual value, mean value
+- Handles agents with only one invocation (no outlier detection possible -- skip)
+- Module is at `agentfluent.diagnostics.signals`
+
+### Implementation Notes
+
+- Error keywords should be configurable (list, not hardcoded inline)
+- Outlier threshold (2x mean) should be configurable
+- For MVP, "mean" is computed across all invocations of the same agent_type in the analyzed data
+- Severity: error patterns with "blocked"/"permission denied" are "critical"; others are "warning"
+
+### Dependencies
+
+- E3-S1 (agent models with output_text and efficiency metrics)
+
+---
+
+### E6-S2: Implement signal-to-config correlation engine
+
+**Issue title:** Implement signal-to-config correlation engine
+**Labels:** `epic:diagnostics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Map detected behavior signals to specific agent configuration surfaces and generate actionable recommendations.
+
+### Acceptance Criteria
+
+- Given a list of `DiagnosticSignal` objects and optionally the agent's `AgentConfig`, when `correlate(signals, config)` is called, then `Recommendation` objects are returned
+- Correlation rules (MVP set):
+  - Error pattern "blocked"/"permission denied"/"don't have access" -> check `tools`/`disallowedTools` in config -> recommend reviewing tool access
+  - Error pattern "failed"/"error"/"retry" -> check prompt body for error handling instructions -> recommend adding error handling guidance
+  - Token outlier -> check prompt body length and specificity -> recommend more focused instructions
+  - Token outlier + large tools list -> recommend restricting tool list
+  - Duration outlier -> check model selection -> recommend a faster model if task is simple
+  - Duration outlier + high tool_uses -> check prompt for clear task boundaries -> recommend more specific task scoping
+- When `AgentConfig` is None (agent def not found), recommendations are generic ("check your agent's tool configuration")
+- When `AgentConfig` is available, recommendations reference specific config fields ("your agent 'pm' has no `tools` restriction in `~/.claude/agents/pm.md`")
+- Module is at `agentfluent.diagnostics.correlator`
+
+### Implementation Notes
+
+- Correlation rules should be structured data (list of rule objects), not a chain of if/else
+- This makes rules easy to add, test individually, and eventually configure
+- When config is available, recommendations become much more specific -- this is where E5 and E6 connect
+
+### Dependencies
+
+- E5-S1 (config models, for optional config input), E6-S1 (signal extraction)
+
+---
+
+### E6-S3: Implement recommendation templates
+
+**Issue title:** Implement recommendation templates
+**Labels:** `epic:diagnostics`, `enhancement`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+Structured recommendation templates that produce human-readable, actionable output.
+
+### Acceptance Criteria
+
+- Each recommendation includes: target_config_surface (prompt/tools/model/hooks), severity, human-readable message, evidence references (signal type + data)
+- Messages follow the pattern: "[What was observed] + [Why it matters] + [What to change]"
+- Examples:
+  - "Agent 'pm' output contains 'blocked' (2 occurrences). This indicates tool access issues. Check that `tools` in `~/.claude/agents/pm.md` includes the required tools, and verify hook permissions."
+  - "Agent 'pm' averages 2,259 tokens per tool call, 2.3x above the mean for custom agents. Consider adding more specific instructions to the prompt body to reduce exploration."
+  - "Agent 'pm' invocations average 13.4s per tool call, significantly above the 8.8s mean. If tasks are routine, consider switching from claude-opus-4-6 to claude-sonnet-4-20250514."
+- Templates are in `agentfluent.diagnostics.recommendations`
+- Templates support both human-readable (Rich) and structured (JSON) output
+
+### Implementation Notes
+
+- Template strings with format placeholders -- not hardcoded prose
+- JSON output should include the structured data (not just the rendered string)
+
+### Dependencies
+
+- E6-S2 (correlator produces the data that templates render)
+
+---
+
+### E6-S4: Integrate diagnostics into analyze command
+
+**Issue title:** Integrate diagnostics into analyze command
+**Labels:** `epic:diagnostics`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Add diagnostics output to the `agentfluent analyze` command.
+
+### Acceptance Criteria
+
+- Given `agentfluent analyze --project SLUG --diagnostics`, then diagnostics section is appended to the analytics output
+- Diagnostics section shows: detected signals grouped by agent, recommendations sorted by severity
+- Without `--diagnostics` flag, diagnostics are still shown if signals are detected, but in a summary form ("3 diagnostic signals detected. Run with --diagnostics for details.")
+- `--format json` includes a `diagnostics` key with signals and recommendations
+- When no agent invocations exist in the analyzed sessions, diagnostics section states "No agent invocations found -- diagnostics require agent activity"
+- When agent config files are found, diagnostics cross-reference them for more specific recommendations
+
+### Implementation Notes
+
+- The analyze command now orchestrates: parse -> extract agents -> compute analytics -> extract signals -> correlate with config -> format output
+- Config scanning (from E5) is optional for diagnostics -- if agent def files aren't found, generic recommendations are still generated
+
+### Dependencies
+
+- E4-S5 (analyze command), E6-S1 (signals), E6-S2 (correlator), E6-S3 (templates)
+
+---
+
+### E6-S5: Add diagnostics tests
+
+**Issue title:** Add diagnostics tests
+**Labels:** `epic:diagnostics`, `testing`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Tests for behavior signal extraction, correlation engine, and recommendation generation.
+
+### Acceptance Criteria
+
+- Unit tests for signal extraction:
+  - Agent output containing error keywords -> signals detected with correct type and severity
+  - Agent output with no error keywords -> no error signals
+  - Agent invocations with token outlier -> token_outlier signal generated
+  - Agent invocations with duration outlier -> duration_outlier signal generated
+  - Single invocation of agent type -> no outlier detection (insufficient data)
+- Unit tests for correlator:
+  - Error pattern signal + config with no tools restriction -> tool access recommendation
+  - Error pattern signal + config with tools specified -> error handling prompt recommendation
+  - Token outlier signal + config with long tools list -> tool restriction recommendation
+  - Duration outlier signal + config with overqualified model -> model downgrade recommendation
+  - Signals without config -> generic recommendations
+- Unit tests for recommendation templates:
+  - Rendered messages contain the expected pattern (observation + reason + action)
+  - JSON output includes all structured fields
+- Integration test: run full diagnostics pipeline on a real session with agent invocations
+
+### Dependencies
+
+- E1-S3 (test infrastructure), E6-S1 through E6-S3
+
+---
+
+## E7: CLI Output + Formatting
+
+**Issue title:** Epic: CLI output and formatting
+**Labels:** `epic:cli-output`, `enhancement`
+
+**Body:**
+
+### Summary
+
+Polish the CLI output across all commands: consistent Rich formatting, proper JSON output, verbose/quiet modes, help text, exit codes.
+
+### Success Criteria
+
+- [ ] All commands produce consistent Rich table output by default
+- [ ] All commands produce valid, structured JSON with `--format json`
+- [ ] `--verbose` adds per-invocation detail to all commands
+- [ ] `--quiet` produces summary-only output for all commands
+- [ ] Exit codes are consistent: 0 success, 1 error, 2 no data
+- [ ] Help text includes usage examples
+- [ ] JSON output is parseable by `jq` and has a stable schema
+
+### Stories
+
+- [ ] #N -- Implement Rich table formatters for all commands
+- [ ] #N -- Implement JSON output schema and formatters
+- [ ] #N -- Implement verbose and quiet output modes
+- [ ] #N -- Add CLI output tests
+- [ ] #N -- Add help text with usage examples
+
+---
+
+### E7-S1: Implement Rich table formatters for all commands
+
+**Issue title:** Implement Rich table formatters for all commands
+**Labels:** `epic:cli-output`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Create Rich-formatted table output for all three commands (list, analyze, config-check).
+
+### Acceptance Criteria
+
+- `list` command: project table (name, sessions, size, dates), session table (file, size, date, messages)
+- `analyze` command: summary panel, token/cost table, tool frequency table, agent metrics table, diagnostics panel (if applicable)
+- `config-check` command: per-agent score card with dimension scores, recommendations list with severity color-coding
+- Color coding: green (good/high score), yellow (warning/medium), red (critical/low score)
+- Tables render correctly in 80-column terminal
+- Formatters are in `agentfluent.cli.formatters.table`
+
+### Implementation Notes
+
+- Use Rich Tables, Panels, and Console for formatting
+- Keep formatters separate from command logic -- commands produce data objects, formatters render them
+- Consider a `Formatter` protocol/base class for consistency
+
+### Dependencies
+
+- All commands functional (E2-S4, E4-S5, E5-S4, E6-S4)
+
+---
+
+### E7-S2: Implement JSON output schema and formatters
+
+**Issue title:** Implement JSON output schema and formatters
+**Labels:** `epic:cli-output`, `enhancement`, `priority:high`
+
+**Body:**
+
+### Summary
+
+Structured JSON output mode for all commands, suitable for piping to `jq` or programmatic consumption.
+
+### Acceptance Criteria
+
+- All commands with `--format json` output valid JSON to stdout
+- JSON schema includes a top-level `version` field for future compatibility
+- No Rich formatting, color codes, or escape sequences in JSON output
+- Pydantic models serialize cleanly to JSON (datetime as ISO strings, enums as strings)
+- JSON includes all data shown in table format plus additional detail (no information loss)
+- Formatters are in `agentfluent.cli.formatters.json_output`
+
+### Implementation Notes
+
+- Use Pydantic's `.model_dump(mode="json")` for serialization
+- Print to stdout; all non-data output (warnings, progress) goes to stderr
+- Test with `| jq .` to validate
+
+### Dependencies
+
+- All commands functional, data models finalized
+
+---
+
+### E7-S3: Implement verbose and quiet output modes
+
+**Issue title:** Implement verbose and quiet output modes
+**Labels:** `epic:cli-output`, `enhancement`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+`--verbose` and `--quiet` flags across all commands.
+
+### Acceptance Criteria
+
+- `--verbose`: adds per-invocation breakdown (each agent invocation with metrics), per-session breakdown (when analyzing a project), raw signal data in diagnostics
+- `--quiet`: summary only -- single line or minimal output per command
+  - `list`: "N projects, M total sessions"
+  - `analyze`: "Project X: $Y.YY cost, N tokens, M agent invocations, K diagnostic signals"
+  - `config-check`: "N agents scanned, average score MM/100, K recommendations"
+- `--quiet` output fits in 5 lines or fewer
+- `--verbose` and `--quiet` are mutually exclusive
+- Both work with `--format json` (JSON structure adjusts: minimal for quiet, expanded for verbose)
+
+### Dependencies
+
+- E7-S1 (table formatters), E7-S2 (JSON formatters)
+
+---
+
+### E7-S4: Add CLI output tests
+
+**Issue title:** Add CLI output tests
+**Labels:** `epic:cli-output`, `testing`, `priority:medium`
+
+**Body:**
+
+### Summary
+
+Tests for CLI output formatting, exit codes, and output mode switching.
+
+### Acceptance Criteria
+
+- Tests invoke CLI commands via subprocess (or Typer's test client)
+- Validate:
+  - Exit code 0 on success
+  - Exit code 1 on error (invalid project, missing flags)
+  - Exit code 2 on no data
+  - `--format json` output is valid JSON
+  - `--quiet` output is <= 5 lines
+  - `--version` prints version string
+  - `--help` produces help text
+- Test both table and JSON output for at least one command
+
+### Dependencies
+
+- E7-S1 through E7-S3
+
+---
+
+### E7-S5: Add help text with usage examples
+
+**Issue title:** Add help text with usage examples
+**Labels:** `epic:cli-output`, `documentation`, `priority:low`
+
+**Body:**
+
+### Summary
+
+Enhance `--help` output with usage examples for each command.
+
+### Acceptance Criteria
+
+- Each command's help text includes at least 2 usage examples
+- Examples:
+  - `agentfluent list` -- list all projects
+  - `agentfluent list --project codefluent` -- list sessions in codefluent project
+  - `agentfluent analyze --project codefluent --agent pm` -- analyze PM agent in codefluent
+  - `agentfluent analyze --project codefluent --format json | jq '.cost'` -- programmatic usage
+  - `agentfluent config-check --scope user` -- check user-level agents only
+- Top-level help includes a brief description of AgentFluent's purpose
+
+### Implementation Notes
+
+- Typer supports `help` parameter on commands and `epilog` for examples
+- Consider a `rich_help_panel` for grouped options
+
+### Dependencies
+
+- All commands functional
+
+---
+
+## Implementation Priority Order
+
+The recommended implementation sequence, accounting for dependencies:
+
+### Phase 1: Foundation (E1)
+1. E1-S1 -- Initialize Python package with uv
+2. E1-S2 -- Create CLI skeleton with Typer
+3. E1-S3 -- Set up pytest infrastructure
+4. E1-S4 -- Configure GitHub Actions CI
+5. E1-S5 -- Update CLAUDE.md
+
+### Phase 2: Core Data Layer (E2)
+6. E2-S1 -- Define core data models
+7. E2-S2 -- Implement project/session discovery
+8. E2-S3 -- Implement JSONL parser
+9. E2-S4 -- Wire up list command
+10. E2-S5 -- Parser unit tests
+11. E2-S6 -- Discovery/parser integration tests
+
+### Phase 3: Agent Layer (E3) + Analytics (E4) -- can partially overlap with E5
+12. E3-S1 -- Agent invocation data models
+13. E3-S2 -- Agent invocation extractor
+14. E3-S3 -- Agent extraction tests
+15. E4-S1 -- Model pricing lookup
+16. E4-S2 -- Token and cost analytics
+17. E4-S3 -- Tool pattern analytics
+18. E4-S4 -- Per-agent execution metrics
+19. E4-S5 -- Wire up analyze command
+20. E4-S6 -- Analytics tests
+
+### Phase 4: Config Assessment (E5) -- can develop in parallel with Phase 3
+21. E5-S1 -- Config assessment data models
+22. E5-S2 -- Agent definition scanner/parser
+23. E5-S3 -- Config scoring rubric
+24. E5-S4 -- Wire up config-check command
+25. E5-S5 -- Config assessment tests
+
+### Phase 5: Diagnostics (E6)
+26. E6-S1 -- Behavior signal extraction
+27. E6-S2 -- Signal-to-config correlation engine
+28. E6-S3 -- Recommendation templates
+29. E6-S4 -- Integrate diagnostics into analyze command
+30. E6-S5 -- Diagnostics tests
+
+### Phase 6: Polish (E7)
+31. E7-S1 -- Rich table formatters
+32. E7-S2 -- JSON output formatters
+33. E7-S3 -- Verbose/quiet modes
+34. E7-S4 -- CLI output tests
+35. E7-S5 -- Help text with examples
+
+**Total: 7 epics, 35 stories**

--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -1,0 +1,99 @@
+# Decision Log
+
+Append-only log of significant trade-off decisions made during AgentFluent development.
+
+---
+
+## D001: Python as sole MVP language
+
+**Date:** 2026-04-14
+**Context:** CLAUDE.md lists "TypeScript and Python" as the tech stack. The research doc references TypeScript file names (parser.ts, analytics.ts) for code reuse from CodeFluent.
+**Decision:** MVP will be Python-only. No TypeScript.
+**Rationale:**
+- Fred is a Python developer and will be the primary contributor
+- CodeFluent's Python webapp (FastAPI backend) already has working Python implementations of the JSONL parser, token analytics, config scanner, and pricing lookup
+- CLI tool maps naturally to Python ecosystem (Typer/Click, Rich)
+- Agent SDK has a Python SDK, aligning with the primary target audience
+- TypeScript reuse references in CLAUDE.md were from the VS Code extension side; the Python webapp code is equally reusable
+
+**Action required:** Update CLAUDE.md "Architecture Context > Code Reuse from CodeFluent" section to reference Python module names instead of .ts files, and update "Tech Stack" section to reflect Python-only for MVP.
+
+---
+
+## D002: Stretch MVP scope (Option B) with diagnostics preview
+
+**Date:** 2026-04-14
+**Context:** Two MVP options were presented: (A) execution analytics + config assessment only, (B) add diagnostics preview demonstrating behavior-to-config correlation.
+**Decision:** Option B -- include diagnostics preview.
+**Rationale:**
+- The tagline ("tells you what to change") requires at least a preview of behavior-to-config correlation to be credible
+- Subagent metadata (total_tokens, tool_uses, duration_ms) plus output text pattern matching provides enough signal for meaningful recommendations without needing internal traces
+- Rule-based heuristics (not LLM-powered) keeps complexity bounded
+- Preview scope: error pattern detection, efficiency outliers, duration outliers -- three signal types is achievable
+
+**Trade-off:** Adds approximately 1 week to MVP timeline. Mitigated by keeping diagnostics rule-based and limiting to 3 signal types.
+
+---
+
+## D003: Project-agnostic from day one
+
+**Date:** 2026-04-14
+**Context:** Could have hardcoded the tool to analyze a single known project for faster MVP.
+**Decision:** Project discovery and selection is part of MVP scope.
+**Rationale:**
+- `~/.claude/projects/` contains multiple project directories; users need to choose
+- CodeFluent and AgentFluent's own project sessions serve as test data, requiring multi-project support
+- Discovery is low-complexity (directory listing) with high usability value
+- Avoids hardcoded paths that would need refactoring later
+
+---
+
+## D004: Both user-level and project-level agent definition scanning
+
+**Date:** 2026-04-14
+**Context:** Agent definitions live in two locations: `~/.claude/agents/` (user-level, shared across projects) and `.claude/agents/` (project-level, specific to a repo).
+**Decision:** Scan both locations in MVP. Agent SDK source parsing deferred.
+**Rationale:**
+- Both locations are documented in Anthropic's agent system and are actively used
+- The `--scope` flag (user/project/all) gives users control
+- Agent SDK `AgentDefinition` objects in source code require AST parsing -- significantly more complex, deferred until Agent SDK test data exists
+
+---
+
+## D005: Comprehensive test strategy (unit fixtures + integration against real data)
+
+**Date:** 2026-04-14
+**Context:** Options ranged from minimal unit tests to full integration testing.
+**Decision:** Both unit tests with anonymized fixtures AND integration tests against real session data. CI/CD pipeline from the start.
+**Rationale:**
+- Fred considers extensive testing essential for this project
+- Real session data from CodeFluent and AgentFluent projects is available for integration testing
+- Fixtures ensure reproducibility; real data ensures correctness against actual formats
+- CI/CD infrastructure prevents regressions as the codebase grows
+
+---
+
+## D006: CLI framework recommendation (Typer)
+
+**Date:** 2026-04-14
+**Context:** Fred had no strong preference on CLI framework, only that it be Python.
+**Decision:** Recommend Typer (built on Click) as default, with Click as fallback.
+**Rationale:**
+- Typer provides type-hint-based CLI definition, reducing boilerplate
+- Built on Click, so all Click features are available if needed
+- Auto-generates `--help` from type annotations and docstrings
+- Rich integration for formatted output
+- Developer makes final call on framework choice
+
+---
+
+## D007: uv for dependency management
+
+**Date:** 2026-04-14
+**Context:** Fred specified uv as the dependency management tool. Alternatives considered: pip, poetry, pdm.
+**Decision:** Use uv for all dependency management, virtual environment creation, and script running.
+**Rationale:**
+- Fred's explicit preference
+- uv is fast, supports pyproject.toml natively, handles lockfiles, and replaces pip/pip-tools/virtualenv
+- Aligns with modern Python tooling trends
+- Project scaffolding should use `uv init` and `pyproject.toml`, not `setup.py` or `requirements.txt`

--- a/.claude/specs/prd-mvp.md
+++ b/.claude/specs/prd-mvp.md
@@ -1,0 +1,326 @@
+# PRD: AgentFluent MVP
+
+**Status:** Draft
+**Date:** 2026-04-14
+**Author:** PM Agent
+**Decision log:** See `decisions.md` for key decisions made during planning.
+**Backlog:** See `backlog-mvp.md` for the full epic/story breakdown with issue bodies.
+
+---
+
+## 1. Problem Statement
+
+Developers building AI agents with Claude Code subagents and the Claude Agent SDK have no local-first tool that evaluates agent **quality**. Existing tools monitor execution (traces, latency, cost) but none diagnose **why** an agent misbehaves or **what to change** in its configuration.
+
+The gap is well-documented in the research (see `docs/AGENT_ANALYTICS_RESEARCH.md`):
+- 57% of organizations have agents in production
+- Quality is the top deployment barrier (32% of respondents)
+- Agent success drops from 60% to 25% across multiple runs
+- Every community tool converges on dashboards; none provide quality analysis or prompt diagnostics
+
+## 2. MVP Scope
+
+**Option B (Stretch MVP):** Execution analytics + configuration assessment + diagnostics preview that demonstrates behavior-to-config correlation using limited signals from subagent metadata.
+
+### In Scope
+
+1. **Project/session discovery** -- scan `~/.claude/projects/`, let user select a project, list sessions
+2. **JSONL parsing** -- parse session files, extract messages, handle all content formats
+3. **Agent invocation extraction** -- identify Agent tool_use blocks, extract subagent metadata (type, description, prompt, tokens, tool_uses, duration, agentId)
+4. **Execution analytics** -- token usage, cost, cache efficiency, tool call patterns, per-agent cost attribution, efficiency metrics (tokens/tool_use, duration/tool_use)
+5. **Agent configuration assessment** -- scan agent definition files at `~/.claude/agents/` and `.claude/agents/`, score against best practices (description quality, tool restrictions, model selection)
+6. **Diagnostics preview** -- correlate observable behavior signals (error patterns in output text, high retry counts, efficiency outliers) to specific config improvement recommendations
+7. **CLI interface** -- `agentfluent analyze`, `agentfluent list`, `agentfluent config-check`, JSON output mode for programmatic consumption
+8. **Test infrastructure** -- unit tests with fixtures, integration tests against real session data, CI/CD pipeline
+
+### Out of Scope (Deferred)
+
+- **Agent SDK source parsing** -- scanning Python/TypeScript source for `AgentDefinition` objects. Deferred until Agent SDK test data exists.
+- **Prompt regression detection** (`agentfluent diff`) -- comparing behavior across prompt versions. Requires multiple data points over time.
+- **LLM-powered analysis** -- using Claude API for deeper prompt scoring or recommendation generation. MVP uses rule-based heuristics only.
+- **Webapp dashboard** -- visualization layer. CLI is the analytical core for MVP.
+- **VS Code extension** -- different audience; CodeFluent serves VS Code users.
+- **"Apply fix" automation** -- auto-modifying agent configs based on recommendations. High risk, requires trust.
+- **Managed Agents support** -- different data format (server-side events), different system entirely.
+- **Cross-project aggregation** -- analyzing patterns across multiple projects. Single-project focus for MVP.
+
+## 3. Target User
+
+Python developers building Claude Code subagents and/or Agent SDK agents. They work in the terminal, use `~/.claude/agents/` and `.claude/agents/` for agent definitions, and want to understand whether their agents are performing well without setting up cloud infrastructure.
+
+## 4. Architecture
+
+### Language & Runtime
+
+**Python** (sole language for MVP). Fred is a Python developer; CodeFluent's Python webapp (FastAPI backend) contains working implementations of the JSONL parser, token analytics, config scanner, and pricing lookup that can be ported/adapted.
+
+### Package Structure
+
+```
+agentfluent/
+  __init__.py
+  cli/                  # CLI entry points (Click/Typer)
+    __init__.py
+    main.py             # CLI app, command registration
+    commands/
+      analyze.py        # agentfluent analyze
+      list.py           # agentfluent list
+      config_check.py   # agentfluent config-check
+    formatters/
+      table.py          # Rich table output
+      json_output.py    # JSON output mode
+  core/
+    __init__.py
+    parser.py           # JSONL session parser
+    session.py          # Session/conversation models
+    discovery.py        # Project/session discovery
+  agents/
+    __init__.py
+    extractor.py        # Agent invocation extraction from JSONL
+    models.py           # Agent invocation data models
+  analytics/
+    __init__.py
+    tokens.py           # Token usage, cost, cache metrics
+    pricing.py          # Model pricing lookup
+    tools.py            # Tool call pattern analysis
+    efficiency.py       # Per-agent efficiency metrics
+  config/
+    __init__.py
+    scanner.py          # Agent definition file scanner
+    scoring.py          # Config quality scoring rubric
+    models.py           # Config assessment models
+  diagnostics/
+    __init__.py
+    signals.py          # Behavior signal extraction (errors, retries)
+    correlator.py       # Signal-to-recommendation mapping
+    recommendations.py  # Recommendation models and templates
+tests/
+  __init__.py
+  fixtures/             # Anonymized JSONL test data
+  conftest.py
+  unit/
+    test_parser.py
+    test_extractor.py
+    test_analytics.py
+    test_config_scanner.py
+    test_diagnostics.py
+  integration/
+    test_real_sessions.py
+    test_cli.py
+```
+
+### CLI Framework
+
+Typer (built on Click, provides type hints, auto-generates help). Alternative: plain Click if Typer adds unwanted complexity. Developer's call.
+
+### Key Dependencies (suggestions, developer decides)
+
+- **Typer** or **Click** -- CLI framework
+- **Rich** -- terminal formatting (tables, colors, panels)
+- **Pydantic** -- data models and validation
+- **pytest** -- testing
+- **pytest-cov** -- coverage reporting
+
+### Output Modes
+
+All commands support `--format json` for programmatic consumption and `--format table` (default) for human-readable output.
+
+## 5. Feature Specifications
+
+### 5.1 Project & Session Discovery
+
+**Command:** `agentfluent list [--project PROJECT_SLUG]`
+
+**Behavior:**
+- Scan `~/.claude/projects/` for project directories
+- Without `--project`: list all projects with session counts, total size, date range
+- With `--project`: list all sessions in that project with timestamps, message counts, agent invocation counts
+
+**Acceptance Criteria:**
+- Given `~/.claude/projects/` contains project directories, when `agentfluent list` runs, then all projects are listed with session count and date range
+- Given a valid project slug, when `agentfluent list --project SLUG` runs, then all sessions are listed with metadata
+- Given an invalid project slug, then a clear error message is shown
+- Both `--format json` and `--format table` produce correct output
+
+### 5.2 JSONL Parser
+
+**Behavior:**
+- Read `.jsonl` files line by line, parse JSON
+- Handle `message.content` as both string and array-of-blocks
+- Skip non-analytical message types: `file-history-snapshot`, `progress`, `hook_progress`, `bash_progress`, `system`, `create`
+- Extract: user messages, assistant messages (with tool_use blocks and usage), tool_results (with metadata)
+- Graceful handling of malformed lines (log warning, skip)
+
+**Acceptance Criteria:**
+- Given a JSONL file with mixed message types, when parsed, then only analytical types are returned
+- Given `message.content` as a plain string, when parsed, then text is correctly extracted
+- Given `message.content` as an array of blocks, when parsed, then text is correctly extracted from each block
+- Given a malformed JSON line, when parsed, then parsing continues with remaining lines
+- Parser returns typed data models (Pydantic or dataclass)
+
+### 5.3 Agent Invocation Extraction
+
+**Behavior:**
+- Identify assistant messages containing `tool_use` blocks where `name == "Agent"`
+- Extract from tool_use input: `subagent_type`, `description`, `prompt`
+- Match tool_use to subsequent `tool_result` and extract metadata: `total_tokens`, `tool_uses`, `duration_ms`, `agentId`
+- Distinguish built-in agents (Explore, Plan, general-purpose) from custom agents
+- Compute per-invocation metrics: tokens/tool_use, duration/tool_use
+
+**Acceptance Criteria:**
+- Given a session with Agent tool_use blocks, when extracted, then all agent invocations are identified with correct metadata
+- Given a tool_result with metadata block, when extracted, then total_tokens, tool_uses, duration_ms, and agentId are captured
+- Built-in agents are correctly categorized separately from custom agents
+- Per-invocation efficiency metrics are computed correctly
+
+### 5.4 Execution Analytics
+
+**Command:** `agentfluent analyze [--project PROJECT] [--session SESSION] [--agent AGENT_TYPE]`
+
+**Metrics produced:**
+- **Token usage:** total input/output/cache_creation/cache_read tokens per session
+- **Cost:** dollar cost using model pricing lookup (per session, per agent type)
+- **Cache efficiency:** cache_read / (cache_read + input) ratio
+- **Tool patterns:** tool call frequency by name, unique tool count
+- **Agent-specific:** cost per agent type, invocations per agent type, efficiency metrics (tokens/tool_use, duration/tool_use)
+- **Session summary:** total messages, duration, agent invocations count
+
+**Acceptance Criteria:**
+- Given a session with assistant messages containing usage data, when analyzed, then token totals are correct
+- Given model names in assistant messages, when analyzed, then costs are computed using correct pricing
+- Given agent invocations with metadata, when analyzed, then per-agent cost attribution is correct
+- Given `--agent pm`, when analyzed, then only PM agent invocations are included
+- `--format json` output contains all metrics in a structured schema
+
+### 5.5 Agent Configuration Assessment
+
+**Command:** `agentfluent config-check [--scope user|project|all] [--agent AGENT_NAME]`
+
+**Behavior:**
+- Scan `~/.claude/agents/*.md` (user scope) and `.claude/agents/*.md` (project scope)
+- Parse YAML frontmatter for: model, tools, disallowedTools, description, other config fields
+- Score each agent definition against a rubric:
+  - **Description quality:** Is it present? Is it specific enough to trigger correct delegation? (Check length, presence of action verbs, specificity)
+  - **Tool restrictions:** Are `tools` or `disallowedTools` specified? (Principle of least privilege)
+  - **Model selection:** Is a model specified? Is it appropriate for the task? (Cost vs capability)
+  - **Prompt body quality:** Length, presence of structured sections, error handling instructions, success criteria
+- Produce a per-agent score and specific improvement recommendations
+
+**Acceptance Criteria:**
+- Given agent .md files with YAML frontmatter, when scanned, then all config fields are correctly parsed
+- Given an agent with no `tools` restriction, then a recommendation to restrict tools is generated
+- Given an agent with a vague 1-word description, then a recommendation to improve description is generated
+- Given `--scope user`, then only `~/.claude/agents/` is scanned
+- Given `--scope project`, then only `.claude/agents/` is scanned
+- Default (`--scope all`) scans both locations
+- `--format json` output includes scores and recommendations per agent
+
+### 5.6 Diagnostics Preview
+
+**Command:** Output included in `agentfluent analyze` when agent invocations are present. Also available via `agentfluent analyze --diagnostics`.
+
+**Behavior:**
+- Extract behavior signals from observable data:
+  - **Error patterns in output text:** regex/keyword matching for "blocked", "unable to", "don't have access", "failed", "error", "retry"
+  - **High token consumption:** invocations with tokens/tool_use significantly above agent-type average
+  - **Duration outliers:** invocations taking significantly longer than average for agent type
+  - **Low tool efficiency:** high tool_uses with low output quality signals
+- Correlate signals to config surfaces:
+  - Error pattern in output -> check if agent definition restricts relevant tools, check if prompt addresses error handling
+  - High token consumption -> check if prompt is focused, check if tools list is minimal
+  - Duration outlier -> check model selection (overqualified model for simple task)
+- Generate specific, actionable recommendations:
+  - "Agent 'pm' reported 'blocked' in output. Check that allowed_tools includes Write access and that hook permissions are configured."
+  - "Agent 'pm' uses 2,259 tokens per tool call (above average). Consider adding more specific instructions to reduce exploration."
+
+**Acceptance Criteria:**
+- Given agent output containing error keywords, when analyzed, then error signals are detected and reported
+- Given an agent invocation with tokens/tool_use 2x above type average, then an efficiency warning is generated
+- Each recommendation references a specific config surface (prompt, tools, model, hooks)
+- Recommendations are actionable (say what to change, not just what's wrong)
+- `--format json` output includes signals and recommendations in structured format
+
+### 5.7 CLI Output & Formatting
+
+**Behavior:**
+- Default: Rich-formatted tables with color coding for scores/thresholds
+- `--format json`: structured JSON to stdout (pipe-friendly, no color codes)
+- `--format table`: explicit table format (same as default)
+- `--verbose`: include additional detail (per-invocation breakdowns, raw signal data)
+- `--quiet`: summary only (counts, totals, overall score)
+- Global `--help` and per-command help with examples
+
+**Acceptance Criteria:**
+- JSON output is valid JSON parseable by `jq`
+- Table output renders correctly in standard 80-column terminal
+- `--quiet` output fits in 5 lines or fewer per command
+- Exit codes: 0 for success, 1 for error, 2 for "no data found"
+
+## 6. Data Models (Key Types)
+
+These are guidance for the developer -- exact implementation is their decision.
+
+```
+SessionMessage: type, timestamp, content (text), tool_use blocks, usage, metadata
+AgentInvocation: agent_type, description, prompt, total_tokens, tool_uses, duration_ms, agent_id, output_text, is_builtin
+ExecutionMetrics: total_tokens (by type), cost, cache_efficiency, tool_counts, duration, agent_invocations
+AgentConfig: name, file_path, scope (user/project), model, tools, disallowed_tools, description, prompt_body
+ConfigScore: agent_name, overall_score, dimension_scores, recommendations
+DiagnosticSignal: signal_type, severity, agent_invocation_ref, evidence (text snippet or metric value)
+Recommendation: target_config_surface, severity, message, evidence_refs
+```
+
+## 7. Test Strategy
+
+### Unit Tests (fixtures)
+- Anonymized JSONL snippets covering: plain text content, array content, agent tool_use, tool_result with metadata, malformed lines, all skip types
+- Parser correctness for each message type
+- Agent extraction with and without metadata
+- Analytics computation with known expected values
+- Config scoring with known rubric outcomes
+- Signal detection with known patterns
+
+### Integration Tests (real data)
+- Run against actual sessions from `~/.claude/projects/` (CodeFluent and AgentFluent project sessions)
+- Validate end-to-end: discovery -> parsing -> extraction -> analytics -> output
+- CLI invocation tests (subprocess, check exit codes and output structure)
+
+### CI/CD
+- pytest with coverage reporting
+- Pre-commit hooks or CI checks for linting (ruff) and type checking (mypy or pyright)
+- GitHub Actions workflow
+
+## 8. Success Criteria
+
+The MVP is successful when:
+1. `agentfluent list` discovers and lists projects/sessions from `~/.claude/projects/`
+2. `agentfluent analyze` produces correct token, cost, and tool metrics for sessions containing agent invocations
+3. `agentfluent config-check` scans agent definition files and produces scored assessments with actionable recommendations
+4. Diagnostics preview detects at least 3 signal types (error patterns, token outliers, duration outliers) and maps them to config surface recommendations
+5. All output is available in both human-readable (table) and machine-readable (JSON) formats
+6. Test suite covers core parsing, extraction, analytics, and config scoring with >80% coverage on those modules
+7. CI pipeline runs tests on every PR
+
+## 9. Sequencing
+
+Implementation order (each epic builds on the previous):
+
+1. **E1: Project Scaffolding** -- Python package, CLI skeleton, test infrastructure, CI
+2. **E2: JSONL Parser + Session Discovery** -- core data layer everything else depends on
+3. **E3: Agent Invocation Extraction** -- identifies agent data within parsed sessions
+4. **E4: Execution Analytics** -- token/cost/tool metrics, depends on E2+E3
+5. **E5: Agent Configuration Assessment** -- independent of session data, can parallel with E4
+6. **E6: Diagnostics Preview** -- correlates E4 analytics with E5 config data
+7. **E7: CLI Output + Formatting** -- polishes output across all commands
+
+Note: E5 (config assessment) could be developed in parallel with E3+E4 since it reads agent definition files independently of session data. The developer should use judgment on parallelization.
+
+## 10. Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| JSONL format changes in future Claude Code versions | Parser breaks | Defensive parsing with graceful degradation; version detection if format includes version field |
+| Limited test data for custom agents | Can't validate diagnostics | Use CodeFluent project sessions (PM agent invocations exist); create test fixtures from real data |
+| Agent definition format changes | Config scanner breaks | Parse defensively; log warnings for unrecognized fields |
+| Diagnostics recommendations feel generic | Low perceived value | Start with high-confidence signals (error keywords) and expand; label recommendations with confidence level |
+| Scope creep into LLM-powered features | Delays MVP | Hard boundary: MVP is rule-based only. LLM features are a separate epic post-MVP. |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ data/
 .env
 .env.local
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # IDE
 .vscode/
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,223 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AgentFluent is a local-first agent analytics tool. Its primary target is developers building agents with the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) (Python and TypeScript), with secondary support for Claude Code subagents. It analyzes session data (JSONL files from `~/.claude/projects/`) to evaluate agent **quality** -- not just execution monitoring. The core differentiator is behavior-to-improvement diagnostics: analyzing observed agent behavior and distilling concrete, actionable improvements -- whether that means updating a stored prompt, adding or configuring an MCP server, writing a new rule, command, skill, or subagent, adjusting tool access, or changing model selection.
+
+Tagline: "The tools that exist tell you what your agent did. This tool tells you what to change."
+
+## How AgentFluent Differs from CodeFluent
+
+AgentFluent is a standalone sibling project to [CodeFluent](https://github.com/frederick-douglas-pearce/codefluent). They share data sources (Claude Code JSONL sessions) and some infrastructure, but analyze fundamentally different things:
+
+- **CodeFluent** measures **human AI fluency** -- how well a developer collaborates with Claude Code in interactive sessions. It scores human prompts against 11 research-backed fluency behaviors (from Anthropic's AI Fluency Index) and coaches developers to improve their prompting patterns. Config maturity scoring helps users set up their `.claude/` project to support better human-AI collaboration.
+- **AgentFluent** diagnoses **agent quality** -- why an agent misbehaves and what concrete changes to its configuration fix it. It correlates observed behavior (retries, errors, tool patterns) back to specific gaps in the agent's prompt, tool setup, rules, or other configuration surfaces.
+
+The analysis is fundamentally different because agents and interactive sessions have different structures:
+
+- **Prompts are static artifacts, not ephemeral.** Agent prompts live in code (`ClaudeAgentOptions`, `AgentDefinition`) or `.claude/agents/*.md` files -- they're version-controlled and run identically every time. A flaw compounds at scale instead of being corrected mid-conversation.
+- **Descriptions are trigger logic.** An agent's `description` field controls when it gets delegated to -- a poor description means the agent never fires or fires for wrong tasks. No equivalent exists in interactive use.
+- **No conversational feedback loop.** A human course-corrects mid-session. An agent runs its prompt blind -- retries, errors, and wrong tool choices repeat systematically.
+- **The config surface is the entire agent.** In CodeFluent, config supports the human. In AgentFluent, the config *is* the agent -- prompt, allowed_tools, hooks, MCP servers, subagent definitions, model, skills, commands -- there's nothing else to tune.
+
+CodeFluent asks: "How fluent is the developer?" AgentFluent asks: "How do we make this agent better?"
+
+## Project Status
+
+Early stage -- scaffolding and research phase. No application code yet. The research document at `docs/AGENT_ANALYTICS_RESEARCH.md` contains the full market analysis, competitive landscape, technical feasibility study, and bootstrap strategy.
+
+## Architecture Context
+
+### Code Reuse from CodeFluent
+
+- **JSONL parser** (`parser.ts`) -- same session format
+- **Token analytics** (`analytics.ts`) -- same metrics
+- **Config scanner** (`configScanner.ts`) -- needs agent-specific categories
+- **Pricing lookup** (`pricing.ts`) -- identical
+- **Cache infrastructure** -- same pattern
+- **Conversation assembly** -- same gap-based splitting
+
+### Novel Components (to build)
+
+- Agent behavior metrics (task completion, tool errors, retry patterns, stuck detection)
+- Behavior-to-improvement correlation engine -- maps observed agent issues to specific config changes
+- Agent-specific scoring rubric and prompt templates
+- Prompt version tracking and regression analysis
+- Recommendation engine spanning the full agent config surface (prompts, tools, MCP servers, rules, commands, skills, subagents, model selection, hooks)
+
+### Data Sources
+
+Agent SDK and Claude Code subagent sessions are stored as JSONL in `~/.claude/projects/`. Key fields:
+- `type: "user"` -- programmatic prompt (system prompt + user message)
+- `type: "assistant"` -- model responses with `tool_use` blocks
+- `type: "tool_result"` -- tool execution results, including metadata block with `total_tokens`, `tool_uses`, `duration_ms`, `agentId`
+
+### Four Core Features
+
+1. **Agent Execution Analytics** -- token usage, cost, tool call patterns, error rates (reuse from CodeFluent)
+2. **Agent Behavior Diagnostics** -- score agent configuration against best practices, correlate behavior to prompt and config issues, generate specific improvement recommendations (novel)
+3. **Regression Detection** -- compare agent behavior across prompt/config versions (novel)
+4. **Agent Configuration Assessment** -- tool access audit, model selection, hook coverage, MCP server review (reuse/adapt from CodeFluent)
+
+## Delivery Strategy
+
+- **CLI tool as the primary interface** -- `agentfluent analyze`, `agentfluent diff`, JSON output for programmatic consumption. Fits Agent SDK developers' workflow (terminal, CI/CD pipelines) and enables integration into PR checks when agent configs change.
+- **Webapp dashboard for visualization** -- charts, trends, side-by-side comparisons. The CLI is the analytical core; the webapp is a view into it.
+- **VS Code extension is a future consideration** -- not the initial focus. CodeFluent already serves the VS Code interactive user. AgentFluent lives where agent developers work: terminal and CI pipelines.
+
+## Product Development Workflow
+
+This project uses a PM subagent (`~/.claude/agents/pm.md`) for feature specification and backlog management. The PM agent reads project context, creates GitHub issues (epics and stories), and writes longer-form specs to `.claude/specs/`. It has no access to Bash, Edit, or code -- only Read, Write (scoped to `.claude/specs/` via hook), and GitHub MCP tools (issues + labels only).
+
+### When to invoke the PM agent
+
+Delegate to the pm subagent when the human's request involves:
+- A new feature or capability that needs scoping before implementation
+- A pain point or problem statement that needs translation into stories
+- Scope or priority questions ("should we do A or B first?")
+- Ambiguous requirements where assumptions would be required to proceed
+
+Do NOT invoke the PM agent for:
+- Bug fixes with clear reproduction steps
+- Refactoring with no behavior change
+- Purely technical decisions (dependency updates, tooling, CI)
+- Requests that reference an existing GitHub issue with clear acceptance criteria
+
+### Spec and issue conventions
+
+- **PRDs:** `.claude/specs/prd-<feature-slug>.md`
+- **Decision log:** `.claude/specs/decisions.md` (append-only)
+- **Epics:** GitHub issues with `epic:` label prefix
+- **Stories:** GitHub issues tagged with parent epic label
+
+### Working from specs
+
+When implementing from a PM-produced spec or issue:
+- Reference the story's acceptance criteria as your definition of done
+- Do not exceed the scope defined in the spec
+- If the spec is technically infeasible or incomplete, STOP and report
+  back to the human before proceeding -- do not silently adapt
+
+## Code Style & Conventions
+
+- Keep files small: if a file exceeds 300 lines, consider splitting
+- Use descriptive variable names over comments
+- Error handling: wrap external calls (API, file I/O) in try/catch with user-friendly messages
+
+## Branching & PR Workflow
+
+- **`main`** -- Always releasable. All changes require a PR with passing CI before merge.
+- **Feature branches** -- `feature/<issue-number>-short-description` (e.g., `feature/12-session-parser`)
+- **Bug fix branches** -- `fix/<issue-number>-short-description` (e.g., `fix/15-token-count-overflow`)
+- **Commit to feature/fix branches freely** -- push often, squash or merge to main via PR.
+
+### Commit Messages (Conventional Commits)
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+**Required prefixes:**
+- `feat:` -- new feature (triggers minor version bump)
+- `fix:` -- bug fix (triggers patch version bump)
+- `docs:` -- documentation only
+- `test:` -- adding or updating tests
+- `chore:` -- maintenance, dependencies, CI
+- `refactor:` -- code change that neither fixes a bug nor adds a feature
+
+**Breaking changes:** Add `!` after the type (e.g., `feat!: remove legacy API`) or include `BREAKING CHANGE:` in the commit body. Triggers a major version bump.
+
+## Production Standards
+
+- **All new features must have tests.** No merging without test coverage for the change.
+- **No regressions:** All tests must pass before any commit to main.
+- **Security:** Sanitize user-controlled strings before rendering. Never interpolate untrusted input into shell commands. Redact API keys in error messages.
+
+## JSONL Data Format
+
+Claude Code and Agent SDK sessions are stored at `~/.claude/projects/` as JSONL files. AgentFluent's analysis targets differ from CodeFluent's -- we care about agent behavior signals, not human fluency signals.
+
+### Directory structure
+```
+~/.claude/projects/
+├── -home-user-project-name/
+│   ├── session-uuid-1.jsonl
+│   ├── session-uuid-2.jsonl
+│   └── ...
+└── -home-user-other-project/
+    └── ...
+```
+
+### Message types AgentFluent extracts
+
+**`type: "assistant"` -- Model responses (token usage + tool calls)**
+```json
+{
+  "type": "assistant",
+  "message": {
+    "model": "claude-opus-4-6",
+    "role": "assistant",
+    "content": [
+      {"type": "text", "text": "..."},
+      {"type": "tool_use", "name": "Agent", "input": {
+        "subagent_type": "pm",
+        "description": "...",
+        "prompt": "..."
+      }}
+    ],
+    "usage": {
+      "input_tokens": 3,
+      "output_tokens": 2,
+      "cache_creation_input_tokens": 14450,
+      "cache_read_input_tokens": 19155
+    }
+  },
+  "timestamp": "2026-02-27T01:10:24.420Z"
+}
+```
+
+**`type: "tool_result"` -- Tool execution results (agent metadata here)**
+```json
+{
+  "type": "tool_result",
+  "content": "agent's final summary text",
+  "metadata": {
+    "total_tokens": 31621,
+    "tool_uses": 14,
+    "duration_ms": 122963,
+    "agentId": "uuid"
+  }
+}
+```
+
+**`type: "user"` -- Prompts**
+```json
+{
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": "plain string OR array of content blocks"
+  },
+  "timestamp": "2026-02-27T01:10:20.969Z"
+}
+```
+**NOTE:** `message.content` can be either a plain string or an array of blocks (`[{"type": "text", "text": "..."}]`). The parser MUST handle both.
+
+### Key signals for agent analysis
+
+- **Agent tool_use blocks** -- `name: "Agent"` with `subagent_type`, `description`, `prompt` in input. Identifies which agent was invoked and the delegation prompt.
+- **tool_result metadata** -- `total_tokens`, `tool_uses`, `duration_ms`, `agentId`. Enables cost-per-invocation, efficiency metrics, and continuity tracking.
+- **Error patterns in tool_result content** -- self-reported failures ("blocked", "unable to", "don't have access") extractable via pattern matching.
+- **Retry sequences** -- consecutive tool_use/tool_result pairs for the same tool indicate retry behavior.
+- **Tool diversity** -- count of unique tool names in assistant content blocks.
+
+### Types to skip
+
+- `file-history-snapshot` -- metadata
+- `progress`, `hook_progress`, `bash_progress` -- streaming events
+- `system` -- system messages
+- `create` -- file creation events
+
+## Tech Stack
+
+TypeScript and Python (Agent SDK support). Node.js runtime. JSONL as the primary data format.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project overview, architecture context, JSONL data format specs, conventions, and PM workflow
- Add MVP PRD (`.claude/specs/prd-mvp.md`) covering 7 feature areas with acceptance criteria
- Add decision log (`.claude/specs/decisions.md`) with 7 key decisions: Python-only, uv, stretch MVP scope, project-agnostic, dual-scope scanning, Typer, comprehensive testing
- Add full backlog (`.claude/specs/backlog-mvp.md`) with 7 epics and 35 stories matching GitHub issues #1-#42
- Gitignore `.claude/settings.local.json`

## Test plan

- [ ] Verify all spec files render correctly on GitHub
- [ ] Verify `.claude/settings.local.json` is excluded from the commit
- [ ] Confirm issue references (#1-#42) link correctly in backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)