### PR TITLE
feat(traces): implement subagent trace parser

### DIFF
--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -115,6 +115,7 @@ def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[C
                         type="tool_result",
                         tool_use_id=item.get("tool_use_id"),
                         text=result_text,
+                        is_error=item.get("is_error"),
                     )
                 )
             else:

--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -54,6 +54,7 @@ class ContentBlock(BaseModel):
     input: dict[str, Any] | None = None
     # tool_result fields (only present when type == "tool_result")
     tool_use_id: str | None = None
+    is_error: bool | None = None
 
 
 class ToolResultMetadata(BaseModel):

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -27,8 +27,10 @@ ERROR_PATTERNS: list[tuple[str, Severity]] = [
     ("timed out", Severity.WARNING),
 ]
 
-# Compiled pattern for efficient matching
-_ERROR_RE = re.compile(
+# Compiled pattern for efficient matching. Public so other modules
+# (e.g., traces.parser) reuse the same regex instead of recompiling from
+# ERROR_PATTERNS.
+ERROR_REGEX = re.compile(
     "|".join(re.escape(kw) for kw, _ in ERROR_PATTERNS),
     re.IGNORECASE,
 )
@@ -47,7 +49,7 @@ def _extract_error_signals(invocations: list[AgentInvocation]) -> list[Diagnosti
         if not inv.output_text:
             continue
 
-        for match in _ERROR_RE.finditer(inv.output_text):
+        for match in ERROR_REGEX.finditer(inv.output_text):
             keyword = match.group(0).lower()
             severity = _KEYWORD_SEVERITY.get(keyword, Severity.WARNING)
 

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -1,0 +1,189 @@
+"""Parse subagent trace JSONL files into ``SubagentTrace`` instances.
+
+Consumes one file at ``<project>/<session-uuid>/subagents/agent-<agentId>.jsonl``
+by delegating to ``core.parser.parse_session`` for line reading, SKIP_TYPES
+filtering, per-message parsing, and streaming-snapshot deduplication. This
+module's job is the subagent-specific shape on top of that: pairing
+``tool_use``/``tool_result`` blocks, truncating summaries, detecting errors,
+aggregating ``Usage``, and deriving the trace's scalar fields.
+
+Downstream deferrals: retry sequence detection populates
+``SubagentTrace.retry_sequences`` in #104 (parser leaves it empty here);
+the linker in #105 overwrites ``agent_type`` from the parent
+``AgentInvocation.agent_type`` (parser leaves it as ``UNKNOWN_AGENT_TYPE``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from agentfluent.core.parser import parse_session
+from agentfluent.core.session import ContentBlock, SessionMessage, Usage
+from agentfluent.diagnostics.signals import ERROR_PATTERNS
+from agentfluent.traces.discovery import AGENT_FILENAME_PATTERN
+from agentfluent.traces.models import (
+    INPUT_SUMMARY_MAX_CHARS,
+    RESULT_SUMMARY_MAX_CHARS,
+    UNKNOWN_AGENT_TYPE,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+_SUBAGENT_ERROR_RE = re.compile(
+    "|".join(re.escape(kw) for kw, _ in ERROR_PATTERNS),
+    re.IGNORECASE,
+)
+
+
+def _truncate_input(input_dict: dict[str, Any] | None) -> str:
+    """Serialize a tool_use input dict and truncate to the model's max.
+
+    ``default=str`` handles non-serializable values (datetimes, Paths);
+    ``ensure_ascii=False`` preserves unicode for readability. Python str
+    slicing is codepoint-aware, so the truncation never produces invalid
+    unicode (though it can split extended grapheme clusters — acceptable
+    for summary display).
+    """
+    if input_dict is None:
+        return ""
+    serialized = json.dumps(input_dict, default=str, ensure_ascii=False)
+    return serialized[:INPUT_SUMMARY_MAX_CHARS]
+
+
+def _truncate_result(text: str | None) -> str:
+    if text is None:
+        return ""
+    return text[:RESULT_SUMMARY_MAX_CHARS]
+
+
+def _detect_is_error(block: ContentBlock) -> bool:
+    """Detect whether a tool_result block represents an error.
+
+    Explicit ``is_error`` field is authoritative when present (True or
+    False). When missing, fall back to regex-matching the result text
+    against ``ERROR_PATTERNS`` keywords (case-insensitive).
+    """
+    if block.is_error is not None:
+        return block.is_error
+    if not block.text:
+        return False
+    return bool(_SUBAGENT_ERROR_RE.search(block.text))
+
+
+def _sum_usage(messages: list[SessionMessage]) -> Usage:
+    """Aggregate ``Usage`` across assistant messages. User messages have
+    no ``usage`` and are skipped."""
+    total = Usage()
+    for msg in messages:
+        if msg.usage is None:
+            continue
+        total.input_tokens += msg.usage.input_tokens
+        total.output_tokens += msg.usage.output_tokens
+        total.cache_creation_input_tokens += msg.usage.cache_creation_input_tokens
+        total.cache_read_input_tokens += msg.usage.cache_read_input_tokens
+    return total
+
+
+def _compute_duration_ms(messages: list[SessionMessage]) -> int | None:
+    """Timestamp span from first to last message, in milliseconds.
+
+    Returns ``None`` when fewer than two timestamped messages exist.
+    """
+    timestamps = [msg.timestamp for msg in messages if msg.timestamp is not None]
+    if len(timestamps) < 2:
+        return None
+    first = timestamps[0]
+    last = timestamps[-1]
+    return int(round((last - first).total_seconds() * 1000))
+
+
+def _extract_delegation_prompt(messages: list[SessionMessage]) -> str:
+    """First user message's text content; empty string if no user messages."""
+    for msg in messages:
+        if msg.type == "user":
+            return msg.text
+    return ""
+
+
+def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
+    """Pair ``tool_use`` blocks (in assistant messages) with ``tool_result``
+    blocks (in user messages) by ``tool_use_id`` and build
+    ``SubagentToolCall`` entries.
+
+    Per-call ``Usage`` is left at default zero: the JSONL shape provides
+    one ``usage`` per assistant message but a single message can carry
+    multiple ``tool_use`` blocks, so faithful per-call token attribution
+    is not possible. Trace-level ``usage`` is the source of truth.
+    """
+    results: dict[str, ContentBlock] = {}
+    for msg in messages:
+        if msg.type != "user":
+            continue
+        for block in msg.content_blocks:
+            if block.type == "tool_result" and block.tool_use_id:
+                results[block.tool_use_id] = block
+
+    tool_calls: list[SubagentToolCall] = []
+    for msg in messages:
+        if msg.type != "assistant":
+            continue
+        for block in msg.content_blocks:
+            if block.type != "tool_use" or block.id is None:
+                continue
+            result_block = results.get(block.id)
+            is_error = _detect_is_error(result_block) if result_block else False
+            result_text = result_block.text if result_block else None
+            tool_calls.append(
+                SubagentToolCall(
+                    tool_name=block.name or "",
+                    input_summary=_truncate_input(block.input),
+                    result_summary=_truncate_result(result_text),
+                    is_error=is_error,
+                    timestamp=msg.timestamp,
+                ),
+            )
+    return tool_calls
+
+
+def parse_subagent_trace(path: Path) -> SubagentTrace:
+    """Parse one subagent JSONL file into a ``SubagentTrace``.
+
+    ``path`` must match the ``agent-<agentId>.jsonl`` pattern; the filename
+    is the authoritative source of ``agent_id``. Delegates to
+    ``core.parser.parse_session`` for all line-level concerns, then builds
+    subagent-specific fields on top.
+
+    Raises:
+        FileNotFoundError: ``path`` does not exist. Discovery (#129)
+            guarantees existence at call time; this guard catches direct-
+            caller programmer errors rather than a user-facing case.
+        ValueError: ``path.name`` does not match ``agent-<agentId>.jsonl``.
+    """
+    if not path.exists():
+        msg = f"Subagent trace file not found: {path}"
+        raise FileNotFoundError(msg)
+
+    filename_match = AGENT_FILENAME_PATTERN.match(path.name)
+    if filename_match is None:
+        msg = f"Malformed subagent filename (expected agent-<agentId>.jsonl): {path.name}"
+        raise ValueError(msg)
+    agent_id = filename_match.group(1)
+
+    messages = parse_session(path)
+    tool_calls = _pair_tool_calls(messages)
+
+    return SubagentTrace(
+        agent_id=agent_id,
+        agent_type=UNKNOWN_AGENT_TYPE,
+        delegation_prompt=_extract_delegation_prompt(messages),
+        tool_calls=tool_calls,
+        retry_sequences=[],
+        total_errors=sum(1 for tc in tool_calls if tc.is_error),
+        total_retries=0,
+        usage=_sum_usage(messages),
+        duration_ms=_compute_duration_ms(messages),
+        source_file=path.resolve(),
+    )

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -7,22 +7,27 @@ module's job is the subagent-specific shape on top of that: pairing
 ``tool_use``/``tool_result`` blocks, truncating summaries, detecting errors,
 aggregating ``Usage``, and deriving the trace's scalar fields.
 
-Downstream deferrals: retry sequence detection populates
-``SubagentTrace.retry_sequences`` in #104 (parser leaves it empty here);
-the linker in #105 overwrites ``agent_type`` from the parent
-``AgentInvocation.agent_type`` (parser leaves it as ``UNKNOWN_AGENT_TYPE``).
+Unlike the sibling ``parse_session`` (which warn-logs and returns an empty
+list for missing paths), ``parse_subagent_trace`` raises ``FileNotFoundError``
+on a missing path — the trace-discovery step guarantees path existence at
+call time, so a missing file is a programmer error rather than a user
+condition.
+
+Two fields on ``SubagentTrace`` are intentionally left unpopulated here and
+filled in by later work: retry-sequence detection populates
+``retry_sequences`` / ``total_retries``, and the trace-to-parent linker
+overwrites ``agent_type`` with the parent ``AgentInvocation`` value.
 """
 
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
-from agentfluent.diagnostics.signals import ERROR_PATTERNS
+from agentfluent.diagnostics.signals import ERROR_REGEX
 from agentfluent.traces.discovery import AGENT_FILENAME_PATTERN
 from agentfluent.traces.models import (
     INPUT_SUMMARY_MAX_CHARS,
@@ -30,11 +35,6 @@ from agentfluent.traces.models import (
     UNKNOWN_AGENT_TYPE,
     SubagentToolCall,
     SubagentTrace,
-)
-
-_SUBAGENT_ERROR_RE = re.compile(
-    "|".join(re.escape(kw) for kw, _ in ERROR_PATTERNS),
-    re.IGNORECASE,
 )
 
 
@@ -70,7 +70,7 @@ def _detect_is_error(block: ContentBlock) -> bool:
         return block.is_error
     if not block.text:
         return False
-    return bool(_SUBAGENT_ERROR_RE.search(block.text))
+    return bool(ERROR_REGEX.search(block.text))
 
 
 def _sum_usage(messages: list[SessionMessage]) -> Usage:
@@ -157,7 +157,7 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
     subagent-specific fields on top.
 
     Raises:
-        FileNotFoundError: ``path`` does not exist. Discovery (#129)
+        FileNotFoundError: ``path`` does not exist. The discovery step
             guarantees existence at call time; this guard catches direct-
             caller programmer errors rather than a user-facing case.
         ValueError: ``path.name`` does not match ``agent-<agentId>.jsonl``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,31 @@
 """Shared test fixtures for AgentFluent."""
 
+import json
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def write_jsonl(tmp_path: Path) -> Callable[[str, list[dict[str, Any]]], Path]:
+    """Return a helper that writes a list of dicts as a JSONL file under tmp_path.
+
+    Used by parser tests that want to construct session/subagent trace
+    content inline rather than maintain on-disk fixtures.
+    """
+
+    def _write(filename: str, lines: list[dict[str, Any]]) -> Path:
+        path = tmp_path / filename
+        with path.open("w") as f:
+            for line in lines:
+                f.write(json.dumps(line) + "\n")
+        return path
+
+    return _write
 
 
 @pytest.fixture()

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -287,6 +287,46 @@ class TestToolUseResultOnUserMessage:
         messages = parse_session(path)
         assert messages[0].metadata is None
 
+    def test_is_error_flows_from_normalize_content(self, tmp_path: Path) -> None:
+        """The `is_error` field on a tool_result JSONL block propagates to ContentBlock."""
+        path = self._write(
+            tmp_path,
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_err",
+                                "content": "permission denied",
+                                "is_error": True,
+                            },
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_ok",
+                                "content": "42",
+                                "is_error": False,
+                            },
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_missing",
+                                "content": "no flag",
+                            },
+                        ],
+                    },
+                    "timestamp": "2026-04-14T08:00:00.000Z",
+                },
+            ],
+        )
+        messages = parse_session(path)
+        blocks = messages[0].content_blocks
+        by_id = {b.tool_use_id: b for b in blocks}
+        assert by_id["toolu_err"].is_error is True
+        assert by_id["toolu_ok"].is_error is False
+        assert by_id["toolu_missing"].is_error is None
+
 
 class TestTimestamps:
     def test_timestamps_parsed(self, basic_session_path: Path) -> None:

--- a/tests/unit/test_session_models.py
+++ b/tests/unit/test_session_models.py
@@ -55,6 +55,20 @@ class TestContentBlock:
         assert block.type == "tool_use"
         assert block.name == "Agent"
 
+    def test_tool_result_is_error_field(self) -> None:
+        default = ContentBlock(type="tool_result", tool_use_id="toolu_01")
+        assert default.is_error is None
+
+        flagged = ContentBlock(
+            type="tool_result", tool_use_id="toolu_01", is_error=True,
+        )
+        assert flagged.is_error is True
+
+        ok = ContentBlock(
+            type="tool_result", tool_use_id="toolu_01", is_error=False,
+        )
+        assert ok.is_error is False
+
 
 class TestToolResultMetadata:
     def test_from_json_with_alias(self) -> None:

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -1,0 +1,494 @@
+"""Tests for the subagent trace parser."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.traces.models import (
+    INPUT_SUMMARY_MAX_CHARS,
+    RESULT_SUMMARY_MAX_CHARS,
+    UNKNOWN_AGENT_TYPE,
+    SubagentTrace,
+)
+from agentfluent.traces.parser import parse_subagent_trace
+
+
+def _write(tmp_path: Path, filename: str, lines: list[dict[str, Any]]) -> Path:
+    path = tmp_path / filename
+    with path.open("w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return path
+
+
+def _user(
+    content: Any,  # noqa: ANN401
+    timestamp: str | None = "2026-04-21T10:00:00.000Z",
+) -> dict[str, Any]:
+    msg: dict[str, Any] = {
+        "type": "user",
+        "message": {"role": "user", "content": content},
+    }
+    if timestamp is not None:
+        msg["timestamp"] = timestamp
+    return msg
+
+
+def _assistant(
+    content: list[dict[str, Any]],
+    *,
+    message_id: str = "msg_01",
+    timestamp: str | None = "2026-04-21T10:00:01.000Z",
+    usage: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    msg: dict[str, Any] = {
+        "type": "assistant",
+        "message": {
+            "id": message_id,
+            "role": "assistant",
+            "model": "claude-opus-4-6",
+            "content": content,
+        },
+    }
+    if timestamp is not None:
+        msg["timestamp"] = timestamp
+    if usage is not None:
+        msg["message"]["usage"] = usage
+    return msg
+
+
+def _tool_use(
+    tool_use_id: str, name: str = "Bash", inp: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp or {}}
+
+
+def _tool_result(
+    tool_use_id: str,
+    content: str = "ok",
+    *,
+    is_error: bool | None = None,
+) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": content,
+    }
+    if is_error is not None:
+        block["is_error"] = is_error
+    return block
+
+
+class TestParseSubagentTrace:
+    def test_happy_path(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-uuid-1.jsonl",
+            [
+                _user("Review the backlog"),
+                _assistant(
+                    [_tool_use("t1", "Read", {"file_path": "/tmp/notes.md"})],
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                ),
+                _user([_tool_result("t1", "notes content")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+
+        assert isinstance(trace, SubagentTrace)
+        assert trace.agent_id == "uuid-1"
+        assert trace.agent_type == UNKNOWN_AGENT_TYPE
+        assert trace.delegation_prompt == "Review the backlog"
+        assert len(trace.tool_calls) == 1
+        assert trace.tool_calls[0].tool_name == "Read"
+        assert trace.tool_calls[0].result_summary == "notes content"
+        assert trace.total_errors == 0
+        assert trace.total_retries == 0
+        assert trace.retry_sequences == []
+        assert trace.usage.input_tokens == 10
+
+    def test_agent_id_from_filename(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "agent-abc-123-def.jsonl", [_user("hi")])
+        assert parse_subagent_trace(path).agent_id == "abc-123-def"
+
+    def test_agent_type_is_unknown(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "agent-x.jsonl", [_user("hi")])
+        assert parse_subagent_trace(path).agent_type == UNKNOWN_AGENT_TYPE
+
+    def test_source_file_resolved(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "agent-x.jsonl", [_user("hi")])
+        trace = parse_subagent_trace(path)
+        assert trace.source_file == path.resolve()
+        assert trace.source_file.is_absolute()
+
+
+class TestDelegationPrompt:
+    def test_string_content(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "agent-x.jsonl", [_user("the prompt")])
+        assert parse_subagent_trace(path).delegation_prompt == "the prompt"
+
+    def test_list_of_blocks_content(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [_user([{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}])],
+        )
+        assert parse_subagent_trace(path).delegation_prompt == "line1\nline2"
+
+    def test_no_user_messages(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path, "agent-x.jsonl", [_assistant([{"type": "text", "text": "hi"}])],
+        )
+        assert parse_subagent_trace(path).delegation_prompt == ""
+
+
+class TestToolCallPairing:
+    def test_single_tool_use(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"cmd": "ls"})]),
+                _user([_tool_result("t1", "file.txt")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.tool_calls) == 1
+        assert trace.tool_calls[0].tool_name == "Bash"
+
+    def test_multiple_tool_use_in_one_message(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [
+                        _tool_use("t1", "Read"),
+                        _tool_use("t2", "Grep"),
+                        _tool_use("t3", "Bash"),
+                    ],
+                ),
+                _user(
+                    [_tool_result("t1"), _tool_result("t2"), _tool_result("t3")],
+                ),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert [tc.tool_name for tc in trace.tool_calls] == ["Read", "Grep", "Bash"]
+
+    def test_orphan_tool_use(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [_user("go"), _assistant([_tool_use("t1", "Read")])],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.tool_calls) == 1
+        assert trace.tool_calls[0].tool_name == "Read"
+        assert trace.tool_calls[0].result_summary == ""
+        assert trace.tool_calls[0].is_error is False
+
+    def test_orphan_tool_result_skipped(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _user([_tool_result("t_nomatch", "stranded")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls == []
+
+    def test_pairs_by_id_not_position(self, tmp_path: Path) -> None:
+        # tool_results come in reverse order of tool_uses
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "First"), _tool_use("t2", "Second")]),
+                _user([_tool_result("t2", "result_two"), _tool_result("t1", "result_one")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        by_name = {tc.tool_name: tc.result_summary for tc in trace.tool_calls}
+        assert by_name["First"] == "result_one"
+        assert by_name["Second"] == "result_two"
+
+
+class TestInputResultSummaries:
+    def test_input_truncated(self, tmp_path: Path) -> None:
+        long_value = "x" * (INPUT_SUMMARY_MAX_CHARS * 2)
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"cmd": long_value})]),
+                _user([_tool_result("t1")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.tool_calls[0].input_summary) == INPUT_SUMMARY_MAX_CHARS
+
+    def test_result_truncated(self, tmp_path: Path) -> None:
+        long_result = "y" * (RESULT_SUMMARY_MAX_CHARS * 2)
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", long_result)]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.tool_calls[0].result_summary) == RESULT_SUMMARY_MAX_CHARS
+
+    def test_non_serializable_input_does_not_crash(self, tmp_path: Path) -> None:
+        # Input dict from JSONL only contains JSON-native types, so a
+        # non-serializable value can't actually round-trip through the
+        # file; simulate by injecting on-disk-valid JSON that _truncate_input
+        # will pass through json.dumps cleanly.
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1", "Bash", {"nested": {"deep": [1, 2, 3]}})],
+                ),
+                _user([_tool_result("t1")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert '"nested"' in trace.tool_calls[0].input_summary
+
+    def test_unicode_preserved(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"q": "café ☕"})]),
+                _user([_tool_result("t1", "résumé ✓")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert "café" in trace.tool_calls[0].input_summary
+        assert "résumé" in trace.tool_calls[0].result_summary
+
+
+class TestIsErrorDetection:
+    def test_explicit_true(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", "some text", is_error=True)]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
+    def test_explicit_false_wins_over_keywords(self, tmp_path: Path) -> None:
+        # Result text contains "failed" but is_error=False is authoritative.
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", "no operation failed here", is_error=False)]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is False
+
+    def test_keyword_fallback_fires(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", "permission denied on /etc/shadow")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
+    def test_keyword_fallback_stays_false(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", "all good, wrote 42 bytes")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is False
+
+
+class TestUsageAggregation:
+    def test_sums_across_assistants(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1", "Bash")],
+                    message_id="msg_a",
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                ),
+                _user([_tool_result("t1")]),
+                _assistant(
+                    [{"type": "text", "text": "done"}],
+                    message_id="msg_b",
+                    usage={"input_tokens": 20, "output_tokens": 3, "cache_read_input_tokens": 100},
+                ),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.usage.input_tokens == 30
+        assert trace.usage.output_tokens == 8
+        assert trace.usage.cache_read_input_tokens == 100
+
+    def test_user_messages_skipped(self, tmp_path: Path) -> None:
+        # Only user messages → zero usage (users have no usage field).
+        path = _write(
+            tmp_path, "agent-x.jsonl", [_user("one"), _user("two")],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.usage.total_tokens == 0
+
+
+class TestDurationMs:
+    def test_span_calculated(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                _assistant(
+                    [{"type": "text", "text": "done"}],
+                    timestamp="2026-04-21T10:00:05.500Z",
+                ),
+            ],
+        )
+        # 5.5 seconds = 5500 ms
+        assert parse_subagent_trace(path).duration_ms == 5500
+
+    def test_single_message_returns_none(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "agent-x.jsonl", [_user("only one")])
+        assert parse_subagent_trace(path).duration_ms is None
+
+    def test_no_timestamps_returns_none(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp=None),
+                _assistant([{"type": "text", "text": "hi"}], timestamp=None),
+            ],
+        )
+        assert parse_subagent_trace(path).duration_ms is None
+
+
+class TestEdgeCases:
+    def test_empty_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "agent-x.jsonl"
+        path.write_text("")
+        trace = parse_subagent_trace(path)
+        assert trace.tool_calls == []
+        assert trace.delegation_prompt == ""
+        assert trace.usage.total_tokens == 0
+        assert trace.duration_ms is None
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="not found"):
+            parse_subagent_trace(tmp_path / "agent-nope.jsonl")
+
+    def test_malformed_filename_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "not-an-agent.jsonl"
+        path.write_text("")
+        with pytest.raises(ValueError, match="Malformed subagent filename"):
+            parse_subagent_trace(path)
+
+    def test_streaming_snapshots_deduplicated(self, tmp_path: Path) -> None:
+        # Two assistant snapshots sharing message_id; dedup keeps the
+        # one with higher output_tokens. Both carry the same tool_use_id,
+        # so the pairing emits exactly one tool_call.
+        now = datetime.now(UTC)
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1", "Bash", {"cmd": "ls"})],
+                    message_id="msg_shared",
+                    timestamp=now.isoformat().replace("+00:00", "Z"),
+                    usage={"input_tokens": 5, "output_tokens": 2},
+                ),
+                _assistant(
+                    [_tool_use("t1", "Bash", {"cmd": "ls"})],
+                    message_id="msg_shared",
+                    timestamp=now.isoformat().replace("+00:00", "Z"),
+                    usage={"input_tokens": 5, "output_tokens": 8},
+                ),
+                _user([_tool_result("t1", "file")]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.tool_calls) == 1
+        # Dedup kept the snapshot with higher output_tokens (8).
+        assert trace.usage.output_tokens == 8
+
+
+class TestTotalErrors:
+    def test_counts_is_error(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1"), _tool_use("t2"), _tool_use("t3")],
+                ),
+                _user(
+                    [
+                        _tool_result("t1", is_error=True),
+                        _tool_result("t2", is_error=False),
+                        _tool_result("t3", is_error=True),
+                    ],
+                ),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.total_errors == 2
+
+    def test_total_retries_is_zero_for_now(self, tmp_path: Path) -> None:
+        """Retry detection is deferred to #104; parser emits zero."""
+        path = _write(
+            tmp_path,
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"cmd": "fails"})]),
+                _user([_tool_result("t1", "error", is_error=True)]),
+                _assistant([_tool_use("t2", "Bash", {"cmd": "fails"})]),
+                _user([_tool_result("t2", "error", is_error=True)]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.total_retries == 0
+        assert trace.retry_sequences == []

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -17,13 +17,7 @@ from agentfluent.traces.models import (
 )
 from agentfluent.traces.parser import parse_subagent_trace
 
-
-def _write(tmp_path: Path, filename: str, lines: list[dict[str, Any]]) -> Path:
-    path = tmp_path / filename
-    with path.open("w") as f:
-        for line in lines:
-            f.write(json.dumps(line) + "\n")
-    return path
+WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
 
 
 def _user(
@@ -85,9 +79,8 @@ def _tool_result(
 
 
 class TestParseSubagentTrace:
-    def test_happy_path(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_happy_path(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-uuid-1.jsonl",
             [
                 _user("Review the backlog"),
@@ -112,45 +105,43 @@ class TestParseSubagentTrace:
         assert trace.retry_sequences == []
         assert trace.usage.input_tokens == 10
 
-    def test_agent_id_from_filename(self, tmp_path: Path) -> None:
-        path = _write(tmp_path, "agent-abc-123-def.jsonl", [_user("hi")])
+    def test_agent_id_from_filename(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-abc-123-def.jsonl", [_user("hi")])
         assert parse_subagent_trace(path).agent_id == "abc-123-def"
 
-    def test_agent_type_is_unknown(self, tmp_path: Path) -> None:
-        path = _write(tmp_path, "agent-x.jsonl", [_user("hi")])
+    def test_agent_type_is_unknown(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("hi")])
         assert parse_subagent_trace(path).agent_type == UNKNOWN_AGENT_TYPE
 
-    def test_source_file_resolved(self, tmp_path: Path) -> None:
-        path = _write(tmp_path, "agent-x.jsonl", [_user("hi")])
+    def test_source_file_resolved(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("hi")])
         trace = parse_subagent_trace(path)
         assert trace.source_file == path.resolve()
         assert trace.source_file.is_absolute()
 
 
 class TestDelegationPrompt:
-    def test_string_content(self, tmp_path: Path) -> None:
-        path = _write(tmp_path, "agent-x.jsonl", [_user("the prompt")])
+    def test_string_content(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("the prompt")])
         assert parse_subagent_trace(path).delegation_prompt == "the prompt"
 
-    def test_list_of_blocks_content(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_list_of_blocks_content(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [_user([{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}])],
         )
         assert parse_subagent_trace(path).delegation_prompt == "line1\nline2"
 
-    def test_no_user_messages(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path, "agent-x.jsonl", [_assistant([{"type": "text", "text": "hi"}])],
+    def test_no_user_messages(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl", [_assistant([{"type": "text", "text": "hi"}])],
         )
         assert parse_subagent_trace(path).delegation_prompt == ""
 
 
 class TestToolCallPairing:
-    def test_single_tool_use(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_single_tool_use(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -162,9 +153,8 @@ class TestToolCallPairing:
         assert len(trace.tool_calls) == 1
         assert trace.tool_calls[0].tool_name == "Bash"
 
-    def test_multiple_tool_use_in_one_message(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_multiple_tool_use_in_one_message(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -183,9 +173,8 @@ class TestToolCallPairing:
         trace = parse_subagent_trace(path)
         assert [tc.tool_name for tc in trace.tool_calls] == ["Read", "Grep", "Bash"]
 
-    def test_orphan_tool_use(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_orphan_tool_use(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [_user("go"), _assistant([_tool_use("t1", "Read")])],
         )
@@ -195,9 +184,8 @@ class TestToolCallPairing:
         assert trace.tool_calls[0].result_summary == ""
         assert trace.tool_calls[0].is_error is False
 
-    def test_orphan_tool_result_skipped(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_orphan_tool_result_skipped(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -206,10 +194,9 @@ class TestToolCallPairing:
         )
         assert parse_subagent_trace(path).tool_calls == []
 
-    def test_pairs_by_id_not_position(self, tmp_path: Path) -> None:
+    def test_pairs_by_id_not_position(self, write_jsonl: WriteJSONL) -> None:
         # tool_results come in reverse order of tool_uses
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -224,10 +211,9 @@ class TestToolCallPairing:
 
 
 class TestInputResultSummaries:
-    def test_input_truncated(self, tmp_path: Path) -> None:
+    def test_input_truncated(self, write_jsonl: WriteJSONL) -> None:
         long_value = "x" * (INPUT_SUMMARY_MAX_CHARS * 2)
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -238,10 +224,9 @@ class TestInputResultSummaries:
         trace = parse_subagent_trace(path)
         assert len(trace.tool_calls[0].input_summary) == INPUT_SUMMARY_MAX_CHARS
 
-    def test_result_truncated(self, tmp_path: Path) -> None:
+    def test_result_truncated(self, write_jsonl: WriteJSONL) -> None:
         long_result = "y" * (RESULT_SUMMARY_MAX_CHARS * 2)
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -252,13 +237,12 @@ class TestInputResultSummaries:
         trace = parse_subagent_trace(path)
         assert len(trace.tool_calls[0].result_summary) == RESULT_SUMMARY_MAX_CHARS
 
-    def test_non_serializable_input_does_not_crash(self, tmp_path: Path) -> None:
+    def test_non_serializable_input_does_not_crash(self, write_jsonl: WriteJSONL) -> None:
         # Input dict from JSONL only contains JSON-native types, so a
         # non-serializable value can't actually round-trip through the
         # file; simulate by injecting on-disk-valid JSON that _truncate_input
         # will pass through json.dumps cleanly.
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -271,9 +255,8 @@ class TestInputResultSummaries:
         trace = parse_subagent_trace(path)
         assert '"nested"' in trace.tool_calls[0].input_summary
 
-    def test_unicode_preserved(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_unicode_preserved(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -287,9 +270,8 @@ class TestInputResultSummaries:
 
 
 class TestIsErrorDetection:
-    def test_explicit_true(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_explicit_true(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -299,10 +281,9 @@ class TestIsErrorDetection:
         )
         assert parse_subagent_trace(path).tool_calls[0].is_error is True
 
-    def test_explicit_false_wins_over_keywords(self, tmp_path: Path) -> None:
+    def test_explicit_false_wins_over_keywords(self, write_jsonl: WriteJSONL) -> None:
         # Result text contains "failed" but is_error=False is authoritative.
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -312,9 +293,8 @@ class TestIsErrorDetection:
         )
         assert parse_subagent_trace(path).tool_calls[0].is_error is False
 
-    def test_keyword_fallback_fires(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_keyword_fallback_fires(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -324,9 +304,8 @@ class TestIsErrorDetection:
         )
         assert parse_subagent_trace(path).tool_calls[0].is_error is True
 
-    def test_keyword_fallback_stays_false(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_keyword_fallback_stays_false(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -338,9 +317,8 @@ class TestIsErrorDetection:
 
 
 class TestUsageAggregation:
-    def test_sums_across_assistants(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_sums_across_assistants(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -362,19 +340,15 @@ class TestUsageAggregation:
         assert trace.usage.output_tokens == 8
         assert trace.usage.cache_read_input_tokens == 100
 
-    def test_user_messages_skipped(self, tmp_path: Path) -> None:
-        # Only user messages → zero usage (users have no usage field).
-        path = _write(
-            tmp_path, "agent-x.jsonl", [_user("one"), _user("two")],
-        )
+    def test_user_messages_skipped(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("one"), _user("two")])
         trace = parse_subagent_trace(path)
         assert trace.usage.total_tokens == 0
 
 
 class TestDurationMs:
-    def test_span_calculated(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_span_calculated(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go", timestamp="2026-04-21T10:00:00.000Z"),
@@ -387,13 +361,12 @@ class TestDurationMs:
         # 5.5 seconds = 5500 ms
         assert parse_subagent_trace(path).duration_ms == 5500
 
-    def test_single_message_returns_none(self, tmp_path: Path) -> None:
-        path = _write(tmp_path, "agent-x.jsonl", [_user("only one")])
+    def test_single_message_returns_none(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("only one")])
         assert parse_subagent_trace(path).duration_ms is None
 
-    def test_no_timestamps_returns_none(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+    def test_no_timestamps_returns_none(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go", timestamp=None),
@@ -423,13 +396,12 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="Malformed subagent filename"):
             parse_subagent_trace(path)
 
-    def test_streaming_snapshots_deduplicated(self, tmp_path: Path) -> None:
+    def test_streaming_snapshots_deduplicated(self, write_jsonl: WriteJSONL) -> None:
         # Two assistant snapshots sharing message_id; dedup keeps the
         # one with higher output_tokens. Both carry the same tool_use_id,
         # so the pairing emits exactly one tool_call.
         now = datetime.now(UTC)
-        path = _write(
-            tmp_path,
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -454,10 +426,9 @@ class TestEdgeCases:
         assert trace.usage.output_tokens == 8
 
 
-class TestTotalErrors:
-    def test_counts_is_error(self, tmp_path: Path) -> None:
-        path = _write(
-            tmp_path,
+class TestAggregateCounts:
+    def test_total_errors_counts_is_error(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),
@@ -476,10 +447,9 @@ class TestTotalErrors:
         trace = parse_subagent_trace(path)
         assert trace.total_errors == 2
 
-    def test_total_retries_is_zero_for_now(self, tmp_path: Path) -> None:
-        """Retry detection is deferred to #104; parser emits zero."""
-        path = _write(
-            tmp_path,
+    def test_total_retries_is_zero_for_now(self, write_jsonl: WriteJSONL) -> None:
+        """Retry detection is deferred to a later story; parser emits zero."""
+        path = write_jsonl(
             "agent-x.jsonl",
             [
                 _user("go"),


### PR DESCRIPTION
## Summary

Adds `parse_subagent_trace(path: Path) -> SubagentTrace` in a new `agentfluent.traces.parser` module — the biggest remaining unit in v0.3 E2. Produces `SubagentTrace` instances from real subagent JSONL files, the evidence layer that E3 (#107), E4 (#110), and E5 (#111) downstream stories will all consume.

Closes #103.

## Approach

**Reuses `core.parser.parse_session(path)`** for line reading, `SKIP_TYPES` filtering, per-message parsing, and streaming-snapshot deduplication — satisfying architect A's hard constraint against duplicated parsing infrastructure. On top of that, the new parser handles the subagent-specific shape:
- Pair `tool_use` / `tool_result` blocks by `tool_use_id` (two-pass; mirrors `agents.extractor.extract_agent_invocations`)
- Truncate `input_summary` / `result_summary` to the 200/500 constants from `traces.models`
- Detect `is_error` (explicit field primary, `ERROR_PATTERNS` keyword fallback)
- Aggregate `Usage` across assistant messages
- Derive `agent_id` from filename, `delegation_prompt` from first user message, `duration_ms` from timestamp span

## Cross-module change

Adds `is_error: bool | None = None` to `ContentBlock` in `core/session.py` and populates it in `_normalize_content` (one line each). Without this, the subagent parser would have had to re-parse raw JSONL or fall back to keyword scanning exclusively — a genuine capability regression. Two-line change, fully backwards-compatible (optional field with `None` default, grep-verified no existing test introspects the attribute).

## Design decisions

- **`agent_type = UNKNOWN_AGENT_TYPE`** — no prompt pattern-matching; linker (#105) overwrites from parent `AgentInvocation.agent_type`.
- **`agent_id` from filename** — authoritative per architect A.
- **Per-call `Usage` left at default zero** — JSONL has one `usage` per assistant message but can carry multiple `tool_use` blocks; no faithful per-call attribution is possible. Trace-level `usage` is source of truth (documented in helper docstring).
- **Missing file raises `FileNotFoundError`** — diverges from `parse_session`'s silent-empty convention intentionally. Discovery (#129) guarantees existence at call time.

## Architect deferrals

- Retry sequence detection + `total_retries` summation + `tool_call_indices` → **#104** (parser leaves `retry_sequences=[]`, `total_retries=0`)
- Linker overwriting `agent_type` + adding `AgentInvocation.trace` → **#105**
- Real subagent JSONL fixtures + integration tests → **#106**

## Test plan

- [x] `uv run pytest tests/unit/test_traces_parser.py -v` → 31 passed (happy path, pairing, truncation, is_error detection, usage aggregation, duration calc, edge cases, total_errors)
- [x] `uv run pytest tests/unit/test_parser.py tests/unit/test_session_models.py -v` → existing + 2 new `is_error` tests pass
- [x] `uv run pytest -m "not integration"` → 370 passed total (no regressions)
- [x] `uv run mypy src/agentfluent/` → clean (strict mode)
- [x] `uv run ruff check src/ tests/` → clean
- [x] CI green

## Reference

- Plan: `plans/yes-let-s-start-by-misty-cocke.md`
- Architect A interface contract: comment on #98
- Architect A / architect B reviews of #103, #101, #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)