### PR TITLE
feat(security): add secrets-protection hooks for Claude Code sessions

### DIFF
--- a/.claude/hooks/block_secret_reads.py
+++ b/.claude/hooks/block_secret_reads.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block reads of files likely to contain credentials.
+
+Receives the PreToolUse event JSON on stdin. Denies the tool call when the
+target file path (or Bash command argument) matches known credential files:
+.env variants, shell rc files, SSH private keys, and named secrets files.
+
+Emits a JSON decision on stdout and exits 0 (the modern pattern); exit 2
++ stderr is the legacy fallback but not used here.
+
+Cross-platform: stdlib only, no shell dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import PurePath
+
+# The BLOCKED_BASENAMES set and the CREDENTIAL_TOKEN_PATTERNS list must stay in
+# sync — they express the same credential-file list in two matching contexts
+# (exact basename vs. substring-in-command-or-pattern). Update both together.
+BLOCKED_BASENAMES: frozenset[str] = frozenset(
+    {
+        ".env",
+        ".envrc",
+        "credentials",
+        "credentials.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "secrets.json",
+        ".bashrc",
+        ".bash_profile",
+        ".profile",
+        ".zshrc",
+        ".zshenv",
+        ".zprofile",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "id_dsa",
+    }
+)
+
+BLOCKED_SUFFIXES: frozenset[str] = frozenset({".pem"})
+
+CREDENTIAL_TOKEN_PATTERNS: list[str] = [
+    r"\.env(\b|[._-][A-Za-z0-9_-]+)",
+    r"\.envrc\b",
+    r"credentials\.json\b",
+    r"secrets\.ya?ml\b",
+    r"secrets\.json\b",
+    r"\.bashrc\b",
+    r"\.bash_profile\b",
+    r"\.profile\b",
+    r"\.zshrc\b",
+    r"\.zshenv\b",
+    r"\.zprofile\b",
+    r"\bid_rsa\b",
+    r"\bid_ed25519\b",
+    r"\bid_ecdsa\b",
+    r"\bid_dsa\b",
+    r"\.pem\b",
+]
+CREDENTIAL_TOKEN_REGEX = re.compile("|".join(CREDENTIAL_TOKEN_PATTERNS), re.IGNORECASE)
+
+FILE_PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
+PATH_SEARCH_TOOLS = {"Grep", "Glob"}
+
+DENY_REASON = (
+    "Blocked by AgentFluent secrets-protection hook (.claude/hooks/block_secret_reads.py). "
+    "This file is a likely credential source (.env, shell rc, SSH key, or named secrets file). "
+    "Reading it would persist its contents in the Claude Code session JSONL. "
+    "If you need to verify the file exists, use `test -f <path>`. "
+    "See docs/SECURITY.md for the full policy."
+)
+
+
+def path_is_blocked(path_str: str) -> bool:
+    if not path_str:
+        return False
+    p = PurePath(path_str)
+    name = p.name
+    if name in BLOCKED_BASENAMES:
+        return True
+    if p.suffix in BLOCKED_SUFFIXES:
+        return True
+    if name.startswith((".env.", ".env-", ".env_")):
+        return True
+    return False
+
+
+def bash_command_is_blocked(command: str) -> bool:
+    if not command:
+        return False
+    return CREDENTIAL_TOKEN_REGEX.search(command) is not None
+
+
+def check(event: dict) -> tuple[bool, str]:
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input") or {}
+
+    if tool_name in FILE_PATH_TOOLS:
+        path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+        if path_is_blocked(path):
+            return True, f"{DENY_REASON} (path: {path})"
+
+    if tool_name in PATH_SEARCH_TOOLS:
+        path = tool_input.get("path") or ""
+        pattern = tool_input.get("pattern") or ""
+        if path and path_is_blocked(path):
+            return True, f"{DENY_REASON} (search path: {path})"
+        if pattern and CREDENTIAL_TOKEN_REGEX.search(pattern):
+            return True, f"{DENY_REASON} (search pattern targets credential file: {pattern})"
+
+    if tool_name == "Bash":
+        command = tool_input.get("command") or ""
+        if bash_command_is_blocked(command):
+            return True, f"{DENY_REASON} (command: {command[:200]})"
+
+    return False, ""
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        # Fail closed: this is a security-critical PreToolUse hook. If we can't
+        # parse the event we cannot confirm the call is safe, so deny rather
+        # than allow through a malformed event of unknown provenance.
+        print(
+            f"block_secret_reads: failed to parse hook event JSON, denying by default: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    blocked, reason = check(event)
+    if blocked:
+        emit_decision("deny", reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/detect_secrets_in_output.py
+++ b/.claude/hooks/detect_secrets_in_output.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: block Claude from reasoning about tool output with secrets.
+
+PostToolUse cannot redact non-MCP tool output inline. Instead, this hook uses
+the detect-and-block pattern: if the tool response contains a known API key
+or token pattern, it emits `{"decision": "block", "reason": ...}` so Claude
+Code surfaces a block signal alongside the result and Claude knows not to
+echo, summarize, or otherwise act on the leaked value.
+
+Caveat: PostToolUse fires AFTER the tool has executed. The raw output is
+already persisted in the session JSONL, and Claude still technically receives
+the tool_result in-session. This hook prevents further propagation (summaries,
+follow-up prompts quoting the value) but does NOT prevent the on-disk leak.
+The PreToolUse block_secret_reads.py hook is the primary defense against
+on-disk leakage; this is a secondary guard.
+
+Cross-platform: stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), "anthropic-key"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}"), "openai-project-key"),
+    (re.compile(r"sk-[A-Za-z0-9]{40,}"), "openai-key-legacy"),
+    (re.compile(r"ghp_[A-Za-z0-9]{30,}"), "github-pat-classic"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{40,}"), "github-pat-fine"),
+    (re.compile(r"AKIA[A-Z0-9]{16}"), "aws-access-key-id"),
+    (re.compile(r"AIza[A-Za-z0-9_-]{35}"), "gcp-api-key"),
+]
+
+DENY_REASON_TEMPLATE = (
+    "Blocked by AgentFluent secrets-protection hook "
+    "(.claude/hooks/detect_secrets_in_output.py). "
+    "Tool output contained a value matching a known credential pattern: {kinds}. "
+    "Claude is being prevented from reasoning about this output to avoid further "
+    "propagation (e.g. echoing in summaries). "
+    "IMPORTANT: the raw value has already been persisted in the session JSONL "
+    "because PostToolUse fires after tool execution. Rotate any key that may have "
+    "leaked and see docs/SECURITY.md for full remediation steps."
+)
+
+
+def stringify_response(resp: object) -> str:
+    """Coerce tool_response (dict, list, str, etc.) into a single searchable string."""
+    if isinstance(resp, str):
+        return resp
+    try:
+        return json.dumps(resp, default=str)
+    except (TypeError, ValueError):
+        return str(resp)
+
+
+def find_secret_kinds(text: str) -> list[str]:
+    kinds: list[str] = []
+    for pattern, label in SECRET_PATTERNS:
+        if pattern.search(text):
+            kinds.append(label)
+    return kinds
+
+
+def emit_block(reason: str) -> None:
+    payload = {"decision": "block", "reason": reason}
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(
+            f"detect_secrets_in_output: failed to parse hook event JSON: {e}",
+            file=sys.stderr,
+        )
+        return 0
+
+    response = event.get("tool_response")
+    if response is None:
+        return 0
+
+    text = stringify_response(response)
+    kinds = find_secret_kinds(text)
+    if kinds:
+        reason = DENY_REASON_TEMPLATE.format(kinds=", ".join(sorted(set(kinds))))
+        emit_block(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,27 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write|Grep|Glob|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block_secret_reads.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/detect_secrets_in_output.py"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,17 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 - **Integration tests:** `tests/integration/` -- marked with `@pytest.mark.integration`, run against real `~/.claude/projects/` data, skipped in CI
 - **CI runs:** `pytest -m "not integration"` (unit tests only)
 
+## Secrets handling
+
+Do not read `.env`, `.envrc`, `credentials.json`, `secrets.ya?ml`, SSH private keys (`id_rsa`, `id_ed25519`, `*.pem`), or shell rc files (`.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, `.zprofile`). Anything you read via Read, Bash (`cat`, `grep`, `source`), or Grep is persisted verbatim in the Claude Code session JSONL at `~/.claude/projects/<slug>/*.jsonl`, where it stays in plaintext forever — `.gitignore` does not protect against this.
+
+Two hooks enforce this:
+
+- **`.claude/hooks/block_secret_reads.py`** (PreToolUse) — denies Read/Edit/Write/Grep/Glob/NotebookEdit/Bash calls targeting the filenames above. If you see a block message from this hook, the read was prevented *before* it executed, so nothing leaked.
+- **`.claude/hooks/detect_secrets_in_output.py`** (PostToolUse) — scans Read/Grep/Bash output for known secret patterns (`sk-ant-*`, `sk-proj-*`, `ghp_*`, `github_pat_*`, `AKIA*`, `AIza*`). If you see a block message from this hook, it means the tool already executed and the raw value was persisted to the JSONL transcript. You did not see the value, but it is on disk — report to the user that the key is compromised and should be rotated. Do not retry the same command.
+
+The rule generalizes beyond what the hooks catch: if a tool result happens to contain credential-looking values, never echo them in replies; do not emit generated code that prints env vars matching `KEY|TOKEN|SECRET|PASSWORD`; if you need to verify a credential file exists, use `test -f <path>` rather than reading it. See [`docs/SECURITY.md`](docs/SECURITY.md) for the full policy, the layered defense model, and the bypass surface the hooks do not cover.
+
 ## JSONL Data Format
 
 Claude Code and Agent SDK sessions are stored at `~/.claude/projects/` as JSONL files. AgentFluent's analysis targets differ from CodeFluent's -- we care about agent behavior signals, not human fluency signals.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ See `docs/AGENT_ANALYTICS_RESEARCH.md` for the full market analysis and technica
 ## Status
 
 Early stage -- defining scope, architecture, and initial backlog.
+
+## Secrets handling
+
+AgentFluent reads local Claude Code session data from `~/.claude/projects/`. Those JSONL files can contain any file contents Claude (or its subagents) has ever read during a session -- including `.env` files, shell rc files, and other credential sources. `.gitignore` does not protect against this persistence.
+
+This repo ships Claude Code hooks (`.claude/settings.json` + `.claude/hooks/`) that block reads of common credential files and detect known API key patterns in tool output. See [`docs/SECURITY.md`](docs/SECURITY.md) for the leak vector, the layered defense, how to audit your existing session store for historical leaks, and the discipline rules that pair with the hooks.
+
+AgentFluent itself emits only aggregate metrics today, but the rule is forward-looking: any future feature that surfaces raw session content must re-apply secret-pattern redaction at the display layer.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,151 @@
+# Secrets handling for AgentFluent and Claude Code
+
+This document is the canonical reference for protecting API keys and other credentials from leaking into Claude Code's local session store. It applies whether you are developing AgentFluent or using it to analyze your own Claude Code sessions.
+
+## The leak vector
+
+Claude Code persists every tool call and its output to a JSONL transcript at `~/.claude/projects/<project-slug>/<session-id>.jsonl`. When Claude (or any of its subagents) reads a file containing secrets — a `.env`, a `credentials.json`, an SSH private key, or a shell rc file that exports `ANTHROPIC_API_KEY` — the file's contents land in two places in that transcript:
+
+- `.toolUseResult.stdout` — the raw tool output
+- `.message.content[0].content` — the tool_result block fed back to the model
+
+Both copies are plaintext and permanent. `.gitignore` prevents the file from being committed to git. It does **not** prevent Claude Code from persisting its contents locally.
+
+This is not a Claude Code bug. Session persistence is a product feature — you want Claude to remember what it saw. The problem is only that credentials are in the set of things Claude sometimes sees.
+
+## Defense-in-depth architecture
+
+AgentFluent ships two Claude Code hooks in `.claude/settings.json` to reduce this risk:
+
+### PreToolUse block (primary defense)
+
+Script: `.claude/hooks/block_secret_reads.py`
+
+Denies Read, Edit, Write, Grep, Glob, NotebookEdit, and Bash tool calls whose target file path (or Bash command text) matches a list of known credential-file patterns:
+
+- `.env`, `.env.*`, `.envrc`
+- `credentials`, `credentials.json`
+- `secrets.yaml`, `secrets.yml`, `secrets.json`
+- `*.pem`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`
+- `.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, `.zprofile`
+
+**This is the only layer that actually prevents the on-disk leak.** Because it blocks the tool call before it executes, the file's contents never enter the JSONL transcript.
+
+### PostToolUse detect-and-block (secondary defense)
+
+Script: `.claude/hooks/detect_secrets_in_output.py`
+
+Scans Read, Grep, and Bash tool output for known API key patterns (`sk-ant-*`, `sk-proj-*`, `ghp_*`, `github_pat_*`, `AKIA*`, `AIza*`). If a match is found, the hook emits a block signal that tells Claude not to reason about, echo, or summarize the output, even though the tool result itself still arrives in-session (PostToolUse fires after execution — Claude technically receives the output and then the block signal on top of it).
+
+**Important caveat.** PostToolUse fires *after* the tool has already executed, which means the raw output has already been written to the JSONL transcript. This layer prevents Claude from reasoning about the leaked value in the current session (which stops it from propagating into summaries or follow-up prompts), but it does **not** prevent the on-disk leak. For that, only the PreToolUse layer works.
+
+If a PostToolUse block fires, treat the underlying value as compromised and rotate it. The fact that it leaked once means it is in your local JSONL store forever.
+
+### Known bypass surface (documented, accepted)
+
+The hooks use pattern matching, which is not airtight. These cases are not caught:
+
+- Glob expansion: `cat .e*` or `cat ~/.env*`
+- Heredoc / Python tricks: `python -c "print(open('.env').read())"`
+- Indirection through a shell variable whose name does not contain `.env`
+- Base64-encoded or otherwise obfuscated filenames
+
+The hook is defense-in-depth against normal Claude usage, not a guarantee against a motivated adversary. Pair it with the discipline rules below.
+
+## Required discipline
+
+### Keep secrets in `.env` files only
+
+- Never `export ANTHROPIC_API_KEY=...` (or any other secret) in `.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, or `.zprofile`. Environment exports leak via `env` / `printenv` / any subprocess that prints its environment in an error message — independently of file-read hooks.
+- Store secrets in a per-project `.env` file. Load them into your application at startup (`python-dotenv`, `dotenv-rs`, `direnv` with explicit unload, etc.) — your code reads `.env`, Claude does not.
+- `.env` must be in `.gitignore`. That protects commits. The hook protects Claude's transcript.
+
+### Never paste raw secrets into Claude prompts
+
+No amount of hook configuration catches you pasting `sk-ant-...` into Claude's input. If you need Claude to debug credential handling, describe the shape of the value (`sk-ant-api03-<108 chars>`), never the value itself.
+
+### Rotate keys suspected of prior leakage
+
+If Claude read a `.env` or exported environment at any point before you installed these hooks, assume the key is leaked on disk. Rotate it:
+
+- Anthropic: <https://console.anthropic.com/settings/keys>
+- OpenAI: <https://platform.openai.com/api-keys>
+- GitHub: <https://github.com/settings/tokens> (classic) or <https://github.com/settings/personal-access-tokens/fine-grained>
+- AWS IAM: rotate the access key pair and revoke the old one.
+
+## Verifying the hook is active
+
+In a session in this repo, ask Claude to read a file named `.env` (create one with throwaway content for testing). The tool call should return a block message starting with `"Blocked by AgentFluent secrets-protection hook"`.
+
+You can also inspect the settings file directly:
+
+```bash
+cat .claude/settings.json
+```
+
+and confirm the `PreToolUse` and `PostToolUse` entries are present.
+
+## Auditing your existing session store for historical leaks
+
+Run this one-liner against `~/.claude/projects/` to surface any JSONL files that contain known secret patterns:
+
+```bash
+grep -rlE '(sk-ant-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|AKIA[A-Z0-9]{16}|AIza[A-Za-z0-9_-]{35})' ~/.claude/projects/ 2>/dev/null
+```
+
+If it returns matches, rotate every key that appears and then decide how to handle the on-disk copies (see next section).
+
+## Historical JSONL cleanup
+
+If the audit surfaces leaked keys in existing JSONL files, you have three options:
+
+1. **Leave the files alone.** After rotation, the leaked keys are inert — they no longer authenticate. Residual risk: someone with local filesystem access could see the old key values, which may be useful for forensic reconstruction of your history but grants no API access.
+2. **Scrub the affected JSONL in place.** Write a script that rewrites each line, redacting values matching the secret patterns. Preserves the session structure for tools like AgentFluent and CodeFluent that read this data. Risk: any bug in the scrubbing script could corrupt legitimate session data.
+3. **Delete the affected session files entirely.** Clean but loses the analysis history.
+
+The default recommendation is option 1 (leave alone, after rotation). Only choose scrubbing or deletion if you have a specific reason — e.g., you know you will share a backup of `~/.claude/` with someone who should not see the old values.
+
+## Deploying the hooks at user scope as well
+
+The hooks shipped in `.claude/settings.json` protect contributors working on this repo. They do not protect your other work in other projects. Mirror the same hook configuration into `~/.claude/settings.json` to cover every Claude Code session on your machine, regardless of project:
+
+```bash
+# One-time setup: copy the hook scripts to a user-scoped location
+mkdir -p ~/.claude/hooks
+cp .claude/hooks/block_secret_reads.py ~/.claude/hooks/
+cp .claude/hooks/detect_secrets_in_output.py ~/.claude/hooks/
+
+# Then add matching PreToolUse / PostToolUse entries to ~/.claude/settings.json,
+# pointing the `command` fields at ~/.claude/hooks/*.py with absolute paths.
+```
+
+### How project-level and user-level hooks interact
+
+Both scopes load. Per the Claude Code hooks documentation, *"all matching hooks run in parallel, and identical handlers are deduplicated automatically. Command hooks are deduplicated by command string."* That means:
+
+- If you copy the same hook configuration (same `command` string) into both `~/.claude/settings.json` and the project's `.claude/settings.json`, it runs once, not twice.
+- If the command strings differ (e.g. user-scope uses an absolute path like `python3 /home/you/.claude/hooks/block_secret_reads.py` while the project uses the relative path `python3 .claude/hooks/block_secret_reads.py`), both commands fire.
+
+Deploying at both scopes is safe and is the right move for layered coverage: project scope protects contributors on this repo; user scope protects every other Claude Code session on your machine.
+
+One subtlety: Claude Code's settings precedence rule — *"more specific scopes take precedence"* — applies to scalar settings like permissions (e.g. a project-scope `deny` overrides a user-scope `allow`). The hooks documentation describes its own merge behavior (parallel execution with command-string deduplication), which is why copying a hook into both scopes does not cause double execution.
+
+## Forward-compatibility rule for AgentFluent features
+
+Any future AgentFluent feature that surfaces raw session content to the user — verbose diagnostics, prompt diff viewers, regression analysis, recommendation engine snippets that quote session data — **must re-apply secret-pattern redaction at the display layer**.
+
+The reason: historical JSONL files on a user's machine may still contain leaked values from before the hooks were installed. A feature that reads session JSONL and shows text without redacting risks surfacing those historical leaks in UI output, log files, or exported reports.
+
+Implementers of such features should import and reuse the regex patterns from `.claude/hooks/detect_secrets_in_output.py` (or an equivalent helper extracted into the main codebase when the first consumer lands), rather than writing new pattern lists.
+
+## Scope limits
+
+These hooks protect the Claude-Code-transcript leak vector. They do not protect:
+
+- Secrets at rest on your filesystem (that is a filesystem permissions problem; use `chmod 600` on `.env` and similar)
+- Secrets in your shell history (`~/.bash_history`, `~/.zsh_history`)
+- Secrets logged by your own applications into log files
+- Secrets transmitted in network requests
+- Screen-capture or shoulder-surfing attacks
+
+For those threats, use the appropriate OS and application-level controls. This document and these hooks address only the narrow case of Claude Code persisting credentials into its session store.

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentfluent"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Closes #72. Ships two Claude Code hooks that prevent credentials from leaking into the local session JSONL store, plus canonical documentation.

- **PreToolUse** (`.claude/hooks/block_secret_reads.py`, primary defense): denies Read / Edit / Write / Grep / Glob / NotebookEdit / Bash tool calls targeting dotenv variants, shell rc files, named secrets files, SSH private keys, and `*.pem`. Fails closed on malformed event JSON.
- **PostToolUse** (`.claude/hooks/detect_secrets_in_output.py`, secondary defense): scans Read / Grep / Bash output for known API-key patterns (Anthropic, OpenAI, GitHub, AWS, GCP). Emits `{decision: block, reason: ...}` so Claude receives a block signal.
- **`docs/SECURITY.md`**: canonical policy — leak vector, layered defense, required discipline, rotation procedure, forward-compat rule for future features that surface raw session content.
- **`CLAUDE.md`**: `## Secrets handling` section so Claude generalizes beyond the pattern matcher.
- **`README.md`**: callout linking to SECURITY.md.

Architect review on the issue identified two corrections incorporated here: (1) PostToolUse cannot mutate non-MCP tool output inline, so the layer uses detect-and-block rather than inline redaction; (2) shell rc files are in the block list because credential exports there are a parallel leak vector independent of file reads.

Incidental: `uv.lock` version bumped 0.0.0 → 0.1.0 — release-please did not sync the lockfile in #69.

## Test plan

- [x] Unit tests for `block_secret_reads.py` — 12 cases pass (dotenv variants, shell rc files, SSH keys, pem, allow-list controls, malformed-JSON fail-closed)
- [x] Unit tests for `detect_secrets_in_output.py` — 7 cases pass (real event shapes for Read and Bash, secret patterns, clean output, missing/None response)
- [x] Live manual verification in this session:
  - PreToolUse blocks `Read` on `/tmp/hook-test/.env`
  - PreToolUse blocks `Bash` command containing `.env`
  - PreToolUse allows normal `Read` (README.md) and `Bash` (ls)
  - PostToolUse blocks `Read` of a file whose content contains `sk-ant-...`
- [x] Existing test suite: `uv run pytest -m "not integration"` — 256 passed, 0 regressions
- [x] Hook scripts compile cleanly (`python3 -m py_compile`)
- [x] `.claude/settings.json` is valid JSON
- [x] CI: `check` workflow passes on this PR

## Follow-ups (out of scope for this PR)

- Rotate both Anthropic API keys surfaced by the audit (user action: <https://console.anthropic.com/settings/keys>)
- Remove credential exports from `~/.bashrc` / `~/.profile` / `~/.zshrc` (user action; documented in SECURITY.md)
- File sister-repo issue in `frederick-douglas-pearce/codefluent` to mirror the hooks + docs (CodeFluent's risk is acute because it sends prompt content to the Anthropic API for scoring)
- Score for the presence of a `.env`-blocking hook as a config-maturity signal in AgentFluent's `config-check` rubric (v0.2+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
