### PR TITLE
feat: --verbose and --quiet output modes (#40)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -35,24 +35,37 @@ console = Console()
 err_console = Console(stderr=True)
 
 
-def _print_quiet(result: AnalysisResult) -> None:
+def _print_quiet(result: AnalysisResult, project_name: str) -> None:
     """Print a one-line summary."""
     tm = result.token_metrics
     am = result.agent_metrics
-    parts = [
-        f"Sessions: {result.session_count}",
-        f"Tokens: {format_tokens(tm.total_tokens)}",
-        f"Cost: {format_cost(tm.total_cost)}",
-        f"Agent invocations: {am.total_invocations}",
-    ]
-    if result.diagnostics and result.diagnostics.signals:
-        parts.append(f"Diagnostic signals: {len(result.diagnostics.signals)}")
-    console.print(" | ".join(parts))
+    signal_count = len(result.diagnostics.signals) if result.diagnostics else 0
+    console.print(
+        f"Project {project_name}: "
+        f"{format_cost(tm.total_cost)} cost, "
+        f"{format_tokens(tm.total_tokens)} tokens, "
+        f"{am.total_invocations} agent invocations, "
+        f"{signal_count} diagnostic signals"
+    )
 
 
-def _print_json(result: AnalysisResult) -> None:
-    """Print JSON output."""
-    print(format_json_output("analyze", result.model_dump(mode="json")))
+def _print_json(result: AnalysisResult, *, quiet: bool, project_name: str) -> None:
+    """Print JSON output. Quiet emits a minimal summary; default emits the full tree."""
+    if quiet:
+        tm = result.token_metrics
+        am = result.agent_metrics
+        signal_count = len(result.diagnostics.signals) if result.diagnostics else 0
+        payload: dict[str, object] = {
+            "project": project_name,
+            "session_count": result.session_count,
+            "total_cost": tm.total_cost,
+            "total_tokens": tm.total_tokens,
+            "total_invocations": am.total_invocations,
+            "diagnostic_signal_count": signal_count,
+        }
+    else:
+        payload = result.model_dump(mode="json")
+    print(format_json_output("analyze", payload))
 
 
 @app.callback(invoke_without_command=True, epilog=ANALYZE_EPILOG)
@@ -97,6 +110,9 @@ def analyze(
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
     """Analyze agent sessions for token usage, cost, and behavior diagnostics."""
+    if verbose and quiet:
+        raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
     project_info = find_project(project)
     if project_info is None:
         err_console.print(f"[red]Project not found:[/red] {project}")
@@ -136,9 +152,9 @@ def analyze(
         )
 
     if format == "json":
-        _print_json(result)
+        _print_json(result, quiet=quiet, project_name=project_info.display_name)
     elif quiet:
-        _print_quiet(result)
+        _print_quiet(result, project_info.display_name)
     else:
         format_analysis_table(
             console, result, verbose=verbose, show_diagnostics=diagnostics,

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from agentfluent.cli.formatters.helpers import average_score
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_config_check_table
 from agentfluent.config import assess_agents
@@ -35,18 +36,24 @@ err_console = Console(stderr=True)
 
 def _print_quiet(scores: list[ConfigScore]) -> None:
     """Print a one-line summary."""
-    avg = sum(s.overall_score for s in scores) // len(scores) if scores else 0
     total_recs = sum(len(s.recommendations) for s in scores)
     console.print(
         f"Agents: {len(scores)} | "
-        f"Avg score: {avg}/100 | "
+        f"Avg score: {average_score(scores)}/100 | "
         f"Recommendations: {total_recs}"
     )
 
 
-def _print_json(scores: list[ConfigScore]) -> None:
-    """Print JSON output."""
-    payload = {"scores": [s.model_dump(mode="json") for s in scores]}
+def _print_json(scores: list[ConfigScore], *, quiet: bool) -> None:
+    """Print JSON output. Quiet emits a minimal summary; default emits all scores."""
+    if quiet:
+        payload: dict[str, object] = {
+            "agent_count": len(scores),
+            "average_score": average_score(scores),
+            "recommendation_count": sum(len(s.recommendations) for s in scores),
+        }
+    else:
+        payload = {"scores": [s.model_dump(mode="json") for s in scores]}
     print(format_json_output("config-check", payload))
 
 
@@ -73,6 +80,9 @@ def config_check(
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
     """Scan agent definitions and score them against best practices."""
+    if verbose and quiet:
+        raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
     if scope not in ("user", "project", "all"):
         err_console.print(f"[red]Invalid scope:[/red] {scope}")
         err_console.print("Valid scopes: user, project, all")
@@ -92,7 +102,7 @@ def config_check(
         raise typer.Exit(code=2)
 
     if format == "json":
-        _print_json(scores)
+        _print_json(scores, quiet=quiet)
     elif quiet:
         _print_quiet(scores)
     else:

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -12,7 +12,11 @@ from agentfluent.cli.formatters.table import (
     format_projects_table,
     format_sessions_table,
 )
-from agentfluent.core.discovery import discover_projects, find_project
+from agentfluent.core.discovery import (
+    ProjectInfo,
+    discover_projects,
+    find_project,
+)
 from agentfluent.core.parser import parse_session
 
 LIST_EPILOG = """\
@@ -36,74 +40,95 @@ console = Console()
 err_console = Console(stderr=True)
 
 
-def _list_projects_table() -> None:
+def _discover_or_exit() -> list[ProjectInfo]:
+    """Discover projects; print error and exit on failure."""
+    try:
+        return discover_projects()
+    except FileNotFoundError as e:
+        err_console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+
+
+def _list_projects_table(*, verbose: bool, quiet: bool) -> None:
     """Display all projects as a Rich table."""
-    try:
-        projects = discover_projects()
-    except FileNotFoundError as e:
-        err_console.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
+    projects = _discover_or_exit()
+    if quiet:
+        total_sessions = sum(p.session_count for p in projects)
+        console.print(f"{len(projects)} projects, {total_sessions} total sessions")
+        return
+    format_projects_table(console, projects, verbose=verbose)
 
-    format_projects_table(console, projects)
 
-
-def _list_projects_json() -> None:
+def _list_projects_json(*, quiet: bool) -> None:
     """Output all projects as JSON."""
-    try:
-        projects = discover_projects()
-    except FileNotFoundError as e:
-        err_console.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
-
-    payload = {
-        "projects": [
-            {
-                "name": p.display_name,
-                "slug": p.slug,
-                "session_count": p.session_count,
-                "total_size_bytes": p.total_size_bytes,
-                "earliest_session": (
-                    p.earliest_session.isoformat() if p.earliest_session else None
-                ),
-                "latest_session": p.latest_session.isoformat() if p.latest_session else None,
-            }
-            for p in projects
-        ]
-    }
+    projects = _discover_or_exit()
+    if quiet:
+        payload: dict[str, object] = {
+            "project_count": len(projects),
+            "total_sessions": sum(p.session_count for p in projects),
+        }
+    else:
+        payload = {
+            "projects": [
+                {
+                    "name": p.display_name,
+                    "slug": p.slug,
+                    "session_count": p.session_count,
+                    "total_size_bytes": p.total_size_bytes,
+                    "earliest_session": (
+                        p.earliest_session.isoformat() if p.earliest_session else None
+                    ),
+                    "latest_session": (
+                        p.latest_session.isoformat() if p.latest_session else None
+                    ),
+                }
+                for p in projects
+            ]
+        }
     print(format_json_output("list-projects", payload))
 
 
-def _list_sessions_table(project_slug: str) -> None:
+def _find_or_exit(project_slug: str) -> ProjectInfo:
+    """Look up a project by slug; print error and exit if not found."""
+    project = find_project(project_slug)
+    if project is None:
+        err_console.print(f"[red]Project not found: {project_slug}[/red]")
+        raise typer.Exit(code=1)
+    return project
+
+
+def _list_sessions_table(project_slug: str, *, verbose: bool, quiet: bool) -> None:
     """Display sessions for a project as a Rich table."""
-    project = find_project(project_slug)
-    if project is None:
-        err_console.print(f"[red]Project not found: {project_slug}[/red]")
-        raise typer.Exit(code=1)
-
+    project = _find_or_exit(project_slug)
+    if quiet:
+        console.print(f"Project {project.display_name}: {len(project.sessions)} sessions")
+        return
     sessions = [(s, len(parse_session(s.path))) for s in project.sessions]
-    format_sessions_table(console, project.display_name, sessions)
+    format_sessions_table(console, project.display_name, sessions, verbose=verbose)
 
 
-def _list_sessions_json(project_slug: str) -> None:
+def _list_sessions_json(project_slug: str, *, quiet: bool) -> None:
     """Output sessions for a project as JSON."""
-    project = find_project(project_slug)
-    if project is None:
-        err_console.print(f"[red]Project not found: {project_slug}[/red]")
-        raise typer.Exit(code=1)
-
-    sessions = []
-    for s in project.sessions:
-        messages = parse_session(s.path)
-        sessions.append(
-            {
-                "filename": s.filename,
-                "size_bytes": s.size_bytes,
-                "modified": s.modified.isoformat(),
-                "message_count": len(messages),
-                "subagent_count": s.subagent_count,
-            }
-        )
-    payload = {"project": project.display_name, "sessions": sessions}
+    project = _find_or_exit(project_slug)
+    if quiet:
+        payload: dict[str, object] = {
+            "project": project.display_name,
+            "session_count": len(project.sessions),
+        }
+    else:
+        sessions = []
+        for s in project.sessions:
+            messages = parse_session(s.path)
+            sessions.append(
+                {
+                    "filename": s.filename,
+                    "size_bytes": s.size_bytes,
+                    "modified": s.modified.isoformat(),
+                    "message_count": len(messages),
+                    "subagent_count": s.subagent_count,
+                }
+            )
+        payload = {"project": project.display_name, "sessions": sessions}
     print(format_json_output("list-sessions", payload))
 
 
@@ -125,13 +150,15 @@ def list_cmd(
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
     """List available projects, or sessions within a project."""
+    if verbose and quiet:
+        raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
     if project:
         if format == "json":
-            _list_sessions_json(project)
+            _list_sessions_json(project, quiet=quiet)
         else:
-            _list_sessions_table(project)
+            _list_sessions_table(project, verbose=verbose, quiet=quiet)
     else:
         if format == "json":
-            _list_projects_json()
+            _list_projects_json(quiet=quiet)
         else:
-            _list_projects_table()
+            _list_projects_table(verbose=verbose, quiet=quiet)

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from agentfluent.config.models import Severity
+
+if TYPE_CHECKING:
+    from agentfluent.config.models import ConfigScore
 
 SEVERITY_COLORS: dict[Severity, str] = {
     Severity.CRITICAL: "red",
@@ -48,3 +52,8 @@ def score_color(score: int) -> str:
     if score >= 50:
         return "yellow"
     return "red"
+
+
+def average_score(scores: list[ConfigScore]) -> int:
+    """Integer average of overall_score across agents; 0 for an empty list."""
+    return sum(s.overall_score for s in scores) // len(scores) if scores else 0

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -15,6 +15,7 @@ from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
     SEVERITY_COLORS,
+    average_score,
     format_cost,
     format_date,
     format_size,
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 def format_projects_table(
     console: Console,
     projects: list[ProjectInfo],
+    *,
+    verbose: bool = False,
 ) -> None:
     """Render discovered projects as a Rich table."""
     if not projects:
@@ -43,14 +46,19 @@ def format_projects_table(
     table.add_column("Sessions", justify="right")
     table.add_column("Size", justify="right")
     table.add_column("Latest", style="dim")
+    if verbose:
+        table.add_column("Slug", style="dim")
 
     for p in projects:
-        table.add_row(
+        row = [
             p.display_name,
             str(p.session_count),
             format_size(p.total_size_bytes),
             format_date(p.latest_session),
-        )
+        ]
+        if verbose:
+            row.append(p.slug)
+        table.add_row(*row)
 
     console.print(table)
 
@@ -59,6 +67,8 @@ def format_sessions_table(
     console: Console,
     project_name: str,
     sessions: list[tuple[SessionInfo, int]],
+    *,
+    verbose: bool = False,
 ) -> None:
     """Render per-session stats as a Rich table.
 
@@ -70,7 +80,8 @@ def format_sessions_table(
         return
 
     table = Table(title=f"Sessions — {project_name}")
-    table.add_column("File", style="cyan")
+    file_label = "Path" if verbose else "File"
+    table.add_column(file_label, style="cyan")
     table.add_column("Size", justify="right")
     table.add_column("Modified", style="dim")
     table.add_column("Messages", justify="right")
@@ -78,7 +89,7 @@ def format_sessions_table(
 
     for info, message_count in sessions:
         table.add_row(
-            info.filename,
+            str(info.path) if verbose else info.filename,
             format_size(info.size_bytes),
             format_date(info.modified),
             str(message_count),
@@ -171,6 +182,43 @@ def format_analysis_table(
             "",
         )
         console.print(agent_table)
+
+    if verbose and len(result.sessions) > 1:
+        session_table = Table(title="Per-Session Breakdown", show_header=True)
+        session_table.add_column("Session", style="cyan")
+        session_table.add_column("Tokens", justify="right")
+        session_table.add_column("Cost", justify="right")
+        session_table.add_column("Tool calls", justify="right")
+        session_table.add_column("Invocations", justify="right")
+        for s in result.sessions:
+            session_table.add_row(
+                s.session_path.name,
+                format_tokens(s.token_metrics.total_tokens),
+                format_cost(s.token_metrics.total_cost),
+                str(s.tool_metrics.total_tool_calls),
+                str(s.agent_metrics.total_invocations),
+            )
+        console.print(session_table)
+
+    if verbose and am.total_invocations > 0:
+        inv_table = Table(title="Per-Invocation Detail", show_header=True)
+        inv_table.add_column("Agent", style="cyan")
+        inv_table.add_column("Description")
+        inv_table.add_column("Tokens", justify="right")
+        inv_table.add_column("Tool uses", justify="right")
+        inv_table.add_column("Duration", justify="right")
+        for s in result.sessions:
+            for inv in s.invocations:
+                tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
+                tools = str(inv.tool_uses) if inv.tool_uses else "-"
+                duration = f"{inv.duration_ms / 1000:.1f}s" if inv.duration_ms else "-"
+                desc = (
+                    inv.description
+                    if len(inv.description) <= 60
+                    else inv.description[:57] + "..."
+                )
+                inv_table.add_row(inv.agent_type, desc, tokens, tools, duration)
+        console.print(inv_table)
 
     diag = result.diagnostics
     if diag:
@@ -303,9 +351,8 @@ def format_config_check_table(
             rec_table.add_row(*row)
         console.print(rec_table)
 
-    avg = sum(s.overall_score for s in scores) // len(scores) if scores else 0
     console.print(
         f"\n[bold]Agents scanned:[/bold] {len(scores)}, "
-        f"[bold]average score:[/bold] {avg}/100, "
+        f"[bold]average score:[/bold] {average_score(scores)}/100, "
         f"[bold]recommendations:[/bold] {len(all_recs)}"
     )


### PR DESCRIPTION
Closes #40.

## Summary

Verbose/quiet output modes across all three commands, in both table and JSON. Flags are mutually exclusive (rejected via `typer.BadParameter`, exit code 2).

### Per-command behavior

**`list`**
- `--verbose` (projects): adds a `Slug` column to the projects table
- `--verbose` (sessions): swaps filename → full `Path` column
- `--quiet` (projects): `"N projects, M total sessions"`
- `--quiet` (sessions): `"Project X: N sessions"` — also skips `parse_session()` per session (real efficiency win)

**`analyze`**
- `--verbose`: adds `Per-Session Breakdown` (only when >1 session) and `Per-Invocation Detail` tables alongside existing token/tool/agent tables
- `--quiet`: one-line `"Project X: \$Y.YY cost, N tokens, M agent invocations, K diagnostic signals"`

**`config-check`**
- `--verbose`: already shows `suggested_action` column in recommendations (kept as-is per AC)
- `--quiet`: already matches spec (kept as-is)

### JSON quiet shapes (new)

- `list-projects` quiet: `{project_count, total_sessions}`
- `list-sessions` quiet: `{project, session_count}`
- `analyze` quiet: `{project, session_count, total_cost, total_tokens, total_invocations, diagnostic_signal_count}`
- `config-check` quiet: `{agent_count, average_score, recommendation_count}`

Verbose JSON = default JSON (full tree already includes per-session/per-invocation detail).

### Incidental cleanup (from `/simplify`)

- Extracted `average_score(scores)` to `formatters/helpers.py` — consolidates 3 duplicated inlined expressions.
- Renamed `diagnostic_signals` → `diagnostic_signal_count` for consistent `*_count` naming across quiet JSON payloads.

## Test plan

- [x] `uv run pytest -m \"not integration\"` → 225 passed
- [x] `uv run ruff check src/` clean
- [x] `uv run mypy src/agentfluent/` clean
- [x] `agentfluent list --verbose --quiet` → exit 2, BadParameter message
- [x] `agentfluent list --quiet --format json | jq '.data.project_count'` → 7
- [x] `agentfluent list --project <slug> --quiet` → `Project X: N sessions` (no JSONL parse)
- [x] `agentfluent analyze --project <slug> --latest 1 --quiet` → one-line cost summary
- [x] `agentfluent analyze --project <slug> --latest 1 --quiet --format json | jq '.data.diagnostic_signal_count'` → 0
- [x] `agentfluent analyze --project <slug> --verbose` → renders Per-Session Breakdown + Per-Invocation Detail tables
- [x] `agentfluent config-check --quiet --format json | jq '.data.average_score'` → matches existing quiet output

Envelope / ANSI / exit-code tests are deferred to #41 (its explicit scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)