### PR TITLE
chore: drop Python 3.13 classifier to match tested versions (#88)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",


### PR DESCRIPTION
## Summary

Removes `"Programming Language :: Python :: 3.13"` from `pyproject.toml` classifiers. Only Python 3.12 is actually verified:

| Surface | Value |
|---|---|
| `.python-version` | `3.12` |
| CI (`uv python install` reads `.python-version`) | 3.12 |
| `[tool.mypy] python_version` | `"3.12"` |
| `[tool.ruff] target-version` | `"py312"` |

The 3.13 classifier made the PyPI `pyversions` badge advertise support that nothing exercised. Now matches reality.

`requires-python = ">=3.12"` is unchanged — it's the compatibility floor, not a claim about tested versions.

Closes #88.

## Test plan

- [x] `uv build` succeeds with the fix applied
- [x] Installed wheel exposes only `Programming Language :: Python :: 3` and `Programming Language :: Python :: 3.12` via `importlib.metadata`
- [ ] CI passes on this PR
- [ ] After next release, the README's `pyversions` shields.io badge renders "3.12" only (PyPI regenerates from classifiers on upload)

## Out of scope

- Adding a CI matrix to test 3.13 — deferred until user demand for 3.13 support emerges
