### PR TITLE
Implement agent invocation extraction from sessions

### DIFF
--- a/src/agentfluent/agents/extractor.py
+++ b/src/agentfluent/agents/extractor.py
@@ -1,0 +1,78 @@
+"""Extract agent invocations from parsed session messages.
+
+Identifies Agent tool_use blocks in assistant messages and matches them
+to their corresponding tool_result blocks to build AgentInvocation objects.
+"""
+
+from __future__ import annotations
+
+from agentfluent.agents.models import AgentInvocation, is_builtin_agent
+from agentfluent.core.session import SessionMessage
+
+
+def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvocation]:
+    """Extract agent invocations from a list of parsed session messages.
+
+    Scans for assistant messages containing Agent tool_use blocks (name == "Agent"),
+    then matches each to its corresponding tool_result by tool_use_id.
+
+    Args:
+        messages: Parsed session messages from the JSONL parser.
+
+    Returns:
+        List of AgentInvocation objects in session order.
+    """
+    # Build a lookup of tool_result messages by tool_use_id
+    tool_results: dict[str, SessionMessage] = {}
+    for msg in messages:
+        if msg.type == "tool_result" and msg.tool_use_id:
+            tool_results[msg.tool_use_id] = msg
+
+    invocations: list[AgentInvocation] = []
+
+    for msg in messages:
+        if msg.type != "assistant":
+            continue
+
+        for tool_use in msg.tool_use_blocks:
+            if tool_use.name != "Agent":
+                continue
+
+            agent_type = tool_use.input.get("subagent_type", "unknown")
+            description = tool_use.input.get("description", "")
+            prompt = tool_use.input.get("prompt", "")
+
+            # Match to tool_result
+            result = tool_results.get(tool_use.id)
+
+            total_tokens = None
+            tool_uses_count = None
+            duration_ms = None
+            agent_id = None
+            output_text = ""
+
+            if result is not None:
+                output_text = result.text
+
+                if result.metadata is not None:
+                    total_tokens = result.metadata.total_tokens
+                    tool_uses_count = result.metadata.tool_uses
+                    duration_ms = result.metadata.duration_ms
+                    agent_id = result.metadata.agent_id
+
+            invocations.append(
+                AgentInvocation(
+                    agent_type=agent_type,
+                    is_builtin=is_builtin_agent(agent_type),
+                    description=description,
+                    prompt=prompt,
+                    tool_use_id=tool_use.id,
+                    total_tokens=total_tokens,
+                    tool_uses=tool_uses_count,
+                    duration_ms=duration_ms,
+                    agent_id=agent_id,
+                    output_text=output_text,
+                )
+            )
+
+    return invocations

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -1,0 +1,71 @@
+"""Data models for agent invocations extracted from session data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Built-in agent types (case-insensitive matching).
+# Update this set as Anthropic adds new built-in agents.
+BUILTIN_AGENT_TYPES: frozenset[str] = frozenset(
+    {
+        "explore",
+        "plan",
+        "general-purpose",
+        "code-reviewer",
+        "statusline-setup",
+        "claude-code-guide",
+    }
+)
+
+
+def is_builtin_agent(agent_type: str) -> bool:
+    """Check if an agent type is a built-in Claude Code agent."""
+    return agent_type.lower() in BUILTIN_AGENT_TYPES
+
+
+@dataclass
+class AgentInvocation:
+    """A single agent invocation extracted from a session.
+
+    Combines data from the Agent tool_use block (in the assistant message)
+    with the corresponding tool_result (including metadata).
+    """
+
+    agent_type: str
+    """Agent type (e.g., 'pm', 'Explore', 'Plan')."""
+
+    is_builtin: bool
+    """Whether this is a built-in Claude Code agent."""
+
+    description: str
+    """The description passed to the Agent tool."""
+
+    prompt: str
+    """The delegation prompt sent to the agent."""
+
+    tool_use_id: str
+    """The tool_use ID linking this invocation to its tool_result."""
+
+    # From tool_result metadata (may be None if no metadata or agent was interrupted)
+    total_tokens: int | None = None
+    tool_uses: int | None = None
+    duration_ms: int | None = None
+    agent_id: str | None = None
+
+    # From tool_result content
+    output_text: str = ""
+    """The agent's final summary/output text."""
+
+    @property
+    def tokens_per_tool_use(self) -> float | None:
+        """Average tokens per tool call. None if data unavailable."""
+        if self.total_tokens is not None and self.tool_uses and self.tool_uses > 0:
+            return self.total_tokens / self.tool_uses
+        return None
+
+    @property
+    def duration_per_tool_use(self) -> float | None:
+        """Average duration (ms) per tool call. None if data unavailable."""
+        if self.duration_ms is not None and self.tool_uses and self.tool_uses > 0:
+            return self.duration_ms / self.tool_uses
+        return None

--- a/tests/integration/test_agent_extraction.py
+++ b/tests/integration/test_agent_extraction.py
@@ -1,0 +1,63 @@
+"""Integration tests for agent extraction against real session data."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentfluent.agents.extractor import extract_agent_invocations
+from agentfluent.core.discovery import DEFAULT_PROJECTS_DIR, discover_projects
+from agentfluent.core.parser import parse_session
+
+has_real_data = DEFAULT_PROJECTS_DIR.exists() and any(DEFAULT_PROJECTS_DIR.iterdir())
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not has_real_data, reason="No real session data at ~/.claude/projects/"),
+]
+
+
+class TestAgentExtractionReal:
+    def test_extract_from_session_with_agents(self) -> None:
+        """Find a real session with agent invocations and extract them."""
+        projects = discover_projects()
+        for p in projects:
+            for s in p.sessions:
+                messages = parse_session(s.path)
+                invocations = extract_agent_invocations(messages)
+                if invocations:
+                    # Validate the invocations we found
+                    for inv in invocations:
+                        assert inv.agent_type, "Agent type should not be empty"
+                        assert inv.tool_use_id, "Tool use ID should not be empty"
+                        assert isinstance(inv.is_builtin, bool)
+                        # If metadata exists, values should be positive
+                        if inv.total_tokens is not None:
+                            assert inv.total_tokens >= 0
+                        if inv.tool_uses is not None:
+                            assert inv.tool_uses >= 0
+                        if inv.duration_ms is not None:
+                            assert inv.duration_ms >= 0
+                    return  # Found and validated at least one session
+
+        pytest.skip("No sessions with agent invocations found in real data")
+
+    def test_builtin_and_custom_agents_distinguishable(self) -> None:
+        """Verify real data contains both built-in and custom agents."""
+        all_invocations = []
+        projects = discover_projects()
+        for p in projects:
+            for s in p.sessions:
+                messages = parse_session(s.path)
+                all_invocations.extend(extract_agent_invocations(messages))
+
+        if not all_invocations:
+            pytest.skip("No agent invocations found in real data")
+
+        builtin = [i for i in all_invocations if i.is_builtin]
+        custom = [i for i in all_invocations if not i.is_builtin]
+
+        # At minimum, we should find built-in agents (Explore, Plan are common)
+        assert len(builtin) >= 1, "Expected at least one built-in agent invocation"
+        # Custom agents may or may not exist depending on user's setup
+        # Just verify the classification works without asserting count
+        assert all(not i.is_builtin for i in custom)

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -1,0 +1,79 @@
+"""Tests for agent invocation models."""
+
+from agentfluent.agents.models import BUILTIN_AGENT_TYPES, AgentInvocation, is_builtin_agent
+
+
+class TestIsBuiltinAgent:
+    def test_known_builtins(self) -> None:
+        assert is_builtin_agent("Explore")
+        assert is_builtin_agent("explore")
+        assert is_builtin_agent("Plan")
+        assert is_builtin_agent("general-purpose")
+
+    def test_custom_agents(self) -> None:
+        assert not is_builtin_agent("pm")
+        assert not is_builtin_agent("my-custom-agent")
+        assert not is_builtin_agent("unknown")
+
+    def test_case_insensitive(self) -> None:
+        assert is_builtin_agent("EXPLORE")
+        assert is_builtin_agent("plan")
+        assert is_builtin_agent("General-Purpose")
+
+    def test_builtin_set_is_frozen(self) -> None:
+        assert isinstance(BUILTIN_AGENT_TYPES, frozenset)
+
+
+class TestAgentInvocation:
+    def test_with_full_metadata(self) -> None:
+        inv = AgentInvocation(
+            agent_type="pm",
+            is_builtin=False,
+            description="Review backlog",
+            prompt="Create issues",
+            tool_use_id="toolu_01ABC",
+            total_tokens=31621,
+            tool_uses=14,
+            duration_ms=122963,
+            agent_id="agent-abc123",
+            output_text="Created 5 issues.",
+        )
+        assert inv.tokens_per_tool_use == 31621 / 14
+        assert inv.duration_per_tool_use == 122963 / 14
+
+    def test_without_metadata(self) -> None:
+        inv = AgentInvocation(
+            agent_type="pm",
+            is_builtin=False,
+            description="Review backlog",
+            prompt="Create issues",
+            tool_use_id="toolu_01ABC",
+        )
+        assert inv.tokens_per_tool_use is None
+        assert inv.duration_per_tool_use is None
+        assert inv.total_tokens is None
+        assert inv.output_text == ""
+
+    def test_zero_tool_uses(self) -> None:
+        inv = AgentInvocation(
+            agent_type="pm",
+            is_builtin=False,
+            description="test",
+            prompt="test",
+            tool_use_id="toolu_01",
+            total_tokens=1000,
+            tool_uses=0,
+            duration_ms=5000,
+        )
+        assert inv.tokens_per_tool_use is None
+        assert inv.duration_per_tool_use is None
+
+    def test_builtin_classification(self) -> None:
+        inv = AgentInvocation(
+            agent_type="Explore",
+            is_builtin=True,
+            description="Search code",
+            prompt="Find files",
+            tool_use_id="toolu_01",
+        )
+        assert inv.is_builtin is True

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -1,0 +1,214 @@
+"""Tests for agent invocation extractor."""
+
+from pathlib import Path
+
+from agentfluent.agents.extractor import extract_agent_invocations
+from agentfluent.core.parser import parse_session
+from agentfluent.core.session import (
+    ContentBlock,
+    SessionMessage,
+    ToolResultMetadata,
+)
+
+
+class TestExtractFromFixtures:
+    def test_session_with_agents(self, agent_session_path: Path) -> None:
+        messages = parse_session(agent_session_path)
+        invocations = extract_agent_invocations(messages)
+
+        assert len(invocations) == 2
+
+        # First: PM agent (custom)
+        pm = invocations[0]
+        assert pm.agent_type == "pm"
+        assert pm.is_builtin is False
+        assert pm.description == "Review backlog and create issues"
+        assert "backlog" in pm.prompt.lower()
+        assert pm.total_tokens == 31621
+        assert pm.tool_uses == 14
+        assert pm.duration_ms == 122963
+        assert pm.agent_id == "agent-abc123"
+        assert "Created 5 issues" in pm.output_text
+
+        # Second: Explore agent (built-in)
+        explore = invocations[1]
+        assert explore.agent_type == "Explore"
+        assert explore.is_builtin is True
+        assert explore.total_tokens == 8500
+        assert explore.tool_uses == 5
+        assert explore.agent_id == "agent-def456"
+
+    def test_session_without_agents(self, basic_session_path: Path) -> None:
+        messages = parse_session(basic_session_path)
+        invocations = extract_agent_invocations(messages)
+        assert invocations == []
+
+    def test_session_with_regular_tools_only(self, tool_calls_session_path: Path) -> None:
+        messages = parse_session(tool_calls_session_path)
+        invocations = extract_agent_invocations(messages)
+        assert invocations == []
+
+
+class TestExtractFromConstructedMessages:
+    def test_agent_without_matching_result(self) -> None:
+        """Agent tool_use with no corresponding tool_result (interrupted)."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_orphan",
+                        name="Agent",
+                        input={
+                            "subagent_type": "pm",
+                            "description": "Interrupted task",
+                            "prompt": "Do something",
+                        },
+                    ),
+                ],
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        assert len(invocations) == 1
+        assert invocations[0].agent_type == "pm"
+        assert invocations[0].total_tokens is None
+        assert invocations[0].output_text == ""
+
+    def test_tool_result_without_metadata(self) -> None:
+        """Agent tool_result that lacks the metadata block."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_no_meta",
+                        name="Agent",
+                        input={
+                            "subagent_type": "Explore",
+                            "description": "Quick search",
+                            "prompt": "Find files",
+                        },
+                    ),
+                ],
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_no_meta",
+                content_blocks=[ContentBlock(type="text", text="Found 3 files.")],
+                metadata=None,
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        assert len(invocations) == 1
+        assert invocations[0].is_builtin is True
+        assert invocations[0].output_text == "Found 3 files."
+        assert invocations[0].total_tokens is None
+        assert invocations[0].agent_id is None
+
+    def test_multiple_agents_in_one_message(self) -> None:
+        """Assistant message with multiple Agent tool_use blocks."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_a",
+                        name="Agent",
+                        input={"subagent_type": "Explore", "description": "A", "prompt": "A"},
+                    ),
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_b",
+                        name="Agent",
+                        input={"subagent_type": "pm", "description": "B", "prompt": "B"},
+                    ),
+                ],
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_a",
+                content_blocks=[ContentBlock(type="text", text="Result A")],
+                metadata=ToolResultMetadata(total_tokens=1000, tool_uses=5),
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_b",
+                content_blocks=[ContentBlock(type="text", text="Result B")],
+                metadata=ToolResultMetadata(total_tokens=2000, tool_uses=10),
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        assert len(invocations) == 2
+        assert invocations[0].agent_type == "Explore"
+        assert invocations[0].total_tokens == 1000
+        assert invocations[1].agent_type == "pm"
+        assert invocations[1].total_tokens == 2000
+
+    def test_mixed_agent_and_regular_tools(self) -> None:
+        """Assistant message with both Agent and regular tool_use blocks."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_read",
+                        name="Read",
+                        input={"file_path": "/tmp/test"},
+                    ),
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_agent",
+                        name="Agent",
+                        input={"subagent_type": "Plan", "description": "Plan", "prompt": "Plan"},
+                    ),
+                ],
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_read",
+                content_blocks=[ContentBlock(type="text", text="file content")],
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_agent",
+                content_blocks=[ContentBlock(type="text", text="Plan result")],
+                metadata=ToolResultMetadata(total_tokens=500, tool_uses=3),
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        # Only the Agent tool_use should be extracted
+        assert len(invocations) == 1
+        assert invocations[0].agent_type == "Plan"
+
+    def test_efficiency_metrics_computed(self) -> None:
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_1",
+                        name="Agent",
+                        input={"subagent_type": "pm", "description": "D", "prompt": "P"},
+                    ),
+                ],
+            ),
+            SessionMessage(
+                type="tool_result",
+                tool_use_id="toolu_1",
+                content_blocks=[ContentBlock(type="text", text="Done")],
+                metadata=ToolResultMetadata(
+                    total_tokens=10000, tool_uses=5, duration_ms=50000
+                ),
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        assert invocations[0].tokens_per_tool_use == 2000.0
+        assert invocations[0].duration_per_tool_use == 10000.0
+
+    def test_empty_messages(self) -> None:
+        assert extract_agent_invocations([]) == []


### PR DESCRIPTION
## Summary

Complete E3 (Agent Invocation Extraction) — all 3 stories:

**#19 — Agent models:**
- `AgentInvocation` dataclass with metadata + computed efficiency metrics
- `BUILTIN_AGENT_TYPES` set with case-insensitive matching

**#20 — Extractor:**
- `extract_agent_invocations()` scans for Agent tool_use, matches to tool_result by ID
- Handles interrupted agents, missing metadata, multiple agents per message

**#21 — Tests:**
- 8 model tests (classification, metrics, edge cases)
- 9 extractor tests (fixtures + constructed messages covering all edge cases)
- 2 integration tests (real data: found built-in + custom agents)

Closes #19, closes #20, closes #21

## Test plan

- [x] 17 new unit tests pass
- [x] 2 integration tests pass against real session data
- [x] 76 total unit tests, 15 integration tests
- [x] ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)