### PR TITLE
test: CLI output tests + exit code normalization (#41)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
+from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.helpers import format_cost, format_tokens
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
@@ -117,19 +118,19 @@ def analyze(
     if project_info is None:
         err_console.print(f"[red]Project not found:[/red] {project}")
         err_console.print("Use [bold]agentfluent list[/bold] to see available projects.")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=EXIT_USER_ERROR)
 
     session_infos = project_info.sessions
     if not session_infos:
         name = project_info.display_name
         err_console.print(f"[yellow]No sessions found for project:[/yellow] {name}")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=EXIT_NO_DATA)
 
     if session:
         session_infos = [s for s in session_infos if s.filename == session]
         if not session_infos:
             err_console.print(f"[red]Session not found:[/red] {session}")
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=EXIT_USER_ERROR)
 
     if latest is not None and latest > 0:
         session_infos = session_infos[:latest]

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.helpers import average_score
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_config_check_table
@@ -86,20 +87,20 @@ def config_check(
     if scope not in ("user", "project", "all"):
         err_console.print(f"[red]Invalid scope:[/red] {scope}")
         err_console.print("Valid scopes: user, project, all")
-        raise typer.Exit(code=2)
+        raise typer.Exit(code=EXIT_USER_ERROR)
 
     scores = assess_agents(scope, agent_filter=agent)
 
     if not scores:
         if agent:
             err_console.print(f"[yellow]No agent found named:[/yellow] {agent}")
-        else:
-            err_console.print("[yellow]No agent definition files found.[/yellow]")
-            err_console.print(
-                "Agent definitions are `.md` files in "
-                "`~/.claude/agents/` (user) or `.claude/agents/` (project)."
-            )
-        raise typer.Exit(code=2)
+            raise typer.Exit(code=EXIT_USER_ERROR)
+        err_console.print("[yellow]No agent definition files found.[/yellow]")
+        err_console.print(
+            "Agent definitions are `.md` files in "
+            "`~/.claude/agents/` (user) or `.claude/agents/` (project)."
+        )
+        raise typer.Exit(code=EXIT_NO_DATA)
 
     if format == "json":
         _print_json(scores, quiet=quiet)

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import (
     format_projects_table,
@@ -46,7 +47,7 @@ def _discover_or_exit() -> list[ProjectInfo]:
         return discover_projects()
     except FileNotFoundError as e:
         err_console.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=EXIT_NO_DATA) from None
 
 
 def _list_projects_table(*, verbose: bool, quiet: bool) -> None:
@@ -93,7 +94,7 @@ def _find_or_exit(project_slug: str) -> ProjectInfo:
     project = find_project(project_slug)
     if project is None:
         err_console.print(f"[red]Project not found: {project_slug}[/red]")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_USER_ERROR)
     return project
 
 

--- a/src/agentfluent/cli/exit_codes.py
+++ b/src/agentfluent/cli/exit_codes.py
@@ -1,0 +1,18 @@
+"""Exit code invariant for AgentFluent commands.
+
+0 = success.
+1 = user named something specific and it's wrong (bad project slug, unknown
+    session, unknown agent name, invalid scope value).
+2 = system searched and found nothing (no projects dir, project has no
+    sessions, no agent definitions found).
+
+`typer.BadParameter` exits 2 by Click convention for argument-level usage
+errors (e.g., `--verbose --quiet` together). That's a framework-handled
+separate category and does not fold into the invariant above.
+"""
+
+from __future__ import annotations
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+EXIT_NO_DATA = 2

--- a/src/agentfluent/cli/formatters/json_output.py
+++ b/src/agentfluent/cli/formatters/json_output.py
@@ -30,3 +30,31 @@ def format_json_output(command: CommandName, data: Any) -> str:
         "data": data,
     }
     return json.dumps(envelope, indent=2, default=str)
+
+
+def parse_json_output(
+    text: str, *, expected_command: CommandName | None = None,
+) -> Any:
+    """Validate the envelope and return its `data` payload.
+
+    Raises ValueError on schema violation (missing keys, wrong version,
+    wrong command).
+    """
+    envelope = json.loads(text)
+    missing = {"version", "command", "data"} - envelope.keys()
+    if missing:
+        msg = f"JSON envelope missing keys: {sorted(missing)}"
+        raise ValueError(msg)
+    if envelope["version"] != SCHEMA_VERSION:
+        msg = (
+            f"JSON envelope version {envelope['version']!r} does not match "
+            f"SCHEMA_VERSION {SCHEMA_VERSION!r}"
+        )
+        raise ValueError(msg)
+    if expected_command is not None and envelope["command"] != expected_command:
+        msg = (
+            f"JSON envelope command {envelope['command']!r} does not match "
+            f"expected {expected_command!r}"
+        )
+        raise ValueError(msg)
+    return envelope["data"]

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,67 @@
+"""Fixtures for CLI tests: isolated home directory + CliRunner."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.main import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """Click/Typer test runner. Click 8.2+ always separates stderr by default."""
+    return CliRunner()
+
+
+@pytest.fixture()
+def cli_app() -> typer.Typer:
+    """The top-level Typer app under test."""
+    return app
+
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ~/.claude/projects/ and ~/.claude/agents/ to a tmp dir.
+
+    Returns the root tmp dir; caller can populate `projects/` and `agents/`
+    subdirs as needed. The chdir is load-bearing: `scan_agents()` also
+    resolves project-scope agents relative to cwd, so we block that path
+    by pointing cwd at a tree with no `.claude/agents/` subdir.
+    """
+    projects_dir = tmp_path / "projects"
+    user_agents_dir = tmp_path / "agents"
+    projects_dir.mkdir()
+    user_agents_dir.mkdir()
+
+    monkeypatch.setattr(
+        "agentfluent.core.discovery.DEFAULT_PROJECTS_DIR", projects_dir,
+    )
+    monkeypatch.setattr(
+        "agentfluent.config.scanner.DEFAULT_USER_AGENTS_DIR", user_agents_dir,
+    )
+    monkeypatch.chdir(tmp_path)
+
+    return tmp_path
+
+
+@pytest.fixture()
+def populated_home(isolated_home: Path, fixtures_dir: Path) -> Path:
+    """Isolated home with one project (one session) and one user agent.
+
+    The project directory is named `-home-user-test-project` so that
+    `discovery.slug_to_display_name()` derives the display name `"project"`
+    (the last dash-separated segment). Tests use `--project project`.
+    """
+    project_dir = isolated_home / "projects" / "-home-user-test-project"
+    project_dir.mkdir()
+    shutil.copy(fixtures_dir / "session_basic.jsonl", project_dir / "session-1.jsonl")
+
+    agent_file = isolated_home / "agents" / "well-configured.md"
+    shutil.copy(fixtures_dir / "agents" / "well_configured.md", agent_file)
+
+    return isolated_home

--- a/tests/unit/cli/test_exit_codes.py
+++ b/tests/unit/cli/test_exit_codes.py
@@ -1,0 +1,108 @@
+"""Exit code contract tests.
+
+The invariant: user named something specific and it's wrong = 1;
+system searched and found nothing = 2. `typer.BadParameter` exits 2
+by Click convention; that's intentional and out of the invariant's scope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_OK, EXIT_USER_ERROR
+
+
+class TestListExitCodes:
+    def test_success_lists_projects(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list"])
+        assert result.exit_code == EXIT_OK
+
+    def test_missing_project(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--project", "does-not-exist"])
+        assert result.exit_code == EXIT_USER_ERROR
+
+    def test_no_projects_dir(
+        self, runner: CliRunner, cli_app: typer.Typer, isolated_home: Path,
+    ) -> None:
+        (isolated_home / "projects").rmdir()
+        result = runner.invoke(cli_app, ["list"])
+        assert result.exit_code == EXIT_NO_DATA
+
+
+class TestAnalyzeExitCodes:
+    def test_success(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--project", "project"])
+        assert result.exit_code == EXIT_OK
+
+    def test_missing_project(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "does-not-exist"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+
+    def test_missing_named_session(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--session", "no-such.jsonl"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+
+    def test_project_with_no_sessions(
+        self, runner: CliRunner, cli_app: typer.Typer, isolated_home: Path,
+    ) -> None:
+        empty_project = isolated_home / "projects" / "-home-user-empty"
+        empty_project.mkdir()
+        result = runner.invoke(cli_app, ["analyze", "--project", "empty"])
+        assert result.exit_code == EXIT_NO_DATA
+
+
+class TestConfigCheckExitCodes:
+    def test_success(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--scope", "user"])
+        assert result.exit_code == EXIT_OK
+
+    def test_invalid_scope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--scope", "nonsense"])
+        assert result.exit_code == EXIT_USER_ERROR
+
+    def test_missing_named_agent(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["config-check", "--agent", "does-not-exist"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+
+    def test_no_agents_found(
+        self, runner: CliRunner, cli_app: typer.Typer, isolated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--scope", "user"])
+        assert result.exit_code == EXIT_NO_DATA
+
+
+class TestBadParameter:
+    """Typer's BadParameter exits 2 by Click convention. Documented exception."""
+
+    def test_verbose_and_quiet_exits_2(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--verbose", "--quiet"])
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr

--- a/tests/unit/cli/test_help.py
+++ b/tests/unit/cli/test_help.py
@@ -1,0 +1,45 @@
+"""Top-level --help / --version and per-command --help examples."""
+
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent import __version__
+
+
+class TestVersion:
+    def test_version_flag(self, runner: CliRunner, cli_app: typer.Typer) -> None:
+        result = runner.invoke(cli_app, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.stdout
+
+
+class TestHelp:
+    def test_top_level_help(self, runner: CliRunner, cli_app: typer.Typer) -> None:
+        result = runner.invoke(cli_app, ["--help"])
+        assert result.exit_code == 0
+        assert "list" in result.stdout
+        assert "analyze" in result.stdout
+        assert "config-check" in result.stdout
+
+    def test_list_help_has_examples(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--help"])
+        assert result.exit_code == 0
+        assert "Examples" in result.stdout
+
+    def test_analyze_help_has_examples(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--help"])
+        assert result.exit_code == 0
+        assert "Examples" in result.stdout
+
+    def test_config_check_help_has_examples(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--help"])
+        assert result.exit_code == 0
+        assert "Examples" in result.stdout

--- a/tests/unit/cli/test_json_output.py
+++ b/tests/unit/cli/test_json_output.py
@@ -1,0 +1,104 @@
+"""JSON envelope schema + ANSI-escape tests (#39 contract)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.formatters.json_output import parse_json_output
+
+ANSI_ESC = "\x1b"
+
+
+def _assert_clean_envelope(stdout: str, expected_command: str) -> object:
+    """Assert no ANSI escapes, valid envelope, expected command; return data."""
+    assert ANSI_ESC not in stdout, "JSON output must not contain ANSI escape sequences"
+    return parse_json_output(stdout, expected_command=expected_command)  # type: ignore[arg-type]
+
+
+class TestListJsonEnvelope:
+    def test_projects_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--format", "json"])
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "list-projects")
+        assert "projects" in data
+
+    def test_sessions_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["list", "--project", "project", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "list-sessions")
+        assert "sessions" in data
+
+    def test_projects_quiet_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--format", "json", "--quiet"])
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "list-projects")
+        assert data == {"project_count": 1, "total_sessions": 1}
+
+
+class TestAnalyzeJsonEnvelope:
+    def test_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "analyze")
+        assert "token_metrics" in data
+        assert "sessions" in data
+
+    def test_quiet_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--format", "json", "--quiet"],
+        )
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "analyze")
+        assert set(data.keys()) == {
+            "project",
+            "session_count",
+            "total_cost",
+            "total_tokens",
+            "total_invocations",
+            "diagnostic_signal_count",
+        }
+
+
+class TestConfigCheckJsonEnvelope:
+    def test_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["config-check", "--scope", "user", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "config-check")
+        assert "scores" in data
+
+    def test_quiet_envelope(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["config-check", "--scope", "user", "--format", "json", "--quiet"],
+        )
+        assert result.exit_code == 0
+        data = _assert_clean_envelope(result.stdout, "config-check")
+        assert set(data.keys()) == {
+            "agent_count",
+            "average_score",
+            "recommendation_count",
+        }

--- a/tests/unit/cli/test_output_modes.py
+++ b/tests/unit/cli/test_output_modes.py
@@ -1,0 +1,73 @@
+"""Verbose/quiet mode tests: line count + mutual exclusivity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+def _visible_line_count(output: str) -> int:
+    """Count non-empty lines from command output."""
+    return sum(1 for line in output.splitlines() if line.strip())
+
+
+class TestQuietLineCount:
+    """AC: --quiet output is <= 5 lines."""
+
+    def test_list_projects(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--quiet"])
+        assert result.exit_code == 0
+        assert _visible_line_count(result.stdout) <= 5
+
+    def test_list_sessions(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--project", "project", "--quiet"])
+        assert result.exit_code == 0
+        assert _visible_line_count(result.stdout) <= 5
+
+    def test_analyze(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--quiet"],
+        )
+        assert result.exit_code == 0
+        assert _visible_line_count(result.stdout) <= 5
+
+    def test_config_check(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--scope", "user", "--quiet"])
+        assert result.exit_code == 0
+        assert _visible_line_count(result.stdout) <= 5
+
+
+class TestVerboseQuietMutualExclusion:
+    def test_list(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--verbose", "--quiet"])
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr
+
+    def test_analyze(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--verbose", "--quiet"],
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr
+
+    def test_config_check(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--verbose", "--quiet"])
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr


### PR DESCRIPTION
Closes #41. Completes epic E7 (CLI output and formatting, #7).

## Summary

31 new CliRunner-driven tests in \`tests/unit/cli/\` covering every AC in #41:
- Exit codes 0/1/2 per command
- JSON envelope schema (\`version\`, \`command\`, \`data\` keys; SCHEMA_VERSION match)
- No ANSI escapes in \`--format json\` output
- \`--quiet\` output <= 5 lines
- \`--verbose\` + \`--quiet\` raises BadParameter (exit 2)
- \`--version\` prints version
- Each command's \`--help\` includes an Examples section

## Exit code normalization

Per architect review ([comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/41#issuecomment-4266483727)), the six inconsistent exit codes in commands were fixed to match a single invariant **before** writing the tests, so tests codify correct behavior rather than baking in the drift:

> User named something specific and it's wrong = 1; system searched and found nothing = 2.

Changes:
- \`list\`: \`FileNotFoundError\` on projects dir 1 → 2 (system found nothing)
- \`analyze\`: project not found 2 → 1; session not found 2 → 1 (user errors)
- \`config-check\`: invalid scope 2 → 1; named agent not found 2 → 1 (user errors)

\`typer.BadParameter\` keeps its Click-convention exit 2 for argument-level usage errors (\`--verbose --quiet\`) — documented as an out-of-invariant exception in \`cli/exit_codes.py\`.

## Incidental improvements

- \`src/agentfluent/cli/exit_codes.py\`: \`EXIT_OK\` / \`EXIT_USER_ERROR\` / \`EXIT_NO_DATA\` constants with docstring explaining the invariant; replaces 6 literal exit codes in commands and 9 in tests.
- \`parse_json_output()\` helper added alongside \`format_json_output()\` — symmetric parser that validates envelope shape, version, and (optionally) command. Tests use it directly; gives external CLI consumers a documented parse path.
- Test isolation: monkeypatches \`DEFAULT_PROJECTS_DIR\` + \`DEFAULT_USER_AGENTS_DIR\` + chdir (the last blocks project-scoped agent discovery that resolves off cwd).

## Test plan

- [x] \`uv run pytest -m \"not integration\"\` → 256 passed (was 225; +31 new)
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run mypy src/agentfluent/\` clean
- [x] New tests cover every AC item in #41
- [x] Exit code invariant holds across all three commands
- [x] Envelope validated via \`parse_json_output\` (rejects missing keys / wrong version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)