### PR TITLE
Define core data models for parsed JSONL sessions

### DIFF
--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -1,0 +1,129 @@
+"""Data models for parsed JSONL session messages.
+
+These models are the contract between the parser and all downstream consumers
+(analytics, agent extraction, diagnostics). They normalize the varying JSONL
+formats into a consistent structure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Usage(BaseModel):
+    """Token usage from an assistant message."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+
+class ToolUseBlock(BaseModel):
+    """A tool_use content block from an assistant message."""
+
+    id: str
+    name: str
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class ContentBlock(BaseModel):
+    """A single content block (text or tool_use) from a message.
+
+    The raw JSONL content can be either a plain string or an array of typed blocks.
+    The parser normalizes both forms into a list of ContentBlock.
+    """
+
+    type: str  # "text" or "tool_use"
+    text: str | None = None
+    # tool_use fields (only present when type == "tool_use")
+    id: str | None = None
+    name: str | None = None
+    input: dict[str, Any] | None = None
+
+
+class ToolResultMetadata(BaseModel):
+    """Metadata from a tool_result message (present on agent invocation results)."""
+
+    model_config = {"populate_by_name": True}
+
+    total_tokens: int | None = None
+    tool_uses: int | None = None
+    duration_ms: int | None = None
+    agent_id: str | None = Field(None, alias="agentId")
+
+
+class SessionMessage(BaseModel):
+    """A single parsed message from a JSONL session file.
+
+    This is the primary unit of parsed data. The parser produces a list of these,
+    and all downstream consumers (analytics, extraction, diagnostics) work with them.
+    """
+
+    type: str
+    """Message type: 'user', 'assistant', or 'tool_result'."""
+
+    timestamp: datetime | None = None
+    """When the message was recorded. May be absent on tool_result messages."""
+
+    # Content fields
+    content_blocks: list[ContentBlock] = Field(default_factory=list)
+    """Normalized content. For user/assistant messages, text and tool_use blocks.
+    For tool_result, a single text block with the result content."""
+
+    # Assistant-specific fields
+    model: str | None = None
+    """Model name (e.g., 'claude-opus-4-6'). Only on assistant messages."""
+
+    usage: Usage | None = None
+    """Token usage. Only on assistant messages."""
+
+    # tool_result-specific fields
+    tool_use_id: str | None = None
+    """The tool_use ID this result corresponds to. Only on tool_result messages."""
+
+    is_error: bool = False
+    """Whether the tool result is an error. Only on tool_result messages."""
+
+    metadata: ToolResultMetadata | None = None
+    """Agent invocation metadata. Only on tool_result messages from Agent calls."""
+
+    @property
+    def text(self) -> str:
+        """Extract concatenated text content from all text blocks."""
+        parts = [b.text for b in self.content_blocks if b.type == "text" and b.text]
+        return "\n".join(parts)
+
+    @property
+    def tool_use_blocks(self) -> list[ToolUseBlock]:
+        """Extract tool_use blocks from content."""
+        return [
+            ToolUseBlock(id=b.id or "", name=b.name or "", input=b.input or {})
+            for b in self.content_blocks
+            if b.type == "tool_use" and b.name
+        ]
+
+
+# Message types that the parser should skip
+SKIP_TYPES: frozenset[str] = frozenset(
+    {
+        "file-history-snapshot",
+        "progress",
+        "hook_progress",
+        "bash_progress",
+        "system",
+        "create",
+    }
+)

--- a/tests/unit/test_session_models.py
+++ b/tests/unit/test_session_models.py
@@ -1,0 +1,189 @@
+"""Tests for core session data models."""
+
+from datetime import UTC, datetime
+
+from agentfluent.core.session import (
+    SKIP_TYPES,
+    ContentBlock,
+    SessionMessage,
+    ToolResultMetadata,
+    ToolUseBlock,
+    Usage,
+)
+
+
+class TestUsage:
+    def test_total_tokens(self) -> None:
+        usage = Usage(
+            input_tokens=150,
+            output_tokens=25,
+            cache_creation_input_tokens=5000,
+            cache_read_input_tokens=0,
+        )
+        assert usage.total_tokens == 5175
+
+    def test_defaults_to_zero(self) -> None:
+        usage = Usage()
+        assert usage.total_tokens == 0
+
+
+class TestToolUseBlock:
+    def test_basic(self) -> None:
+        block = ToolUseBlock(id="toolu_01ABC", name="Read", input={"file_path": "/tmp/test"})
+        assert block.id == "toolu_01ABC"
+        assert block.name == "Read"
+        assert block.input["file_path"] == "/tmp/test"
+
+    def test_empty_input(self) -> None:
+        block = ToolUseBlock(id="toolu_01", name="Bash")
+        assert block.input == {}
+
+
+class TestContentBlock:
+    def test_text_block(self) -> None:
+        block = ContentBlock(type="text", text="Hello world")
+        assert block.text == "Hello world"
+        assert block.name is None
+
+    def test_tool_use_block(self) -> None:
+        block = ContentBlock(
+            type="tool_use",
+            id="toolu_01",
+            name="Agent",
+            input={"subagent_type": "pm"},
+        )
+        assert block.type == "tool_use"
+        assert block.name == "Agent"
+
+
+class TestToolResultMetadata:
+    def test_from_json_with_alias(self) -> None:
+        """agentId in JSONL maps to agent_id in Python."""
+        meta = ToolResultMetadata.model_validate(
+            {"total_tokens": 31621, "tool_uses": 14, "duration_ms": 122963, "agentId": "abc123"}
+        )
+        assert meta.agent_id == "abc123"
+        assert meta.total_tokens == 31621
+
+    def test_all_optional(self) -> None:
+        meta = ToolResultMetadata()
+        assert meta.agent_id is None
+        assert meta.total_tokens is None
+
+    def test_python_field_name(self) -> None:
+        """Can also construct with the Python field name."""
+        meta = ToolResultMetadata(agent_id="xyz")
+        assert meta.agent_id == "xyz"
+
+
+class TestSessionMessage:
+    def test_user_message_string_content(self) -> None:
+        """User message with plain string content."""
+        msg = SessionMessage(
+            type="user",
+            timestamp=datetime(2026, 4, 10, 10, 0, tzinfo=UTC),
+            content_blocks=[ContentBlock(type="text", text="Hello")],
+        )
+        assert msg.type == "user"
+        assert msg.text == "Hello"
+        assert msg.tool_use_blocks == []
+
+    def test_user_message_array_content(self) -> None:
+        """User message with array-of-blocks content."""
+        msg = SessionMessage(
+            type="user",
+            content_blocks=[
+                ContentBlock(type="text", text="First part"),
+                ContentBlock(type="text", text="Second part"),
+            ],
+        )
+        assert msg.text == "First part\nSecond part"
+
+    def test_assistant_message_with_tool_use(self) -> None:
+        msg = SessionMessage(
+            type="assistant",
+            model="claude-opus-4-6",
+            usage=Usage(input_tokens=3000, output_tokens=150),
+            content_blocks=[
+                ContentBlock(type="text", text="I'll delegate this."),
+                ContentBlock(
+                    type="tool_use",
+                    id="toolu_01ABC",
+                    name="Agent",
+                    input={"subagent_type": "pm", "prompt": "Do the thing"},
+                ),
+            ],
+        )
+        assert msg.text == "I'll delegate this."
+        assert len(msg.tool_use_blocks) == 1
+        assert msg.tool_use_blocks[0].name == "Agent"
+        assert msg.tool_use_blocks[0].input["subagent_type"] == "pm"
+        assert msg.usage is not None
+        assert msg.usage.input_tokens == 3000
+
+    def test_tool_result_with_metadata(self) -> None:
+        msg = SessionMessage(
+            type="tool_result",
+            tool_use_id="toolu_01ABC",
+            content_blocks=[ContentBlock(type="text", text="Created 5 issues.")],
+            metadata=ToolResultMetadata(
+                total_tokens=31621,
+                tool_uses=14,
+                duration_ms=122963,
+                agent_id="agent-abc123",
+            ),
+        )
+        assert msg.type == "tool_result"
+        assert msg.tool_use_id == "toolu_01ABC"
+        assert msg.text == "Created 5 issues."
+        assert msg.metadata is not None
+        assert msg.metadata.agent_id == "agent-abc123"
+
+    def test_tool_result_without_metadata(self) -> None:
+        msg = SessionMessage(
+            type="tool_result",
+            tool_use_id="toolu_01EDIT",
+            content_blocks=[ContentBlock(type="text", text="File edited successfully.")],
+        )
+        assert msg.metadata is None
+
+    def test_tool_result_with_error(self) -> None:
+        msg = SessionMessage(
+            type="tool_result",
+            tool_use_id="toolu_01FAIL",
+            is_error=True,
+            content_blocks=[ContentBlock(type="text", text="Permission denied")],
+        )
+        assert msg.is_error is True
+
+    def test_empty_content(self) -> None:
+        msg = SessionMessage(type="user")
+        assert msg.text == ""
+        assert msg.tool_use_blocks == []
+
+    def test_optional_fields_default(self) -> None:
+        msg = SessionMessage(type="user")
+        assert msg.timestamp is None
+        assert msg.model is None
+        assert msg.usage is None
+        assert msg.tool_use_id is None
+        assert msg.metadata is None
+        assert msg.is_error is False
+
+
+class TestSkipTypes:
+    def test_expected_types(self) -> None:
+        expected = {
+            "file-history-snapshot",
+            "progress",
+            "hook_progress",
+            "bash_progress",
+            "system",
+            "create",
+        }
+        assert SKIP_TYPES == expected
+
+    def test_analytical_types_not_skipped(self) -> None:
+        assert "user" not in SKIP_TYPES
+        assert "assistant" not in SKIP_TYPES
+        assert "tool_result" not in SKIP_TYPES


### PR DESCRIPTION
## Summary

Add Pydantic v2 models in `agentfluent.core.session`:
- `Usage` — token counts with `total_tokens` computed property
- `ToolUseBlock` — tool call with id, name, input dict
- `ContentBlock` — normalized text or tool_use block (handles both string and array content)
- `ToolResultMetadata` — agent invocation metadata (`agentId` aliased to `agent_id` for Python conventions)
- `SessionMessage` — unified message model with `text` and `tool_use_blocks` properties
- `SKIP_TYPES` — frozenset of message types the parser should filter out

Closes #13

## Test plan

- [x] 19 unit tests covering all models, aliases, defaults, and edge cases
- [x] `ToolResultMetadata` correctly handles `agentId` → `agent_id` alias
- [x] `SessionMessage.text` concatenates text blocks; `tool_use_blocks` extracts tool calls
- [x] ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)