### PR TITLE
feat(traces): link subagent traces to parent AgentInvocation

### DIFF
--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
+from agentfluent.traces.models import SubagentTrace
+
 # Built-in agent types (case-insensitive matching).
 # Update this set as Anthropic adds new built-in agents.
 BUILTIN_AGENT_TYPES: frozenset[str] = frozenset(
@@ -56,6 +58,13 @@ class AgentInvocation(BaseModel):
     # From tool_result content
     output_text: str = ""
     """The agent's final summary/output text."""
+
+    # Populated by the linker (traces.linker.link_traces) when a subagent trace
+    # file exists for this invocation's agent_id. `None` for invocations with
+    # no matching trace file (e.g., older sessions before trace capture, or
+    # when discovery failed). Downstream diagnostics read this as the evidence
+    # layer for trace-level signals.
+    trace: SubagentTrace | None = None
 
     @property
     def tokens_per_tool_use(self) -> float | None:

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -59,11 +59,9 @@ class AgentInvocation(BaseModel):
     output_text: str = ""
     """The agent's final summary/output text."""
 
-    # Populated by the linker (traces.linker.link_traces) when a subagent trace
-    # file exists for this invocation's agent_id. `None` for invocations with
-    # no matching trace file (e.g., older sessions before trace capture, or
-    # when discovery failed). Downstream diagnostics read this as the evidence
-    # layer for trace-level signals.
+    # Attached by trace linking when a matching subagent file exists; `None`
+    # otherwise (e.g., older sessions predating trace capture). Serves as the
+    # evidence layer for trace-level diagnostics.
     trace: SubagentTrace | None = None
 
     @property

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -293,10 +293,12 @@ def _link_subagent_traces(
     appears in ``invocations``; skipped files cost one dict lookup each.
     Orphan traces (file exists, no matching invocation) are debug-logged.
     """
+    # Discover subagent files for this session and build the lookup map.
     session_dir = session_path.parent / session_path.stem
     subagent_files = discover_session_subagents(session_dir)
     path_map = {info.agent_id: info.path for info in subagent_files}
 
+    # Lazy loader: only parses traces for invocations that actually exist.
     def loader(agent_id: str) -> SubagentTrace | None:
         file_path = path_map.get(agent_id)
         if file_path is None:
@@ -311,6 +313,7 @@ def _link_subagent_traces(
 
     invocations = link_traces(invocations, loader)
 
+    # Orphans: trace files with no matching invocation.
     linked_ids = {inv.agent_id for inv in invocations if inv.trace is not None}
     for orphan_id in path_map.keys() - linked_ids:
         logger.debug(

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -6,6 +6,7 @@ analysis pipeline. Reusable by the CLI, future webapp, and tests.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -30,6 +31,12 @@ from agentfluent.analytics.tools import (
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import SessionMessage
 from agentfluent.diagnostics.models import DiagnosticsResult
+from agentfluent.traces.discovery import discover_session_subagents
+from agentfluent.traces.linker import link_traces
+from agentfluent.traces.models import SubagentTrace
+from agentfluent.traces.parser import parse_subagent_trace
+
+logger = logging.getLogger(__name__)
 
 
 class SessionAnalysis(BaseModel):
@@ -80,6 +87,8 @@ def analyze_session(
         invocations = [
             inv for inv in invocations if inv.agent_type.lower() == agent_filter.lower()
         ]
+
+    invocations = _link_subagent_traces(invocations, path)
 
     agent_metrics = compute_agent_metrics(
         invocations, session_total_tokens=token_metrics.total_tokens
@@ -271,6 +280,45 @@ def _merge_agent_metrics(
         custom_invocations=custom_count,
         agent_token_percentage=agent_token_pct,
     )
+
+
+def _link_subagent_traces(
+    invocations: list[AgentInvocation], session_path: Path,
+) -> list[AgentInvocation]:
+    """Discover subagent trace files for ``session_path`` and attach them
+    to matching invocations.
+
+    Scoped per session: subagent files for a session ``<uuid>.jsonl`` live
+    under ``<uuid>/subagents/``. Lazy-loads only traces whose ``agent_id``
+    appears in ``invocations``; skipped files cost one dict lookup each.
+    Orphan traces (file exists, no matching invocation) are debug-logged.
+    """
+    session_dir = session_path.parent / session_path.stem
+    subagent_files = discover_session_subagents(session_dir)
+    path_map = {info.agent_id: info.path for info in subagent_files}
+
+    def loader(agent_id: str) -> SubagentTrace | None:
+        file_path = path_map.get(agent_id)
+        if file_path is None:
+            return None
+        try:
+            return parse_subagent_trace(file_path)
+        except (FileNotFoundError, ValueError):
+            logger.debug(
+                "Skipping malformed or missing subagent trace: %s", file_path,
+            )
+            return None
+
+    invocations = link_traces(invocations, loader)
+
+    linked_ids = {inv.agent_id for inv in invocations if inv.trace is not None}
+    for orphan_id in path_map.keys() - linked_ids:
+        logger.debug(
+            "Orphan subagent trace (no matching invocation): agent_id=%s",
+            orphan_id,
+        )
+
+    return invocations
 
 
 def _count_type(messages: list[SessionMessage], msg_type: str) -> int:

--- a/src/agentfluent/traces/linker.py
+++ b/src/agentfluent/traces/linker.py
@@ -1,0 +1,51 @@
+"""Link parsed subagent traces to their parent ``AgentInvocation`` instances.
+
+The parser produces a ``SubagentTrace`` with ``agent_type = UNKNOWN_AGENT_TYPE``
+because the JSONL content alone isn't a reliable source. The parent session's
+``Agent`` tool_use block carries the authoritative ``agent_type`` (as
+``subagent_type`` in the tool input, extracted into ``AgentInvocation.agent_type``).
+The linker matches traces to invocations by ``agent_id`` and overwrites the
+trace's ``agent_type`` with the parent's value. Downstream diagnostics
+(``#107``, ``#110``, ``#111``) read ``invocation.trace.agent_type`` as
+authoritative post-linking.
+
+The loader is a ``Callable`` rather than a pre-parsed dict so that trace
+files are only parsed on demand. With 350+ subagent files per project —
+some >1MB — lazy parsing materially affects startup time on ``analyze``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.traces.models import SubagentTrace
+
+
+def link_traces(
+    invocations: list[AgentInvocation],
+    trace_loader: Callable[[str], SubagentTrace | None],
+) -> list[AgentInvocation]:
+    """Attach matching subagent traces to each invocation, in place.
+
+    For every invocation with a non-``None`` ``agent_id``, call
+    ``trace_loader(agent_id)``. When the loader returns a trace, overwrite
+    its ``agent_type`` with the invocation's ``agent_type`` (parent is
+    authoritative) and assign it to ``invocation.trace``. Invocations
+    without an ``agent_id`` or with an unmatched loader return keep
+    ``trace = None``.
+
+    Returns the same list object it received, with ``trace`` fields
+    mutated. Callers that want to track orphan traces (files whose
+    ``agent_id`` doesn't match any invocation) should diff against the
+    set of keys they passed into the loader's closure.
+    """
+    for invocation in invocations:
+        if invocation.agent_id is None:
+            continue
+        trace = trace_loader(invocation.agent_id)
+        if trace is None:
+            continue
+        trace.agent_type = invocation.agent_type
+        invocation.trace = trace
+    return invocations

--- a/src/agentfluent/traces/linker.py
+++ b/src/agentfluent/traces/linker.py
@@ -5,9 +5,8 @@ because the JSONL content alone isn't a reliable source. The parent session's
 ``Agent`` tool_use block carries the authoritative ``agent_type`` (as
 ``subagent_type`` in the tool input, extracted into ``AgentInvocation.agent_type``).
 The linker matches traces to invocations by ``agent_id`` and overwrites the
-trace's ``agent_type`` with the parent's value. Downstream diagnostics
-(``#107``, ``#110``, ``#111``) read ``invocation.trace.agent_type`` as
-authoritative post-linking.
+trace's ``agent_type`` with the parent's value. Trace-level diagnostics read
+``invocation.trace.agent_type`` as authoritative post-linking.
 
 The loader is a ``Callable`` rather than a pre-parsed dict so that trace
 files are only parsed on demand. With 350+ subagent files per project —

--- a/tests/unit/test_traces_linker.py
+++ b/tests/unit/test_traces_linker.py
@@ -172,100 +172,100 @@ class TestLinkTraces:
         assert trace.agent_type == "custom-agent"
 
 
-class TestPipelineIntegration:
-    """End-to-end wiring: analyze_session discovers and links subagent traces."""
+def _build_project(
+    tmp_path: Path,
+    session_uuid: str,
+    agent_id: str,
+    *,
+    include_trace_file: bool,
+) -> Path:
+    """Create a minimal project layout with optional subagent trace."""
+    session_path = tmp_path / f"{session_uuid}.jsonl"
+    session_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "model": "claude-opus-4-6",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "Agent",
+                            "input": {
+                                "subagent_type": "plan",
+                                "description": "Plan work",
+                                "prompt": "Plan the work",
+                            },
+                        },
+                    ],
+                },
+                "timestamp": "2026-04-21T10:00:00.000Z",
+            },
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": "plan complete",
+                        },
+                    ],
+                },
+                "toolUseResult": {
+                    "agentId": agent_id,
+                    "agentType": "plan",
+                    "totalTokens": 100,
+                },
+                "timestamp": "2026-04-21T10:00:01.000Z",
+            },
+        )
+        + "\n",
+    )
 
-    def _build_project(
-        self,
-        tmp_path: Path,
-        session_uuid: str,
-        agent_id: str,
-        *,
-        include_trace_file: bool,
-    ) -> Path:
-        """Create a minimal project layout with optional subagent trace."""
-        session_path = tmp_path / f"{session_uuid}.jsonl"
-        session_path.write_text(
+    if include_trace_file:
+        subagents_dir = tmp_path / session_uuid / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / f"agent-{agent_id}.jsonl").write_text(
             json.dumps(
                 {
-                    "type": "assistant",
-                    "message": {
-                        "id": "msg_1",
-                        "role": "assistant",
-                        "model": "claude-opus-4-6",
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "id": "toolu_1",
-                                "name": "Agent",
-                                "input": {
-                                    "subagent_type": "plan",
-                                    "description": "Plan work",
-                                    "prompt": "Plan the work",
-                                },
-                            },
-                        ],
-                    },
-                    "timestamp": "2026-04-21T10:00:00.000Z",
+                    "type": "user",
+                    "message": {"role": "user", "content": "Plan the work"},
+                    "timestamp": "2026-04-21T10:00:00.100Z",
                 },
             )
             + "\n"
             + json.dumps(
                 {
-                    "type": "user",
+                    "type": "assistant",
                     "message": {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": "toolu_1",
-                                "content": "plan complete",
-                            },
-                        ],
+                        "id": "msg_inner",
+                        "role": "assistant",
+                        "model": "claude-opus-4-6",
+                        "content": [{"type": "text", "text": "done"}],
+                        "usage": {"input_tokens": 5, "output_tokens": 2},
                     },
-                    "toolUseResult": {
-                        "agentId": agent_id,
-                        "agentType": "plan",
-                        "totalTokens": 100,
-                    },
-                    "timestamp": "2026-04-21T10:00:01.000Z",
+                    "timestamp": "2026-04-21T10:00:00.500Z",
                 },
             )
             + "\n",
         )
 
-        if include_trace_file:
-            subagents_dir = tmp_path / session_uuid / "subagents"
-            subagents_dir.mkdir(parents=True)
-            (subagents_dir / f"agent-{agent_id}.jsonl").write_text(
-                json.dumps(
-                    {
-                        "type": "user",
-                        "message": {"role": "user", "content": "Plan the work"},
-                        "timestamp": "2026-04-21T10:00:00.100Z",
-                    },
-                )
-                + "\n"
-                + json.dumps(
-                    {
-                        "type": "assistant",
-                        "message": {
-                            "id": "msg_inner",
-                            "role": "assistant",
-                            "model": "claude-opus-4-6",
-                            "content": [{"type": "text", "text": "done"}],
-                            "usage": {"input_tokens": 5, "output_tokens": 2},
-                        },
-                        "timestamp": "2026-04-21T10:00:00.500Z",
-                    },
-                )
-                + "\n",
-            )
+    return session_path
 
-        return session_path
+
+class TestPipelineIntegration:
+    """End-to-end wiring: analyze_session discovers and links subagent traces."""
 
     def test_matching_trace_gets_linked(self, tmp_path: Path) -> None:
-        session_path = self._build_project(
+        session_path = _build_project(
             tmp_path, "uuid-1", "aid-1", include_trace_file=True,
         )
 
@@ -280,7 +280,7 @@ class TestPipelineIntegration:
         assert inv.trace.agent_id == "aid-1"
 
     def test_no_matching_trace_leaves_trace_none(self, tmp_path: Path) -> None:
-        session_path = self._build_project(
+        session_path = _build_project(
             tmp_path, "uuid-1", "aid-1", include_trace_file=False,
         )
 
@@ -291,7 +291,7 @@ class TestPipelineIntegration:
 
     def test_orphan_trace_file_is_ignored(self, tmp_path: Path) -> None:
         # Subagent file exists, but its agent_id doesn't match any invocation.
-        session_path = self._build_project(
+        session_path = _build_project(
             tmp_path, "uuid-1", "aid-1", include_trace_file=True,
         )
         # Drop the real trace file, add an orphan instead.
@@ -307,7 +307,7 @@ class TestPipelineIntegration:
     ) -> None:
         """Read the trace back via parse_subagent_trace and confirm the
         overwrite sticks on the object analyze_session returns."""
-        session_path = self._build_project(
+        session_path = _build_project(
             tmp_path, "uuid-1", "aid-1", include_trace_file=True,
         )
         trace_path = tmp_path / "uuid-1" / "subagents" / "agent-aid-1.jsonl"

--- a/tests/unit/test_traces_linker.py
+++ b/tests/unit/test_traces_linker.py
@@ -1,0 +1,323 @@
+"""Tests for the subagent trace linker."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.analytics.pipeline import analyze_session
+from agentfluent.traces.linker import link_traces
+from agentfluent.traces.models import UNKNOWN_AGENT_TYPE, SubagentTrace
+from agentfluent.traces.parser import parse_subagent_trace
+
+WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
+
+
+def _invocation(
+    agent_type: str = "plan",
+    *,
+    agent_id: str | None = "aid-1",
+    tool_use_id: str = "toolu_1",
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        is_builtin=True,
+        description="",
+        prompt="",
+        tool_use_id=tool_use_id,
+        agent_id=agent_id,
+    )
+
+
+def _trace(agent_id: str = "aid-1") -> SubagentTrace:
+    """A trace with the parser's default UNKNOWN_AGENT_TYPE."""
+    return SubagentTrace(
+        agent_id=agent_id,
+        delegation_prompt="do work",
+    )
+
+
+class TestLinkTraces:
+    def test_empty_invocations_returns_empty(self) -> None:
+        calls: list[str] = []
+
+        def loader(aid: str) -> SubagentTrace | None:
+            calls.append(aid)
+            return _trace(aid)
+
+        result = link_traces([], loader)
+        assert result == []
+        assert calls == []
+
+    def test_agent_id_none_skips_loader(self) -> None:
+        calls: list[str] = []
+
+        def loader(aid: str) -> SubagentTrace | None:
+            calls.append(aid)
+            return _trace(aid)
+
+        inv = _invocation(agent_id=None)
+        result = link_traces([inv], loader)
+
+        assert calls == []
+        assert result[0].trace is None
+
+    def test_match_links_trace_and_overwrites_agent_type(self) -> None:
+        inv = _invocation(agent_type="plan", agent_id="aid-1")
+        trace = _trace("aid-1")
+        assert trace.agent_type == UNKNOWN_AGENT_TYPE
+
+        def loader(aid: str) -> SubagentTrace | None:
+            return trace if aid == "aid-1" else None
+
+        result = link_traces([inv], loader)
+
+        assert result[0].trace is trace
+        # Parent's agent_type is authoritative.
+        assert result[0].trace.agent_type == "plan"
+
+    def test_no_match_leaves_trace_none(self) -> None:
+        def loader(aid: str) -> SubagentTrace | None:
+            return None
+
+        inv = _invocation(agent_id="aid-1")
+        result = link_traces([inv], loader)
+        assert result[0].trace is None
+
+    def test_idempotent_overwrite_when_agent_type_matches(self) -> None:
+        # Trace already carries the same agent_type as the parent — still gets
+        # assigned without any error.
+        inv = _invocation(agent_type="pm", agent_id="aid-1")
+        trace = _trace("aid-1")
+        trace.agent_type = "pm"
+
+        def loader(aid: str) -> SubagentTrace | None:
+            return trace
+
+        result = link_traces([inv], loader)
+        assert result[0].trace.agent_type == "pm"
+
+    def test_returns_same_list_object(self) -> None:
+        """Mutation semantics: the linker modifies the input list in place."""
+        def loader(aid: str) -> SubagentTrace | None:
+            return None
+
+        invs = [_invocation()]
+        result = link_traces(invs, loader)
+        assert result is invs
+
+    def test_loader_receives_exact_agent_id(self) -> None:
+        received: list[str] = []
+
+        def loader(aid: str) -> SubagentTrace | None:
+            received.append(aid)
+            return None
+
+        invs = [
+            _invocation(agent_id="aid-x"),
+            _invocation(agent_id="aid-y"),
+            _invocation(agent_id=None),  # not called
+        ]
+        link_traces(invs, loader)
+        assert received == ["aid-x", "aid-y"]
+
+    def test_multiple_invocations_same_agent_id_call_loader_each_time(
+        self,
+    ) -> None:
+        # Each invocation is matched independently. Caching is the caller's
+        # concern (the closure around the path map); the linker doesn't dedup.
+        call_count = [0]
+
+        def loader(aid: str) -> SubagentTrace | None:
+            call_count[0] += 1
+            return _trace(aid)
+
+        invs = [_invocation(agent_id="shared"), _invocation(agent_id="shared")]
+        link_traces(invs, loader)
+        assert call_count[0] == 2
+        assert invs[0].trace is not None
+        assert invs[1].trace is not None
+
+    def test_mixed_matches_and_misses(self) -> None:
+        def loader(aid: str) -> SubagentTrace | None:
+            return _trace(aid) if aid == "match" else None
+
+        invs = [
+            _invocation(agent_id="match"),
+            _invocation(agent_id="miss"),
+            _invocation(agent_id=None),
+            _invocation(agent_id="match"),
+        ]
+        link_traces(invs, loader)
+        assert invs[0].trace is not None
+        assert invs[1].trace is None
+        assert invs[2].trace is None
+        assert invs[3].trace is not None
+
+    def test_unknown_to_known_overwrite(self) -> None:
+        """Trace loaded with UNKNOWN_AGENT_TYPE gets the parent's type."""
+        inv = _invocation(agent_type="custom-agent", agent_id="aid-1")
+        trace = _trace("aid-1")
+        assert trace.agent_type == UNKNOWN_AGENT_TYPE
+
+        def loader(aid: str) -> SubagentTrace | None:
+            return trace
+
+        link_traces([inv], loader)
+        assert inv.trace is trace
+        assert inv.trace.agent_type == "custom-agent"
+        assert trace.agent_type == "custom-agent"
+
+
+class TestPipelineIntegration:
+    """End-to-end wiring: analyze_session discovers and links subagent traces."""
+
+    def _build_project(
+        self,
+        tmp_path: Path,
+        session_uuid: str,
+        agent_id: str,
+        *,
+        include_trace_file: bool,
+    ) -> Path:
+        """Create a minimal project layout with optional subagent trace."""
+        session_path = tmp_path / f"{session_uuid}.jsonl"
+        session_path.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "model": "claude-opus-4-6",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_1",
+                                "name": "Agent",
+                                "input": {
+                                    "subagent_type": "plan",
+                                    "description": "Plan work",
+                                    "prompt": "Plan the work",
+                                },
+                            },
+                        ],
+                    },
+                    "timestamp": "2026-04-21T10:00:00.000Z",
+                },
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_1",
+                                "content": "plan complete",
+                            },
+                        ],
+                    },
+                    "toolUseResult": {
+                        "agentId": agent_id,
+                        "agentType": "plan",
+                        "totalTokens": 100,
+                    },
+                    "timestamp": "2026-04-21T10:00:01.000Z",
+                },
+            )
+            + "\n",
+        )
+
+        if include_trace_file:
+            subagents_dir = tmp_path / session_uuid / "subagents"
+            subagents_dir.mkdir(parents=True)
+            (subagents_dir / f"agent-{agent_id}.jsonl").write_text(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {"role": "user", "content": "Plan the work"},
+                        "timestamp": "2026-04-21T10:00:00.100Z",
+                    },
+                )
+                + "\n"
+                + json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "id": "msg_inner",
+                            "role": "assistant",
+                            "model": "claude-opus-4-6",
+                            "content": [{"type": "text", "text": "done"}],
+                            "usage": {"input_tokens": 5, "output_tokens": 2},
+                        },
+                        "timestamp": "2026-04-21T10:00:00.500Z",
+                    },
+                )
+                + "\n",
+            )
+
+        return session_path
+
+    def test_matching_trace_gets_linked(self, tmp_path: Path) -> None:
+        session_path = self._build_project(
+            tmp_path, "uuid-1", "aid-1", include_trace_file=True,
+        )
+
+        result = analyze_session(session_path)
+
+        assert len(result.invocations) == 1
+        inv = result.invocations[0]
+        assert inv.agent_id == "aid-1"
+        assert inv.trace is not None
+        # Parent's agent_type ("plan") overwrites the parser's UNKNOWN default.
+        assert inv.trace.agent_type == "plan"
+        assert inv.trace.agent_id == "aid-1"
+
+    def test_no_matching_trace_leaves_trace_none(self, tmp_path: Path) -> None:
+        session_path = self._build_project(
+            tmp_path, "uuid-1", "aid-1", include_trace_file=False,
+        )
+
+        result = analyze_session(session_path)
+
+        assert len(result.invocations) == 1
+        assert result.invocations[0].trace is None
+
+    def test_orphan_trace_file_is_ignored(self, tmp_path: Path) -> None:
+        # Subagent file exists, but its agent_id doesn't match any invocation.
+        session_path = self._build_project(
+            tmp_path, "uuid-1", "aid-1", include_trace_file=True,
+        )
+        # Drop the real trace file, add an orphan instead.
+        (tmp_path / "uuid-1" / "subagents" / "agent-aid-1.jsonl").unlink()
+        (tmp_path / "uuid-1" / "subagents" / "agent-orphan.jsonl").write_text("")
+
+        result = analyze_session(session_path)
+
+        assert result.invocations[0].trace is None
+
+    def test_roundtrip_of_real_parser_preserves_agent_type_overwrite(
+        self, tmp_path: Path,
+    ) -> None:
+        """Read the trace back via parse_subagent_trace and confirm the
+        overwrite sticks on the object analyze_session returns."""
+        session_path = self._build_project(
+            tmp_path, "uuid-1", "aid-1", include_trace_file=True,
+        )
+        trace_path = tmp_path / "uuid-1" / "subagents" / "agent-aid-1.jsonl"
+
+        # Baseline: parser produces UNKNOWN (no linker in the picture).
+        baseline_trace = parse_subagent_trace(trace_path)
+        assert baseline_trace.agent_type == UNKNOWN_AGENT_TYPE
+
+        # analyze_session applies the linker and the invocation carries an
+        # overwritten trace.
+        result = analyze_session(session_path)
+        assert result.invocations[0].trace is not None
+        assert result.invocations[0].trace.agent_type == "plan"


### PR DESCRIPTION
## Summary

Adds the final wiring piece of v0.3 E2: parsed `SubagentTrace` objects are now matched to their parent `AgentInvocation` by `agent_id`, exposed as `invocation.trace`, and carry the authoritative `agent_type` from the parent.

Closes #105.

## Changes

1. **New field on `AgentInvocation`**: `trace: SubagentTrace | None = None`. Extends the existing `agents → traces → core` import direction (no cycle).

2. **New module `agentfluent.traces.linker`** with:
   ```
   link_traces(invocations, trace_loader: Callable[[str], SubagentTrace | None]) -> list[AgentInvocation]
   ```
   Takes a `Callable` loader, not a pre-parsed dict — architect A's lazy-parsing requirement (350+ subagent files per project, some >1MB). Only traces with matching `agent_id`s get parsed. Mutates in place, returns the same list.

3. **`agent_type` overwrite** (architect B's contract): when a trace is linked, the linker sets `trace.agent_type = invocation.agent_type`. The parent carries the reliably-populated value (from the `Agent` tool_use input's `subagent_type`); the parser leaves `trace.agent_type = UNKNOWN_AGENT_TYPE` by design. Downstream (#107, #110, #111) reads `invocation.trace.agent_type` as authoritative post-linking.

4. **Pipeline wiring** in `analytics/pipeline.py::analyze_session`: after `extract_agent_invocations`, discover subagent files for the session (`<uuid>/subagents/`), build an `agent_id → path` map, wrap `parse_subagent_trace` in a closure that catches `FileNotFoundError`/`ValueError` (malformed files degrade gracefully), call `link_traces`, then debug-log any orphan trace files (file exists, no matching invocation).

## Design choices

| Decision | Choice | Rationale |
|---|---|---|
| Loader type | `Callable`, not pre-parsed dict | Architect A: lazy parsing matters for large file sets |
| Return semantics | Same list, mutated | Architect A endorsed mutation over copy for simplicity |
| `agent_type` overwrite | Always, when linked | Architect B: parent is authoritative |
| Orphan logging | Pipeline (not linker) | Linker only sees invocations; pipeline has both sets |
| Exception handling | Catch `FileNotFoundError`/`ValueError` in the loader closure | Resilience — one bad file shouldn't crash the whole session |

## Test plan

- [x] `uv run pytest tests/unit/test_traces_linker.py -v` → 14 passed (10 unit + 4 integration)
- [x] `uv run pytest -m "not integration"` → 404 passed (390 → 404)
- [x] `uv run mypy src/agentfluent/` → clean
- [x] `uv run ruff check src/ tests/` → clean

### Coverage

**Unit (with mock loader):** empty invocations / `agent_id=None` skips loader / match links + overwrites `agent_type` / no match leaves `trace=None` / idempotent overwrite / same-list-object identity / loader receives exact `agent_id` / multiple invocations sharing `agent_id` each call loader / mixed match+miss / UNKNOWN→known overwrite from parser default.

**Integration (end-to-end via `analyze_session` + tmp_path):** matching trace gets linked / no trace file leaves `trace=None` / orphan trace file is ignored / baseline `parse_subagent_trace` returns UNKNOWN to confirm the overwrite in `analyze_session` is the actual linker's effect.

## Deferred

- Real persistent JSONL fixtures under `tests/fixtures/subagents/` → **#106**
- Downstream consumers reading `invocation.trace` → **#107 / #110 / #111**

## Reference

- Architect A review on #105: lazy-loader requirement
- Architect B downstream feedback on #101 / #105: `agent_type` overwrite contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)