### PR TITLE
feat(traces): detect retry sequences during subagent trace parsing

### DIFF
--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -13,10 +13,10 @@ on a missing path — the trace-discovery step guarantees path existence at
 call time, so a missing file is a programmer error rather than a user
 condition.
 
-Two fields on ``SubagentTrace`` are intentionally left unpopulated here and
-filled in by later work: retry-sequence detection populates
-``retry_sequences`` / ``total_retries``, and the trace-to-parent linker
-overwrites ``agent_type`` with the parent ``AgentInvocation`` value.
+The ``agent_type`` field is intentionally left at ``UNKNOWN_AGENT_TYPE`` here
+and filled in by the trace-to-parent linker from the parent
+``AgentInvocation`` value. Retry-sequence detection runs during parse and
+populates ``retry_sequences`` / ``total_retries`` before returning.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ from agentfluent.traces.models import (
     SubagentToolCall,
     SubagentTrace,
 )
+from agentfluent.traces.retry import detect_retry_sequences
 
 
 def _truncate_input(input_dict: dict[str, Any] | None) -> str:
@@ -174,15 +175,16 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
 
     messages = parse_session(path)
     tool_calls = _pair_tool_calls(messages)
+    retry_sequences = detect_retry_sequences(tool_calls)
 
     return SubagentTrace(
         agent_id=agent_id,
         agent_type=UNKNOWN_AGENT_TYPE,
         delegation_prompt=_extract_delegation_prompt(messages),
         tool_calls=tool_calls,
-        retry_sequences=[],
+        retry_sequences=retry_sequences,
         total_errors=sum(1 for tc in tool_calls if tc.is_error),
-        total_retries=0,
+        total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
         usage=_sum_usage(messages),
         duration_ms=_compute_duration_ms(messages),
         source_file=path.resolve(),

--- a/src/agentfluent/traces/retry.py
+++ b/src/agentfluent/traces/retry.py
@@ -48,9 +48,10 @@ def _build_retry_sequence(
     whose ``is_error`` is true; both are ``None`` when no call in the run
     errored (rare but legal).
     """
+    indices = list(range(start, end))
     first_error_message: str | None = None
     last_error_message: str | None = None
-    for idx in range(start, end):
+    for idx in indices:
         if tool_calls[idx].is_error:
             if first_error_message is None:
                 first_error_message = tool_calls[idx].result_summary
@@ -62,7 +63,7 @@ def _build_retry_sequence(
         first_error_message=first_error_message,
         last_error_message=last_error_message,
         eventual_success=not tool_calls[end - 1].is_error,
-        tool_call_indices=list(range(start, end)),
+        tool_call_indices=indices,
     )
 
 

--- a/src/agentfluent/traces/retry.py
+++ b/src/agentfluent/traces/retry.py
@@ -1,0 +1,90 @@
+"""Detect retry sequences within a subagent's tool_calls.
+
+A retry sequence is two or more consecutive tool calls (in
+``SubagentTrace.tool_calls`` order) that share a ``tool_name`` and have
+similar ``input_summary`` values — i.e., the agent called the same tool
+again with the same or nearly-the-same arguments. That pattern is the
+signal for the ``RETRY_LOOP`` diagnostic downstream of the parser.
+
+**Similarity is measured against the predecessor**, not against the first
+call in the run. Real retry chains drift ("edit file X line 40" ->
+"edit file X line 41" -> "edit file X line 42"): comparing each call
+to the previous one lets the chain extend under gradual drift, where
+comparing to the first would cut it short. Adjacent pairs are what
+makes the run a retry sequence; the head and tail can be quite
+different as long as every step is a small change.
+
+``SIMILARITY_THRESHOLD = 0.80`` is the direct translation of the AC's
+"edit distance < 20%" formulation, applied via
+``difflib.SequenceMatcher.ratio()``. An exact ``input_summary`` match is
+the common case and short-circuits before the matcher runs.
+"""
+
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+
+from agentfluent.traces.models import RetrySequence, SubagentToolCall
+
+SIMILARITY_THRESHOLD = 0.80
+
+
+def _is_similar_retry(a: SubagentToolCall, b: SubagentToolCall) -> bool:
+    if a.tool_name != b.tool_name:
+        return False
+    if a.input_summary == b.input_summary:
+        return True
+    return SequenceMatcher(None, a.input_summary, b.input_summary).ratio() >= SIMILARITY_THRESHOLD
+
+
+def _build_retry_sequence(
+    tool_calls: list[SubagentToolCall], start: int, end: int,
+) -> RetrySequence:
+    """Construct a ``RetrySequence`` from the half-open run ``[start, end)``.
+
+    ``end - start`` is always ``>= 2`` by the caller's emission gate, so
+    ``attempts`` always satisfies the model's ``ge=1`` validator. First /
+    last error messages come from the first / last calls within the run
+    whose ``is_error`` is true; both are ``None`` when no call in the run
+    errored (rare but legal).
+    """
+    first_error_message: str | None = None
+    last_error_message: str | None = None
+    for idx in range(start, end):
+        if tool_calls[idx].is_error:
+            if first_error_message is None:
+                first_error_message = tool_calls[idx].result_summary
+            last_error_message = tool_calls[idx].result_summary
+
+    return RetrySequence(
+        tool_name=tool_calls[start].tool_name,
+        attempts=end - start,
+        first_error_message=first_error_message,
+        last_error_message=last_error_message,
+        eventual_success=not tool_calls[end - 1].is_error,
+        tool_call_indices=list(range(start, end)),
+    )
+
+
+def detect_retry_sequences(
+    tool_calls: list[SubagentToolCall],
+) -> list[RetrySequence]:
+    """Return the retry sequences found in ``tool_calls``.
+
+    Scans left-to-right; a run ``[i, j)`` qualifies when every adjacent
+    pair ``(j-1, j)`` passes ``_is_similar_retry`` and ``j - i >= 2``.
+    Interleaved unrelated tool calls break a run. The scan never revisits
+    a position, so two separate runs of the same tool across the list
+    produce two independent sequences.
+    """
+    sequences: list[RetrySequence] = []
+    i = 0
+    n = len(tool_calls)
+    while i < n:
+        j = i + 1
+        while j < n and _is_similar_retry(tool_calls[j - 1], tool_calls[j]):
+            j += 1
+        if j - i >= 2:
+            sequences.append(_build_retry_sequence(tool_calls, i, j))
+        i = j
+    return sequences

--- a/tests/unit/test_traces_retry.py
+++ b/tests/unit/test_traces_retry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
@@ -111,7 +112,6 @@ class TestDetectRetrySequences:
         # yield 2*16/(20+20) = 0.80. `>=` makes this qualify.
         a = "aaaaaaaaaaaaaaaaaaaa"              # 20 a's
         b = "aaaaaaaaaaaaaaaabbbb"              # 16 a's then 4 b's
-        from difflib import SequenceMatcher
         ratio = SequenceMatcher(None, a, b).ratio()
         assert ratio == SIMILARITY_THRESHOLD, f"expected {SIMILARITY_THRESHOLD}, got {ratio}"
 

--- a/tests/unit/test_traces_retry.py
+++ b/tests/unit/test_traces_retry.py
@@ -1,0 +1,327 @@
+"""Tests for retry sequence detection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from agentfluent.traces.models import RetrySequence, SubagentToolCall
+from agentfluent.traces.parser import parse_subagent_trace
+from agentfluent.traces.retry import (
+    SIMILARITY_THRESHOLD,
+    _is_similar_retry,
+    detect_retry_sequences,
+)
+
+WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
+
+
+def _call(
+    name: str = "Bash",
+    input_str: str = '{"cmd":"ls"}',
+    *,
+    is_error: bool = False,
+    result: str = "ok",
+) -> SubagentToolCall:
+    return SubagentToolCall(
+        tool_name=name,
+        input_summary=input_str,
+        result_summary=result,
+        is_error=is_error,
+    )
+
+
+class TestDetectRetrySequences:
+    def test_empty_list_returns_empty(self) -> None:
+        assert detect_retry_sequences([]) == []
+
+    def test_single_call_returns_empty(self) -> None:
+        assert detect_retry_sequences([_call()]) == []
+
+    def test_two_identical_emits_one_sequence(self) -> None:
+        seqs = detect_retry_sequences([_call(), _call()])
+        assert len(seqs) == 1
+        assert isinstance(seqs[0], RetrySequence)
+        assert seqs[0].tool_name == "Bash"
+        assert seqs[0].attempts == 2
+        assert seqs[0].tool_call_indices == [0, 1]
+
+    def test_three_identical_emits_one_sequence_attempts_three(self) -> None:
+        seqs = detect_retry_sequences([_call(), _call(), _call()])
+        assert len(seqs) == 1
+        assert seqs[0].attempts == 3
+        assert seqs[0].tool_call_indices == [0, 1, 2]
+
+    def test_two_identical_then_different_emits_one_sequence(self) -> None:
+        seqs = detect_retry_sequences(
+            [_call(), _call(), _call(name="Read", input_str='{"file":"x"}')],
+        )
+        assert len(seqs) == 1
+        assert seqs[0].attempts == 2
+        assert seqs[0].tool_call_indices == [0, 1]
+
+    def test_dissimilar_same_tool_adjacent_emits_nothing(self) -> None:
+        # Different JSON bodies for the same tool; ratio falls below threshold.
+        seqs = detect_retry_sequences(
+            [
+                _call(input_str='{"cmd":"ls /tmp"}'),
+                _call(input_str='{"cmd":"rm -rf /"}'),
+            ],
+        )
+        assert seqs == []
+
+    def test_same_input_different_tool_emits_nothing(self) -> None:
+        seqs = detect_retry_sequences(
+            [_call(name="Bash"), _call(name="Read")],
+        )
+        assert seqs == []
+
+    def test_interleaved_breaks_run(self) -> None:
+        # [Bash, Bash, Read, Bash, Bash] -> two separate Bash runs of 2
+        seqs = detect_retry_sequences(
+            [
+                _call(name="Bash"),
+                _call(name="Bash"),
+                _call(name="Read", input_str='{"file":"x"}'),
+                _call(name="Bash"),
+                _call(name="Bash"),
+            ],
+        )
+        assert len(seqs) == 2
+        assert seqs[0].tool_call_indices == [0, 1]
+        assert seqs[1].tool_call_indices == [3, 4]
+
+    def test_two_separate_runs_of_same_tool(self) -> None:
+        # [B, B, C, B, B] -> two runs of attempts=2
+        seqs = detect_retry_sequences(
+            [
+                _call(name="Bash", input_str='{"cmd":"ls"}'),
+                _call(name="Bash", input_str='{"cmd":"ls"}'),
+                _call(name="Read", input_str='{"file":"x"}'),
+                _call(name="Bash", input_str='{"cmd":"pwd"}'),
+                _call(name="Bash", input_str='{"cmd":"pwd"}'),
+            ],
+        )
+        assert [s.attempts for s in seqs] == [2, 2]
+
+    def test_similarity_boundary_inclusive(self) -> None:
+        # Craft two strings whose SequenceMatcher.ratio() is exactly
+        # SIMILARITY_THRESHOLD (0.80). 20-char strings sharing 16 chars
+        # yield 2*16/(20+20) = 0.80. `>=` makes this qualify.
+        a = "aaaaaaaaaaaaaaaaaaaa"              # 20 a's
+        b = "aaaaaaaaaaaaaaaabbbb"              # 16 a's then 4 b's
+        from difflib import SequenceMatcher
+        ratio = SequenceMatcher(None, a, b).ratio()
+        assert ratio == SIMILARITY_THRESHOLD, f"expected {SIMILARITY_THRESHOLD}, got {ratio}"
+
+        seqs = detect_retry_sequences([_call(input_str=a), _call(input_str=b)])
+        assert len(seqs) == 1
+
+    def test_similarity_just_below_threshold_rejected(self) -> None:
+        # 20-char strings sharing 15 chars -> 2*15/40 = 0.75 < 0.80
+        a = "aaaaaaaaaaaaaaaaaaaa"
+        b = "aaaaaaaaaaaaaaabbbbb"
+        seqs = detect_retry_sequences([_call(input_str=a), _call(input_str=b)])
+        assert seqs == []
+
+    def test_drift_chain_tolerates_gradual_change(self) -> None:
+        # Adjacent pairs each pass threshold; head-vs-tail would fail.
+        # 40-char strings, shifting 4 chars per step.
+        a = "a" * 40
+        b = ("a" * 36) + "bbbb"       # vs a: ratio = 2*36/80 = 0.90
+        c = ("a" * 32) + "bbbbbbbb"   # vs b: 2*36/80 = 0.90 (shared 36 a's); vs a: 0.80
+        d = ("a" * 28) + "bbbbbbbbbbbb"  # vs c: 0.90; vs a: 0.70
+
+        assert _is_similar_retry(_call(input_str=a), _call(input_str=b))
+        assert _is_similar_retry(_call(input_str=b), _call(input_str=c))
+        assert _is_similar_retry(_call(input_str=c), _call(input_str=d))
+        # Head-to-tail would fail:
+        assert not _is_similar_retry(_call(input_str=a), _call(input_str=d))
+
+        seqs = detect_retry_sequences(
+            [
+                _call(input_str=a),
+                _call(input_str=b),
+                _call(input_str=c),
+                _call(input_str=d),
+            ],
+        )
+        # Predecessor-based comparison emits one sequence spanning all four.
+        assert len(seqs) == 1
+        assert seqs[0].attempts == 4
+        assert seqs[0].tool_call_indices == [0, 1, 2, 3]
+
+    def test_all_errors_run_captures_first_and_last(self) -> None:
+        seqs = detect_retry_sequences(
+            [
+                _call(is_error=True, result="err1"),
+                _call(is_error=True, result="err2"),
+                _call(is_error=True, result="err3"),
+            ],
+        )
+        assert len(seqs) == 1
+        assert seqs[0].first_error_message == "err1"
+        assert seqs[0].last_error_message == "err3"
+        assert seqs[0].eventual_success is False
+
+    def test_mixed_errors_populates_fields_correctly(self) -> None:
+        # [err1, ok, err2, ok] — first error is at index 0, last error at 2,
+        # eventual_success driven by the last call's is_error (False => success).
+        seqs = detect_retry_sequences(
+            [
+                _call(is_error=True, result="err1"),
+                _call(is_error=False, result="ok1"),
+                _call(is_error=True, result="err2"),
+                _call(is_error=False, result="ok2"),
+            ],
+        )
+        assert len(seqs) == 1
+        assert seqs[0].first_error_message == "err1"
+        assert seqs[0].last_error_message == "err2"
+        assert seqs[0].eventual_success is True
+
+    def test_no_error_repeat_chain_has_none_error_messages(self) -> None:
+        # Legal but rare: three successful identical calls form a sequence.
+        seqs = detect_retry_sequences(
+            [_call(is_error=False), _call(is_error=False), _call(is_error=False)],
+        )
+        assert len(seqs) == 1
+        assert seqs[0].first_error_message is None
+        assert seqs[0].last_error_message is None
+        assert seqs[0].eventual_success is True
+
+    def test_single_error_has_first_equal_last(self) -> None:
+        seqs = detect_retry_sequences(
+            [_call(is_error=False, result="ok"), _call(is_error=True, result="boom")],
+        )
+        assert len(seqs) == 1
+        assert seqs[0].first_error_message == "boom"
+        assert seqs[0].last_error_message == "boom"
+        assert seqs[0].eventual_success is False
+
+    def test_tool_call_indices_match_range(self) -> None:
+        # [B, B, B, R, B, B] -> two runs at [0,1,2] and [4,5]
+        seqs = detect_retry_sequences(
+            [
+                _call(name="Bash"),
+                _call(name="Bash"),
+                _call(name="Bash"),
+                _call(name="Read", input_str='{"file":"x"}'),
+                _call(name="Bash"),
+                _call(name="Bash"),
+            ],
+        )
+        assert seqs[0].tool_call_indices == [0, 1, 2]
+        assert seqs[1].tool_call_indices == [4, 5]
+        assert seqs[0].attempts == 3
+        assert seqs[1].attempts == 2
+
+
+class TestParserIntegration:
+    """Confirm `parse_subagent_trace` wires in the detector."""
+
+    def _write_trace_with_calls(
+        self,
+        write_jsonl: WriteJSONL,
+        tool_calls: list[tuple[str, str, dict[str, Any], bool, str]],
+    ) -> Path:
+        """Build a JSONL trace with one assistant-user pair per tool call.
+
+        Each `tool_calls` tuple is (tool_use_id, tool_name, input, is_error, result).
+        """
+        lines: list[dict[str, Any]] = [
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "go"},
+                "timestamp": "2026-04-21T10:00:00.000Z",
+            },
+        ]
+        for i, (tool_use_id, name, inp, is_err, result) in enumerate(tool_calls):
+            lines.append(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": f"msg_{i}",
+                        "role": "assistant",
+                        "model": "claude-opus-4-6",
+                        "content": [
+                            {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp},
+                        ],
+                    },
+                    "timestamp": f"2026-04-21T10:00:{i + 1:02d}.000Z",
+                },
+            )
+            lines.append(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tool_use_id,
+                                "content": result,
+                                "is_error": is_err,
+                            },
+                        ],
+                    },
+                    "timestamp": f"2026-04-21T10:00:{i + 1:02d}.500Z",
+                },
+            )
+        return write_jsonl("agent-integration.jsonl", lines)
+
+    def test_no_retries_leaves_fields_empty(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        path = self._write_trace_with_calls(
+            write_jsonl,
+            [
+                ("t1", "Bash", {"cmd": "ls"}, False, "ok"),
+                ("t2", "Read", {"file": "x"}, False, "ok"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.retry_sequences == []
+        assert trace.total_retries == 0
+
+    def test_one_retry_produces_total_retries_one(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        path = self._write_trace_with_calls(
+            write_jsonl,
+            [
+                ("t1", "Bash", {"cmd": "ls"}, True, "err"),
+                ("t2", "Bash", {"cmd": "ls"}, False, "ok"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.retry_sequences) == 1
+        assert trace.retry_sequences[0].attempts == 2
+        assert trace.retry_sequences[0].eventual_success is True
+        # total_retries = sum(attempts - 1) = 2 - 1 = 1
+        assert trace.total_retries == 1
+
+    def test_two_separate_runs_sums_across(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        path = self._write_trace_with_calls(
+            write_jsonl,
+            [
+                # Run 1: three Bash ls
+                ("t1", "Bash", {"cmd": "ls"}, True, "err"),
+                ("t2", "Bash", {"cmd": "ls"}, True, "err"),
+                ("t3", "Bash", {"cmd": "ls"}, False, "ok"),
+                # Breaker
+                ("t4", "Read", {"file": "x"}, False, "ok"),
+                # Run 2: two Bash pwd
+                ("t5", "Bash", {"cmd": "pwd"}, False, "ok"),
+                ("t6", "Bash", {"cmd": "pwd"}, False, "ok"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert len(trace.retry_sequences) == 2
+        attempts = sorted(seq.attempts for seq in trace.retry_sequences)
+        assert attempts == [2, 3]
+        # total_retries = (3-1) + (2-1) = 3
+        assert trace.total_retries == 3


### PR DESCRIPTION
## Summary

Populates `SubagentTrace.retry_sequences` and `SubagentTrace.total_retries` — the two fields #103's parser left empty. A retry sequence is 2+ consecutive tool calls sharing a `tool_name` with a similar `input_summary` (exact match or `SequenceMatcher.ratio() >= 0.80`).

Closes #104.

## New module: `agentfluent.traces.retry`

- **`SIMILARITY_THRESHOLD = 0.80`** — direct translation of the AC's "edit distance < 20%" to `difflib.SequenceMatcher.ratio()`. Inclusive boundary (`>=`).
- **`detect_retry_sequences(tool_calls)`** — public entry; takes `list[SubagentToolCall]` so #107 can call it without going through a `SubagentTrace`.
- **`_is_similar_retry(a, b)`** — same tool name, exact-match short-circuit, else the matcher.
- **`_build_retry_sequence(tool_calls, start, end)`** — constructs the model from a half-open slice. First/last error messages come from the first/last erroring calls in the slice (both `None` if no errors).

**Key design choice:** similarity compares each call to its **predecessor**, not to the first call in the run. Real retry chains drift ("edit line 40" → "edit line 41" → "edit line 42"); predecessor-comparison preserves them under drift. Documented in the module docstring so it isn't "fixed" back.

## Wiring in `parse_subagent_trace`

```python
retry_sequences = detect_retry_sequences(tool_calls)
...
total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
```

`total_retries` counts only the retry portion (not the original attempt). The `traces/parser.py` module docstring no longer claims retry detection is "intentionally left unpopulated."

## Test plan

- [x] `uv run pytest tests/unit/test_traces_retry.py -v` → **20 passed** (17 unit + 3 parser-integration)
- [x] `uv run pytest -m "not integration"` → **390 passed** (370 before + 20 new)
- [x] `uv run mypy src/agentfluent/` → clean
- [x] `uv run ruff check src/ tests/` → clean

### Coverage

- Empty / single / multiple identical runs
- Interleaved tools breaking a run
- Two separate runs of the same tool
- Similarity boundary **exactly at 0.80** (inclusive) and **just below** (rejected) — crafted strings with computed ratios
- Drift chain that exercises predecessor-comparison (head-to-tail fails threshold; adjacent pairs all pass)
- All-errors / mixed-errors / no-error / single-error sequences — verifies `first_error_message`, `last_error_message`, `eventual_success`
- `tool_call_indices` integrity via `list(range(start, end))`
- Parser integration: no retries (`total_retries=0`), one retry (`total_retries=1`), two separate runs (`total_retries` sums across)

## Architect-confirmed choices

- Store retry_sequences on `SubagentTrace` during parsing (architect A's required change to #104's AC)
- stdlib `difflib.SequenceMatcher` — no sklearn dependency (reserved for #110 clustering)
- `SIMILARITY_THRESHOLD = 0.80` with `>=` comparison

## Deferred

- Emission of `DiagnosticSignal(type=RETRY_LOOP)` filtered by `attempts >= 3` → **#107**
- Recommendation templates citing retry sequences → **#107** + correlator rules
- Real subagent JSONL fixtures demonstrating retry patterns → **#106**

## Reference

- Plan: `plans/yes-let-s-start-by-misty-cocke.md`
- Architect A review on #104 (verdict: Concerns, addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)