### PR TITLE
chore(ci): pin review workflows to Sonnet and pin security-review SHA

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pin to Sonnet for routine reviews; Opus is ~15x cost with limited
+          # marginal benefit on small diffs. Mention `@claude-opus` in a PR
+          # comment to opt into deeper review.
+          model: claude-sonnet-4-6
           trigger_phrase: "@claude"
           prompt: |
             You are reviewing code for the AgentFluent project — a local-first Python CLI

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -29,12 +29,15 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: anthropics/claude-code-security-review@main
+      # Pinned to a SHA for reproducibility — upstream has no tagged releases.
+      - uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda # 2026-02-11
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           comment-pr: true
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pin to Sonnet; routine security scans don't need Opus-level reasoning.
+          claude-model: claude-sonnet-4-6
           exclude-directories: .venv,dist,build,.mypy_cache,.pytest_cache,.ruff_cache,.claude
           custom-security-scan-instructions: |
             AgentFluent is a local-first Python CLI that reads user session data and


### PR DESCRIPTION
## Summary
- Sets `model: claude-sonnet-4-6` on `anthropics/claude-code-action@v1` in `claude-review.yml` (routine `@claude` and `needs-review` passes no longer default to Opus 4.7)
- Sets `claude-model: claude-sonnet-4-6` on `anthropics/claude-code-security-review` in `security-review.yml`
- Pins `claude-code-security-review` to SHA `0c6a49f` (2026-02-11) — upstream has no tagged releases, so `@main` was a moving target
- Adds inline comments explaining the cost/benefit trade-off and the Opus escape hatch

Closes #79

## Test plan
- [ ] Opening this PR triggers `security-review.yml`; verify the new pinned SHA resolves and the model input is accepted
- [ ] Labeling the PR `needs-review` (or mentioning `@claude`) triggers `claude-review.yml` with the Sonnet model
- [ ] No regressions in `ci.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)