### PR TITLE
feat(cli): add --claude-config-dir flag and CLAUDE_CONFIG_DIR env var

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -14,6 +14,7 @@ from agentfluent.cli.formatters.helpers import format_cost, format_tokens
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.core.discovery import find_project
+from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
 
 ANALYZE_EPILOG = """\
@@ -117,9 +118,8 @@ def analyze(
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
 
     config_dir: Path | None = ctx.obj.claude_config_dir if ctx.obj else None
-    projects_dir = (config_dir / "projects") if config_dir else None
 
-    project_info = find_project(project, base_path=projects_dir)
+    project_info = find_project(project, base_path=projects_dir_for(config_dir))
     if project_info is None:
         err_console.print(f"[red]Project not found:[/red] {project}")
         err_console.print("Use [bold]agentfluent list[/bold] to see available projects.")

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -71,6 +72,7 @@ def _print_json(result: AnalysisResult, *, quiet: bool, project_name: str) -> No
 
 @app.callback(invoke_without_command=True, epilog=ANALYZE_EPILOG)
 def analyze(
+    ctx: typer.Context,
     project: str = typer.Option(
         ...,
         "--project",
@@ -114,7 +116,10 @@ def analyze(
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
 
-    project_info = find_project(project)
+    config_dir: Path | None = ctx.obj.claude_config_dir if ctx.obj else None
+    projects_dir = (config_dir / "projects") if config_dir else None
+
+    project_info = find_project(project, base_path=projects_dir)
     if project_info is None:
         err_console.print(f"[red]Project not found:[/red] {project}")
         err_console.print("Use [bold]agentfluent list[/bold] to see available projects.")

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -14,6 +14,7 @@ from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_config_check_table
 from agentfluent.config import assess_agents
 from agentfluent.config.models import ConfigScore
+from agentfluent.core.paths import agents_dir_for
 
 CONFIG_CHECK_EPILOG = """\
 Examples:
@@ -92,9 +93,10 @@ def config_check(
         raise typer.Exit(code=EXIT_USER_ERROR)
 
     config_dir: Path | None = ctx.obj.claude_config_dir if ctx.obj else None
-    user_path = (config_dir / "agents") if config_dir else None
 
-    scores = assess_agents(scope, agent_filter=agent, user_path=user_path)
+    scores = assess_agents(
+        scope, agent_filter=agent, user_path=agents_dir_for(config_dir),
+    )
 
     if not scores:
         if agent:

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -60,6 +61,7 @@ def _print_json(scores: list[ConfigScore], *, quiet: bool) -> None:
 
 @app.callback(invoke_without_command=True, epilog=CONFIG_CHECK_EPILOG)
 def config_check(
+    ctx: typer.Context,
     scope: str = typer.Option(
         "all",
         "--scope",
@@ -89,7 +91,10 @@ def config_check(
         err_console.print("Valid scopes: user, project, all")
         raise typer.Exit(code=EXIT_USER_ERROR)
 
-    scores = assess_agents(scope, agent_filter=agent)
+    config_dir: Path | None = ctx.obj.claude_config_dir if ctx.obj else None
+    user_path = (config_dir / "agents") if config_dir else None
+
+    scores = assess_agents(scope, agent_filter=agent, user_path=user_path)
 
     if not scores:
         if agent:

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -20,11 +20,7 @@ from agentfluent.core.discovery import (
     find_project,
 )
 from agentfluent.core.parser import parse_session
-
-
-def _projects_dir(config_dir: Path | None) -> Path | None:
-    """Derive the projects subdirectory from the config root override."""
-    return (config_dir / "projects") if config_dir else None
+from agentfluent.core.paths import projects_dir_for
 
 LIST_EPILOG = """\
 Examples:
@@ -50,7 +46,7 @@ err_console = Console(stderr=True)
 def _discover_or_exit(config_dir: Path | None) -> list[ProjectInfo]:
     """Discover projects; print error and exit on failure."""
     try:
-        return discover_projects(base_path=_projects_dir(config_dir))
+        return discover_projects(base_path=projects_dir_for(config_dir))
     except FileNotFoundError as e:
         err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=EXIT_NO_DATA) from None
@@ -99,7 +95,7 @@ def _list_projects_json(*, config_dir: Path | None, quiet: bool) -> None:
 
 def _find_or_exit(project_slug: str, config_dir: Path | None) -> ProjectInfo:
     """Look up a project by slug; print error and exit if not found."""
-    project = find_project(project_slug, base_path=_projects_dir(config_dir))
+    project = find_project(project_slug, base_path=projects_dir_for(config_dir))
     if project is None:
         err_console.print(f"[red]Project not found: {project_slug}[/red]")
         raise typer.Exit(code=EXIT_USER_ERROR)

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -19,6 +20,11 @@ from agentfluent.core.discovery import (
     find_project,
 )
 from agentfluent.core.parser import parse_session
+
+
+def _projects_dir(config_dir: Path | None) -> Path | None:
+    """Derive the projects subdirectory from the config root override."""
+    return (config_dir / "projects") if config_dir else None
 
 LIST_EPILOG = """\
 Examples:
@@ -41,18 +47,20 @@ console = Console()
 err_console = Console(stderr=True)
 
 
-def _discover_or_exit() -> list[ProjectInfo]:
+def _discover_or_exit(config_dir: Path | None) -> list[ProjectInfo]:
     """Discover projects; print error and exit on failure."""
     try:
-        return discover_projects()
+        return discover_projects(base_path=_projects_dir(config_dir))
     except FileNotFoundError as e:
         err_console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=EXIT_NO_DATA) from None
 
 
-def _list_projects_table(*, verbose: bool, quiet: bool) -> None:
+def _list_projects_table(
+    *, config_dir: Path | None, verbose: bool, quiet: bool,
+) -> None:
     """Display all projects as a Rich table."""
-    projects = _discover_or_exit()
+    projects = _discover_or_exit(config_dir)
     if quiet:
         total_sessions = sum(p.session_count for p in projects)
         console.print(f"{len(projects)} projects, {total_sessions} total sessions")
@@ -60,9 +68,9 @@ def _list_projects_table(*, verbose: bool, quiet: bool) -> None:
     format_projects_table(console, projects, verbose=verbose)
 
 
-def _list_projects_json(*, quiet: bool) -> None:
+def _list_projects_json(*, config_dir: Path | None, quiet: bool) -> None:
     """Output all projects as JSON."""
-    projects = _discover_or_exit()
+    projects = _discover_or_exit(config_dir)
     if quiet:
         payload: dict[str, object] = {
             "project_count": len(projects),
@@ -89,18 +97,20 @@ def _list_projects_json(*, quiet: bool) -> None:
     print(format_json_output("list-projects", payload))
 
 
-def _find_or_exit(project_slug: str) -> ProjectInfo:
+def _find_or_exit(project_slug: str, config_dir: Path | None) -> ProjectInfo:
     """Look up a project by slug; print error and exit if not found."""
-    project = find_project(project_slug)
+    project = find_project(project_slug, base_path=_projects_dir(config_dir))
     if project is None:
         err_console.print(f"[red]Project not found: {project_slug}[/red]")
         raise typer.Exit(code=EXIT_USER_ERROR)
     return project
 
 
-def _list_sessions_table(project_slug: str, *, verbose: bool, quiet: bool) -> None:
+def _list_sessions_table(
+    project_slug: str, *, config_dir: Path | None, verbose: bool, quiet: bool,
+) -> None:
     """Display sessions for a project as a Rich table."""
-    project = _find_or_exit(project_slug)
+    project = _find_or_exit(project_slug, config_dir)
     if quiet:
         console.print(f"Project {project.display_name}: {len(project.sessions)} sessions")
         return
@@ -108,9 +118,11 @@ def _list_sessions_table(project_slug: str, *, verbose: bool, quiet: bool) -> No
     format_sessions_table(console, project.display_name, sessions, verbose=verbose)
 
 
-def _list_sessions_json(project_slug: str, *, quiet: bool) -> None:
+def _list_sessions_json(
+    project_slug: str, *, config_dir: Path | None, quiet: bool,
+) -> None:
     """Output sessions for a project as JSON."""
-    project = _find_or_exit(project_slug)
+    project = _find_or_exit(project_slug, config_dir)
     if quiet:
         payload: dict[str, object] = {
             "project": project.display_name,
@@ -135,6 +147,7 @@ def _list_sessions_json(project_slug: str, *, quiet: bool) -> None:
 
 @app.callback(invoke_without_command=True, epilog=LIST_EPILOG)
 def list_cmd(
+    ctx: typer.Context,
     project: Optional[str] = typer.Option(  # noqa: UP007, UP045
         None,
         "--project",
@@ -153,13 +166,18 @@ def list_cmd(
     """List available projects, or sessions within a project."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+    config_dir = ctx.obj.claude_config_dir if ctx.obj else None
     if project:
         if format == "json":
-            _list_sessions_json(project, quiet=quiet)
+            _list_sessions_json(project, config_dir=config_dir, quiet=quiet)
         else:
-            _list_sessions_table(project, verbose=verbose, quiet=quiet)
+            _list_sessions_table(
+                project, config_dir=config_dir, verbose=verbose, quiet=quiet,
+            )
     else:
         if format == "json":
-            _list_projects_json(quiet=quiet)
+            _list_projects_json(config_dir=config_dir, quiet=quiet)
         else:
-            _list_projects_table(verbose=verbose, quiet=quiet)
+            _list_projects_table(
+                config_dir=config_dir, verbose=verbose, quiet=quiet,
+            )

--- a/src/agentfluent/cli/main.py
+++ b/src/agentfluent/cli/main.py
@@ -1,11 +1,16 @@
 """AgentFluent CLI application."""
 
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import typer
+from rich.console import Console
 
 from agentfluent import __version__
 from agentfluent.cli.commands import analyze, config_check, list_cmd
+from agentfluent.cli.exit_codes import EXIT_USER_ERROR
+from agentfluent.core.paths import validate_claude_config_dir
 
 TOP_LEVEL_HELP = """\
 Local-first agent analytics for the Claude Agent SDK and Claude Code subagents.
@@ -28,6 +33,10 @@ Common workflows:
   agentfluent config-check
       Score agent definitions against best practices.
 
+  agentfluent --claude-config-dir /custom/path list
+      Point at a non-default Claude config directory (also honors
+      $CLAUDE_CONFIG_DIR).
+
 Run any command with --help for command-specific options and examples.
 """
 
@@ -42,6 +51,15 @@ app.add_typer(list_cmd.app, name="list")
 app.add_typer(analyze.app, name="analyze")
 app.add_typer(config_check.app, name="config-check")
 
+err_console = Console(stderr=True)
+
+
+@dataclass
+class CliState:
+    """State passed from the top-level callback to subcommands via ``ctx.obj``."""
+
+    claude_config_dir: Path | None = None
+
 
 def version_callback(value: bool) -> None:
     if value:
@@ -51,6 +69,7 @@ def version_callback(value: bool) -> None:
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: Optional[bool] = typer.Option(  # noqa: UP007, UP045
         None,
         "--version",
@@ -59,5 +78,22 @@ def main(
         callback=version_callback,
         is_eager=True,
     ),
+    claude_config_dir: Optional[Path] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--claude-config-dir",
+        envvar="CLAUDE_CONFIG_DIR",
+        help=(
+            "Override the Claude config directory. Defaults to ~/.claude. "
+            "Project-scope paths (.claude/ under the current directory) are "
+            "not affected."
+        ),
+    ),
 ) -> None:
     """Local-first agent analytics with prompt diagnostics."""
+    try:
+        resolved = validate_claude_config_dir(claude_config_dir)
+    except (FileNotFoundError, NotADirectoryError) as e:
+        err_console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=EXIT_USER_ERROR) from None
+
+    ctx.obj = CliState(claude_config_dir=resolved)

--- a/src/agentfluent/config/__init__.py
+++ b/src/agentfluent/config/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from agentfluent.config.models import ConfigScore
 from agentfluent.config.scanner import scan_agents
 from agentfluent.config.scoring import score_agent
@@ -11,6 +13,7 @@ def assess_agents(
     scope: str = "all",
     *,
     agent_filter: str | None = None,
+    user_path: Path | None = None,
 ) -> list[ConfigScore]:
     """Scan and score agent definitions.
 
@@ -19,11 +22,13 @@ def assess_agents(
     Args:
         scope: Which locations to scan -- "user", "project", or "all".
         agent_filter: If set, only score this agent name (case-insensitive).
+        user_path: Override for the user agents directory. Forwarded to
+            ``scan_agents``. Defaults to ``~/.claude/agents/``.
 
     Returns:
         List of ConfigScore results.
     """
-    agents = scan_agents(scope)
+    agents = scan_agents(scope, user_path=user_path)
 
     if agent_filter:
         agents = [a for a in agents if a.name.lower() == agent_filter.lower()]

--- a/src/agentfluent/config/scanner.py
+++ b/src/agentfluent/config/scanner.py
@@ -13,10 +13,11 @@ from typing import Any
 import yaml
 
 from agentfluent.config.models import AgentConfig, Scope
+from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_USER_AGENTS_DIR = Path.home() / ".claude" / "agents"
+DEFAULT_USER_AGENTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / "agents"
 
 
 def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:

--- a/src/agentfluent/config/scanner.py
+++ b/src/agentfluent/config/scanner.py
@@ -13,11 +13,11 @@ from typing import Any
 import yaml
 
 from agentfluent.config.models import AgentConfig, Scope
-from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR
+from agentfluent.core.paths import AGENTS_SUBDIR, DEFAULT_CLAUDE_CONFIG_DIR
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_USER_AGENTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / "agents"
+DEFAULT_USER_AGENTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / AGENTS_SUBDIR
 
 
 def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:

--- a/src/agentfluent/core/discovery.py
+++ b/src/agentfluent/core/discovery.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR
+
+DEFAULT_PROJECTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / "projects"
 
 
 @dataclass

--- a/src/agentfluent/core/discovery.py
+++ b/src/agentfluent/core/discovery.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR
+from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR, PROJECTS_SUBDIR
 
-DEFAULT_PROJECTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / "projects"
+DEFAULT_PROJECTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / PROJECTS_SUBDIR
 
 
 @dataclass

--- a/src/agentfluent/core/paths.py
+++ b/src/agentfluent/core/paths.py
@@ -1,9 +1,9 @@
 """Path resolution for Claude config directories.
 
-Single source of truth for the Claude config root. Subdirectory constants
-(e.g., `DEFAULT_PROJECTS_DIR`, `DEFAULT_USER_AGENTS_DIR`) live with the
-modules that use them, but derive from this root so an override replaces
-the root once and all subdirectories compose from it.
+Single source of truth for the Claude config root and its named
+subdirectories. Callers compose paths from the helpers below rather
+than repeating the `"projects"` / `"agents"` subdirectory names inline,
+so an override replaces the root once and every subdirectory follows.
 """
 
 from __future__ import annotations
@@ -13,6 +13,29 @@ from pathlib import Path
 DEFAULT_CLAUDE_CONFIG_DIR = Path.home() / ".claude"
 
 CLAUDE_CONFIG_DIR_ENV_VAR = "CLAUDE_CONFIG_DIR"
+
+PROJECTS_SUBDIR = "projects"
+AGENTS_SUBDIR = "agents"
+
+
+def projects_dir_for(config_root: Path | None) -> Path | None:
+    """Derive the projects subdirectory from a config root override.
+
+    Returns ``None`` when no override applies, so callers can pass the
+    result directly to ``discover_projects(base_path=...)`` which falls
+    back to ``DEFAULT_PROJECTS_DIR``.
+    """
+    return (config_root / PROJECTS_SUBDIR) if config_root else None
+
+
+def agents_dir_for(config_root: Path | None) -> Path | None:
+    """Derive the user agents subdirectory from a config root override.
+
+    Returns ``None`` when no override applies, so callers can pass the
+    result directly to ``scan_agents(user_path=...)`` which falls back
+    to ``DEFAULT_USER_AGENTS_DIR``.
+    """
+    return (config_root / AGENTS_SUBDIR) if config_root else None
 
 
 def validate_claude_config_dir(override: Path | None) -> Path | None:

--- a/src/agentfluent/core/paths.py
+++ b/src/agentfluent/core/paths.py
@@ -1,0 +1,43 @@
+"""Path resolution for Claude config directories.
+
+Single source of truth for the Claude config root. Subdirectory constants
+(e.g., `DEFAULT_PROJECTS_DIR`, `DEFAULT_USER_AGENTS_DIR`) live with the
+modules that use them, but derive from this root so an override replaces
+the root once and all subdirectories compose from it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DEFAULT_CLAUDE_CONFIG_DIR = Path.home() / ".claude"
+
+CLAUDE_CONFIG_DIR_ENV_VAR = "CLAUDE_CONFIG_DIR"
+
+
+def validate_claude_config_dir(override: Path | None) -> Path | None:
+    """Validate an override path for the Claude config directory.
+
+    The caller (CLI or programmatic) is responsible for providing the
+    override value — typically resolved from a `--claude-config-dir` flag
+    or `$CLAUDE_CONFIG_DIR` env var via Typer's envvar binding.
+
+    Returns the resolved absolute path when `override` is provided and
+    valid, or `None` when no override applies (caller uses the default).
+
+    Raises:
+        FileNotFoundError: Override path does not exist.
+        NotADirectoryError: Override path exists but is not a directory.
+    """
+    if override is None:
+        return None
+
+    if not override.exists():
+        msg = f"Claude config directory not found: {override}"
+        raise FileNotFoundError(msg)
+
+    if not override.is_dir():
+        msg = f"Claude config directory path is not a directory: {override}"
+        raise NotADirectoryError(msg)
+
+    return override.resolve()

--- a/tests/unit/cli/test_claude_config_dir.py
+++ b/tests/unit/cli/test_claude_config_dir.py
@@ -1,0 +1,196 @@
+"""CLI tests for --claude-config-dir flag and CLAUDE_CONFIG_DIR env var.
+
+Covers precedence (flag > env > default), validation errors, and the scope
+boundary: project-scope paths (.claude/ under CWD) are not affected by the
+override.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.exit_codes import EXIT_OK, EXIT_USER_ERROR
+
+
+def _make_config_with_project(
+    root: Path, fixtures_dir: Path, slug: str = "-home-user-test-project",
+) -> None:
+    """Populate a config root with one project + one session fixture."""
+    project_dir = root / "projects" / slug
+    project_dir.mkdir(parents=True)
+    shutil.copy(fixtures_dir / "session_basic.jsonl", project_dir / "s1.jsonl")
+
+
+def _make_config_with_user_agent(root: Path, fixtures_dir: Path) -> None:
+    agents = root / "agents"
+    agents.mkdir(parents=True)
+    shutil.copy(
+        fixtures_dir / "agents" / "well_configured.md",
+        agents / "well-configured.md",
+    )
+
+
+class TestFlagResolution:
+    def test_flag_points_list_at_custom_projects(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        custom = tmp_path / "custom-claude"
+        _make_config_with_project(custom, fixtures_dir)
+
+        result = runner.invoke(
+            cli_app, ["--claude-config-dir", str(custom), "list"],
+        )
+
+        assert result.exit_code == EXIT_OK
+        assert "project" in result.stdout
+
+    def test_env_var_used_when_flag_absent(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        custom = tmp_path / "env-claude"
+        _make_config_with_project(custom, fixtures_dir)
+
+        result = runner.invoke(
+            cli_app, ["list"], env={"CLAUDE_CONFIG_DIR": str(custom)},
+        )
+
+        assert result.exit_code == EXIT_OK
+
+    def test_flag_takes_precedence_over_env(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        # Env points at an empty config; flag points at one with a project.
+        env_dir = tmp_path / "env-dir"
+        (env_dir / "projects").mkdir(parents=True)
+
+        flag_dir = tmp_path / "flag-dir"
+        _make_config_with_project(flag_dir, fixtures_dir, slug="-x-flag-wins")
+
+        result = runner.invoke(
+            cli_app,
+            ["--claude-config-dir", str(flag_dir), "list", "--quiet"],
+            env={"CLAUDE_CONFIG_DIR": str(env_dir)},
+        )
+
+        assert result.exit_code == EXIT_OK
+        # --quiet prints "<n> projects, <m> total sessions"; flag dir has 1.
+        assert "1 projects" in result.stdout
+
+
+class TestValidation:
+    def test_nonexistent_path_exits_user_error(
+        self, runner: CliRunner, cli_app: typer.Typer, tmp_path: Path,
+    ) -> None:
+        missing = tmp_path / "does-not-exist"
+        result = runner.invoke(
+            cli_app, ["--claude-config-dir", str(missing), "list"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "not found" in result.stderr
+
+    def test_file_instead_of_dir_exits_user_error(
+        self, runner: CliRunner, cli_app: typer.Typer, tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "notadir.txt"
+        f.write_text("")
+        result = runner.invoke(cli_app, ["--claude-config-dir", str(f), "list"])
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "not a directory" in result.stderr
+
+
+class TestAllCommandsHonorOverride:
+    def test_config_check_user_scope_uses_override(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        custom = tmp_path / "cc"
+        _make_config_with_user_agent(custom, fixtures_dir)
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--claude-config-dir", str(custom),
+                "config-check", "--scope", "user",
+            ],
+        )
+
+        assert result.exit_code == EXIT_OK
+
+    def test_analyze_uses_override(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        custom = tmp_path / "an"
+        _make_config_with_project(custom, fixtures_dir)
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--claude-config-dir", str(custom),
+                "analyze", "--project", "project", "--quiet",
+            ],
+        )
+
+        assert result.exit_code == EXIT_OK
+
+
+class TestScopeBoundary:
+    """Project-scope paths (.claude/ under CWD) are NOT affected by the override."""
+
+    def test_project_scope_reads_cwd_not_override(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+        fixtures_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Set up a CWD containing project-scope agents.
+        cwd = tmp_path / "work"
+        project_agents = cwd / ".claude" / "agents"
+        project_agents.mkdir(parents=True)
+        shutil.copy(
+            fixtures_dir / "agents" / "well_configured.md",
+            project_agents / "project-agent.md",
+        )
+        monkeypatch.chdir(cwd)
+
+        # Override points at an unrelated (empty) config tree.
+        override = tmp_path / "override"
+        (override / "agents").mkdir(parents=True)
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--claude-config-dir", str(override),
+                "config-check", "--scope", "project",
+            ],
+        )
+
+        # The project-scope agent is still discovered despite the override.
+        # (The override's agents/ dir is empty; scope=project reads CWD.)
+        assert result.exit_code == EXIT_OK
+        assert "Agents scanned: 1" in result.stdout

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,41 @@
+"""Tests for core.paths module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentfluent.core.paths import (
+    CLAUDE_CONFIG_DIR_ENV_VAR,
+    DEFAULT_CLAUDE_CONFIG_DIR,
+    validate_claude_config_dir,
+)
+
+
+class TestDefaults:
+    def test_default_is_home_dot_claude(self) -> None:
+        assert DEFAULT_CLAUDE_CONFIG_DIR == Path.home() / ".claude"
+
+    def test_env_var_name(self) -> None:
+        assert CLAUDE_CONFIG_DIR_ENV_VAR == "CLAUDE_CONFIG_DIR"
+
+
+class TestValidateClaudeConfigDir:
+    def test_none_returns_none(self) -> None:
+        assert validate_claude_config_dir(None) is None
+
+    def test_valid_directory_returns_resolved_path(self, tmp_path: Path) -> None:
+        result = validate_claude_config_dir(tmp_path)
+        assert result == tmp_path.resolve()
+
+    def test_nonexistent_path_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError, match="not found"):
+            validate_claude_config_dir(missing)
+
+    def test_file_not_directory_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "notadir.txt"
+        f.write_text("")
+        with pytest.raises(NotADirectoryError, match="not a directory"):
+            validate_claude_config_dir(f)


### PR DESCRIPTION
## Summary

Adds a top-level `--claude-config-dir` CLI flag and `CLAUDE_CONFIG_DIR` env var for pointing AgentFluent at a non-default Claude config directory.

- Flag > env > default (`~/.claude`) precedence, bound via Typer's `envvar`.
- New `core/paths.py` with a single `DEFAULT_CLAUDE_CONFIG_DIR` constant. Both `DEFAULT_PROJECTS_DIR` (core/discovery.py) and `DEFAULT_USER_AGENTS_DIR` (config/scanner.py) now derive from it — override replaces the root once and subdirectories compose from it.
- `assess_agents()` accepts a `user_path` kwarg and forwards to `scan_agents()` so `config-check --scope user` honors the override.
- Validation: override must exist and be a directory; otherwise exits with `EXIT_USER_ERROR` and a clear message.
- **Scope boundary preserved:** project-scope paths (`.claude/` under CWD) are *not* affected by the override. Covered by a dedicated test.

Closes #90.

## Architect context

Follows architect C's review of #90:
- Single config-root constant (`DEFAULT_CLAUDE_CONFIG_DIR`) — **done** (core/paths.py). E6 (#117 MCP discovery) can import from the same module.
- `assess_agents()` forwards `user_path` — **done**.

## Test plan

- [x] `uv run pytest -m "not integration"` → 285 passed (6 new paths, 8 new CLI integration)
- [x] `uv run mypy src/agentfluent/` → clean
- [x] `uv run ruff check src/ tests/` → clean
- [x] New tests cover: default constants, validate_claude_config_dir (None / valid / missing / not-a-dir), flag > env precedence, env-alone usage, all three commands (list / analyze / config-check) honoring the override, scope boundary (project scope reads CWD)

## Follow-up — ran in an isolated worktree subagent first

I originally launched #90 in a parallel `general-purpose` subagent with worktree isolation so #115 and #90 could progress in parallel. The subagent hit sandbox restrictions (`Write` for new files and `git checkout -b` were denied in the worktree), so I completed #90 in the main checkout after #115 was pushed. Worth knowing for future parallel delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)