### PR TITLE
fix(pricing): add opus-4-7, reprice opus/haiku, filter <synthetic>

### DIFF
--- a/src/agentfluent/analytics/pricing.py
+++ b/src/agentfluent/analytics/pricing.py
@@ -23,14 +23,22 @@ class ModelPricing:
 
 
 # Pricing data: USD per 1M tokens.
+# Source: https://platform.claude.com/docs/en/about-claude/pricing
+# Last verified: 2026-04-18
+# Cache write prices reflect the 5-minute TTL tier (1.25x input).
 # Update this dict when Anthropic changes pricing.
 _PRICING: dict[str, ModelPricing] = {
+    # Opus 4.5, 4.6, 4.7 share the same pricing tier ($5 / $25 / $6.25 / $0.50).
+    "claude-opus-4-7": ModelPricing(
+        input=5.0, output=25.0, cache_creation=6.25, cache_read=0.50,
+    ),
     "claude-opus-4-6": ModelPricing(
-        input=15.0, output=75.0, cache_creation=18.75, cache_read=1.875,
+        input=5.0, output=25.0, cache_creation=6.25, cache_read=0.50,
     ),
     "claude-opus-4-5-20251101": ModelPricing(
-        input=15.0, output=75.0, cache_creation=18.75, cache_read=1.875,
+        input=5.0, output=25.0, cache_creation=6.25, cache_read=0.50,
     ),
+    # Sonnet 4, 4.5, 4.6 share the same pricing tier ($3 / $15 / $3.75 / $0.30).
     "claude-sonnet-4-6": ModelPricing(
         input=3.0, output=15.0, cache_creation=3.75, cache_read=0.30,
     ),
@@ -40,19 +48,26 @@ _PRICING: dict[str, ModelPricing] = {
     "claude-sonnet-4-20250514": ModelPricing(
         input=3.0, output=15.0, cache_creation=3.75, cache_read=0.30,
     ),
+    # Haiku 4.5 is $1 / $5 / $1.25 / $0.10 (distinct from Haiku 3.5's $0.80 / $4).
     "claude-haiku-4-5-20251001": ModelPricing(
-        input=0.80, output=4.0, cache_creation=1.0, cache_read=0.08,
+        input=1.0, output=5.0, cache_creation=1.25, cache_read=0.10,
     ),
 }
 
 # Aliases map short names and variant identifiers to canonical model names.
 _ALIASES: dict[str, str] = {
-    "opus": "claude-opus-4-6",
+    "opus": "claude-opus-4-7",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001",
+    "claude-opus-4-7[1m]": "claude-opus-4-7",
     "claude-opus-4-6[1m]": "claude-opus-4-6",
     "claude-sonnet-4-6[1m]": "claude-sonnet-4-6",
 }
+
+# Sentinel model names emitted by Claude Code for synthetic/internal messages.
+# These are not real API model calls and should be skipped before pricing lookup.
+SYNTHETIC_MODELS: frozenset[str] = frozenset({"<synthetic>"})
+
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
@@ -60,8 +75,9 @@ DEFAULT_MODEL = "claude-sonnet-4-6"
 def get_pricing(model: str) -> ModelPricing | None:
     """Look up pricing for a model name.
 
-    Checks exact match first, then aliases. Returns None with a warning
-    if the model is unknown.
+    Checks exact match first, then aliases. Returns None and logs at DEBUG
+    level if the model is unknown. The caller is expected to skip synthetic
+    sentinel values (see ``SYNTHETIC_MODELS``) before invoking this function.
     """
     pricing = _PRICING.get(model)
     if pricing:
@@ -71,7 +87,7 @@ def get_pricing(model: str) -> ModelPricing | None:
     if canonical:
         return _PRICING.get(canonical)
 
-    logger.warning("Unknown model '%s' -- no pricing available", model)
+    logger.debug("Unknown model '%s' -- no pricing available", model)
     return None
 
 

--- a/src/agentfluent/analytics/tokens.py
+++ b/src/agentfluent/analytics/tokens.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from agentfluent.analytics.pricing import compute_cost, get_pricing
+from agentfluent.analytics.pricing import SYNTHETIC_MODELS, compute_cost, get_pricing
 from agentfluent.core.session import SessionMessage
 
 
@@ -83,6 +83,11 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
 
     for msg in messages:
         if msg.type != "assistant" or msg.usage is None:
+            continue
+
+        # Skip synthetic/internal sentinel models emitted by Claude Code.
+        # These are not real API calls -- no tokens billed, no pricing needed.
+        if msg.model in SYNTHETIC_MODELS:
             continue
 
         api_call_count += 1

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -1,6 +1,11 @@
 """Tests for model pricing lookup."""
 
+import logging
+
+import pytest
+
 from agentfluent.analytics.pricing import (
+    SYNTHETIC_MODELS,
     ModelPricing,
     compute_cost,
     get_known_models,
@@ -15,29 +20,46 @@ class TestGetPricing:
         assert pricing.input == 3.0
         assert pricing.output == 15.0
 
-    def test_opus_model(self) -> None:
+    def test_opus_4_6_model(self) -> None:
         pricing = get_pricing("claude-opus-4-6")
         assert pricing is not None
-        assert pricing.input == 15.0
-        assert pricing.output == 75.0
-        assert pricing.cache_creation == 18.75
-        assert pricing.cache_read == 1.875
+        assert pricing.input == 5.0
+        assert pricing.output == 25.0
+        assert pricing.cache_creation == 6.25
+        assert pricing.cache_read == 0.50
+
+    def test_opus_4_7_model(self) -> None:
+        # Verifies issue #75: claude-opus-4-7 must return non-None pricing.
+        pricing = get_pricing("claude-opus-4-7")
+        assert pricing is not None
+        assert pricing.input == 5.0
+        assert pricing.output == 25.0
+        assert pricing.cache_creation == 6.25
+        assert pricing.cache_read == 0.50
 
     def test_haiku_model(self) -> None:
         pricing = get_pricing("claude-haiku-4-5-20251001")
         assert pricing is not None
-        assert pricing.input == 0.80
-        assert pricing.output == 4.0
+        assert pricing.input == 1.0
+        assert pricing.output == 5.0
+        assert pricing.cache_creation == 1.25
+        assert pricing.cache_read == 0.10
 
-    def test_alias_short_name(self) -> None:
+    def test_alias_short_name_opus(self) -> None:
         pricing = get_pricing("opus")
         assert pricing is not None
-        assert pricing.input == 15.0
+        # "opus" now resolves to opus-4-7 (current flagship).
+        assert pricing.input == 5.0
 
-    def test_alias_with_context_suffix(self) -> None:
+    def test_alias_with_context_suffix_4_6(self) -> None:
         pricing = get_pricing("claude-opus-4-6[1m]")
         assert pricing is not None
-        assert pricing.input == 15.0
+        assert pricing.input == 5.0
+
+    def test_alias_with_context_suffix_4_7(self) -> None:
+        pricing = get_pricing("claude-opus-4-7[1m]")
+        assert pricing is not None
+        assert pricing.input == 5.0
 
     def test_sonnet_alias(self) -> None:
         pricing = get_pricing("sonnet")
@@ -49,6 +71,25 @@ class TestGetPricing:
 
     def test_empty_string_returns_none(self) -> None:
         assert get_pricing("") is None
+
+    def test_unknown_model_logs_at_debug_not_warning(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Issue #75: the "Unknown model" message should be DEBUG, not WARNING,
+        # so it does not clutter stderr on normal CLI runs.
+        with caplog.at_level(logging.DEBUG, logger="agentfluent.analytics.pricing"):
+            assert get_pricing("some-future-model") is None
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("some-future-model" in r.getMessage() for r in debug_records)
+        assert warning_records == []
+
+
+class TestSyntheticModels:
+    def test_synthetic_sentinel_exported(self) -> None:
+        # Issue #75: <synthetic> is filtered at the aggregation layer, but the
+        # shared frozenset lives in pricing so other consumers can import it.
+        assert "<synthetic>" in SYNTHETIC_MODELS
 
 
 class TestComputeCost:
@@ -79,8 +120,8 @@ class TestComputeCost:
         pricing = get_pricing("claude-opus-4-6")
         assert pricing is not None
         cost = compute_cost(pricing, input_tokens=1_000_000, output_tokens=1_000_000)
-        # 1M * 15/1M + 1M * 75/1M = 15 + 75 = 90
-        assert cost == 90.0
+        # 1M * 5/1M + 1M * 25/1M = 5 + 25 = 30
+        assert cost == 30.0
 
 
 class TestGetKnownModels:
@@ -89,6 +130,10 @@ class TestGetKnownModels:
         assert isinstance(models, list)
         assert models == sorted(models)
         assert len(models) >= 6
+
+    def test_includes_opus_4_7(self) -> None:
+        models = get_known_models()
+        assert "claude-opus-4-7" in models
 
     def test_does_not_include_aliases(self) -> None:
         models = get_known_models()

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,5 +1,9 @@
 """Tests for token and cost analytics."""
 
+import logging
+
+import pytest
+
 from agentfluent.analytics.tokens import compute_token_metrics
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
 
@@ -95,15 +99,27 @@ class TestCostComputation:
         assert abs(metrics.total_cost - 4.5) < 0.001
 
     def test_opus_cost(self) -> None:
-        # Opus: input=15/1M, output=75/1M
+        # Opus 4.6 (as of 2026-04): input=5/1M, output=25/1M
         messages = [_assistant(
             model="claude-opus-4-6",
             input_tokens=1_000_000,
             output_tokens=100_000,
         )]
         metrics = compute_token_metrics(messages)
-        # 1M * 15/1M + 100K * 75/1M = 15.0 + 7.5 = 22.5
-        assert abs(metrics.total_cost - 22.5) < 0.001
+        # 1M * 5/1M + 100K * 25/1M = 5.0 + 2.5 = 7.5
+        assert abs(metrics.total_cost - 7.5) < 0.001
+
+    def test_opus_4_7_cost(self) -> None:
+        # Issue #75: opus-4-7 has known pricing and produces non-zero cost.
+        messages = [_assistant(
+            model="claude-opus-4-7",
+            input_tokens=1_000_000,
+            output_tokens=100_000,
+        )]
+        metrics = compute_token_metrics(messages)
+        # 1M * 5/1M + 100K * 25/1M = 5.0 + 2.5 = 7.5
+        assert abs(metrics.total_cost - 7.5) < 0.001
+        assert "claude-opus-4-7" in metrics.by_model
 
     def test_unknown_model_zero_cost(self) -> None:
         messages = [_assistant(model="unknown-model", input_tokens=1000, output_tokens=500)]
@@ -117,9 +133,45 @@ class TestCostComputation:
             _assistant(model="claude-opus-4-6", input_tokens=1_000_000, output_tokens=0),
         ]
         metrics = compute_token_metrics(messages)
-        # Sonnet: 1M * 3/1M = 3.0, Opus: 1M * 15/1M = 15.0
-        assert abs(metrics.total_cost - 18.0) < 0.001
+        # Sonnet: 1M * 3/1M = 3.0, Opus 4.6: 1M * 5/1M = 5.0
+        assert abs(metrics.total_cost - 8.0) < 0.001
         assert len(metrics.by_model) == 2
+
+
+class TestSyntheticFiltering:
+    def test_synthetic_model_skipped(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Issue #75: <synthetic> is a Claude Code sentinel, not a real model.
+        # It must be filtered before pricing lookup -- no counter bump,
+        # no pricing warning, no entry in by_model.
+        messages = [_assistant(
+            model="<synthetic>",
+            input_tokens=1000,
+            output_tokens=500,
+        )]
+        with caplog.at_level(logging.DEBUG, logger="agentfluent.analytics.pricing"):
+            metrics = compute_token_metrics(messages)
+        assert metrics.input_tokens == 0
+        assert metrics.output_tokens == 0
+        assert metrics.total_cost == 0.0
+        assert metrics.api_call_count == 0
+        assert "<synthetic>" not in metrics.by_model
+        # No "Unknown model" log entry at any level.
+        assert not any(
+            "<synthetic>" in r.getMessage() for r in caplog.records
+        )
+
+    def test_synthetic_mixed_with_real_model(self) -> None:
+        # A real message alongside a synthetic one: real one is counted,
+        # synthetic is silently dropped.
+        messages = [
+            _assistant(model="<synthetic>", input_tokens=999, output_tokens=999),
+            _assistant(model="claude-sonnet-4-6", input_tokens=100, output_tokens=50),
+        ]
+        metrics = compute_token_metrics(messages)
+        assert metrics.input_tokens == 100
+        assert metrics.output_tokens == 50
+        assert metrics.api_call_count == 1
+        assert list(metrics.by_model.keys()) == ["claude-sonnet-4-6"]
 
 
 class TestPerModelBreakdown:


### PR DESCRIPTION
Closes #75.

## Summary
- Add `claude-opus-4-7` pricing entry and reprice `claude-opus-4-6` / `claude-opus-4-5-20251101` / `claude-haiku-4-5-20251001` against the current [platform.claude.com pricing page](https://platform.claude.com/docs/en/about-claude/pricing) (verified 2026-04-18). Opus 4.5/4.6/4.7 share the new $5 / $25 / $6.25 / $0.50 tier; Haiku 4.5 is $1 / $5 / $1.25 / $0.10 (the old values were Haiku 3.5 rates). Sonnet tier unchanged.
- Filter `<synthetic>` in `compute_token_metrics` before pricing lookup. `<synthetic>` is a Claude Code sentinel for internal messages, not a real API call -- it no longer increments counters, appears in `by_model`, or triggers a pricing log entry. `SYNTHETIC_MODELS` frozenset lives in `pricing.py` for reuse.
- Downgrade the "Unknown model" log from `WARNING` to `DEBUG`. The `$0.0000` cost cell already surfaces the unknown-cost case on screen; users who want stderr visibility can run with `--verbose`.

## Pricing changes
| model | old input / output / write / read | new input / output / write / read |
|---|---|---|
| claude-opus-4-7 | _(missing)_ | 5 / 25 / 6.25 / 0.50 |
| claude-opus-4-6 | 15 / 75 / 18.75 / 1.875 | 5 / 25 / 6.25 / 0.50 |
| claude-opus-4-5-20251101 | 15 / 75 / 18.75 / 1.875 | 5 / 25 / 6.25 / 0.50 |
| claude-haiku-4-5-20251001 | 0.80 / 4 / 1.0 / 0.08 | 1 / 5 / 1.25 / 0.10 |
| claude-sonnet-4-6 / 4-5 / 4 | 3 / 15 / 3.75 / 0.30 | _(unchanged)_ |

`opus` short alias is repointed from `claude-opus-4-6` to `claude-opus-4-7` (current flagship). `claude-opus-4-7[1m]` alias added.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` -- 281 passed
- [x] Full suite passes: `uv run pytest` -- 294 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New coverage:
  - `test_opus_4_7_model` and `test_opus_4_7_cost` -- opus-4-7 returns non-None pricing and produces non-zero cost
  - `test_unknown_model_logs_at_debug_not_warning` -- no stderr warning on unknown models
  - `test_synthetic_model_skipped` / `test_synthetic_mixed_with_real_model` -- `<synthetic>` is filtered, no log, no by_model entry; real models alongside synthetic still count correctly
- [x] Manual smoke: `compute_token_metrics` over a mixed message list (synthetic + opus-4-7 + opus-4-6 + haiku-4-5) produces no log output and correct per-model costs

## Breaking changes
None. The pricing changes correct values that were previously wrong or missing; the `<synthetic>` filter removes a fake row that was producing `$0.0000`; the log level change is visible only in `--verbose` runs.