### PR TITLE
feat: label cost output as API rate (#76)

### DIFF
--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -23,6 +23,12 @@ from agentfluent.cli.formatters.helpers import (
     score_color,
 )
 
+API_RATE_FOOTNOTE = (
+    "API rate — pay-per-token equivalent. "
+    "Subscription plans (Pro/Max/Team/Enterprise) have fixed monthly cost "
+    "independent of usage."
+)
+
 if TYPE_CHECKING:
     from agentfluent.analytics.pipeline import AnalysisResult
     from agentfluent.config.models import ConfigScore
@@ -119,13 +125,13 @@ def format_analysis_table(
     token_table.add_row("Cache creation tokens", format_tokens(tm.cache_creation_input_tokens))
     token_table.add_row("Cache read tokens", format_tokens(tm.cache_read_input_tokens))
     token_table.add_row("Total tokens", format_tokens(tm.total_tokens))
-    token_table.add_row("Total cost", format_cost(tm.total_cost))
+    token_table.add_row("Total cost (API rate)", format_cost(tm.total_cost))
     token_table.add_row("Cache efficiency", f"{tm.cache_efficiency}%")
     token_table.add_row("API calls", str(tm.api_call_count))
     console.print(token_table)
 
     if tm.by_model and (verbose or len(tm.by_model) > 1):
-        model_table = Table(title="Cost by Model", show_header=True)
+        model_table = Table(title="Cost by Model (API rate)", show_header=True)
         model_table.add_column("Model", style="cyan")
         model_table.add_column("Tokens", justify="right")
         model_table.add_column("Cost", justify="right")
@@ -187,7 +193,7 @@ def format_analysis_table(
         session_table = Table(title="Per-Session Breakdown", show_header=True)
         session_table.add_column("Session", style="cyan")
         session_table.add_column("Tokens", justify="right")
-        session_table.add_column("Cost", justify="right")
+        session_table.add_column("Cost (API rate)", justify="right")
         session_table.add_column("Tool calls", justify="right")
         session_table.add_column("Invocations", justify="right")
         for s in result.sessions:
@@ -219,6 +225,8 @@ def format_analysis_table(
                 )
                 inv_table.add_row(inv.agent_type, desc, tokens, tools, duration)
         console.print(inv_table)
+
+    console.print(API_RATE_FOOTNOTE, style="dim")
 
     diag = result.diagnostics
     if diag:

--- a/tests/unit/cli/test_cost_labeling.py
+++ b/tests/unit/cli/test_cost_labeling.py
@@ -1,0 +1,73 @@
+"""Cost-label UI tests (#76): verify API-rate labeling and footnote render.
+
+The JSON output schema still uses `total_cost` -- it is an API contract and
+must NOT change. Only the human-readable table labels get the "(API rate)"
+qualifier plus an explanatory footnote.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestCostLabeling:
+    """AC: table output labels cost as API-rate and prints the footnote."""
+
+    def test_total_cost_row_renamed(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--project", "project"])
+        assert result.exit_code == 0
+        assert "Total cost (API rate)" in result.stdout
+
+    def test_footnote_rendered(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--project", "project"])
+        assert result.exit_code == 0
+        assert "API rate" in result.stdout
+        assert "pay-per-token equivalent" in result.stdout
+        assert "Subscription plans" in result.stdout
+
+    def test_footnote_printed_once(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--verbose"],
+        )
+        assert result.exit_code == 0
+        # The footnote sentinel "pay-per-token equivalent" appears exactly once
+        # even in verbose mode where multiple cost-bearing tables render.
+        assert result.stdout.count("pay-per-token equivalent") == 1
+
+
+class TestJsonSchemaUnchanged:
+    """Guardrail: JSON output key stays `total_cost` -- API contract."""
+
+    def test_json_quiet_still_uses_total_cost_key(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--format", "json", "--quiet"],
+        )
+        assert result.exit_code == 0
+        assert '"total_cost"' in result.stdout
+        # The UI-layer label should not leak into JSON output.
+        assert "API rate" not in result.stdout


### PR DESCRIPTION
## Summary

- Rename `Total cost` row to `Total cost (API rate)` in the Token Usage table, `Cost by Model` title to `Cost by Model (API rate)`, and the Per-Session Breakdown `Cost` column to `Cost (API rate)`.
- Add a dim-styled footnote after the cost-bearing tables: "API rate — pay-per-token equivalent. Subscription plans (Pro/Max/Team/Enterprise) have fixed monthly cost independent of usage."
- JSON output schema is intentionally untouched — the `total_cost` key remains the API contract. Labeling change is UI-only.

The current "Total cost" figure reflects pay-per-token API pricing and does not match what a Pro/Max/Team/Enterprise subscriber actually paid (their fixed monthly fee). Target users of AgentFluent are frequently on Max plans, so showing "$278 total cost" when they paid $200 flat was misleading. This is Option A from the issue spec; Option B (infer plan from session metadata) stays out of scope.

Downstream: issue #70 (README rewrite) can now capture screenshots that accurately reflect cost semantics.

Closes #76

## Test plan

- [x] `uv run pytest -m "not integration"` — all 260 tests pass (4 new tests in `tests/unit/cli/test_cost_labeling.py`).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/agentfluent/` — clean.
- [x] New tests cover: renamed row label, footnote content, footnote prints exactly once (even in verbose mode), and JSON `total_cost` key unchanged.
- [ ] Manual visual spot-check of `agentfluent analyze --project <name>` output.