### PR TITLE
refactor(parser): extract iter_raw_messages iterator

### DIFF
--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -25,13 +25,18 @@ from agentfluent.core.session import (
 logger = logging.getLogger(__name__)
 
 
-def iter_raw_messages(path: Path) -> Iterator[dict[str, Any]]:
-    """Iterate a JSONL file, yielding decoded dicts for analytical messages.
+def iter_raw_messages(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
+    """Iterate a JSONL file, yielding (line_num, data) for analytical messages.
 
     Encapsulates the line-reading, JSON-decoding, and SKIP_TYPES filtering
-    that every session-file parser needs. Callers dispatch on ``type`` and
-    build their own typed objects. Used by both the main-session parser
+    that every session-file parser needs. Callers dispatch on ``data["type"]``
+    and build their own typed objects. Used by both the main-session parser
     (``parse_session``) and the subagent trace parser.
+
+    ``line_num`` is 1-indexed and refers to the raw line in the file (not
+    the post-filter position), so downstream error logs can pinpoint the
+    originating line even though some lines were skipped. Callers that
+    don't need it can unpack as ``for _, data in ...``.
 
     Silently skips: missing files, empty files, empty lines, malformed
     JSON (warn-logged), non-object JSON (warn-logged), and any message
@@ -64,7 +69,7 @@ def iter_raw_messages(path: Path) -> Iterator[dict[str, Any]]:
             if not msg_type or msg_type in SKIP_TYPES:
                 continue
 
-            yield data
+            yield line_num, data
 
 
 def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[ContentBlock]:
@@ -250,7 +255,7 @@ def parse_session(path: Path, *, deduplicate: bool = True) -> list[SessionMessag
     """
     messages: list[SessionMessage] = []
 
-    for data in iter_raw_messages(path):
+    for line_num, data in iter_raw_messages(path):
         msg_type = data["type"]
         try:
             if msg_type == "user":
@@ -258,10 +263,14 @@ def parse_session(path: Path, *, deduplicate: bool = True) -> list[SessionMessag
             elif msg_type == "assistant":
                 messages.append(_parse_assistant_message(data))
             else:
-                logger.debug("Unknown message type '%s' at %s", msg_type, path.name)
+                logger.debug(
+                    "Unknown message type '%s' at %s:%d",
+                    msg_type, path.name, line_num,
+                )
         except Exception:
             logger.warning(
-                "Failed to parse message at %s", path.name, exc_info=True
+                "Failed to parse message at %s:%d",
+                path.name, line_num, exc_info=True,
             )
             continue
 

--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,48 @@ from agentfluent.core.session import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def iter_raw_messages(path: Path) -> Iterator[dict[str, Any]]:
+    """Iterate a JSONL file, yielding decoded dicts for analytical messages.
+
+    Encapsulates the line-reading, JSON-decoding, and SKIP_TYPES filtering
+    that every session-file parser needs. Callers dispatch on ``type`` and
+    build their own typed objects. Used by both the main-session parser
+    (``parse_session``) and the subagent trace parser.
+
+    Silently skips: missing files, empty files, empty lines, malformed
+    JSON (warn-logged), non-object JSON (warn-logged), and any message
+    whose ``type`` is in ``SKIP_TYPES`` or is missing.
+    """
+    if not path.exists():
+        logger.warning("Session file not found: %s", path)
+        return
+
+    if path.stat().st_size == 0:
+        return
+
+    with path.open() as f:
+        for line_num, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Malformed JSON at %s:%d", path.name, line_num)
+                continue
+
+            if not isinstance(data, dict):
+                logger.warning("Non-object JSON at %s:%d", path.name, line_num)
+                continue
+
+            msg_type = data.get("type")
+            if not msg_type or msg_type in SKIP_TYPES:
+                continue
+
+            yield data
 
 
 def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[ContentBlock]:
@@ -207,47 +250,20 @@ def parse_session(path: Path, *, deduplicate: bool = True) -> list[SessionMessag
     """
     messages: list[SessionMessage] = []
 
-    if not path.exists():
-        logger.warning("Session file not found: %s", path)
-        return messages
-
-    if path.stat().st_size == 0:
-        return messages
-
-    with path.open() as f:
-        for line_num, line in enumerate(f, start=1):
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("Malformed JSON at %s:%d", path.name, line_num)
-                continue
-
-            if not isinstance(data, dict):
-                logger.warning("Non-object JSON at %s:%d", path.name, line_num)
-                continue
-
-            msg_type = data.get("type")
-            if not msg_type or msg_type in SKIP_TYPES:
-                continue
-
-            try:
-                if msg_type == "user":
-                    messages.append(_parse_user_message(data))
-                elif msg_type == "assistant":
-                    messages.append(_parse_assistant_message(data))
-                else:
-                    logger.debug(
-                        "Unknown message type '%s' at %s:%d", msg_type, path.name, line_num
-                    )
-            except Exception:
-                logger.warning(
-                    "Failed to parse message at %s:%d", path.name, line_num, exc_info=True
-                )
-                continue
+    for data in iter_raw_messages(path):
+        msg_type = data["type"]
+        try:
+            if msg_type == "user":
+                messages.append(_parse_user_message(data))
+            elif msg_type == "assistant":
+                messages.append(_parse_assistant_message(data))
+            else:
+                logger.debug("Unknown message type '%s' at %s", msg_type, path.name)
+        except Exception:
+            logger.warning(
+                "Failed to parse message at %s", path.name, exc_info=True
+            )
+            continue
 
     if deduplicate:
         messages = deduplicate_messages(messages)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -322,19 +322,19 @@ class TestIterRawMessages:
     def test_skips_empty_lines(self, tmp_path: Path) -> None:
         path = tmp_path / "s.jsonl"
         path.write_text('\n{"type": "user"}\n\n{"type": "assistant"}\n\n')
-        types = [d["type"] for d in iter_raw_messages(path)]
+        types = [d["type"] for _, d in iter_raw_messages(path)]
         assert types == ["user", "assistant"]
 
     def test_skips_malformed_json(self, tmp_path: Path) -> None:
         path = tmp_path / "bad.jsonl"
         path.write_text('{"type": "user"}\nnot json\n{"type": "assistant"}\n')
-        types = [d["type"] for d in iter_raw_messages(path)]
+        types = [d["type"] for _, d in iter_raw_messages(path)]
         assert types == ["user", "assistant"]
 
     def test_skips_non_object_json(self, tmp_path: Path) -> None:
         path = tmp_path / "arr.jsonl"
         path.write_text('{"type": "user"}\n["array"]\n42\n{"type": "assistant"}\n')
-        types = [d["type"] for d in iter_raw_messages(path)]
+        types = [d["type"] for _, d in iter_raw_messages(path)]
         assert types == ["user", "assistant"]
 
     def test_filters_skip_types(self, tmp_path: Path) -> None:
@@ -350,13 +350,13 @@ class TestIterRawMessages:
             {"type": "assistant"},
         ]
         path.write_text("\n".join(json.dumps(ln) for ln in lines) + "\n")
-        types = [d["type"] for d in iter_raw_messages(path)]
+        types = [d["type"] for _, d in iter_raw_messages(path)]
         assert types == ["user", "assistant"]
 
     def test_skips_missing_type(self, tmp_path: Path) -> None:
         path = tmp_path / "notype.jsonl"
         path.write_text('{"foo": "bar"}\n{"type": ""}\n{"type": "user"}\n')
-        types = [d["type"] for d in iter_raw_messages(path)]
+        types = [d["type"] for _, d in iter_raw_messages(path)]
         assert types == ["user"]
 
     def test_yields_raw_dicts_with_all_fields(self, tmp_path: Path) -> None:
@@ -368,5 +368,19 @@ class TestIterRawMessages:
             "toolUseResult": {"status": "success", "custom_field": 42},
         }
         path.write_text(json.dumps(entry) + "\n")
-        [result] = list(iter_raw_messages(path))
+        [(line_num, result)] = list(iter_raw_messages(path))
         assert result == entry
+        assert line_num == 1
+
+    def test_line_num_reflects_raw_line_position(self, tmp_path: Path) -> None:
+        """line_num is the raw file position; skipped lines still advance it."""
+        path = tmp_path / "mixed.jsonl"
+        path.write_text(
+            "\n"                            # line 1: empty, skipped
+            "not json\n"                    # line 2: malformed, skipped
+            '{"type": "progress"}\n'        # line 3: SKIP_TYPES, skipped
+            '{"type": "user"}\n'            # line 4: yielded
+            '{"type": "assistant"}\n',      # line 5: yielded
+        )
+        pairs = list(iter_raw_messages(path))
+        assert [line_num for line_num, _ in pairs] == [4, 5]

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from agentfluent.core.parser import parse_session
+from agentfluent.core.parser import iter_raw_messages, parse_session
 from agentfluent.core.session import SessionMessage
 
 
@@ -302,3 +302,71 @@ class TestTimestamps:
         messages = parse_session(agent_session_path)
         for msg in messages:
             assert msg.timestamp is not None, f"{msg.type} message missing timestamp"
+
+
+class TestIterRawMessages:
+    """Direct tests for the shared iter_raw_messages iterator.
+
+    The subagent trace parser (#103) consumes this iterator, so its
+    contract is part of the public surface.
+    """
+
+    def test_missing_file_yields_nothing(self, tmp_path: Path) -> None:
+        assert list(iter_raw_messages(tmp_path / "nope.jsonl")) == []
+
+    def test_empty_file_yields_nothing(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.jsonl"
+        path.write_text("")
+        assert list(iter_raw_messages(path)) == []
+
+    def test_skips_empty_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "s.jsonl"
+        path.write_text('\n{"type": "user"}\n\n{"type": "assistant"}\n\n')
+        types = [d["type"] for d in iter_raw_messages(path)]
+        assert types == ["user", "assistant"]
+
+    def test_skips_malformed_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.jsonl"
+        path.write_text('{"type": "user"}\nnot json\n{"type": "assistant"}\n')
+        types = [d["type"] for d in iter_raw_messages(path)]
+        assert types == ["user", "assistant"]
+
+    def test_skips_non_object_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "arr.jsonl"
+        path.write_text('{"type": "user"}\n["array"]\n42\n{"type": "assistant"}\n')
+        types = [d["type"] for d in iter_raw_messages(path)]
+        assert types == ["user", "assistant"]
+
+    def test_filters_skip_types(self, tmp_path: Path) -> None:
+        path = tmp_path / "skip.jsonl"
+        lines = [
+            {"type": "user"},
+            {"type": "file-history-snapshot"},
+            {"type": "progress"},
+            {"type": "hook_progress"},
+            {"type": "bash_progress"},
+            {"type": "system"},
+            {"type": "create"},
+            {"type": "assistant"},
+        ]
+        path.write_text("\n".join(json.dumps(ln) for ln in lines) + "\n")
+        types = [d["type"] for d in iter_raw_messages(path)]
+        assert types == ["user", "assistant"]
+
+    def test_skips_missing_type(self, tmp_path: Path) -> None:
+        path = tmp_path / "notype.jsonl"
+        path.write_text('{"foo": "bar"}\n{"type": ""}\n{"type": "user"}\n')
+        types = [d["type"] for d in iter_raw_messages(path)]
+        assert types == ["user"]
+
+    def test_yields_raw_dicts_with_all_fields(self, tmp_path: Path) -> None:
+        path = tmp_path / "raw.jsonl"
+        entry = {
+            "type": "user",
+            "timestamp": "2026-04-20T10:00:00Z",
+            "message": {"role": "user", "content": "hello"},
+            "toolUseResult": {"status": "success", "custom_field": 42},
+        }
+        path.write_text(json.dumps(entry) + "\n")
+        [result] = list(iter_raw_messages(path))
+        assert result == entry


### PR DESCRIPTION
## Summary

- Extracts JSONL line reading, JSON decoding, and SKIP_TYPES filtering from `parse_session` into a reusable `iter_raw_messages(path) -> Iterator[dict[str, Any]]` iterator in `core/parser.py`.
- `parse_session` now consumes the iterator instead of duplicating the line-level concerns inline. Behavior-preserving refactor.
- The subagent trace parser (#103) will consume the same iterator — format-evolution fixes (malformed-line handling, new SKIP_TYPES) now live in one place.

Closes #115.

## Architect context

Architect A's review of #103 flagged the "two independent JSONL parsers" risk — subagent parsing would reimplement the same low-level line/JSON/SKIP_TYPES logic. Extracting now means #103 is strictly about subagent-specific message shapes, not line reading.

## Test plan

- [x] `uv run pytest -m "not integration"` → 279 passed
- [x] `uv run mypy src/agentfluent/` → clean
- [x] `uv run ruff check src/ tests/` → clean
- [x] 8 new contract tests for `iter_raw_messages` (`TestIterRawMessages` class): missing file, empty file, empty lines, malformed JSON, non-object JSON, SKIP_TYPES, missing/empty type, raw-dict preservation
- [x] All 19 existing `parse_session` tests still pass without modification

## Minor note

The inner try/except in `parse_session` lost line-number context in its warning log (it previously said `"Failed to parse message at %s:%d"` with line_num). That log line catches rare Pydantic validation failures downstream of iter_raw_messages. Line-level logging for malformed JSON and non-object lines is preserved inside the iterator itself. Happy to add line_num back via a tuple yield shape if you'd rather not lose that context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)