### PR TITLE
feat(traces): define SubagentTrace, SubagentToolCall, RetrySequence models

### DIFF
--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -1,0 +1,110 @@
+"""Data models for parsed subagent trace JSONL files.
+
+These models are the foundational contract for the v0.3 subagent trace
+parser epic (E2). They are consumed by downstream stories across E3
+(trace-level diagnostics), E4 (delegation pattern recognition), and E5
+(model-routing diagnostics).
+
+The parser (#103) produces ``SubagentTrace`` instances from files at
+``~/.claude/projects/<slug>/<session-uuid>/subagents/agent-<agentId>.jsonl``.
+The retry-sequence detector (#104) populates ``retry_sequences`` during
+parsing. The linker (#105) attaches the trace to its parent
+``AgentInvocation`` and overwrites ``agent_type`` with the parent's
+reliably-populated value.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from functools import cached_property
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentfluent.core.session import Usage
+
+INPUT_SUMMARY_MAX_CHARS = 200
+RESULT_SUMMARY_MAX_CHARS = 500
+UNKNOWN_AGENT_TYPE = "unknown"
+
+
+class SubagentToolCall(BaseModel):
+    """One internal tool invocation inside a subagent trace.
+
+    A ``SubagentToolCall`` pairs the ``tool_use`` block with the
+    subsequent ``tool_result`` block from the JSONL file. The parser
+    (#103) truncates ``input_summary`` and ``result_summary`` to the
+    module-level ``INPUT_SUMMARY_MAX_CHARS`` and
+    ``RESULT_SUMMARY_MAX_CHARS`` constants; the model itself does not
+    enforce those limits so fixtures and replay tools can construct
+    untruncated instances.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    tool_name: str
+    input_summary: str
+    result_summary: str
+    is_error: bool = False
+    usage: Usage = Field(default_factory=Usage)
+    timestamp: datetime | None = None
+
+
+class RetrySequence(BaseModel):
+    """A group of consecutive same-tool calls with similar input.
+
+    Produced by #104's detection algorithm during parse. ``tool_call_indices``
+    reference entries in the owning ``SubagentTrace.tool_calls`` list so
+    downstream consumers (#107) can cite specific calls as evidence without
+    duplicating payloads. Index integrity is a #104 invariant: the model
+    itself does not validate bounds against the parent trace.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    tool_name: str
+    attempts: int = Field(ge=1)
+    first_error_message: str | None = None
+    last_error_message: str | None = None
+    eventual_success: bool = False
+    tool_call_indices: list[int] = Field(default_factory=list)
+
+
+class SubagentTrace(BaseModel):
+    """A parsed subagent session — the full internal trace of one agent invocation.
+
+    ``agent_type`` is set from three sources, in priority order:
+    (1) overwritten by the linker (#105) from the parent
+    ``AgentInvocation.agent_type`` after matching on ``agent_id``;
+    (2) inferred by the parser (#103) from the delegation prompt when
+    unlinked; (3) the default ``UNKNOWN_AGENT_TYPE`` for programmatically-
+    constructed instances or traces whose agent type cannot be determined.
+
+    ``unique_tool_names`` is a ``cached_property``, not a field. It does
+    NOT appear in ``model_dump()`` or ``model_dump_json()`` output; the
+    cache lives in the instance ``__dict__``. The trace is effectively
+    write-once after the parser finalizes ``tool_calls`` — mutating
+    ``tool_calls`` after first access leaves the cache stale.
+
+    ``source_file`` may hold an absolute path that can leak usernames if
+    serialized verbatim. The parser (#103) is responsible for normalizing
+    the path before setting this field; the model stores whatever it
+    receives.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    agent_id: str
+    agent_type: str = UNKNOWN_AGENT_TYPE
+    delegation_prompt: str
+    tool_calls: list[SubagentToolCall] = Field(default_factory=list)
+    retry_sequences: list[RetrySequence] = Field(default_factory=list)
+    total_errors: int = 0
+    total_retries: int = 0
+    usage: Usage = Field(default_factory=Usage)
+    duration_ms: int | None = None
+    source_file: Path | None = None
+
+    @cached_property
+    def unique_tool_names(self) -> set[str]:
+        return {tc.tool_name for tc in self.tool_calls}

--- a/tests/unit/test_traces_models.py
+++ b/tests/unit/test_traces_models.py
@@ -20,6 +20,12 @@ from agentfluent.traces.models import (
 )
 
 
+def _tool_call(name: str = "Read") -> SubagentToolCall:
+    return SubagentToolCall(
+        tool_name=name, input_summary="", result_summary="",
+    )
+
+
 class TestConstants:
     def test_truncation_constants_exposed(self) -> None:
         assert INPUT_SUMMARY_MAX_CHARS == 200
@@ -202,11 +208,7 @@ class TestSubagentTrace:
         trace = SubagentTrace(
             agent_id="u",
             delegation_prompt="p",
-            tool_calls=[
-                SubagentToolCall(tool_name="Bash", input_summary="", result_summary=""),
-                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
-                SubagentToolCall(tool_name="Bash", input_summary="", result_summary=""),
-            ],
+            tool_calls=[_tool_call("Bash"), _tool_call("Read"), _tool_call("Bash")],
         )
         assert trace.unique_tool_names == {"Bash", "Read"}
 
@@ -217,9 +219,7 @@ class TestSubagentTrace:
         trace = SubagentTrace(
             agent_id="u",
             delegation_prompt="p",
-            tool_calls=[
-                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
-            ],
+            tool_calls=[_tool_call()],
         )
         # Identity check: the cached_property returns the same object on re-access.
         assert trace.unique_tool_names is trace.unique_tool_names
@@ -228,9 +228,7 @@ class TestSubagentTrace:
         trace = SubagentTrace(
             agent_id="u",
             delegation_prompt="p",
-            tool_calls=[
-                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
-            ],
+            tool_calls=[_tool_call()],
         )
         # Access once to populate the cache.
         _ = trace.unique_tool_names

--- a/tests/unit/test_traces_models.py
+++ b/tests/unit/test_traces_models.py
@@ -1,0 +1,309 @@
+"""Tests for subagent trace data models."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from agentfluent.core.session import Usage
+from agentfluent.traces.models import (
+    INPUT_SUMMARY_MAX_CHARS,
+    RESULT_SUMMARY_MAX_CHARS,
+    UNKNOWN_AGENT_TYPE,
+    RetrySequence,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+
+class TestConstants:
+    def test_truncation_constants_exposed(self) -> None:
+        assert INPUT_SUMMARY_MAX_CHARS == 200
+        assert RESULT_SUMMARY_MAX_CHARS == 500
+
+    def test_unknown_agent_type_sentinel(self) -> None:
+        assert UNKNOWN_AGENT_TYPE == "unknown"
+
+
+class TestSubagentToolCall:
+    def test_with_all_fields(self) -> None:
+        usage = Usage(input_tokens=10, output_tokens=5)
+        ts = datetime(2026, 4, 21, 12, 0, 0, tzinfo=UTC)
+        tc = SubagentToolCall(
+            tool_name="Bash",
+            input_summary="ls -la",
+            result_summary="total 4\n-rw-r--r-- 1 user user 0 file.txt",
+            is_error=False,
+            usage=usage,
+            timestamp=ts,
+        )
+        assert tc.tool_name == "Bash"
+        assert tc.input_summary == "ls -la"
+        assert tc.result_summary.startswith("total 4")
+        assert tc.is_error is False
+        assert tc.usage.input_tokens == 10
+        assert tc.timestamp == ts
+
+    def test_minimal_required_fields(self) -> None:
+        tc = SubagentToolCall(
+            tool_name="Read",
+            input_summary="path",
+            result_summary="contents",
+        )
+        assert tc.is_error is False
+        assert tc.usage.input_tokens == 0
+        assert tc.usage.output_tokens == 0
+        assert tc.timestamp is None
+
+    def test_json_round_trip(self) -> None:
+        tc = SubagentToolCall(
+            tool_name="Grep",
+            input_summary="pattern",
+            result_summary="match",
+            is_error=True,
+            usage=Usage(input_tokens=1, output_tokens=2),
+            timestamp=datetime(2026, 4, 21, tzinfo=UTC),
+        )
+        restored = SubagentToolCall.model_validate_json(tc.model_dump_json())
+        assert restored == tc
+
+    def test_extra_fields_ignored(self) -> None:
+        tc = SubagentToolCall.model_validate(
+            {
+                "tool_name": "Read",
+                "input_summary": "x",
+                "result_summary": "y",
+                "future_field": 42,
+            },
+        )
+        assert tc.tool_name == "Read"
+        assert not hasattr(tc, "future_field")
+
+
+class TestRetrySequence:
+    def test_with_all_fields(self) -> None:
+        seq = RetrySequence(
+            tool_name="Bash",
+            attempts=3,
+            first_error_message="permission denied",
+            last_error_message="permission denied",
+            eventual_success=False,
+            tool_call_indices=[4, 5, 6],
+        )
+        assert seq.tool_name == "Bash"
+        assert seq.attempts == 3
+        assert seq.tool_call_indices == [4, 5, 6]
+        assert seq.eventual_success is False
+
+    def test_attempts_ge_1_validator(self) -> None:
+        with pytest.raises(ValidationError):
+            RetrySequence(tool_name="Bash", attempts=0)
+        with pytest.raises(ValidationError):
+            RetrySequence(tool_name="Bash", attempts=-1)
+
+    def test_default_empty_indices(self) -> None:
+        seq = RetrySequence(tool_name="Read", attempts=2)
+        assert seq.tool_call_indices == []
+
+    def test_optional_error_messages(self) -> None:
+        seq = RetrySequence(
+            tool_name="Read",
+            attempts=2,
+            eventual_success=True,
+        )
+        assert seq.first_error_message is None
+        assert seq.last_error_message is None
+
+    def test_json_round_trip(self) -> None:
+        seq = RetrySequence(
+            tool_name="Bash",
+            attempts=3,
+            first_error_message="first",
+            last_error_message="last",
+            eventual_success=True,
+            tool_call_indices=[1, 2, 3],
+        )
+        restored = RetrySequence.model_validate_json(seq.model_dump_json())
+        assert restored == seq
+
+    def test_extra_fields_ignored(self) -> None:
+        seq = RetrySequence.model_validate(
+            {"tool_name": "Read", "attempts": 2, "future_field": "x"},
+        )
+        assert seq.tool_name == "Read"
+
+
+class TestSubagentTrace:
+    def _minimal(self) -> SubagentTrace:
+        return SubagentTrace(
+            agent_id="uuid-abc",
+            delegation_prompt="Review backlog",
+        )
+
+    def test_minimal_construction(self) -> None:
+        trace = self._minimal()
+        assert trace.agent_id == "uuid-abc"
+        assert trace.agent_type == UNKNOWN_AGENT_TYPE
+        assert trace.delegation_prompt == "Review backlog"
+        assert trace.tool_calls == []
+        assert trace.retry_sequences == []
+        assert trace.total_errors == 0
+        assert trace.total_retries == 0
+        assert trace.usage.input_tokens == 0
+        assert trace.duration_ms is None
+        assert trace.source_file is None
+
+    def test_with_tool_calls_and_retries(self) -> None:
+        tc1 = SubagentToolCall(
+            tool_name="Bash", input_summary="a", result_summary="x",
+        )
+        tc2 = SubagentToolCall(
+            tool_name="Read", input_summary="b", result_summary="y",
+        )
+        retry = RetrySequence(
+            tool_name="Bash", attempts=2, tool_call_indices=[0],
+        )
+        trace = SubagentTrace(
+            agent_id="uuid-1",
+            agent_type="pm",
+            delegation_prompt="Do work",
+            tool_calls=[tc1, tc2],
+            retry_sequences=[retry],
+            total_errors=1,
+            total_retries=2,
+            duration_ms=5000,
+        )
+        assert len(trace.tool_calls) == 2
+        assert len(trace.retry_sequences) == 1
+        assert trace.total_errors == 1
+        assert trace.duration_ms == 5000
+
+    def test_agent_type_defaults_to_unknown(self) -> None:
+        trace = self._minimal()
+        assert trace.agent_type == UNKNOWN_AGENT_TYPE
+
+    def test_source_file_optional(self) -> None:
+        assert self._minimal().source_file is None
+        with_file = SubagentTrace(
+            agent_id="u",
+            delegation_prompt="p",
+            source_file=Path("/tmp/agent-u.jsonl"),
+        )
+        assert with_file.source_file == Path("/tmp/agent-u.jsonl")
+
+    def test_duration_ms_optional(self) -> None:
+        assert self._minimal().duration_ms is None
+
+    def test_unique_tool_names_property(self) -> None:
+        trace = SubagentTrace(
+            agent_id="u",
+            delegation_prompt="p",
+            tool_calls=[
+                SubagentToolCall(tool_name="Bash", input_summary="", result_summary=""),
+                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
+                SubagentToolCall(tool_name="Bash", input_summary="", result_summary=""),
+            ],
+        )
+        assert trace.unique_tool_names == {"Bash", "Read"}
+
+    def test_unique_tool_names_empty_for_no_tool_calls(self) -> None:
+        assert self._minimal().unique_tool_names == set()
+
+    def test_unique_tool_names_is_cached(self) -> None:
+        trace = SubagentTrace(
+            agent_id="u",
+            delegation_prompt="p",
+            tool_calls=[
+                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
+            ],
+        )
+        # Identity check: the cached_property returns the same object on re-access.
+        assert trace.unique_tool_names is trace.unique_tool_names
+
+    def test_unique_tool_names_not_in_json(self) -> None:
+        trace = SubagentTrace(
+            agent_id="u",
+            delegation_prompt="p",
+            tool_calls=[
+                SubagentToolCall(tool_name="Read", input_summary="", result_summary=""),
+            ],
+        )
+        # Access once to populate the cache.
+        _ = trace.unique_tool_names
+        dumped = trace.model_dump()
+        assert "unique_tool_names" not in dumped
+        assert "unique_tool_names" not in trace.model_dump_json()
+
+    def test_json_round_trip_minimal(self) -> None:
+        trace = self._minimal()
+        restored = SubagentTrace.model_validate_json(trace.model_dump_json())
+        assert restored == trace
+
+    def test_json_round_trip_full(self) -> None:
+        trace = SubagentTrace(
+            agent_id="uuid-1",
+            agent_type="pm",
+            delegation_prompt="Do work",
+            tool_calls=[
+                SubagentToolCall(
+                    tool_name="Bash",
+                    input_summary="ls",
+                    result_summary="file.txt",
+                    is_error=False,
+                    usage=Usage(input_tokens=5, output_tokens=3),
+                    timestamp=datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC),
+                ),
+            ],
+            retry_sequences=[
+                RetrySequence(
+                    tool_name="Bash", attempts=2, tool_call_indices=[0],
+                ),
+            ],
+            total_errors=0,
+            total_retries=2,
+            usage=Usage(input_tokens=100, output_tokens=50),
+            duration_ms=1234,
+            source_file=Path("/tmp/agent-uuid-1.jsonl"),
+        )
+        restored = SubagentTrace.model_validate_json(trace.model_dump_json())
+        assert restored == trace
+
+    def test_path_serializes_as_string(self) -> None:
+        trace = SubagentTrace(
+            agent_id="u",
+            delegation_prompt="p",
+            source_file=Path("/tmp/x.jsonl"),
+        )
+        payload = json.loads(trace.model_dump_json())
+        assert isinstance(payload["source_file"], str)
+        assert payload["source_file"] == "/tmp/x.jsonl"
+
+    def test_extra_fields_ignored(self) -> None:
+        trace = SubagentTrace.model_validate(
+            {
+                "agent_id": "u",
+                "delegation_prompt": "p",
+                "future_field": {"nested": True},
+            },
+        )
+        assert trace.agent_id == "u"
+
+    def test_serializes_inside_list_wrapper(self) -> None:
+        """Proves the nesting chain works without #105's AgentInvocation.trace."""
+
+        class _Wrapper(BaseModel):
+            traces: list[SubagentTrace] = []
+
+        wrapper = _Wrapper(
+            traces=[
+                SubagentTrace(agent_id="a", delegation_prompt="p1"),
+                SubagentTrace(agent_id="b", delegation_prompt="p2", agent_type="pm"),
+            ],
+        )
+        restored = _Wrapper.model_validate_json(wrapper.model_dump_json())
+        assert restored == wrapper
+        assert restored.traces[1].agent_type == "pm"


### PR DESCRIPTION
## Summary

Foundational story for the v0.3 E2 subagent trace parser epic. Defines the three Pydantic models (`SubagentTrace`, `SubagentToolCall`, `RetrySequence`) that downstream stories #103/#104/#105 will produce and that #107/#110/#111/#113 will consume.

Closes #101.

### What's here

- New `src/agentfluent/traces/` subpackage (`__init__.py` empty, matches project convention)
- `src/agentfluent/traces/models.py` — three `BaseModel` classes + three module constants (`INPUT_SUMMARY_MAX_CHARS`, `RESULT_SUMMARY_MAX_CHARS`, `UNKNOWN_AGENT_TYPE`)
- `SubagentTrace.unique_tool_names` as `@cached_property` — Architect B's single-source-of-truth requirement for `#107`/`#110`/`#111`
- 26 new unit tests in `tests/unit/test_traces_models.py`

### Architect interface contract (reference)

| Type/Field | Consumers |
|---|---|
| `SubagentTrace` | E3, E4, E5, E6 |
| `SubagentToolCall` | E3, E5, E6 |
| `RetrySequence` | E3 |
| `SubagentTrace.unique_tool_names` | E3, E4, E5 |
| `AgentInvocation.trace` (**deferred to #105**) | E3, E4, E5 |

### Explicit deferrals

This PR is narrow. The following are **NOT** in scope:

- JSONL parsing, `agent_type` inference from delegation prompt, truncation enforcement, `usage` aggregation, `duration_ms` derivation → **#103**
- Retry sequence detection algorithm, `total_retries` summation, `tool_call_indices` generation → **#104**
- Linker that overwrites `SubagentTrace.agent_type` from parent `AgentInvocation.agent_type`; adding `trace: SubagentTrace | None` to `AgentInvocation` → **#105**
- Real subagent JSONL fixtures → **#106**

### Key design choices

- **`cached_property` (not `@property` or `PrivateAttr`)** — O(1) on reuse across three downstream aggregators. Write-once contract documented in the model docstring.
- **No `frozen=True`** — the linker (#105) mutates `agent_type` from the parent, and `frozen` would defeat `cached_property`.
- **No camelCase aliases** — the parser (#103) owns JSONL translation; models stay snake_case-only.
- **Minimal validators** — only `RetrySequence.attempts >= 1`. Cross-field bounds (`tool_call_indices` vs `tool_calls` length) are a #104 invariant, not a model concern.
- **Constants in `models.py`** — the truncation lengths are a stable contract any writer (parser, replay tools, fixtures) must honor. Soft contract, enforced on write by #103; no Pydantic `max_length` validator.

### Test plan

- [x] `uv run pytest tests/unit/test_traces_models.py -v` → 26 passed
- [x] `uv run pytest -m "not integration"` → 320 passed (full unit suite)
- [x] `uv run mypy src/agentfluent/` → clean (strict mode)
- [x] `uv run ruff check src/ tests/` → clean
- [x] Tests cover: construction (minimal + full), defaults, JSON round-trip (incl. `Path` and tz-aware `datetime`), `extra="ignore"` forward-compat, `unique_tool_names` correctness + caching-identity + JSON-exclusion, `attempts >= 1` validator, list-wrapper nesting (proves serialization chain works before #105 adds `AgentInvocation.trace`)

### Reference

- Plan: `plans/yes-let-s-start-by-misty-cocke.md`
- Architect A's interface contract: [comment on #98](https://github.com/frederick-douglas-pearce/agentfluent/issues/98)
- Architect B's `unique_tool_names` / linker-overwrite requirements: [comment on #101](https://github.com/frederick-douglas-pearce/agentfluent/issues/101), [comment on #105](https://github.com/frederick-douglas-pearce/agentfluent/issues/105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)