### PR TITLE
feat: JSON envelope + help examples (#39, #42)

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -6,9 +6,9 @@ analysis pipeline. Reusable by the CLI, future webapp, and tests.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
 
 from agentfluent.agents.extractor import extract_agent_invocations
 from agentfluent.agents.models import AgentInvocation
@@ -29,34 +29,29 @@ from agentfluent.analytics.tools import (
 )
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import SessionMessage
-
-if TYPE_CHECKING:
-    from agentfluent.diagnostics.models import DiagnosticsResult
+from agentfluent.diagnostics.models import DiagnosticsResult
 
 
-@dataclass
-class SessionAnalysis:
+class SessionAnalysis(BaseModel):
     """Complete analysis results for a single session."""
 
     session_path: Path
     token_metrics: TokenMetrics
     tool_metrics: ToolMetrics
     agent_metrics: AgentMetrics
-    invocations: list[AgentInvocation] = field(default_factory=list)
-    """Agent invocations extracted from this session (for diagnostics)."""
+    invocations: list[AgentInvocation] = Field(default_factory=list)
     message_count: int = 0
     user_message_count: int = 0
     assistant_message_count: int = 0
 
 
-@dataclass
-class AnalysisResult:
+class AnalysisResult(BaseModel):
     """Aggregated analysis results across one or more sessions."""
 
-    sessions: list[SessionAnalysis] = field(default_factory=list)
-    token_metrics: TokenMetrics = field(default_factory=TokenMetrics)
-    tool_metrics: ToolMetrics = field(default_factory=ToolMetrics)
-    agent_metrics: AgentMetrics = field(default_factory=AgentMetrics)
+    sessions: list[SessionAnalysis] = Field(default_factory=list)
+    token_metrics: TokenMetrics = Field(default_factory=TokenMetrics)
+    tool_metrics: ToolMetrics = Field(default_factory=ToolMetrics)
+    agent_metrics: AgentMetrics = Field(default_factory=AgentMetrics)
     session_count: int = 0
     diagnostics: DiagnosticsResult | None = None
 

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-from dataclasses import asdict
 from typing import Optional
 
 import typer
@@ -11,9 +9,26 @@ from rich.console import Console
 
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
 from agentfluent.cli.formatters.helpers import format_cost, format_tokens
+from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.core.discovery import find_project
 from agentfluent.diagnostics import run_diagnostics
+
+ANALYZE_EPILOG = """\
+Examples:
+
+  agentfluent analyze --project codefluent
+      Analyze all sessions in the codefluent project.
+
+  agentfluent analyze --project codefluent --agent pm
+      Analyze only PM agent invocations.
+
+  agentfluent analyze --project codefluent --latest 5 --diagnostics
+      Analyze the 5 most recent sessions with behavior diagnostics.
+
+  agentfluent analyze --project codefluent --format json | jq '.data.token_metrics.total_cost'
+      Extract total cost programmatically.
+"""
 
 app = typer.Typer(help="Analyze agent sessions.")
 console = Console()
@@ -37,18 +52,10 @@ def _print_quiet(result: AnalysisResult) -> None:
 
 def _print_json(result: AnalysisResult) -> None:
     """Print JSON output."""
-    data = asdict(result)
-    for session in data.get("sessions", []):
-        if "session_path" in session:
-            session["session_path"] = str(session["session_path"])
-    # DiagnosticsResult is Pydantic; asdict() can't recurse into it.
-    diag = result.diagnostics
-    if diag:
-        data["diagnostics"] = diag.model_dump(mode="json")
-    console.print_json(json.dumps(data, default=str))
+    print(format_json_output("analyze", result.model_dump(mode="json")))
 
 
-@app.callback(invoke_without_command=True)
+@app.callback(invoke_without_command=True, epilog=ANALYZE_EPILOG)
 def analyze(
     project: str = typer.Option(
         ...,

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -2,15 +2,31 @@
 
 from __future__ import annotations
 
-import json
 from typing import Optional
 
 import typer
 from rich.console import Console
 
+from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_config_check_table
 from agentfluent.config import assess_agents
 from agentfluent.config.models import ConfigScore
+
+CONFIG_CHECK_EPILOG = """\
+Examples:
+
+  agentfluent config-check
+      Score all user and project agent definitions.
+
+  agentfluent config-check --scope user
+      Check only user-level agents in ~/.claude/agents/.
+
+  agentfluent config-check --agent pm --verbose
+      Score a specific agent with detailed recommendations.
+
+  agentfluent config-check --format json | jq '.data.scores[] | select(.overall_score < 60)'
+      Find agents that need improvement.
+"""
 
 app = typer.Typer(help="Check agent configuration quality.")
 console = Console()
@@ -30,11 +46,11 @@ def _print_quiet(scores: list[ConfigScore]) -> None:
 
 def _print_json(scores: list[ConfigScore]) -> None:
     """Print JSON output."""
-    data = [s.model_dump(mode="json") for s in scores]
-    console.print_json(json.dumps(data, default=str))
+    payload = {"scores": [s.model_dump(mode="json") for s in scores]}
+    print(format_json_output("config-check", payload))
 
 
-@app.callback(invoke_without_command=True)
+@app.callback(invoke_without_command=True, epilog=CONFIG_CHECK_EPILOG)
 def config_check(
     scope: str = typer.Option(
         "all",

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -2,19 +2,34 @@
 
 from __future__ import annotations
 
-import json
-import sys
 from typing import Optional
 
 import typer
 from rich.console import Console
 
+from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import (
     format_projects_table,
     format_sessions_table,
 )
 from agentfluent.core.discovery import discover_projects, find_project
 from agentfluent.core.parser import parse_session
+
+LIST_EPILOG = """\
+Examples:
+
+  agentfluent list
+      List all projects in ~/.claude/projects/.
+
+  agentfluent list --project codefluent
+      List sessions in the codefluent project.
+
+  agentfluent list --format json | jq '.data.projects[].name'
+      Extract project names (command is "list-projects").
+
+  agentfluent list --project codefluent --format json | jq '.data.sessions[].filename'
+      Extract session filenames (command is "list-sessions").
+"""
 
 app = typer.Typer(help="List projects and sessions.")
 console = Console()
@@ -37,21 +52,25 @@ def _list_projects_json() -> None:
     try:
         projects = discover_projects()
     except FileNotFoundError as e:
-        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
 
-    output = [
-        {
-            "name": p.display_name,
-            "slug": p.slug,
-            "session_count": p.session_count,
-            "total_size_bytes": p.total_size_bytes,
-            "earliest_session": p.earliest_session.isoformat() if p.earliest_session else None,
-            "latest_session": p.latest_session.isoformat() if p.latest_session else None,
-        }
-        for p in projects
-    ]
-    print(json.dumps(output, indent=2))
+    payload = {
+        "projects": [
+            {
+                "name": p.display_name,
+                "slug": p.slug,
+                "session_count": p.session_count,
+                "total_size_bytes": p.total_size_bytes,
+                "earliest_session": (
+                    p.earliest_session.isoformat() if p.earliest_session else None
+                ),
+                "latest_session": p.latest_session.isoformat() if p.latest_session else None,
+            }
+            for p in projects
+        ]
+    }
+    print(format_json_output("list-projects", payload))
 
 
 def _list_sessions_table(project_slug: str) -> None:
@@ -69,13 +88,13 @@ def _list_sessions_json(project_slug: str) -> None:
     """Output sessions for a project as JSON."""
     project = find_project(project_slug)
     if project is None:
-        print(json.dumps({"error": f"Project not found: {project_slug}"}), file=sys.stderr)
+        err_console.print(f"[red]Project not found: {project_slug}[/red]")
         raise typer.Exit(code=1)
 
-    output = []
+    sessions = []
     for s in project.sessions:
         messages = parse_session(s.path)
-        output.append(
+        sessions.append(
             {
                 "filename": s.filename,
                 "size_bytes": s.size_bytes,
@@ -84,10 +103,11 @@ def _list_sessions_json(project_slug: str) -> None:
                 "subagent_count": s.subagent_count,
             }
         )
-    print(json.dumps(output, indent=2))
+    payload = {"project": project.display_name, "sessions": sessions}
+    print(format_json_output("list-sessions", payload))
 
 
-@app.callback(invoke_without_command=True)
+@app.callback(invoke_without_command=True, epilog=LIST_EPILOG)
 def list_cmd(
     project: Optional[str] = typer.Option(  # noqa: UP007, UP045
         None,

--- a/src/agentfluent/cli/formatters/json_output.py
+++ b/src/agentfluent/cli/formatters/json_output.py
@@ -1,0 +1,32 @@
+"""JSON output envelope for CLI commands.
+
+All commands emit JSON in a stable envelope:
+
+    {
+      "version": "1",
+      "command": "<list|analyze|config-check>",
+      "data": { ... command-specific payload ... }
+    }
+
+`version` is a string and bumps independently of the package version when the
+schema changes. Consumers should check `command` before parsing `data`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+SCHEMA_VERSION = "1"
+
+CommandName = Literal["list-projects", "list-sessions", "analyze", "config-check"]
+
+
+def format_json_output(command: CommandName, data: Any) -> str:
+    """Wrap a command payload in the versioned JSON envelope."""
+    envelope = {
+        "version": SCHEMA_VERSION,
+        "command": command,
+        "data": data,
+    }
+    return json.dumps(envelope, indent=2, default=str)

--- a/src/agentfluent/cli/main.py
+++ b/src/agentfluent/cli/main.py
@@ -7,9 +7,34 @@ import typer
 from agentfluent import __version__
 from agentfluent.cli.commands import analyze, config_check, list_cmd
 
+TOP_LEVEL_HELP = """\
+Local-first agent analytics for the Claude Agent SDK and Claude Code subagents.
+
+AgentFluent analyzes session JSONL files in ~/.claude/projects/ to diagnose
+agent quality -- token usage, tool patterns, behavior signals, and config
+health -- and produces specific recommendations for improving agent prompts,
+tool access, model selection, and other configuration surfaces.
+"""
+
+TOP_LEVEL_EPILOG = """\
+Common workflows:
+
+  agentfluent list
+      Discover which projects have session data.
+
+  agentfluent analyze --project <slug> --diagnostics
+      Full analytics with behavior diagnostics.
+
+  agentfluent config-check
+      Score agent definitions against best practices.
+
+Run any command with --help for command-specific options and examples.
+"""
+
 app = typer.Typer(
     name="agentfluent",
-    help="Local-first agent analytics with prompt diagnostics.",
+    help=TOP_LEVEL_HELP,
+    epilog=TOP_LEVEL_EPILOG,
     no_args_is_help=True,
 )
 


### PR DESCRIPTION
Closes #39 and #42.

## Summary

- **#39 JSON envelope**: all three commands (`list`, `analyze`, `config-check`) now emit `{"version": "1", "command": "<name>", "data": {...}}`. Single shared helper `format_json_output(command, data)` in `cli/formatters/json_output.py`. Writes to stdout via `print()` (no ANSI escapes, `jq`-friendly).
- **AnalysisResult / SessionAnalysis → Pydantic**: removes the fragile `asdict() + manual Path patching + Pydantic diagnostics replacement` path in `analyze._print_json`. Now a single `result.model_dump(mode="json")` handles Path, datetime, enums, and nested Pydantic models uniformly.
- **#42 help examples**: per-command epilogs with 3-4 usage examples each; top-level `agentfluent --help` gets a descriptive summary and common-workflow pointers.

## Breaking changes (v1 of the schema)

Previously each command dumped bare arrays/objects; consumers must now read `.data.*`:

- `list` (no project): `.data.projects[]` with `command: "list-projects"`
- `list --project <slug>`: `.data.project` + `.data.sessions[]` with `command: "list-sessions"`
- `analyze`: `.data.{token_metrics, tool_metrics, agent_metrics, sessions, diagnostics, ...}` with `command: "analyze"`
- `config-check`: `.data.scores[]` with `command: "config-check"`

Splitting `list` into two distinct `command` values (rather than sharing `"list"` for both shapes) came out of `/simplify` — it makes the discriminator actually load-bearing.

## Test plan

- [x] `uv run pytest -m "not integration"` → 225 passed
- [x] `uv run ruff check src/` + `uv run mypy src/agentfluent/` clean
- [x] `agentfluent list --format json | jq '.version, .command'` → `"1"`, `"list-projects"`
- [x] `agentfluent list --project <slug> --format json | jq .command` → `"list-sessions"`
- [x] `agentfluent analyze --project <slug> --latest 1 --format json | jq .command` → `"analyze"`
- [x] `agentfluent config-check --format json | jq .command` → `"config-check"`
- [x] `agentfluent analyze ... --format json | grep -c $'\x1b'` → `0` (no ANSI escapes in JSON output)
- [x] `agentfluent --help` shows the top-level description and workflow examples
- [x] Per-command `--help` shows usage examples at the bottom

Envelope schema validation tests (asserting `version`, `command`, `data` keys and no ANSI) are deferred to #41, which explicitly covers CLI output testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)