### PR TITLE
Configure GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint
+        run: uv run ruff check src/ tests/
+
+      - name: Type check
+        run: uv run mypy src/agentfluent/
+
+      - name: Test
+        run: uv run pytest -m "not integration" --cov=agentfluent --cov-report=term-missing


### PR DESCRIPTION
## Summary

Add `.github/workflows/ci.yml` that runs on every PR and push to main:
- **Lint:** `uv run ruff check src/ tests/`
- **Type check:** `uv run mypy src/agentfluent/`
- **Test:** `uv run pytest -m "not integration" --cov=agentfluent`
- Uses `astral-sh/setup-uv@v6` with caching enabled
- Python version resolved from `.python-version` via `uv python install`
- Integration tests excluded (they require real session data)

Closes #11

## Test plan

- [x] All three steps pass locally with same commands
- [x] CI workflow runs on this PR (first real test of the pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)