### PR TITLE
refactor: extract CLI formatters to shared modules (#38)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -8,33 +8,16 @@ from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
+from agentfluent.cli.formatters.helpers import format_cost, format_tokens
+from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.core.discovery import find_project
 from agentfluent.diagnostics import run_diagnostics
-from agentfluent.diagnostics.models import DiagnosticsResult
 
 app = typer.Typer(help="Analyze agent sessions.")
 console = Console()
-
-_SEVERITY_COLORS = {
-    "critical": "red",
-    "warning": "yellow",
-    "info": "cyan",
-}
-
-
-def _format_cost(cost: float) -> str:
-    """Format a dollar cost for display."""
-    if cost < 0.01:
-        return f"${cost:.4f}"
-    return f"${cost:.2f}"
-
-
-def _format_tokens(tokens: int) -> str:
-    """Format token count with comma separator."""
-    return f"{tokens:,}"
+err_console = Console(stderr=True)
 
 
 def _print_quiet(result: AnalysisResult) -> None:
@@ -43,8 +26,8 @@ def _print_quiet(result: AnalysisResult) -> None:
     am = result.agent_metrics
     parts = [
         f"Sessions: {result.session_count}",
-        f"Tokens: {_format_tokens(tm.total_tokens)}",
-        f"Cost: {_format_cost(tm.total_cost)}",
+        f"Tokens: {format_tokens(tm.total_tokens)}",
+        f"Cost: {format_cost(tm.total_cost)}",
         f"Agent invocations: {am.total_invocations}",
     ]
     if result.diagnostics and result.diagnostics.signals:
@@ -52,181 +35,13 @@ def _print_quiet(result: AnalysisResult) -> None:
     console.print(" | ".join(parts))
 
 
-def _print_diagnostics_table(diag: DiagnosticsResult, *, verbose: bool = False) -> None:
-    """Print diagnostics signals and recommendations."""
-    if diag.signals:
-        sig_table = Table(title="Diagnostic Signals", show_header=True)
-        sig_table.add_column("Agent", style="cyan")
-        sig_table.add_column("Type")
-        sig_table.add_column("Severity")
-        sig_table.add_column("Message")
-
-        for sig in diag.signals:
-            color = _SEVERITY_COLORS.get(sig.severity.value, "white")
-            sig_table.add_row(
-                sig.agent_type,
-                sig.signal_type.value,
-                f"[{color}]{sig.severity.value}[/{color}]",
-                sig.message,
-            )
-        console.print(sig_table)
-
-    if diag.recommendations:
-        rec_table = Table(title="Recommendations", show_header=True)
-        rec_table.add_column("Agent", style="cyan")
-        rec_table.add_column("Target")
-        rec_table.add_column("Severity")
-        if verbose:
-            rec_table.add_column("Observation")
-            rec_table.add_column("Action")
-        else:
-            rec_table.add_column("Recommendation")
-
-        for rec in diag.recommendations:
-            color = _SEVERITY_COLORS.get(rec.severity.value, "white")
-            if verbose:
-                rec_table.add_row(
-                    rec.agent_type,
-                    rec.target,
-                    f"[{color}]{rec.severity.value}[/{color}]",
-                    rec.observation,
-                    rec.action,
-                )
-            else:
-                rec_table.add_row(
-                    rec.agent_type,
-                    rec.target,
-                    f"[{color}]{rec.severity.value}[/{color}]",
-                    rec.message,
-                )
-        console.print(rec_table)
-
-    if diag.subagent_trace_count > 0:
-        console.print(
-            f"\n[dim]{diag.subagent_trace_count} subagent trace files available. "
-            "Deep diagnostics (per-tool-call analysis) coming in v1.1.[/dim]"
-        )
-
-
-def _print_diagnostics_summary(diag: DiagnosticsResult) -> None:
-    """Print a brief diagnostics summary when --diagnostics is not passed."""
-    signal_count = len(diag.signals)
-    if signal_count > 0:
-        console.print(
-            f"\n[yellow]{signal_count} diagnostic signal(s) detected.[/yellow] "
-            "Run with [bold]--diagnostics[/bold] for details."
-        )
-
-
-def _print_table(
-    result: AnalysisResult,
-    *,
-    verbose: bool = False,
-    show_diagnostics: bool = False,
-) -> None:
-    """Print Rich-formatted tables."""
-    tm = result.token_metrics
-    am = result.agent_metrics
-    tlm = result.tool_metrics
-
-    # Token summary table
-    token_table = Table(title="Token Usage", show_header=True)
-    token_table.add_column("Metric", style="cyan")
-    token_table.add_column("Value", justify="right")
-    token_table.add_row("Input tokens", _format_tokens(tm.input_tokens))
-    token_table.add_row("Output tokens", _format_tokens(tm.output_tokens))
-    token_table.add_row("Cache creation tokens", _format_tokens(tm.cache_creation_input_tokens))
-    token_table.add_row("Cache read tokens", _format_tokens(tm.cache_read_input_tokens))
-    token_table.add_row("Total tokens", _format_tokens(tm.total_tokens))
-    token_table.add_row("Total cost", _format_cost(tm.total_cost))
-    token_table.add_row("Cache efficiency", f"{tm.cache_efficiency}%")
-    token_table.add_row("API calls", str(tm.api_call_count))
-    console.print(token_table)
-
-    # Per-model breakdown
-    if tm.by_model and (verbose or len(tm.by_model) > 1):
-        model_table = Table(title="Cost by Model", show_header=True)
-        model_table.add_column("Model", style="cyan")
-        model_table.add_column("Tokens", justify="right")
-        model_table.add_column("Cost", justify="right")
-        for model_name, breakdown in sorted(tm.by_model.items()):
-            model_table.add_row(
-                model_name,
-                _format_tokens(breakdown.total_tokens),
-                _format_cost(breakdown.cost),
-            )
-        console.print(model_table)
-
-    # Tool patterns
-    if tlm.total_tool_calls > 0:
-        tool_table = Table(title="Tool Usage", show_header=True)
-        tool_table.add_column("Tool", style="cyan")
-        tool_table.add_column("Calls", justify="right")
-        tool_table.add_column("% of Total", justify="right")
-        for name, count in tlm.tool_frequency.items():
-            pct = round(count / tlm.total_tool_calls * 100, 1)
-            tool_table.add_row(name, str(count), f"{pct}%")
-        tool_table.add_row("", "", "")
-        tool_table.add_row("Total", str(tlm.total_tool_calls), "")
-        tool_table.add_row("Unique tools", str(tlm.unique_tool_count), "")
-        console.print(tool_table)
-
-    # Agent metrics
-    if am.total_invocations > 0:
-        agent_table = Table(title="Agent Invocations", show_header=True)
-        agent_table.add_column("Agent Type", style="cyan")
-        agent_table.add_column("Count", justify="right")
-        agent_table.add_column("Tokens", justify="right")
-        agent_table.add_column("Avg Tokens/Call", justify="right")
-        agent_table.add_column("Duration", justify="right")
-        for _key, m in sorted(am.by_agent_type.items()):
-            label = f"{m.agent_type} {'(builtin)' if m.is_builtin else ''}"
-            avg_tok = (
-                _format_tokens(int(m.avg_tokens_per_invocation))
-                if m.avg_tokens_per_invocation
-                else "-"
-            )
-            duration = f"{m.total_duration_ms / 1000:.1f}s" if m.total_duration_ms else "-"
-            agent_table.add_row(
-                label.strip(),
-                str(m.invocation_count),
-                _format_tokens(m.total_tokens),
-                avg_tok,
-                duration,
-            )
-        agent_table.add_row("", "", "", "", "")
-        agent_table.add_row("Total", str(am.total_invocations), "", "", "")
-        agent_table.add_row(
-            "Agent token %",
-            f"{am.agent_token_percentage}%",
-            "",
-            "",
-            "",
-        )
-        console.print(agent_table)
-
-    # Diagnostics
-    diag = result.diagnostics
-    if diag:
-        if show_diagnostics:
-            _print_diagnostics_table(diag, verbose=verbose)
-        else:
-            _print_diagnostics_summary(diag)
-
-    # Session summary
-    console.print(
-        f"\n[bold]Sessions analyzed:[/bold] {result.session_count}"
-    )
-
-
 def _print_json(result: AnalysisResult) -> None:
     """Print JSON output."""
     data = asdict(result)
-    # Convert Path objects to strings
     for session in data.get("sessions", []):
         if "session_path" in session:
             session["session_path"] = str(session["session_path"])
-    # Replace diagnostics with Pydantic serialization
+    # DiagnosticsResult is Pydantic; asdict() can't recurse into it.
     diag = result.diagnostics
     if diag:
         data["diagnostics"] = diag.model_dump(mode="json")
@@ -277,32 +92,29 @@ def analyze(
     """Analyze agent sessions for token usage, cost, and behavior diagnostics."""
     project_info = find_project(project)
     if project_info is None:
-        console.print(f"[red]Project not found:[/red] {project}")
-        console.print("Use [bold]agentfluent list[/bold] to see available projects.")
-        raise SystemExit(2)
+        err_console.print(f"[red]Project not found:[/red] {project}")
+        err_console.print("Use [bold]agentfluent list[/bold] to see available projects.")
+        raise typer.Exit(code=2)
 
-    # Resolve sessions
     session_infos = project_info.sessions
     if not session_infos:
         name = project_info.display_name
-        console.print(f"[yellow]No sessions found for project:[/yellow] {name}")
-        raise SystemExit(2)
+        err_console.print(f"[yellow]No sessions found for project:[/yellow] {name}")
+        raise typer.Exit(code=2)
 
     if session:
         session_infos = [s for s in session_infos if s.filename == session]
         if not session_infos:
-            console.print(f"[red]Session not found:[/red] {session}")
-            raise SystemExit(2)
+            err_console.print(f"[red]Session not found:[/red] {session}")
+            raise typer.Exit(code=2)
 
     if latest is not None and latest > 0:
         session_infos = session_infos[:latest]
 
     paths = [s.path for s in session_infos]
 
-    # Run analysis
     result = analyze_sessions(paths, agent_filter=agent)
 
-    # Run diagnostics using invocations already extracted by the pipeline
     all_invocations = [inv for s in result.sessions for inv in s.invocations]
     total_subagent_traces = sum(si.subagent_count for si in session_infos)
 
@@ -316,10 +128,11 @@ def analyze(
             "diagnostics require agent activity.[/dim]"
         )
 
-    # Output
     if format == "json":
         _print_json(result)
     elif quiet:
         _print_quiet(result)
     else:
-        _print_table(result, verbose=verbose, show_diagnostics=diagnostics)
+        format_analysis_table(
+            console, result, verbose=verbose, show_diagnostics=diagnostics,
+        )

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -7,29 +7,14 @@ from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
+from agentfluent.cli.formatters.table import format_config_check_table
 from agentfluent.config import assess_agents
-from agentfluent.config.models import ConfigScore, Severity
+from agentfluent.config.models import ConfigScore
 
 app = typer.Typer(help="Check agent configuration quality.")
 console = Console()
-
-# Severity -> Rich color mapping
-_SEVERITY_COLORS: dict[Severity, str] = {
-    Severity.CRITICAL: "red",
-    Severity.WARNING: "yellow",
-    Severity.INFO: "cyan",
-}
-
-
-def _score_color(score: int) -> str:
-    """Return a Rich color based on score value."""
-    if score >= 80:
-        return "green"
-    if score >= 50:
-        return "yellow"
-    return "red"
+err_console = Console(stderr=True)
 
 
 def _print_quiet(scores: list[ConfigScore]) -> None:
@@ -40,62 +25,6 @@ def _print_quiet(scores: list[ConfigScore]) -> None:
         f"Agents: {len(scores)} | "
         f"Avg score: {avg}/100 | "
         f"Recommendations: {total_recs}"
-    )
-
-
-def _print_table(scores: list[ConfigScore], *, verbose: bool = False) -> None:
-    """Print Rich-formatted scoring tables."""
-    # Summary table
-    summary = Table(title="Agent Configuration Scores", show_header=True)
-    summary.add_column("Agent", style="cyan")
-    summary.add_column("Score", justify="right")
-    summary.add_column("Description", justify="right")
-    summary.add_column("Tools", justify="right")
-    summary.add_column("Model", justify="right")
-    summary.add_column("Prompt", justify="right")
-    summary.add_column("Recs", justify="right")
-
-    for s in scores:
-        color = _score_color(s.overall_score)
-        summary.add_row(
-            s.agent_name,
-            f"[{color}]{s.overall_score}/100[/{color}]",
-            f"{s.dimension_scores.get('description', 0)}/25",
-            f"{s.dimension_scores.get('tool_restrictions', 0)}/25",
-            f"{s.dimension_scores.get('model_selection', 0)}/25",
-            f"{s.dimension_scores.get('prompt_body', 0)}/25",
-            str(len(s.recommendations)),
-        )
-    console.print(summary)
-
-    # Recommendations
-    all_recs = [(s.agent_name, r) for s in scores for r in s.recommendations]
-    if all_recs:
-        rec_table = Table(title="Recommendations", show_header=True)
-        rec_table.add_column("Agent", style="cyan")
-        rec_table.add_column("Severity")
-        rec_table.add_column("Recommendation")
-        if verbose:
-            rec_table.add_column("Action")
-
-        for agent_name, rec in all_recs:
-            color = _SEVERITY_COLORS.get(rec.severity, "white")
-            row = [
-                agent_name,
-                f"[{color}]{rec.severity.value}[/{color}]",
-                rec.message,
-            ]
-            if verbose:
-                row.append(rec.suggested_action)
-            rec_table.add_row(*row)
-        console.print(rec_table)
-
-    # Summary line
-    avg = sum(s.overall_score for s in scores) // len(scores) if scores else 0
-    console.print(
-        f"\n[bold]Agents scanned:[/bold] {len(scores)}, "
-        f"[bold]average score:[/bold] {avg}/100, "
-        f"[bold]recommendations:[/bold] {len(all_recs)}"
     )
 
 
@@ -129,26 +58,26 @@ def config_check(
 ) -> None:
     """Scan agent definitions and score them against best practices."""
     if scope not in ("user", "project", "all"):
-        console.print(f"[red]Invalid scope:[/red] {scope}")
-        console.print("Valid scopes: user, project, all")
-        raise SystemExit(2)
+        err_console.print(f"[red]Invalid scope:[/red] {scope}")
+        err_console.print("Valid scopes: user, project, all")
+        raise typer.Exit(code=2)
 
     scores = assess_agents(scope, agent_filter=agent)
 
     if not scores:
         if agent:
-            console.print(f"[yellow]No agent found named:[/yellow] {agent}")
+            err_console.print(f"[yellow]No agent found named:[/yellow] {agent}")
         else:
-            console.print("[yellow]No agent definition files found.[/yellow]")
-            console.print(
+            err_console.print("[yellow]No agent definition files found.[/yellow]")
+            err_console.print(
                 "Agent definitions are `.md` files in "
                 "`~/.claude/agents/` (user) or `.claude/agents/` (project)."
             )
-        raise SystemExit(2)
+        raise typer.Exit(code=2)
 
     if format == "json":
         _print_json(scores)
     elif quiet:
         _print_quiet(scores)
     else:
-        _print_table(scores, verbose=verbose)
+        format_config_check_table(console, scores, verbose=verbose)

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -4,35 +4,21 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
 from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
+from agentfluent.cli.formatters.table import (
+    format_projects_table,
+    format_sessions_table,
+)
 from agentfluent.core.discovery import discover_projects, find_project
 from agentfluent.core.parser import parse_session
 
 app = typer.Typer(help="List projects and sessions.")
 console = Console()
 err_console = Console(stderr=True)
-
-
-def _format_size(size_bytes: int) -> str:
-    """Format bytes as human-readable size."""
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    if size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    return f"{size_bytes / (1024 * 1024):.1f} MB"
-
-
-def _format_date(dt: datetime | None) -> str:
-    """Format a datetime for display."""
-    if dt is None:
-        return "—"
-    return dt.strftime("%Y-%m-%d %H:%M")
 
 
 def _list_projects_table() -> None:
@@ -43,25 +29,7 @@ def _list_projects_table() -> None:
         err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
 
-    if not projects:
-        console.print("No projects found in ~/.claude/projects/")
-        return
-
-    table = Table(title="Projects")
-    table.add_column("Name", style="cyan")
-    table.add_column("Sessions", justify="right")
-    table.add_column("Size", justify="right")
-    table.add_column("Latest", style="dim")
-
-    for p in projects:
-        table.add_row(
-            p.display_name,
-            str(p.session_count),
-            _format_size(p.total_size_bytes),
-            _format_date(p.latest_session),
-        )
-
-    console.print(table)
+    format_projects_table(console, projects)
 
 
 def _list_projects_json() -> None:
@@ -93,28 +61,8 @@ def _list_sessions_table(project_slug: str) -> None:
         err_console.print(f"[red]Project not found: {project_slug}[/red]")
         raise typer.Exit(code=1)
 
-    if not project.sessions:
-        console.print(f"No sessions in project '{project.display_name}'")
-        return
-
-    table = Table(title=f"Sessions — {project.display_name}")
-    table.add_column("File", style="cyan")
-    table.add_column("Size", justify="right")
-    table.add_column("Modified", style="dim")
-    table.add_column("Messages", justify="right")
-    table.add_column("Subagents", justify="right", style="dim")
-
-    for s in project.sessions:
-        messages = parse_session(s.path)
-        table.add_row(
-            s.filename,
-            _format_size(s.size_bytes),
-            _format_date(s.modified),
-            str(len(messages)),
-            str(s.subagent_count) if s.subagent_count > 0 else "—",
-        )
-
-    console.print(table)
+    sessions = [(s, len(parse_session(s.path))) for s in project.sessions]
+    format_sessions_table(console, project.display_name, sessions)
 
 
 def _list_sessions_json(project_slug: str) -> None:

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -1,0 +1,50 @@
+"""Shared formatting utilities for CLI output."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from agentfluent.config.models import Severity
+
+SEVERITY_COLORS: dict[Severity, str] = {
+    Severity.CRITICAL: "red",
+    Severity.WARNING: "yellow",
+    Severity.INFO: "cyan",
+}
+
+
+def format_cost(cost: float) -> str:
+    """Format a dollar cost for display."""
+    if cost < 0.01:
+        return f"${cost:.4f}"
+    return f"${cost:.2f}"
+
+
+def format_tokens(tokens: int) -> str:
+    """Format token count with comma separator."""
+    return f"{tokens:,}"
+
+
+def format_size(size_bytes: int) -> str:
+    """Format bytes as human-readable size."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def format_date(dt: datetime | None) -> str:
+    """Format a datetime for display."""
+    if dt is None:
+        return "—"
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def score_color(score: int) -> str:
+    """Return a Rich color based on score value."""
+    if score >= 80:
+        return "green"
+    if score >= 50:
+        return "yellow"
+    return "red"

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -1,0 +1,311 @@
+"""Rich table formatters for CLI output.
+
+Each command gets its own `format_*_table` function -- no shared Formatter
+base class, since the three commands produce different data shapes that
+would not benefit from unification. Functions render already-computed data
+to a Rich Console; I/O stays in the command callbacks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.table import Table
+
+from agentfluent.cli.formatters.helpers import (
+    SEVERITY_COLORS,
+    format_cost,
+    format_date,
+    format_size,
+    format_tokens,
+    score_color,
+)
+
+if TYPE_CHECKING:
+    from agentfluent.analytics.pipeline import AnalysisResult
+    from agentfluent.config.models import ConfigScore
+    from agentfluent.core.discovery import ProjectInfo, SessionInfo
+    from agentfluent.diagnostics.models import DiagnosticsResult
+
+
+def format_projects_table(
+    console: Console,
+    projects: list[ProjectInfo],
+) -> None:
+    """Render discovered projects as a Rich table."""
+    if not projects:
+        console.print("No projects found in ~/.claude/projects/")
+        return
+
+    table = Table(title="Projects")
+    table.add_column("Name", style="cyan")
+    table.add_column("Sessions", justify="right")
+    table.add_column("Size", justify="right")
+    table.add_column("Latest", style="dim")
+
+    for p in projects:
+        table.add_row(
+            p.display_name,
+            str(p.session_count),
+            format_size(p.total_size_bytes),
+            format_date(p.latest_session),
+        )
+
+    console.print(table)
+
+
+def format_sessions_table(
+    console: Console,
+    project_name: str,
+    sessions: list[tuple[SessionInfo, int]],
+) -> None:
+    """Render per-session stats as a Rich table.
+
+    `sessions` is a list of (SessionInfo, message_count) tuples. The caller
+    owns session parsing so this function stays pure rendering.
+    """
+    if not sessions:
+        console.print(f"No sessions in project '{project_name}'")
+        return
+
+    table = Table(title=f"Sessions — {project_name}")
+    table.add_column("File", style="cyan")
+    table.add_column("Size", justify="right")
+    table.add_column("Modified", style="dim")
+    table.add_column("Messages", justify="right")
+    table.add_column("Subagents", justify="right", style="dim")
+
+    for info, message_count in sessions:
+        table.add_row(
+            info.filename,
+            format_size(info.size_bytes),
+            format_date(info.modified),
+            str(message_count),
+            str(info.subagent_count) if info.subagent_count > 0 else "—",
+        )
+
+    console.print(table)
+
+
+def format_analysis_table(
+    console: Console,
+    result: AnalysisResult,
+    *,
+    verbose: bool = False,
+    show_diagnostics: bool = False,
+) -> None:
+    """Render analyze output: token, cost, tool, agent, and diagnostics tables."""
+    tm = result.token_metrics
+    am = result.agent_metrics
+    tlm = result.tool_metrics
+
+    token_table = Table(title="Token Usage", show_header=True)
+    token_table.add_column("Metric", style="cyan")
+    token_table.add_column("Value", justify="right")
+    token_table.add_row("Input tokens", format_tokens(tm.input_tokens))
+    token_table.add_row("Output tokens", format_tokens(tm.output_tokens))
+    token_table.add_row("Cache creation tokens", format_tokens(tm.cache_creation_input_tokens))
+    token_table.add_row("Cache read tokens", format_tokens(tm.cache_read_input_tokens))
+    token_table.add_row("Total tokens", format_tokens(tm.total_tokens))
+    token_table.add_row("Total cost", format_cost(tm.total_cost))
+    token_table.add_row("Cache efficiency", f"{tm.cache_efficiency}%")
+    token_table.add_row("API calls", str(tm.api_call_count))
+    console.print(token_table)
+
+    if tm.by_model and (verbose or len(tm.by_model) > 1):
+        model_table = Table(title="Cost by Model", show_header=True)
+        model_table.add_column("Model", style="cyan")
+        model_table.add_column("Tokens", justify="right")
+        model_table.add_column("Cost", justify="right")
+        for model_name, breakdown in sorted(tm.by_model.items()):
+            model_table.add_row(
+                model_name,
+                format_tokens(breakdown.total_tokens),
+                format_cost(breakdown.cost),
+            )
+        console.print(model_table)
+
+    if tlm.total_tool_calls > 0:
+        tool_table = Table(title="Tool Usage", show_header=True)
+        tool_table.add_column("Tool", style="cyan")
+        tool_table.add_column("Calls", justify="right")
+        tool_table.add_column("% of Total", justify="right")
+        for name, count in tlm.tool_frequency.items():
+            pct = round(count / tlm.total_tool_calls * 100, 1)
+            tool_table.add_row(name, str(count), f"{pct}%")
+        tool_table.add_row("", "", "")
+        tool_table.add_row("Total", str(tlm.total_tool_calls), "")
+        tool_table.add_row("Unique tools", str(tlm.unique_tool_count), "")
+        console.print(tool_table)
+
+    if am.total_invocations > 0:
+        agent_table = Table(title="Agent Invocations", show_header=True)
+        agent_table.add_column("Agent Type", style="cyan")
+        agent_table.add_column("Count", justify="right")
+        agent_table.add_column("Tokens", justify="right")
+        agent_table.add_column("Avg Tokens/Call", justify="right")
+        agent_table.add_column("Duration", justify="right")
+        for _key, m in sorted(am.by_agent_type.items()):
+            label = f"{m.agent_type} {'(builtin)' if m.is_builtin else ''}"
+            avg_tok = (
+                format_tokens(int(m.avg_tokens_per_invocation))
+                if m.avg_tokens_per_invocation
+                else "-"
+            )
+            duration = f"{m.total_duration_ms / 1000:.1f}s" if m.total_duration_ms else "-"
+            agent_table.add_row(
+                label.strip(),
+                str(m.invocation_count),
+                format_tokens(m.total_tokens),
+                avg_tok,
+                duration,
+            )
+        agent_table.add_row("", "", "", "", "")
+        agent_table.add_row("Total", str(am.total_invocations), "", "", "")
+        agent_table.add_row(
+            "Agent token %",
+            f"{am.agent_token_percentage}%",
+            "",
+            "",
+            "",
+        )
+        console.print(agent_table)
+
+    diag = result.diagnostics
+    if diag:
+        if show_diagnostics:
+            _format_diagnostics_table(console, diag, verbose=verbose)
+        else:
+            _format_diagnostics_summary(console, diag)
+
+    console.print(f"\n[bold]Sessions analyzed:[/bold] {result.session_count}")
+
+
+def _format_diagnostics_table(
+    console: Console,
+    diag: DiagnosticsResult,
+    *,
+    verbose: bool = False,
+) -> None:
+    """Render diagnostic signals and recommendations tables."""
+    if diag.signals:
+        sig_table = Table(title="Diagnostic Signals", show_header=True)
+        sig_table.add_column("Agent", style="cyan")
+        sig_table.add_column("Type")
+        sig_table.add_column("Severity")
+        sig_table.add_column("Message")
+
+        for sig in diag.signals:
+            color = SEVERITY_COLORS.get(sig.severity, "white")
+            sig_table.add_row(
+                sig.agent_type,
+                sig.signal_type.value,
+                f"[{color}]{sig.severity.value}[/{color}]",
+                sig.message,
+            )
+        console.print(sig_table)
+
+    if diag.recommendations:
+        rec_table = Table(title="Recommendations", show_header=True)
+        rec_table.add_column("Agent", style="cyan")
+        rec_table.add_column("Target")
+        rec_table.add_column("Severity")
+        if verbose:
+            rec_table.add_column("Observation")
+            rec_table.add_column("Action")
+        else:
+            rec_table.add_column("Recommendation")
+
+        for rec in diag.recommendations:
+            color = SEVERITY_COLORS.get(rec.severity, "white")
+            if verbose:
+                rec_table.add_row(
+                    rec.agent_type,
+                    rec.target,
+                    f"[{color}]{rec.severity.value}[/{color}]",
+                    rec.observation,
+                    rec.action,
+                )
+            else:
+                rec_table.add_row(
+                    rec.agent_type,
+                    rec.target,
+                    f"[{color}]{rec.severity.value}[/{color}]",
+                    rec.message,
+                )
+        console.print(rec_table)
+
+    if diag.subagent_trace_count > 0:
+        console.print(
+            f"\n[dim]{diag.subagent_trace_count} subagent trace files available. "
+            "Deep diagnostics (per-tool-call analysis) coming in v1.1.[/dim]"
+        )
+
+
+def _format_diagnostics_summary(console: Console, diag: DiagnosticsResult) -> None:
+    """Print a brief diagnostics summary when --diagnostics is not passed."""
+    signal_count = len(diag.signals)
+    if signal_count > 0:
+        console.print(
+            f"\n[yellow]{signal_count} diagnostic signal(s) detected.[/yellow] "
+            "Run with [bold]--diagnostics[/bold] for details."
+        )
+
+
+def format_config_check_table(
+    console: Console,
+    scores: list[ConfigScore],
+    *,
+    verbose: bool = False,
+) -> None:
+    """Render agent configuration scores and recommendations."""
+    summary = Table(title="Agent Configuration Scores", show_header=True)
+    summary.add_column("Agent", style="cyan")
+    summary.add_column("Score", justify="right")
+    summary.add_column("Description", justify="right")
+    summary.add_column("Tools", justify="right")
+    summary.add_column("Model", justify="right")
+    summary.add_column("Prompt", justify="right")
+    summary.add_column("Recs", justify="right")
+
+    for s in scores:
+        color = score_color(s.overall_score)
+        summary.add_row(
+            s.agent_name,
+            f"[{color}]{s.overall_score}/100[/{color}]",
+            f"{s.dimension_scores.get('description', 0)}/25",
+            f"{s.dimension_scores.get('tool_restrictions', 0)}/25",
+            f"{s.dimension_scores.get('model_selection', 0)}/25",
+            f"{s.dimension_scores.get('prompt_body', 0)}/25",
+            str(len(s.recommendations)),
+        )
+    console.print(summary)
+
+    all_recs = [(s.agent_name, r) for s in scores for r in s.recommendations]
+    if all_recs:
+        rec_table = Table(title="Recommendations", show_header=True)
+        rec_table.add_column("Agent", style="cyan")
+        rec_table.add_column("Severity")
+        rec_table.add_column("Recommendation")
+        if verbose:
+            rec_table.add_column("Action")
+
+        for agent_name, rec in all_recs:
+            color = SEVERITY_COLORS.get(rec.severity, "white")
+            row = [
+                agent_name,
+                f"[{color}]{rec.severity.value}[/{color}]",
+                rec.message,
+            ]
+            if verbose:
+                row.append(rec.suggested_action)
+            rec_table.add_row(*row)
+        console.print(rec_table)
+
+    avg = sum(s.overall_score for s in scores) // len(scores) if scores else 0
+    console.print(
+        f"\n[bold]Agents scanned:[/bold] {len(scores)}, "
+        f"[bold]average score:[/bold] {avg}/100, "
+        f"[bold]recommendations:[/bold] {len(all_recs)}"
+    )


### PR DESCRIPTION
Closes #38.

## Summary

- Extract Rich table rendering from `cli/commands/*.py` into `cli/formatters/table.py` as plain module-level functions -- no Formatter protocol/ABC/registry per architect review on #7
- Move shared formatting helpers (`format_cost`, `format_tokens`, `format_size`, `format_date`, `score_color`, `SEVERITY_COLORS`) into `cli/formatters/helpers.py`; drop the duplicates that lived in each command file
- Standardize exit codes on `typer.Exit(code=N)` (was mixed `SystemExit` / `typer.Exit`)
- Add `err_console = Console(stderr=True)` to `analyze` and `config_check` so error messages route to stderr

## Out of scope (deferred to later E7 stories)

- JSON envelope schema + `AnalysisResult` → Pydantic conversion → #39
- `--verbose` / `--quiet` implementation for `list` + mutual exclusivity → #40
- CLI output tests → #41
- Help text with usage examples → #42

## Test plan

- [x] `uv run pytest -m "not integration"` -- 225 passed
- [x] `uv run ruff check src/` -- clean
- [x] `uv run mypy src/agentfluent/` -- clean
- [x] Manual smoke: `agentfluent list` (table + json), `agentfluent analyze --project agentfluent --latest 1`, `agentfluent config-check --scope user` -- output identical to pre-refactor
- [x] Exit code verification: `agentfluent analyze --project nonexistent` exits 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)