### PR TITLE
chore: sync uv.lock to 0.2.0 and gitignore Claude Code lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ data/
 .env
 .env.local
 
-# Claude Code local settings
+# Claude Code local settings and runtime state
 .claude/settings.local.json
+.claude/*.lock
 
 # IDE
 .vscode/

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentfluent"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Two small hygiene fixes surfaced while reviewing pending working-tree state:

1. **`uv.lock` drift sync.** `pyproject.toml` reads `0.2.0` (release-please bumped it in #74) but `uv.lock` still had the `agentfluent` package pinned at `0.1.0`. Every `uv run ...` across every branch has been silently re-syncing the lockfile, producing the same one-line diff on every developer's working tree. One-line commit to the authoritative version.

2. **`.gitignore` for Claude Code lock files.** `.claude/scheduled_tasks.lock` is runtime state written by Claude Code's `ScheduleWakeup` feature (session ID + PID, like a lockfile). It was showing up as untracked in every session that used scheduled wake-ups. Added `.claude/*.lock` to the existing Claude Code section in `.gitignore` — same convention as the adjacent `.claude/settings.local.json`.

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude/settings.local.json'))"` → valid JSON (unrelated but verified in passing)
- [x] `git status` clean after staging both changes — `scheduled_tasks.lock` no longer surfaces
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)