### PR TITLE
Implement project discovery and JSONL session parser

### DIFF
--- a/src/agentfluent/core/discovery.py
+++ b/src/agentfluent/core/discovery.py
@@ -1,0 +1,158 @@
+"""Project and session discovery from ~/.claude/projects/."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+
+@dataclass
+class SessionInfo:
+    """Metadata for a single JSONL session file."""
+
+    filename: str
+    path: Path
+    size_bytes: int
+    modified: datetime
+    subagent_count: int = 0
+    """Number of subagent trace files in <session-uuid>/subagents/."""
+
+
+@dataclass
+class ProjectInfo:
+    """Metadata for a discovered project directory."""
+
+    slug: str
+    """Directory name as-is (e.g., '-home-fdpearce-Documents-Projects-git-codefluent')."""
+
+    display_name: str
+    """Human-friendly name derived from slug (e.g., 'codefluent')."""
+
+    path: Path
+    session_count: int = 0
+    total_size_bytes: int = 0
+    earliest_session: datetime | None = None
+    latest_session: datetime | None = None
+    sessions: list[SessionInfo] = field(default_factory=list)
+
+
+def slug_to_display_name(slug: str) -> str:
+    """Convert a dash-encoded project directory name to a human-friendly name.
+
+    The directory format is: -home-user-path-to-project
+    We take the last path segment as the display name.
+    """
+    # Remove leading dash and split
+    parts = slug.lstrip("-").split("-")
+    # The last segment is typically the project name
+    # For paths like -home-fdpearce-Documents-Projects-git-codefluent -> codefluent
+    return parts[-1] if parts else slug
+
+
+def _count_subagent_files(session_path: Path) -> int:
+    """Count subagent JSONL files for a session.
+
+    Subagent traces live at: <session-uuid>/subagents/agent-<agentId>.jsonl
+    where <session-uuid> is a directory named the same as the session file (minus .jsonl).
+    """
+    session_dir = session_path.parent / session_path.stem
+    subagents_dir = session_dir / "subagents"
+    if not subagents_dir.is_dir():
+        return 0
+    return sum(1 for f in subagents_dir.iterdir() if f.suffix == ".jsonl")
+
+
+def discover_sessions(project_path: Path) -> list[SessionInfo]:
+    """Discover all JSONL session files within a project directory.
+
+    Returns session metadata sorted by modification time (newest first).
+    Only top-level .jsonl files are returned; subagent files are counted but not listed.
+    """
+    sessions: list[SessionInfo] = []
+
+    if not project_path.is_dir():
+        return sessions
+
+    for entry in project_path.iterdir():
+        if entry.is_file() and entry.suffix == ".jsonl":
+            stat = entry.stat()
+            sessions.append(
+                SessionInfo(
+                    filename=entry.name,
+                    path=entry,
+                    size_bytes=stat.st_size,
+                    modified=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+                    subagent_count=_count_subagent_files(entry),
+                )
+            )
+
+    sessions.sort(key=lambda s: s.modified, reverse=True)
+    return sessions
+
+
+def discover_projects(base_path: Path | None = None) -> list[ProjectInfo]:
+    """Discover all projects in the Claude projects directory.
+
+    Args:
+        base_path: Override for the projects directory. Defaults to ~/.claude/projects/.
+
+    Returns:
+        List of ProjectInfo sorted by latest session (newest first).
+
+    Raises:
+        FileNotFoundError: If the base path does not exist.
+    """
+    projects_dir = base_path or DEFAULT_PROJECTS_DIR
+
+    if not projects_dir.exists():
+        msg = f"Projects directory not found: {projects_dir}"
+        raise FileNotFoundError(msg)
+
+    projects: list[ProjectInfo] = []
+
+    for entry in sorted(projects_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Skip hidden directories and non-project entries
+        if entry.name.startswith("."):
+            continue
+
+        sessions = discover_sessions(entry)
+
+        total_size = sum(s.size_bytes for s in sessions)
+        earliest = min((s.modified for s in sessions), default=None)
+        latest = max((s.modified for s in sessions), default=None)
+
+        projects.append(
+            ProjectInfo(
+                slug=entry.name,
+                display_name=slug_to_display_name(entry.name),
+                path=entry,
+                session_count=len(sessions),
+                total_size_bytes=total_size,
+                earliest_session=earliest,
+                latest_session=latest,
+                sessions=sessions,
+            )
+        )
+
+    # Sort by latest session, projects with no sessions last
+    projects.sort(
+        key=lambda p: p.latest_session or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    return projects
+
+
+def find_project(slug_or_name: str, base_path: Path | None = None) -> ProjectInfo | None:
+    """Find a project by slug or display name.
+
+    Matches against both the full slug and the derived display name (case-insensitive).
+    """
+    for project in discover_projects(base_path):
+        if project.slug == slug_or_name or project.display_name.lower() == slug_or_name.lower():
+            return project
+    return None

--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -1,0 +1,188 @@
+"""JSONL session file parser.
+
+Reads session files line by line and produces typed SessionMessage objects.
+Handles both string and array content formats, skips non-analytical message types,
+and gracefully handles malformed lines.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from agentfluent.core.session import (
+    SKIP_TYPES,
+    ContentBlock,
+    SessionMessage,
+    ToolResultMetadata,
+    Usage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[ContentBlock]:
+    """Normalize message content to a list of ContentBlock.
+
+    Handles:
+    - Plain string -> single text ContentBlock
+    - Array of typed blocks -> list of ContentBlock
+    - None/missing -> empty list
+    """
+    if raw_content is None:
+        return []
+
+    if isinstance(raw_content, str):
+        return [ContentBlock(type="text", text=raw_content)] if raw_content else []
+
+    if isinstance(raw_content, list):
+        blocks: list[ContentBlock] = []
+        for item in raw_content:
+            if not isinstance(item, dict):
+                continue
+            block_type = item.get("type", "text")
+            if block_type == "text":
+                blocks.append(ContentBlock(type="text", text=item.get("text", "")))
+            elif block_type == "tool_use":
+                blocks.append(
+                    ContentBlock(
+                        type="tool_use",
+                        id=item.get("id"),
+                        name=item.get("name"),
+                        input=item.get("input"),
+                    )
+                )
+            else:
+                # Preserve unknown block types as text with the type field
+                blocks.append(ContentBlock(type=block_type, text=item.get("text")))
+        return blocks
+
+    return []
+
+
+def _parse_timestamp(raw: str | None) -> datetime | None:
+    """Parse an ISO 8601 timestamp string."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_user_message(data: dict[str, Any]) -> SessionMessage:
+    """Parse a 'user' type message."""
+    message = data.get("message", {})
+    return SessionMessage(
+        type="user",
+        timestamp=_parse_timestamp(data.get("timestamp")),
+        content_blocks=_normalize_content(message.get("content")),
+    )
+
+
+def _parse_assistant_message(data: dict[str, Any]) -> SessionMessage:
+    """Parse an 'assistant' type message."""
+    message = data.get("message", {})
+    usage_data = message.get("usage")
+
+    usage = None
+    if usage_data and isinstance(usage_data, dict):
+        usage = Usage(
+            input_tokens=usage_data.get("input_tokens", 0),
+            output_tokens=usage_data.get("output_tokens", 0),
+            cache_creation_input_tokens=usage_data.get("cache_creation_input_tokens", 0),
+            cache_read_input_tokens=usage_data.get("cache_read_input_tokens", 0),
+        )
+
+    return SessionMessage(
+        type="assistant",
+        timestamp=_parse_timestamp(data.get("timestamp")),
+        model=message.get("model"),
+        content_blocks=_normalize_content(message.get("content")),
+        usage=usage,
+    )
+
+
+def _parse_tool_result(data: dict[str, Any]) -> SessionMessage:
+    """Parse a 'tool_result' type message."""
+    raw_content = data.get("content")
+    content_blocks = _normalize_content(raw_content)
+
+    metadata = None
+    raw_metadata = data.get("metadata")
+    if raw_metadata and isinstance(raw_metadata, dict):
+        metadata = ToolResultMetadata.model_validate(raw_metadata)
+
+    return SessionMessage(
+        type="tool_result",
+        timestamp=_parse_timestamp(data.get("timestamp")),
+        tool_use_id=data.get("tool_use_id"),
+        is_error=bool(data.get("is_error", False)),
+        content_blocks=content_blocks,
+        metadata=metadata,
+    )
+
+
+def parse_session(path: Path) -> list[SessionMessage]:
+    """Parse a JSONL session file into a list of SessionMessage objects.
+
+    Reads the file line by line. Skips non-analytical message types and
+    malformed lines (with a warning log). Returns an empty list for
+    empty files or files that contain no analytical messages.
+
+    Args:
+        path: Path to the .jsonl session file.
+
+    Returns:
+        List of parsed SessionMessage objects in file order.
+    """
+    messages: list[SessionMessage] = []
+
+    if not path.exists():
+        logger.warning("Session file not found: %s", path)
+        return messages
+
+    if path.stat().st_size == 0:
+        return messages
+
+    with path.open() as f:
+        for line_num, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Malformed JSON at %s:%d", path.name, line_num)
+                continue
+
+            if not isinstance(data, dict):
+                logger.warning("Non-object JSON at %s:%d", path.name, line_num)
+                continue
+
+            msg_type = data.get("type")
+            if not msg_type or msg_type in SKIP_TYPES:
+                continue
+
+            try:
+                if msg_type == "user":
+                    messages.append(_parse_user_message(data))
+                elif msg_type == "assistant":
+                    messages.append(_parse_assistant_message(data))
+                elif msg_type == "tool_result":
+                    messages.append(_parse_tool_result(data))
+                else:
+                    logger.debug(
+                        "Unknown message type '%s' at %s:%d", msg_type, path.name, line_num
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to parse message at %s:%d", path.name, line_num, exc_info=True
+                )
+                continue
+
+    return messages

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,169 @@
+"""Tests for project and session discovery."""
+
+from pathlib import Path
+
+import pytest
+
+from agentfluent.core.discovery import (
+    discover_projects,
+    discover_sessions,
+    find_project,
+    slug_to_display_name,
+)
+
+
+class TestSlugToDisplayName:
+    def test_standard_path(self) -> None:
+        slug = "-home-fdpearce-Documents-Projects-git-codefluent"
+        assert slug_to_display_name(slug) == "codefluent"
+
+    def test_short_path(self) -> None:
+        assert slug_to_display_name("-home-user-myproject") == "myproject"
+
+    def test_single_segment(self) -> None:
+        assert slug_to_display_name("-myproject") == "myproject"
+
+    def test_empty_string(self) -> None:
+        assert slug_to_display_name("") == ""
+
+
+class TestDiscoverSessions:
+    def test_finds_jsonl_files(self, tmp_path: Path) -> None:
+        (tmp_path / "session-1.jsonl").write_text('{"type": "user"}\n')
+        (tmp_path / "session-2.jsonl").write_text('{"type": "user"}\n')
+        (tmp_path / "not-a-session.txt").write_text("ignore me")
+
+        sessions = discover_sessions(tmp_path)
+        assert len(sessions) == 2
+        assert all(s.filename.endswith(".jsonl") for s in sessions)
+
+    def test_sorted_newest_first(self, tmp_path: Path) -> None:
+        import time
+
+        (tmp_path / "old.jsonl").write_text("old")
+        time.sleep(0.05)
+        (tmp_path / "new.jsonl").write_text("new")
+
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].filename == "new.jsonl"
+        assert sessions[1].filename == "old.jsonl"
+
+    def test_captures_metadata(self, tmp_path: Path) -> None:
+        content = '{"type": "user"}\n{"type": "assistant"}\n'
+        (tmp_path / "test.jsonl").write_text(content)
+
+        sessions = discover_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert sessions[0].size_bytes == len(content)
+        assert sessions[0].modified is not None
+
+    def test_counts_subagent_files(self, tmp_path: Path) -> None:
+        (tmp_path / "session-abc.jsonl").write_text('{"type": "user"}\n')
+        subagents_dir = tmp_path / "session-abc" / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "agent-001.jsonl").write_text('{"type": "user"}\n')
+        (subagents_dir / "agent-002.jsonl").write_text('{"type": "user"}\n')
+        (subagents_dir / "not-jsonl.txt").write_text("ignore")
+
+        sessions = discover_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert sessions[0].subagent_count == 2
+
+    def test_no_subagent_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "session-abc.jsonl").write_text('{"type": "user"}\n')
+
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].subagent_count == 0
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        sessions = discover_sessions(tmp_path)
+        assert sessions == []
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        sessions = discover_sessions(tmp_path / "does-not-exist")
+        assert sessions == []
+
+
+class TestDiscoverProjects:
+    def test_finds_project_directories(self, tmp_path: Path) -> None:
+        proj1 = tmp_path / "-home-user-project-alpha"
+        proj1.mkdir()
+        (proj1 / "session-1.jsonl").write_text('{"type": "user"}\n')
+
+        proj2 = tmp_path / "-home-user-project-beta"
+        proj2.mkdir()
+
+        projects = discover_projects(tmp_path)
+        assert len(projects) == 2
+
+        names = {p.display_name for p in projects}
+        assert names == {"alpha", "beta"}
+
+    def test_project_metadata(self, tmp_path: Path) -> None:
+        proj = tmp_path / "-home-user-myproject"
+        proj.mkdir()
+        (proj / "s1.jsonl").write_text('{"type": "user"}\n')
+        (proj / "s2.jsonl").write_text('{"type": "user"}\n')
+
+        projects = discover_projects(tmp_path)
+        assert len(projects) == 1
+        assert projects[0].session_count == 2
+        assert projects[0].total_size_bytes > 0
+        assert projects[0].earliest_session is not None
+        assert projects[0].latest_session is not None
+
+    def test_empty_project_included(self, tmp_path: Path) -> None:
+        (tmp_path / "-home-user-empty").mkdir()
+
+        projects = discover_projects(tmp_path)
+        assert len(projects) == 1
+        assert projects[0].session_count == 0
+        assert projects[0].earliest_session is None
+
+    def test_skips_hidden_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / ".hidden").mkdir()
+        (tmp_path / "-home-user-visible").mkdir()
+
+        projects = discover_projects(tmp_path)
+        assert len(projects) == 1
+        assert projects[0].display_name == "visible"
+
+    def test_nonexistent_base_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Projects directory not found"):
+            discover_projects(tmp_path / "nope")
+
+    def test_skips_files_in_base(self, tmp_path: Path) -> None:
+        (tmp_path / "stray-file.txt").write_text("not a project")
+        (tmp_path / "-home-user-real").mkdir()
+
+        projects = discover_projects(tmp_path)
+        assert len(projects) == 1
+
+
+class TestFindProject:
+    def test_find_by_slug(self, tmp_path: Path) -> None:
+        slug = "-home-user-myproject"
+        (tmp_path / slug).mkdir()
+
+        result = find_project(slug, tmp_path)
+        assert result is not None
+        assert result.slug == slug
+
+    def test_find_by_display_name(self, tmp_path: Path) -> None:
+        (tmp_path / "-home-user-myproject").mkdir()
+
+        result = find_project("myproject", tmp_path)
+        assert result is not None
+        assert result.display_name == "myproject"
+
+    def test_find_case_insensitive(self, tmp_path: Path) -> None:
+        (tmp_path / "-home-user-MyProject").mkdir()
+
+        result = find_project("myproject", tmp_path)
+        assert result is not None
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        (tmp_path / "-home-user-other").mkdir()
+
+        result = find_project("nonexistent", tmp_path)
+        assert result is None

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,0 +1,167 @@
+"""Tests for JSONL session parser."""
+
+from pathlib import Path
+
+from agentfluent.core.parser import parse_session
+
+
+class TestParseBasicSession:
+    def test_parses_user_and_assistant(self, basic_session_path: Path) -> None:
+        messages = parse_session(basic_session_path)
+        assert len(messages) == 4
+
+        # First message: user with string content
+        assert messages[0].type == "user"
+        assert messages[0].text == "Analyze the project structure"
+
+        # Second message: assistant with array content
+        assert messages[1].type == "assistant"
+        assert "look at the project structure" in messages[1].text
+        assert messages[1].model == "claude-sonnet-4-20250514"
+        assert messages[1].usage is not None
+        assert messages[1].usage.input_tokens == 150
+
+    def test_string_and_array_content(self, basic_session_path: Path) -> None:
+        messages = parse_session(basic_session_path)
+
+        # First user message has string content
+        assert messages[0].text == "Analyze the project structure"
+
+        # Second user message has array-of-blocks content
+        assert messages[2].text == "Now check the config files"
+
+    def test_cache_tokens_captured(self, basic_session_path: Path) -> None:
+        messages = parse_session(basic_session_path)
+
+        # First assistant has cache_creation
+        assert messages[1].usage is not None
+        assert messages[1].usage.cache_creation_input_tokens == 5000
+        assert messages[1].usage.cache_read_input_tokens == 0
+
+        # Second assistant has cache_read
+        assert messages[3].usage is not None
+        assert messages[3].usage.cache_read_input_tokens == 5000
+
+
+class TestParseAgentSession:
+    def test_extracts_agent_tool_use(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+
+        # Find assistant messages with Agent tool_use
+        assistant_msgs = [m for m in messages if m.type == "assistant"]
+        assert len(assistant_msgs) == 2
+
+        # First assistant has an Agent tool_use
+        tool_uses = assistant_msgs[0].tool_use_blocks
+        assert len(tool_uses) == 1
+        assert tool_uses[0].name == "Agent"
+        assert tool_uses[0].input["subagent_type"] == "pm"
+
+    def test_extracts_tool_result_metadata(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+
+        tool_results = [m for m in messages if m.type == "tool_result"]
+        assert len(tool_results) == 2
+
+        # First tool_result has agent metadata
+        assert tool_results[0].metadata is not None
+        assert tool_results[0].metadata.total_tokens == 31621
+        assert tool_results[0].metadata.tool_uses == 14
+        assert tool_results[0].metadata.duration_ms == 122963
+        assert tool_results[0].metadata.agent_id == "agent-abc123"
+
+    def test_tool_result_content(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+        tool_results = [m for m in messages if m.type == "tool_result"]
+
+        assert "Created 5 issues" in tool_results[0].text
+
+    def test_tool_use_id_captured(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+        tool_results = [m for m in messages if m.type == "tool_result"]
+
+        assert tool_results[0].tool_use_id == "toolu_01ABC123"
+        assert tool_results[1].tool_use_id == "toolu_01DEF456"
+
+
+class TestParseToolCalls:
+    def test_regular_tool_calls(self, tool_calls_session_path: Path) -> None:
+        messages = parse_session(tool_calls_session_path)
+
+        assistant_msgs = [m for m in messages if m.type == "assistant"]
+        assert len(assistant_msgs) == 2
+
+        # First assistant: Read tool
+        tool_uses = assistant_msgs[0].tool_use_blocks
+        assert len(tool_uses) == 1
+        assert tool_uses[0].name == "Read"
+
+        # Second assistant: Edit tool
+        tool_uses = assistant_msgs[1].tool_use_blocks
+        assert len(tool_uses) == 1
+        assert tool_uses[0].name == "Edit"
+
+    def test_tool_result_without_metadata(self, tool_calls_session_path: Path) -> None:
+        messages = parse_session(tool_calls_session_path)
+        tool_results = [m for m in messages if m.type == "tool_result"]
+
+        # Regular tool results have no agent metadata
+        for tr in tool_results:
+            assert tr.metadata is None
+
+
+class TestSkipTypes:
+    def test_filters_non_analytical_types(self, skip_types_session_path: Path) -> None:
+        messages = parse_session(skip_types_session_path)
+
+        # Only user and assistant messages should survive
+        types = {m.type for m in messages}
+        assert types == {"user", "assistant"}
+
+        # Should be exactly 2 messages (1 user + 1 assistant)
+        assert len(messages) == 2
+
+    def test_skipped_types_not_present(self, skip_types_session_path: Path) -> None:
+        messages = parse_session(skip_types_session_path)
+        types = {m.type for m in messages}
+
+        assert "system" not in types
+        assert "progress" not in types
+        assert "hook_progress" not in types
+        assert "bash_progress" not in types
+        assert "file-history-snapshot" not in types
+        assert "create" not in types
+
+
+class TestMalformedInput:
+    def test_skips_bad_lines(self, malformed_session_path: Path) -> None:
+        messages = parse_session(malformed_session_path)
+
+        # Should get 2 valid messages, skipping the malformed line
+        assert len(messages) == 2
+        assert messages[0].type == "user"
+        assert messages[1].type == "assistant"
+
+    def test_empty_file(self, empty_session_path: Path) -> None:
+        messages = parse_session(empty_session_path)
+        assert messages == []
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        messages = parse_session(tmp_path / "does-not-exist.jsonl")
+        assert messages == []
+
+
+class TestTimestamps:
+    def test_timestamps_parsed(self, basic_session_path: Path) -> None:
+        messages = parse_session(basic_session_path)
+
+        assert messages[0].timestamp is not None
+        assert messages[0].timestamp.year == 2026
+        assert messages[0].timestamp.month == 4
+
+    def test_tool_result_no_timestamp(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+        tool_results = [m for m in messages if m.type == "tool_result"]
+
+        # Our fixture tool_results don't have timestamps
+        assert tool_results[0].timestamp is None


### PR DESCRIPTION
## Summary

Two core modules powering the data layer:

**discovery.py** — scan ~/.claude/projects/ for projects and sessions:
- `discover_projects()` with metadata (session count, size, date range)
- `discover_sessions()` with per-session subagent file counting
- `slug_to_display_name()` for human-friendly project names
- `find_project()` lookup by slug or display name
- Configurable base path for testing

**parser.py** — parse JSONL session files into typed models:
- Handles both string and array content formats
- Skips non-analytical types (progress, system, etc.)
- Extracts tool_use blocks, usage data, tool_result metadata with agentId
- Graceful malformed line handling (warns and continues)

Closes #14, closes #15

## Test plan

- [x] 21 discovery tests: slug conversion, session enumeration, subagent counting, project metadata, error cases
- [x] 16 parser tests: all fixture files, both content formats, agent tool_use extraction, metadata, skip types, malformed input, timestamps
- [x] 59 total tests pass
- [x] ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)