### PR TITLE
Create CLI skeleton with Typer stub commands

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -1,0 +1,47 @@
+"""agentfluent analyze -- compute execution analytics and diagnostics."""
+
+from typing import Optional
+
+import typer
+
+app = typer.Typer(help="Analyze agent sessions.")
+
+
+@app.callback(invoke_without_command=True)
+def analyze(
+    project: str = typer.Option(
+        ...,
+        "--project",
+        "-p",
+        help="Project slug to analyze.",
+    ),
+    session: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--session",
+        "-s",
+        help="Specific session file to analyze.",
+    ),
+    agent: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--agent",
+        "-a",
+        help="Filter to a specific agent type (e.g., 'pm').",
+    ),
+    diagnostics: bool = typer.Option(
+        False,
+        "--diagnostics",
+        "-d",
+        help="Show detailed diagnostics.",
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format.",
+        show_choices=True,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
+) -> None:
+    """Analyze agent sessions for token usage, cost, and behavior diagnostics."""
+    typer.echo("Not yet implemented: analyze")

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -1,0 +1,35 @@
+"""agentfluent config-check -- assess agent configuration quality."""
+
+from typing import Optional
+
+import typer
+
+app = typer.Typer(help="Check agent configuration quality.")
+
+
+@app.callback(invoke_without_command=True)
+def config_check(
+    scope: str = typer.Option(
+        "all",
+        "--scope",
+        help="Scanning scope: 'user', 'project', or 'all'.",
+        show_choices=True,
+    ),
+    agent: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--agent",
+        "-a",
+        help="Score a specific agent by name.",
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format.",
+        show_choices=True,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
+) -> None:
+    """Scan agent definitions and score them against best practices."""
+    typer.echo("Not yet implemented: config-check")

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -1,0 +1,29 @@
+"""agentfluent list -- discover projects and sessions."""
+
+from typing import Optional
+
+import typer
+
+app = typer.Typer(help="List projects and sessions.")
+
+
+@app.callback(invoke_without_command=True)
+def list_projects(
+    project: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--project",
+        "-p",
+        help="Project slug to list sessions for.",
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format.",
+        show_choices=True,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
+) -> None:
+    """List available projects, or sessions within a project."""
+    typer.echo("Not yet implemented: list")

--- a/src/agentfluent/cli/main.py
+++ b/src/agentfluent/cli/main.py
@@ -5,12 +5,17 @@ from typing import Optional
 import typer
 
 from agentfluent import __version__
+from agentfluent.cli.commands import analyze, config_check, list_cmd
 
 app = typer.Typer(
     name="agentfluent",
     help="Local-first agent analytics with prompt diagnostics.",
     no_args_is_help=True,
 )
+
+app.add_typer(list_cmd.app, name="list")
+app.add_typer(analyze.app, name="analyze")
+app.add_typer(config_check.app, name="config-check")
 
 
 def version_callback(value: bool) -> None:


### PR DESCRIPTION
## Summary

- Register three stub commands: `list`, `analyze`, `config-check`
- Each command accepts its eventual flags (--project, --session, --agent, --format, etc.)
- Stubs print "Not yet implemented" and exit 0
- --version and --help work at all levels
- Each command in its own module under `cli/commands/`

Closes #9

## Test plan

- [x] `agentfluent --help` lists all three commands
- [x] `agentfluent --version` prints version
- [x] `agentfluent list --help` shows list options
- [x] `agentfluent analyze --help` shows analyze options
- [x] `agentfluent config-check --help` shows config-check options
- [x] All stubs run and exit 0
- [x] `ruff check` passes
- [x] `mypy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)