### PR TITLE
feat(traces): implement subagent directory discovery

### DIFF
--- a/src/agentfluent/core/discovery.py
+++ b/src/agentfluent/core/discovery.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agentfluent.core.paths import DEFAULT_CLAUDE_CONFIG_DIR, PROJECTS_SUBDIR
+from agentfluent.core.paths import (
+    DEFAULT_CLAUDE_CONFIG_DIR,
+    PROJECTS_SUBDIR,
+    SUBAGENTS_SUBDIR,
+)
 
 DEFAULT_PROJECTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / PROJECTS_SUBDIR
 
@@ -61,7 +65,7 @@ def _count_subagent_files(session_path: Path) -> int:
     where <session-uuid> is a directory named the same as the session file (minus .jsonl).
     """
     session_dir = session_path.parent / session_path.stem
-    subagents_dir = session_dir / "subagents"
+    subagents_dir = session_dir / SUBAGENTS_SUBDIR
     if not subagents_dir.is_dir():
         return 0
     return sum(1 for f in subagents_dir.iterdir() if f.suffix == ".jsonl")

--- a/src/agentfluent/core/paths.py
+++ b/src/agentfluent/core/paths.py
@@ -16,6 +16,9 @@ CLAUDE_CONFIG_DIR_ENV_VAR = "CLAUDE_CONFIG_DIR"
 
 PROJECTS_SUBDIR = "projects"
 AGENTS_SUBDIR = "agents"
+SUBAGENTS_SUBDIR = "subagents"
+"""The per-session directory that holds subagent trace JSONL files:
+``<project>/<session-uuid>/subagents/agent-<agentId>.jsonl``."""
 
 
 def projects_dir_for(config_root: Path | None) -> Path | None:

--- a/src/agentfluent/traces/discovery.py
+++ b/src/agentfluent/traces/discovery.py
@@ -3,7 +3,8 @@
 Subagent traces live at
 ``<project_path>/<session-uuid>/subagents/agent-<agentId>.jsonl``. This
 module enumerates those files and extracts ``agentId`` from the
-filename; parsing is #103's job.
+filename. Parsing of trace contents is deferred to the trace parser
+module; this layer only walks directories and names files.
 
 The ``session_id`` keys returned by ``discover_subagent_files`` match the
 directory name, which equals the session JSONL filename's stem — the same

--- a/src/agentfluent/traces/discovery.py
+++ b/src/agentfluent/traces/discovery.py
@@ -1,0 +1,74 @@
+"""Discovery of subagent trace files under a Claude Code project tree.
+
+Subagent traces live at
+``<project_path>/<session-uuid>/subagents/agent-<agentId>.jsonl``. This
+module enumerates those files and extracts ``agentId`` from the
+filename; parsing is #103's job.
+
+The ``session_id`` keys returned by ``discover_subagent_files`` match the
+directory name, which equals the session JSONL filename's stem — the same
+key used by ``core.discovery.SessionInfo``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentfluent.core.paths import SUBAGENTS_SUBDIR
+
+AGENT_FILENAME_PATTERN = re.compile(r"^agent-(.+)\.jsonl$")
+
+
+@dataclass
+class SubagentFileInfo:
+    """Metadata for one subagent trace JSONL file."""
+
+    path: Path
+    agent_id: str
+
+
+def discover_session_subagents(session_dir: Path) -> list[SubagentFileInfo]:
+    """Return subagent file info for one session directory.
+
+    ``session_dir`` is the directory counterpart to a session JSONL file
+    (e.g. ``<project>/<session-uuid>/``). Returns an empty list when the
+    ``subagents/`` subdirectory is missing or contains no files matching
+    the ``agent-<agentId>.jsonl`` pattern.
+    """
+    subagents_dir = session_dir / SUBAGENTS_SUBDIR
+    if not subagents_dir.is_dir():
+        return []
+
+    files: list[SubagentFileInfo] = []
+    for entry in sorted(subagents_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        match = AGENT_FILENAME_PATTERN.match(entry.name)
+        if match is None:
+            continue
+        files.append(SubagentFileInfo(path=entry, agent_id=match.group(1)))
+    return files
+
+
+def discover_subagent_files(
+    project_path: Path,
+) -> dict[str, list[SubagentFileInfo]]:
+    """Return a ``session_id -> subagent files`` mapping for a project.
+
+    Walks each direct subdirectory of ``project_path`` and collects its
+    subagent files via ``discover_session_subagents``. Sessions with no
+    subagent directory (or an empty one) are omitted from the mapping.
+    """
+    if not project_path.is_dir():
+        return {}
+
+    results: dict[str, list[SubagentFileInfo]] = {}
+    for entry in sorted(project_path.iterdir()):
+        if not entry.is_dir():
+            continue
+        subagent_files = discover_session_subagents(entry)
+        if subagent_files:
+            results[entry.name] = subagent_files
+    return results

--- a/tests/unit/test_traces_discovery.py
+++ b/tests/unit/test_traces_discovery.py
@@ -34,6 +34,16 @@ class TestAgentFilenamePattern:
         assert AGENT_FILENAME_PATTERN.match("agent.jsonl") is None
         assert AGENT_FILENAME_PATTERN.match("agent-abc.txt") is None
 
+    def test_rejects_empty_agent_id(self) -> None:
+        # `.+` in the pattern requires at least one character between
+        # "agent-" and ".jsonl", so an empty UUID is rejected.
+        assert AGENT_FILENAME_PATTERN.match("agent-.jsonl") is None
+
+    def test_rejects_leading_dot(self) -> None:
+        # The `^agent-` anchor keeps dotfiles out even if the rest
+        # of the filename would otherwise match.
+        assert AGENT_FILENAME_PATTERN.match(".agent-abc.jsonl") is None
+
 
 class TestDiscoverSessionSubagents:
     def test_missing_subagents_dir_returns_empty(self, tmp_path: Path) -> None:
@@ -70,6 +80,16 @@ class TestDiscoverSessionSubagents:
     def test_skips_nested_directories(self, tmp_path: Path) -> None:
         session_dir = tmp_path / "s1"
         (session_dir / "subagents" / "agent-sub.jsonl").mkdir(parents=True)
+        (session_dir / "subagents" / "agent-real.jsonl").write_text("{}\n")
+
+        files = discover_session_subagents(session_dir)
+        assert [f.agent_id for f in files] == ["real"]
+
+    def test_skips_dotfiles_in_subagents_dir(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "s1"
+        (session_dir / "subagents").mkdir(parents=True)
+        (session_dir / "subagents" / ".agent-hidden.jsonl").write_text("{}\n")
+        (session_dir / "subagents" / ".DS_Store").write_text("")
         (session_dir / "subagents" / "agent-real.jsonl").write_text("{}\n")
 
         files = discover_session_subagents(session_dir)

--- a/tests/unit/test_traces_discovery.py
+++ b/tests/unit/test_traces_discovery.py
@@ -1,0 +1,123 @@
+"""Tests for subagent trace file discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentfluent.traces.discovery import (
+    AGENT_FILENAME_PATTERN,
+    SubagentFileInfo,
+    discover_session_subagents,
+    discover_subagent_files,
+)
+
+
+def _make_session_with_subagents(
+    project_root: Path, session_id: str, agent_ids: list[str],
+) -> Path:
+    """Create a session dir with a subagents/ subdir containing agent-*.jsonl files."""
+    session_dir = project_root / session_id
+    (session_dir / "subagents").mkdir(parents=True)
+    for agent_id in agent_ids:
+        (session_dir / "subagents" / f"agent-{agent_id}.jsonl").write_text("{}\n")
+    return session_dir
+
+
+class TestAgentFilenamePattern:
+    def test_matches_uuid_filename(self) -> None:
+        m = AGENT_FILENAME_PATTERN.match("agent-abc-123.jsonl")
+        assert m is not None
+        assert m.group(1) == "abc-123"
+
+    def test_rejects_non_agent_filename(self) -> None:
+        assert AGENT_FILENAME_PATTERN.match("foo.jsonl") is None
+        assert AGENT_FILENAME_PATTERN.match("agent.jsonl") is None
+        assert AGENT_FILENAME_PATTERN.match("agent-abc.txt") is None
+
+
+class TestDiscoverSessionSubagents:
+    def test_missing_subagents_dir_returns_empty(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session-1"
+        session_dir.mkdir()
+        assert discover_session_subagents(session_dir) == []
+
+    def test_empty_subagents_dir_returns_empty(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session-1"
+        (session_dir / "subagents").mkdir(parents=True)
+        assert discover_session_subagents(session_dir) == []
+
+    def test_returns_matching_files_sorted(self, tmp_path: Path) -> None:
+        session_dir = _make_session_with_subagents(
+            tmp_path, "s1", ["bbb", "aaa", "ccc"],
+        )
+        files = discover_session_subagents(session_dir)
+        # Sorted by filename -> agent-aaa, agent-bbb, agent-ccc
+        assert [f.agent_id for f in files] == ["aaa", "bbb", "ccc"]
+        for f in files:
+            assert f.path.parent.name == "subagents"
+
+    def test_skips_non_matching_files(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "s1"
+        (session_dir / "subagents").mkdir(parents=True)
+        (session_dir / "subagents" / "agent-keep.jsonl").write_text("{}\n")
+        (session_dir / "subagents" / "readme.txt").write_text("hi")
+        (session_dir / "subagents" / "other.jsonl").write_text("{}\n")
+        (session_dir / "subagents" / "agent-bad.log").write_text("")
+
+        files = discover_session_subagents(session_dir)
+        assert [f.agent_id for f in files] == ["keep"]
+
+    def test_skips_nested_directories(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "s1"
+        (session_dir / "subagents" / "agent-sub.jsonl").mkdir(parents=True)
+        (session_dir / "subagents" / "agent-real.jsonl").write_text("{}\n")
+
+        files = discover_session_subagents(session_dir)
+        assert [f.agent_id for f in files] == ["real"]
+
+
+class TestDiscoverSubagentFiles:
+    def test_missing_project_path_returns_empty(self, tmp_path: Path) -> None:
+        assert discover_subagent_files(tmp_path / "nope") == {}
+
+    def test_project_is_file_returns_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("")
+        assert discover_subagent_files(f) == {}
+
+    def test_project_with_no_sessions_returns_empty(self, tmp_path: Path) -> None:
+        assert discover_subagent_files(tmp_path) == {}
+
+    def test_sessions_without_subagents_omitted(self, tmp_path: Path) -> None:
+        # One session with subagents, one without.
+        _make_session_with_subagents(tmp_path, "s1", ["a1"])
+        (tmp_path / "s2").mkdir()
+
+        result = discover_subagent_files(tmp_path)
+        assert list(result.keys()) == ["s1"]
+
+    def test_multiple_sessions_mapped(self, tmp_path: Path) -> None:
+        _make_session_with_subagents(tmp_path, "s1", ["a1", "a2"])
+        _make_session_with_subagents(tmp_path, "s2", ["b1"])
+
+        result = discover_subagent_files(tmp_path)
+        assert set(result.keys()) == {"s1", "s2"}
+        assert [f.agent_id for f in result["s1"]] == ["a1", "a2"]
+        assert [f.agent_id for f in result["s2"]] == ["b1"]
+
+    def test_ignores_files_at_project_level(self, tmp_path: Path) -> None:
+        # Session JSONL files themselves live alongside the session dirs;
+        # they should not be mistaken for session directories.
+        (tmp_path / "s1.jsonl").write_text("{}\n")
+        _make_session_with_subagents(tmp_path, "s1", ["a1"])
+
+        result = discover_subagent_files(tmp_path)
+        assert list(result.keys()) == ["s1"]
+
+    def test_subagent_file_info_shape(self, tmp_path: Path) -> None:
+        _make_session_with_subagents(tmp_path, "s1", ["agent-uuid-123"])
+        result = discover_subagent_files(tmp_path)
+        [info] = result["s1"]
+        assert isinstance(info, SubagentFileInfo)
+        assert info.agent_id == "agent-uuid-123"
+        assert info.path.name == "agent-agent-uuid-123.jsonl"


### PR DESCRIPTION
## Summary

Enumerates subagent trace JSONL files under a project tree — the input source for the parser (#103).

Two entry points in the new `agentfluent.traces.discovery` module:

- **`discover_session_subagents(session_dir)`** — given one session UUID directory, returns its subagent files
- **`discover_subagent_files(project_path)`** — given a project root, returns `session_id -> list[SubagentFileInfo]` mapping, omitting sessions with no subagent directory

`SubagentFileInfo` is a simple dataclass with `path: Path` and `agent_id: str` (extracted from the `agent-<agentId>.jsonl` filename pattern via a module-level compiled regex).

Closes #102.

## Architect follow-up addressed

Per architect A's review of #102 (non-blocking suggestion): the `"subagents"` subdirectory name is now defined once as `SUBAGENTS_SUBDIR` in `core/paths.py` alongside `PROJECTS_SUBDIR` / `AGENTS_SUBDIR`. Both the new module and `core/discovery.py::_count_subagent_files` read from the same constant — no drift risk if Claude Code ever renames the convention.

## Defensive handling (all covered by tests)

- Missing project path → `{}`
- Project path pointing at a file → `{}`
- Project with no session subdirs → `{}`
- Sessions with no `subagents/` dir → omitted from result
- Empty `subagents/` dir → omitted from result
- Non-matching files (`readme.txt`, `foo.jsonl`, `agent-bad.log`) → skipped
- Nested directories named `agent-*.jsonl` → skipped (files only)
- Session `.jsonl` files at project level alongside session dirs → correctly treated as non-directories

## Test plan

- [x] `uv run pytest tests/unit/test_traces_discovery.py -v` → 14 passed
- [x] `uv run pytest tests/unit/test_discovery.py -v` → 21 passed (existing tests still green after the `_count_subagent_files` refactor)
- [x] `uv run pytest -m "not integration"` → 334 passed total
- [x] `uv run mypy src/agentfluent/` → clean (strict mode)
- [x] `uv run ruff check src/ tests/` → clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)