### PR TITLE
feat(diagnostics): add trace-level signal extraction and correlation rules (#107)

### DIFF
--- a/src/agentfluent/diagnostics/__init__.py
+++ b/src/agentfluent/diagnostics/__init__.py
@@ -11,7 +11,6 @@ from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.models import DiagnosticsResult
 from agentfluent.diagnostics.signals import extract_signals
 from agentfluent.diagnostics.trace_signals import extract_trace_signals
-from agentfluent.traces.models import UNKNOWN_AGENT_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +35,12 @@ def run_diagnostics(
     signals = extract_signals(invocations)
 
     # Fold in trace-level signals for any invocation with an attached
-    # subagent trace. The linker normally copies agent_type from parent
-    # to trace, but defend against UNKNOWN_AGENT_TYPE for unlinked or
-    # programmatically-built traces.
+    # subagent trace. Passing agent_type explicitly avoids depending on
+    # the linker having populated trace.agent_type.
     for inv in invocations:
         if inv.trace is None:
             continue
-        for signal in extract_trace_signals(inv.trace):
-            if not signal.agent_type or signal.agent_type == UNKNOWN_AGENT_TYPE:
-                signal.agent_type = inv.agent_type
-            signals.append(signal)
+        signals.extend(extract_trace_signals(inv.trace, agent_type=inv.agent_type))
 
     # Build config lookup for correlation
     configs: dict[str, AgentConfig] | None = None

--- a/src/agentfluent/diagnostics/__init__.py
+++ b/src/agentfluent/diagnostics/__init__.py
@@ -10,6 +10,8 @@ from agentfluent.config.scanner import scan_agents
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.models import DiagnosticsResult
 from agentfluent.diagnostics.signals import extract_signals
+from agentfluent.diagnostics.trace_signals import extract_trace_signals
+from agentfluent.traces.models import UNKNOWN_AGENT_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +34,18 @@ def run_diagnostics(
         DiagnosticsResult with signals and recommendations.
     """
     signals = extract_signals(invocations)
+
+    # Fold in trace-level signals for any invocation with an attached
+    # subagent trace. The linker normally copies agent_type from parent
+    # to trace, but defend against UNKNOWN_AGENT_TYPE for unlinked or
+    # programmatically-built traces.
+    for inv in invocations:
+        if inv.trace is None:
+            continue
+        for signal in extract_trace_signals(inv.trace):
+            if not signal.agent_type or signal.agent_type == UNKNOWN_AGENT_TYPE:
+                signal.agent_type = inv.agent_type
+            signals.append(signal)
 
     # Build config lookup for correlation
     configs: dict[str, AgentConfig] | None = None

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -212,12 +212,201 @@ class DurationOutlierRule:
         )
 
 
+class PermissionFailureRule:
+    """PERMISSION_FAILURE -> recommend adding the denied tool to `tools`."""
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.PERMISSION_FAILURE
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        tool_name = str(signal.detail.get("tool_name", ""))
+        observation = signal.message
+        reason = "The subagent was denied access to a tool it attempted to call."
+
+        if config and tool_name and tool_name not in config.tools:
+            action = (
+                f"Add '{tool_name}' to the tools list in {config.file_path} "
+                "(or remove it from disallowed_tools)."
+            )
+        elif config and tool_name in config.tools:
+            action = (
+                f"'{tool_name}' is listed in {config.file_path} but was "
+                "still denied -- check disallowed_tools and any hooks that "
+                "might block this tool."
+            )
+        else:
+            action = (
+                f"Grant the subagent access to '{tool_name}' in its agent "
+                "configuration, or remove calls to that tool from the prompt."
+                if tool_name
+                else "Grant the subagent access to the denied tool in its config."
+            )
+
+        return DiagnosticRecommendation(
+            target="tools",
+            severity=Severity.CRITICAL,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
+class RetryLoopRule:
+    """RETRY_LOOP -> recommend error-recovery guidance in the prompt."""
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.RETRY_LOOP
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        reason = (
+            "Repeated retries on the same tool indicate the agent lacks "
+            "recovery guidance for failures."
+        )
+
+        if config and config.prompt_body:
+            body_lower = config.prompt_body.lower()
+            has_error_guidance = any(
+                kw in body_lower for kw in ("error", "fail", "handle", "retry")
+            )
+            if has_error_guidance:
+                action = (
+                    f"The prompt in {config.file_path} mentions error handling, "
+                    "but the agent still retried without progress. Consider "
+                    "more specific stop conditions or alternative-tool fallbacks."
+                )
+            else:
+                action = (
+                    f"Add explicit retry / fallback guidance to the prompt "
+                    f"in {config.file_path}."
+                )
+        else:
+            action = (
+                "Add explicit retry / fallback guidance to the agent's "
+                "prompt body."
+            )
+
+        return DiagnosticRecommendation(
+            target="prompt",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
+class StuckPatternRule:
+    """STUCK_PATTERN -> recommend adding exit conditions to the prompt."""
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.STUCK_PATTERN
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        count = signal.detail.get("stuck_count", "multiple")
+        reason = (
+            f"The agent repeated an identical call {count} times without "
+            "progress, indicating no exit condition."
+        )
+
+        if config:
+            action = (
+                f"Add an explicit exit condition or progress check to the "
+                f"prompt in {config.file_path} (e.g., 'after 2 failed attempts, "
+                "return the error instead of retrying')."
+            )
+        else:
+            action = (
+                "Add an explicit exit condition or progress check to the "
+                "agent's prompt."
+            )
+
+        return DiagnosticRecommendation(
+            target="prompt",
+            severity=Severity.CRITICAL,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
+class ErrorSequenceRule:
+    """TOOL_ERROR_SEQUENCE -> recommend fallback instructions or tool review."""
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.TOOL_ERROR_SEQUENCE
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        reason = (
+            "Multiple consecutive tool errors suggest the agent lacks "
+            "fallback instructions for when a tool call fails."
+        )
+
+        if config and len(config.tools) > 8:
+            action = (
+                f"Review the tools list in {config.file_path} -- the agent "
+                "may be reaching for tools it does not need, or a specific "
+                "tool may be misconfigured."
+            )
+            target = "tools"
+        elif config:
+            action = (
+                f"Add fallback instructions to the prompt in "
+                f"{config.file_path} so the agent knows what to do when a "
+                "tool call fails repeatedly."
+            )
+            target = "prompt"
+        else:
+            action = (
+                "Add fallback instructions to the agent's prompt so it "
+                "recovers from repeated tool failures."
+            )
+            target = "prompt"
+
+        return DiagnosticRecommendation(
+            target=target,
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
 # Module-level rule registry. Add new rules here.
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
     TokenOutlierRule(),
     DurationOutlierRule(),
+    PermissionFailureRule(),
+    RetryLoopRule(),
+    StuckPatternRule(),
+    ErrorSequenceRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -15,11 +15,23 @@ from agentfluent.config.models import Severity
 
 
 class SignalType(StrEnum):
-    """Types of behavior signals detected in agent invocations."""
+    """Types of behavior signals detected in agent invocations.
+
+    Metadata-level signals (extracted from `AgentInvocation` fields):
+    - `ERROR_PATTERN`, `TOKEN_OUTLIER`, `DURATION_OUTLIER`
+
+    Trace-level signals (extracted from `SubagentTrace` evidence):
+    - `TOOL_ERROR_SEQUENCE`, `RETRY_LOOP`, `PERMISSION_FAILURE`,
+      `STUCK_PATTERN`
+    """
 
     ERROR_PATTERN = "error_pattern"
     TOKEN_OUTLIER = "token_outlier"
     DURATION_OUTLIER = "duration_outlier"
+    TOOL_ERROR_SEQUENCE = "tool_error_sequence"
+    RETRY_LOOP = "retry_loop"
+    PERMISSION_FAILURE = "permission_failure"
+    STUCK_PATTERN = "stuck_pattern"
 
 
 class DiagnosticSignal(BaseModel):

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -1,0 +1,312 @@
+"""Trace-level behavior signal extraction from a parsed subagent trace.
+
+The first consumer of the `SubagentTrace` evidence layer produced by E2
+(#101–#106). Where `signals.py` mines metadata fields on
+`AgentInvocation`, this module mines the full internal tool-call
+timeline carried on `AgentInvocation.trace` and emits four
+trace-specific signal types:
+
+- `PERMISSION_FAILURE` — a tool result contains a permission-denied
+  keyword. Specific remediation: grant the tool in the agent's config.
+- `STUCK_PATTERN` — 4+ consecutive identical calls to the same tool.
+  Indicates a missing exit condition in the prompt.
+- `RETRY_LOOP` — a `RetrySequence` with `attempts >= 3` that is not
+  `STUCK_PATTERN`. Indicates missing error-recovery guidance.
+- `TOOL_ERROR_SEQUENCE` — 2+ consecutive `is_error=True` results that
+  are not covered by a STUCK or RETRY sequence. Indicates missing
+  fallback instructions.
+
+STUCK and RETRY are mutually exclusive: a single `RetrySequence` emits
+exactly one of them, never both, and TOOL_ERROR_SEQUENCE never emits
+for indices already covered by STUCK or RETRY. This invariant keeps the
+principle "one observed pattern → one signal" — a future dev must not
+"fix" this to independent emission without updating the downstream
+correlator contract.
+
+PERMISSION_FAILURE is intentionally NOT mutually exclusive with
+TOOL_ERROR_SEQUENCE: a permission-denied run produces both a
+specialized recommendation (grant the tool) and the general fallback
+signal. Different remediation axes.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+from agentfluent.traces.models import (
+    RetrySequence,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+# Keywords that signal an authorization/access failure in a tool_result.
+# Substring match is intentional — "not allowed" inside a longer message
+# still indicates a denial. Keep local to this module; do NOT extend
+# `signals.ERROR_PATTERNS`, which governs the metadata-level
+# ERROR_PATTERN signal and has a different remediation contract.
+_PERMISSION_KEYWORDS = (
+    "permission denied",
+    "access denied",
+    "not allowed",
+    "blocked",
+)
+PERMISSION_REGEX = re.compile(
+    "|".join(re.escape(k) for k in _PERMISSION_KEYWORDS),
+    re.IGNORECASE,
+)
+
+# Cap on the `detail.tool_calls` evidence list. The true count lives in
+# the sibling `error_count` / `retry_count` / `stuck_count` detail key.
+_EVIDENCE_CAP = 5
+
+# Minimum consecutive errors to emit TOOL_ERROR_SEQUENCE.
+_ERROR_SEQUENCE_MIN = 2
+# Above this length, escalate TOOL_ERROR_SEQUENCE to critical.
+_ERROR_SEQUENCE_CRITICAL_MIN = 4
+# Minimum attempts to emit RETRY_LOOP (below this, the retry detector's
+# output is below the diagnostic signal threshold).
+_RETRY_LOOP_MIN_ATTEMPTS = 3
+# Minimum identical attempts to emit STUCK_PATTERN instead of RETRY_LOOP.
+_STUCK_MIN_ATTEMPTS = 4
+
+
+def _evidence_from_call(call: SubagentToolCall, index: int) -> dict[str, object]:
+    """Build one evidence entry for `DiagnosticSignal.detail.tool_calls`.
+
+    `index` is the position in the owning `SubagentTrace.tool_calls`
+    list so #108's CLI can cross-reference with `RetrySequence.tool_call_indices`.
+    """
+    return {
+        "index": index,
+        "tool_name": call.tool_name,
+        "input_summary": call.input_summary,
+        "result_summary": call.result_summary,
+        "is_error": call.is_error,
+    }
+
+
+def _extract_permission_failures(trace: SubagentTrace) -> list[DiagnosticSignal]:
+    """Emit one PERMISSION_FAILURE signal per tool call whose result
+    contains a permission-denied keyword."""
+    signals: list[DiagnosticSignal] = []
+    matches: list[tuple[int, SubagentToolCall, str]] = []
+
+    for i, call in enumerate(trace.tool_calls):
+        match = PERMISSION_REGEX.search(call.result_summary)
+        if match is None:
+            continue
+        matches.append((i, call, match.group(0).lower()))
+
+    if not matches:
+        return signals
+
+    # Emit one signal per keyword-matching call. Evidence is capped at
+    # _EVIDENCE_CAP across all matches in the signal so a single denied
+    # call produces a single-entry evidence list; many denials produce
+    # up to 5. We emit one signal per unique tool (keeps recommendations
+    # actionable — a user-facing "this tool was denied" is scoped to the
+    # tool, not the specific call).
+    by_tool: dict[str, list[tuple[int, SubagentToolCall, str]]] = {}
+    for entry in matches:
+        by_tool.setdefault(entry[1].tool_name, []).append(entry)
+
+    for tool_name, entries in by_tool.items():
+        keyword = entries[0][2]
+        evidence = [_evidence_from_call(c, i) for i, c, _ in entries[:_EVIDENCE_CAP]]
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.PERMISSION_FAILURE,
+                severity=Severity.CRITICAL,
+                agent_type=trace.agent_type,
+                message=(
+                    f"Subagent '{trace.agent_type}' was denied access to "
+                    f"tool '{tool_name}' ({keyword!r})."
+                ),
+                detail={
+                    "tool_calls": evidence,
+                    "tool_name": tool_name,
+                    "matched_keyword": keyword,
+                },
+            ),
+        )
+
+    return signals
+
+
+def _extract_retry_and_stuck(
+    trace: SubagentTrace,
+) -> tuple[list[DiagnosticSignal], set[int]]:
+    """Emit STUCK_PATTERN or RETRY_LOOP — never both — per `RetrySequence`.
+
+    STUCK and RETRY are mutually exclusive by design. A `RetrySequence`
+    whose `attempts >= 4` AND whose member calls all share the exact
+    same `input_summary` is STUCK; any other sequence with `attempts >= 3`
+    is RETRY. Sequences with `attempts == 2` are below the diagnostic
+    threshold and do not emit here.
+
+    The returned `covered` set lists all `tool_call_indices` consumed by
+    emitted STUCK or RETRY signals so `_extract_error_sequences` can
+    avoid double-emitting TOOL_ERROR_SEQUENCE on the same bytes.
+    """
+    signals: list[DiagnosticSignal] = []
+    covered: set[int] = set()
+
+    for seq in trace.retry_sequences:
+        if seq.attempts < _RETRY_LOOP_MIN_ATTEMPTS:
+            continue
+
+        calls = [trace.tool_calls[i] for i in seq.tool_call_indices]
+        if not calls:
+            continue
+
+        first_input = calls[0].input_summary
+        all_identical = all(c.input_summary == first_input for c in calls)
+
+        if seq.attempts >= _STUCK_MIN_ATTEMPTS and all_identical:
+            signals.append(_build_stuck_signal(trace, seq, calls))
+        else:
+            signals.append(_build_retry_signal(trace, seq, calls))
+        covered.update(seq.tool_call_indices)
+
+    return signals, covered
+
+
+def _build_stuck_signal(
+    trace: SubagentTrace,
+    seq: RetrySequence,
+    calls: list[SubagentToolCall],
+) -> DiagnosticSignal:
+    pairs = zip(
+        calls[:_EVIDENCE_CAP],
+        seq.tool_call_indices[:_EVIDENCE_CAP],
+        strict=False,
+    )
+    evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+    return DiagnosticSignal(
+        signal_type=SignalType.STUCK_PATTERN,
+        severity=Severity.CRITICAL,
+        agent_type=trace.agent_type,
+        message=(
+            f"Subagent '{trace.agent_type}' repeated tool "
+            f"'{seq.tool_name}' with identical input {seq.attempts} "
+            "times without progress."
+        ),
+        detail={
+            "tool_calls": evidence,
+            "stuck_count": seq.attempts,
+            "tool_name": seq.tool_name,
+            "input_summary": calls[0].input_summary,
+        },
+    )
+
+
+def _build_retry_signal(
+    trace: SubagentTrace,
+    seq: RetrySequence,
+    calls: list[SubagentToolCall],
+) -> DiagnosticSignal:
+    pairs = zip(
+        calls[:_EVIDENCE_CAP],
+        seq.tool_call_indices[:_EVIDENCE_CAP],
+        strict=False,
+    )
+    evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+    return DiagnosticSignal(
+        signal_type=SignalType.RETRY_LOOP,
+        severity=Severity.WARNING,
+        agent_type=trace.agent_type,
+        message=(
+            f"Subagent '{trace.agent_type}' retried tool "
+            f"'{seq.tool_name}' {seq.attempts} times."
+        ),
+        detail={
+            "tool_calls": evidence,
+            "retry_count": seq.attempts,
+            "tool_name": seq.tool_name,
+            "first_error_message": seq.first_error_message,
+            "eventual_success": seq.eventual_success,
+        },
+    )
+
+
+def _extract_error_sequences(
+    trace: SubagentTrace, covered: set[int],
+) -> list[DiagnosticSignal]:
+    """Emit TOOL_ERROR_SEQUENCE for runs of consecutive `is_error=True`
+    tool calls that are not already covered by STUCK/RETRY signals.
+
+    A covered index is dropped from the run before measuring its length,
+    which preserves the `>= 2` threshold — a run straddling a covered
+    region is only emitted if the uncovered portion is itself long
+    enough.
+    """
+    signals: list[DiagnosticSignal] = []
+    calls = trace.tool_calls
+    n = len(calls)
+
+    i = 0
+    while i < n:
+        if not calls[i].is_error:
+            i += 1
+            continue
+        # Consume consecutive errors starting at i.
+        j = i
+        while j < n and calls[j].is_error:
+            j += 1
+        # Filter out covered indices; if uncovered remainder is long
+        # enough, emit.
+        run_indices = [k for k in range(i, j) if k not in covered]
+        if len(run_indices) >= _ERROR_SEQUENCE_MIN:
+            run_calls = [calls[k] for k in run_indices]
+            severity = (
+                Severity.CRITICAL
+                if len(run_indices) >= _ERROR_SEQUENCE_CRITICAL_MIN
+                else Severity.WARNING
+            )
+            pairs = zip(
+                run_calls[:_EVIDENCE_CAP],
+                run_indices[:_EVIDENCE_CAP],
+                strict=False,
+            )
+            evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+            signals.append(
+                DiagnosticSignal(
+                    signal_type=SignalType.TOOL_ERROR_SEQUENCE,
+                    severity=severity,
+                    agent_type=trace.agent_type,
+                    message=(
+                        f"Subagent '{trace.agent_type}' had "
+                        f"{len(run_indices)} consecutive tool errors."
+                    ),
+                    detail={
+                        "tool_calls": evidence,
+                        "error_count": len(run_indices),
+                        "start_index": run_indices[0],
+                        "end_index": run_indices[-1],
+                    },
+                ),
+            )
+        i = j
+
+    return signals
+
+
+def extract_trace_signals(trace: SubagentTrace | None) -> list[DiagnosticSignal]:
+    """Extract all trace-level behavior signals from a parsed subagent trace.
+
+    Handles `None` (unlinked invocation) and empty traces by returning
+    an empty list. Order of signals: PERMISSION_FAILURE first
+    (remediation-specific), then STUCK/RETRY (indexed), then
+    TOOL_ERROR_SEQUENCE (filtered by STUCK/RETRY coverage).
+    """
+    if trace is None or not trace.tool_calls:
+        return []
+
+    signals: list[DiagnosticSignal] = []
+    signals.extend(_extract_permission_failures(trace))
+    retry_stuck, covered = _extract_retry_and_stuck(trace)
+    signals.extend(retry_stuck)
+    signals.extend(_extract_error_sequences(trace, covered))
+    return signals

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -76,7 +76,7 @@ def _evidence_from_call(call: SubagentToolCall, index: int) -> dict[str, object]
     """Build one evidence entry for `DiagnosticSignal.detail.tool_calls`.
 
     `index` is the position in the owning `SubagentTrace.tool_calls`
-    list so #108's CLI can cross-reference with `RetrySequence.tool_call_indices`.
+    list so the CLI can cross-reference with `RetrySequence.tool_call_indices`.
     """
     return {
         "index": index,
@@ -87,9 +87,18 @@ def _evidence_from_call(call: SubagentToolCall, index: int) -> dict[str, object]
     }
 
 
-def _extract_permission_failures(trace: SubagentTrace) -> list[DiagnosticSignal]:
-    """Emit one PERMISSION_FAILURE signal per tool call whose result
-    contains a permission-denied keyword."""
+def _cap_evidence(
+    calls: list[SubagentToolCall], indices: list[int],
+) -> list[dict[str, object]]:
+    """Build an evidence list from parallel call/index lists, capped at _EVIDENCE_CAP."""
+    pairs = zip(calls[:_EVIDENCE_CAP], indices[:_EVIDENCE_CAP], strict=False)
+    return [_evidence_from_call(c, idx) for c, idx in pairs]
+
+
+def _extract_permission_failures(
+    trace: SubagentTrace, agent_type: str,
+) -> list[DiagnosticSignal]:
+    """Emit one PERMISSION_FAILURE signal per unique tool with a denied result."""
     signals: list[DiagnosticSignal] = []
     matches: list[tuple[int, SubagentToolCall, str]] = []
 
@@ -102,26 +111,26 @@ def _extract_permission_failures(trace: SubagentTrace) -> list[DiagnosticSignal]
     if not matches:
         return signals
 
-    # Emit one signal per keyword-matching call. Evidence is capped at
-    # _EVIDENCE_CAP across all matches in the signal so a single denied
-    # call produces a single-entry evidence list; many denials produce
-    # up to 5. We emit one signal per unique tool (keeps recommendations
-    # actionable — a user-facing "this tool was denied" is scoped to the
-    # tool, not the specific call).
+    # One signal per unique tool. Scoping to the tool (not the specific
+    # call) keeps recommendations actionable: "this tool was denied
+    # everywhere" maps to a single config change.
     by_tool: dict[str, list[tuple[int, SubagentToolCall, str]]] = {}
     for entry in matches:
         by_tool.setdefault(entry[1].tool_name, []).append(entry)
 
     for tool_name, entries in by_tool.items():
         keyword = entries[0][2]
-        evidence = [_evidence_from_call(c, i) for i, c, _ in entries[:_EVIDENCE_CAP]]
+        capped = entries[:_EVIDENCE_CAP]
+        evidence = _cap_evidence(
+            [c for _, c, _ in capped], [i for i, _, _ in capped],
+        )
         signals.append(
             DiagnosticSignal(
                 signal_type=SignalType.PERMISSION_FAILURE,
                 severity=Severity.CRITICAL,
-                agent_type=trace.agent_type,
+                agent_type=agent_type,
                 message=(
-                    f"Subagent '{trace.agent_type}' was denied access to "
+                    f"Subagent '{agent_type}' was denied access to "
                     f"tool '{tool_name}' ({keyword!r})."
                 ),
                 detail={
@@ -136,7 +145,7 @@ def _extract_permission_failures(trace: SubagentTrace) -> list[DiagnosticSignal]
 
 
 def _extract_retry_and_stuck(
-    trace: SubagentTrace,
+    trace: SubagentTrace, agent_type: str,
 ) -> tuple[list[DiagnosticSignal], set[int]]:
     """Emit STUCK_PATTERN or RETRY_LOOP — never both — per `RetrySequence`.
 
@@ -161,35 +170,32 @@ def _extract_retry_and_stuck(
         if not calls:
             continue
 
-        first_input = calls[0].input_summary
-        all_identical = all(c.input_summary == first_input for c in calls)
-
-        if seq.attempts >= _STUCK_MIN_ATTEMPTS and all_identical:
-            signals.append(_build_stuck_signal(trace, seq, calls))
+        # STUCK requires attempts >= 4 AND exact input identity; only
+        # compute identity when the attempt threshold qualifies.
+        is_stuck = seq.attempts >= _STUCK_MIN_ATTEMPTS and all(
+            c.input_summary == calls[0].input_summary for c in calls[1:]
+        )
+        if is_stuck:
+            signals.append(_build_stuck_signal(agent_type, seq, calls))
         else:
-            signals.append(_build_retry_signal(trace, seq, calls))
+            signals.append(_build_retry_signal(agent_type, seq, calls))
         covered.update(seq.tool_call_indices)
 
     return signals, covered
 
 
 def _build_stuck_signal(
-    trace: SubagentTrace,
+    agent_type: str,
     seq: RetrySequence,
     calls: list[SubagentToolCall],
 ) -> DiagnosticSignal:
-    pairs = zip(
-        calls[:_EVIDENCE_CAP],
-        seq.tool_call_indices[:_EVIDENCE_CAP],
-        strict=False,
-    )
-    evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+    evidence = _cap_evidence(calls, seq.tool_call_indices)
     return DiagnosticSignal(
         signal_type=SignalType.STUCK_PATTERN,
         severity=Severity.CRITICAL,
-        agent_type=trace.agent_type,
+        agent_type=agent_type,
         message=(
-            f"Subagent '{trace.agent_type}' repeated tool "
+            f"Subagent '{agent_type}' repeated tool "
             f"'{seq.tool_name}' with identical input {seq.attempts} "
             "times without progress."
         ),
@@ -203,22 +209,17 @@ def _build_stuck_signal(
 
 
 def _build_retry_signal(
-    trace: SubagentTrace,
+    agent_type: str,
     seq: RetrySequence,
     calls: list[SubagentToolCall],
 ) -> DiagnosticSignal:
-    pairs = zip(
-        calls[:_EVIDENCE_CAP],
-        seq.tool_call_indices[:_EVIDENCE_CAP],
-        strict=False,
-    )
-    evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+    evidence = _cap_evidence(calls, seq.tool_call_indices)
     return DiagnosticSignal(
         signal_type=SignalType.RETRY_LOOP,
         severity=Severity.WARNING,
-        agent_type=trace.agent_type,
+        agent_type=agent_type,
         message=(
-            f"Subagent '{trace.agent_type}' retried tool "
+            f"Subagent '{agent_type}' retried tool "
             f"'{seq.tool_name}' {seq.attempts} times."
         ),
         detail={
@@ -232,7 +233,7 @@ def _build_retry_signal(
 
 
 def _extract_error_sequences(
-    trace: SubagentTrace, covered: set[int],
+    trace: SubagentTrace, covered: set[int], agent_type: str,
 ) -> list[DiagnosticSignal]:
     """Emit TOOL_ERROR_SEQUENCE for runs of consecutive `is_error=True`
     tool calls that are not already covered by STUCK/RETRY signals.
@@ -265,19 +266,14 @@ def _extract_error_sequences(
                 if len(run_indices) >= _ERROR_SEQUENCE_CRITICAL_MIN
                 else Severity.WARNING
             )
-            pairs = zip(
-                run_calls[:_EVIDENCE_CAP],
-                run_indices[:_EVIDENCE_CAP],
-                strict=False,
-            )
-            evidence = [_evidence_from_call(c, idx) for c, idx in pairs]
+            evidence = _cap_evidence(run_calls, run_indices)
             signals.append(
                 DiagnosticSignal(
                     signal_type=SignalType.TOOL_ERROR_SEQUENCE,
                     severity=severity,
-                    agent_type=trace.agent_type,
+                    agent_type=agent_type,
                     message=(
-                        f"Subagent '{trace.agent_type}' had "
+                        f"Subagent '{agent_type}' had "
                         f"{len(run_indices)} consecutive tool errors."
                     ),
                     detail={
@@ -293,20 +289,32 @@ def _extract_error_sequences(
     return signals
 
 
-def extract_trace_signals(trace: SubagentTrace | None) -> list[DiagnosticSignal]:
+def extract_trace_signals(
+    trace: SubagentTrace | None,
+    *,
+    agent_type: str | None = None,
+) -> list[DiagnosticSignal]:
     """Extract all trace-level behavior signals from a parsed subagent trace.
 
     Handles `None` (unlinked invocation) and empty traces by returning
     an empty list. Order of signals: PERMISSION_FAILURE first
     (remediation-specific), then STUCK/RETRY (indexed), then
     TOOL_ERROR_SEQUENCE (filtered by STUCK/RETRY coverage).
+
+    `agent_type` overrides `trace.agent_type` on emitted signals when
+    provided. The pipeline passes the parent `AgentInvocation.agent_type`
+    to avoid depending on the linker having populated the trace
+    (programmatically-constructed or unlinked traces may still hold
+    `UNKNOWN_AGENT_TYPE`).
     """
     if trace is None or not trace.tool_calls:
         return []
 
+    effective_agent_type = agent_type if agent_type else trace.agent_type
+
     signals: list[DiagnosticSignal] = []
-    signals.extend(_extract_permission_failures(trace))
-    retry_stuck, covered = _extract_retry_and_stuck(trace)
+    signals.extend(_extract_permission_failures(trace, effective_agent_type))
+    retry_stuck, covered = _extract_retry_and_stuck(trace, effective_agent_type)
     signals.extend(retry_stuck)
-    signals.extend(_extract_error_sequences(trace, covered))
+    signals.extend(_extract_error_sequences(trace, covered, effective_agent_type))
     return signals

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -12,13 +12,15 @@ def _signal(
     severity: Severity = Severity.WARNING,
     agent_type: str = "pm",
     keyword: str = "error",
+    detail: dict[str, object] | None = None,
+    message: str | None = None,
 ) -> DiagnosticSignal:
     return DiagnosticSignal(
         signal_type=signal_type,
         severity=severity,
         agent_type=agent_type,
-        message=f"Agent '{agent_type}' output contains '{keyword}'.",
-        detail={"keyword": keyword},
+        message=message or f"Agent '{agent_type}' output contains '{keyword}'.",
+        detail=detail if detail is not None else {"keyword": keyword},
     )
 
 
@@ -144,3 +146,166 @@ class TestCorrelateGeneral:
         assert recs[0].observation
         assert recs[0].reason
         assert recs[0].action
+
+
+def _perm_signal(
+    tool_name: str = "Write",
+    agent_type: str = "pm",
+) -> DiagnosticSignal:
+    return _signal(
+        signal_type=SignalType.PERMISSION_FAILURE,
+        severity=Severity.CRITICAL,
+        agent_type=agent_type,
+        detail={
+            "tool_name": tool_name,
+            "matched_keyword": "permission denied",
+            "tool_calls": [],
+        },
+        message=f"Subagent '{agent_type}' was denied access to tool '{tool_name}'.",
+    )
+
+
+class TestPermissionFailureCorrelation:
+    def test_with_tool_missing_from_config(self) -> None:
+        signals = [_perm_signal(tool_name="Write")]
+        configs = {"pm": _config(tools=["Read", "Grep"])}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+        assert recs[0].severity == Severity.CRITICAL
+        assert "'Write'" in recs[0].action
+        assert "pm.md" in recs[0].config_file
+
+    def test_with_tool_in_config(self) -> None:
+        signals = [_perm_signal(tool_name="Write")]
+        configs = {"pm": _config(tools=["Write", "Read"])}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert "disallowed_tools" in recs[0].action.lower()
+
+    def test_without_config(self) -> None:
+        signals = [_perm_signal(tool_name="Bash")]
+        recs = correlate(signals, None)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+        assert recs[0].config_file == ""
+
+
+def _retry_signal(agent_type: str = "pm") -> DiagnosticSignal:
+    return _signal(
+        signal_type=SignalType.RETRY_LOOP,
+        severity=Severity.WARNING,
+        agent_type=agent_type,
+        detail={
+            "tool_name": "Bash",
+            "retry_count": 3,
+            "first_error_message": "Permission denied",
+            "eventual_success": False,
+            "tool_calls": [],
+        },
+        message=f"Subagent '{agent_type}' retried tool 'Bash' 3 times.",
+    )
+
+
+class TestRetryLoopCorrelation:
+    def test_without_error_guidance_in_prompt(self) -> None:
+        signals = [_retry_signal()]
+        configs = {"pm": _config(prompt_body="You are a PM agent.")}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "prompt"
+        assert "fallback" in recs[0].action.lower()
+
+    def test_with_error_guidance_in_prompt(self) -> None:
+        signals = [_retry_signal()]
+        configs = {"pm": _config(prompt_body="Handle errors and retry gracefully.")}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert "more specific" in recs[0].action.lower()
+
+    def test_without_config(self) -> None:
+        signals = [_retry_signal()]
+        recs = correlate(signals, None)
+        assert len(recs) == 1
+        assert recs[0].config_file == ""
+
+
+def _stuck_signal(agent_type: str = "pm", count: int = 5) -> DiagnosticSignal:
+    return _signal(
+        signal_type=SignalType.STUCK_PATTERN,
+        severity=Severity.CRITICAL,
+        agent_type=agent_type,
+        detail={
+            "tool_name": "Read",
+            "stuck_count": count,
+            "input_summary": "ls /missing",
+            "tool_calls": [],
+        },
+        message=f"Subagent '{agent_type}' repeated tool 'Read' {count} times.",
+    )
+
+
+class TestStuckPatternCorrelation:
+    def test_with_config(self) -> None:
+        signals = [_stuck_signal()]
+        configs = {"pm": _config()}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "prompt"
+        assert recs[0].severity == Severity.CRITICAL
+        assert "exit condition" in recs[0].action.lower()
+
+    def test_stuck_count_in_reason(self) -> None:
+        signals = [_stuck_signal(count=7)]
+        recs = correlate(signals, {"pm": _config()})
+        assert "7" in recs[0].reason
+
+    def test_without_config(self) -> None:
+        signals = [_stuck_signal()]
+        recs = correlate(signals, None)
+        assert len(recs) == 1
+        assert recs[0].config_file == ""
+
+
+def _err_seq_signal(
+    agent_type: str = "pm",
+    count: int = 2,
+    severity: Severity = Severity.WARNING,
+) -> DiagnosticSignal:
+    return _signal(
+        signal_type=SignalType.TOOL_ERROR_SEQUENCE,
+        severity=severity,
+        agent_type=agent_type,
+        detail={
+            "error_count": count,
+            "start_index": 0,
+            "end_index": count - 1,
+            "tool_calls": [],
+        },
+        message=f"Subagent '{agent_type}' had {count} consecutive tool errors.",
+    )
+
+
+class TestErrorSequenceCorrelation:
+    def test_with_small_tools_list(self) -> None:
+        signals = [_err_seq_signal()]
+        configs = {"pm": _config(tools=["Read"])}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "prompt"
+        assert "fallback" in recs[0].action.lower()
+
+    def test_with_large_tools_list(self) -> None:
+        signals = [_err_seq_signal()]
+        configs = {"pm": _config(
+            tools=["Read", "Edit", "Bash", "Grep", "Glob", "Write",
+                   "Agent", "WebFetch", "WebSearch"],
+        )}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+
+    def test_severity_mirrors_signal(self) -> None:
+        signals = [_err_seq_signal(count=4, severity=Severity.CRITICAL)]
+        recs = correlate(signals, None)
+        assert recs[0].severity == Severity.CRITICAL

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,94 @@
+"""Tests for the run_diagnostics pipeline wiring."""
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.diagnostics import run_diagnostics
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.traces.models import (
+    UNKNOWN_AGENT_TYPE,
+    RetrySequence,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+
+def _inv(
+    agent_type: str = "pm",
+    trace: SubagentTrace | None = None,
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        is_builtin=False,
+        description="test",
+        prompt="do something",
+        tool_use_id="toolu_01",
+        output_text="",
+        trace=trace,
+    )
+
+
+def _stuck_trace(agent_type: str = "pm") -> SubagentTrace:
+    """Trace with 5 identical Bash calls -> STUCK_PATTERN."""
+    calls = [
+        SubagentToolCall(
+            tool_name="Bash",
+            input_summary="ls /missing",
+            result_summary="not found",
+            is_error=True,
+        )
+        for _ in range(5)
+    ]
+    return SubagentTrace(
+        agent_id="agent-x",
+        agent_type=agent_type,
+        delegation_prompt="find something",
+        tool_calls=calls,
+        retry_sequences=[
+            RetrySequence(
+                tool_name="Bash",
+                attempts=5,
+                tool_call_indices=[0, 1, 2, 3, 4],
+                first_error_message="not found",
+                last_error_message="not found",
+                eventual_success=False,
+            ),
+        ],
+    )
+
+
+class TestRunDiagnosticsWiring:
+    def test_invocation_with_trace_produces_trace_signals(self) -> None:
+        inv = _inv(trace=_stuck_trace())
+        result = run_diagnostics([inv])
+        trace_signals = [
+            s for s in result.signals if s.signal_type == SignalType.STUCK_PATTERN
+        ]
+        assert len(trace_signals) == 1
+        assert trace_signals[0].agent_type == "pm"
+        # Recommendation should also appear.
+        assert any(
+            r.signal_types == [SignalType.STUCK_PATTERN] for r in result.recommendations
+        )
+
+    def test_invocation_without_trace_emits_no_trace_signals(self) -> None:
+        inv = _inv(trace=None)
+        result = run_diagnostics([inv])
+        trace_types = {
+            SignalType.TOOL_ERROR_SEQUENCE,
+            SignalType.RETRY_LOOP,
+            SignalType.PERMISSION_FAILURE,
+            SignalType.STUCK_PATTERN,
+        }
+        assert not any(s.signal_type in trace_types for s in result.signals)
+
+    def test_unknown_agent_type_on_trace_signal_is_overwritten(self) -> None:
+        # Trace.agent_type stays at UNKNOWN (simulating an unlinked trace
+        # that was still attached somehow). run_diagnostics should
+        # overwrite the signal's agent_type from the parent invocation.
+        trace = _stuck_trace(agent_type=UNKNOWN_AGENT_TYPE)
+        inv = _inv(agent_type="architect", trace=trace)
+        result = run_diagnostics([inv])
+        stuck = [
+            s for s in result.signals if s.signal_type == SignalType.STUCK_PATTERN
+        ]
+        assert len(stuck) == 1
+        assert stuck[0].agent_type == "architect"

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -1,0 +1,291 @@
+"""Tests for trace-level signal extraction."""
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.trace_signals import extract_trace_signals
+from agentfluent.traces.models import (
+    RetrySequence,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+
+def _tc(
+    tool: str = "Bash",
+    inp: str = "ls /tmp",
+    res: str = "ok",
+    err: bool = False,
+) -> SubagentToolCall:
+    return SubagentToolCall(
+        tool_name=tool,
+        input_summary=inp,
+        result_summary=res,
+        is_error=err,
+    )
+
+
+def _rs(
+    tool: str = "Bash",
+    attempts: int = 3,
+    indices: list[int] | None = None,
+    first_err: str | None = None,
+    success: bool = False,
+) -> RetrySequence:
+    return RetrySequence(
+        tool_name=tool,
+        attempts=attempts,
+        first_error_message=first_err,
+        last_error_message=first_err,
+        eventual_success=success,
+        tool_call_indices=indices or list(range(attempts)),
+    )
+
+
+def _trace(
+    calls: list[SubagentToolCall] | None = None,
+    sequences: list[RetrySequence] | None = None,
+    agent_type: str = "general-purpose",
+) -> SubagentTrace:
+    return SubagentTrace(
+        agent_id="agent-test",
+        agent_type=agent_type,
+        delegation_prompt="do the thing",
+        tool_calls=calls or [],
+        retry_sequences=sequences or [],
+    )
+
+
+class TestExtractTraceSignals:
+    def test_none_trace_returns_empty(self) -> None:
+        assert extract_trace_signals(None) == []
+
+    def test_empty_tool_calls_returns_empty(self) -> None:
+        assert extract_trace_signals(_trace()) == []
+
+    def test_healthy_trace_emits_nothing(self) -> None:
+        trace = _trace(calls=[_tc(), _tc(tool="Read")])
+        assert extract_trace_signals(trace) == []
+
+    def test_mixed_trace_emits_multiple_signal_types(self) -> None:
+        # Permission failure at index 0 + error sequence at 1,2.
+        trace = _trace(
+            calls=[
+                _tc(tool="Write", res="Permission denied on /etc", err=True),
+                _tc(tool="Read", res="File not found", err=True),
+                _tc(tool="Read", res="File not found", err=True),
+            ],
+        )
+        signals = extract_trace_signals(trace)
+        types = {s.signal_type for s in signals}
+        assert SignalType.PERMISSION_FAILURE in types
+        assert SignalType.TOOL_ERROR_SEQUENCE in types
+
+
+class TestPermissionFailure:
+    def test_detects_permission_denied(self) -> None:
+        trace = _trace(
+            calls=[_tc(tool="Write", res="Permission denied on /etc/passwd", err=True)],
+        )
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 1
+        assert perms[0].severity == Severity.CRITICAL
+        assert perms[0].detail["matched_keyword"] == "permission denied"
+
+    def test_detects_all_four_keywords(self) -> None:
+        for keyword in ("permission denied", "access denied", "not allowed", "blocked"):
+            trace = _trace(calls=[_tc(tool="Bash", res=f"Error: {keyword} here", err=True)])
+            signals = extract_trace_signals(trace)
+            perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+            assert len(perms) == 1, f"missed keyword: {keyword}"
+            assert perms[0].detail["matched_keyword"] == keyword
+
+    def test_case_insensitive(self) -> None:
+        trace = _trace(calls=[_tc(res="PERMISSION DENIED", err=True)])
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 1
+        assert perms[0].detail["matched_keyword"] == "permission denied"
+
+    def test_evidence_capped_at_five(self) -> None:
+        # 7 permission-denied calls on same tool -> 1 signal, 5 evidence entries.
+        calls = [_tc(tool="Write", res="permission denied", err=True) for _ in range(7)]
+        trace = _trace(calls=calls)
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 1
+        assert len(perms[0].detail["tool_calls"]) == 5  # type: ignore[arg-type]
+
+    def test_groups_by_tool(self) -> None:
+        # Two tools each denied -> two PERMISSION_FAILURE signals.
+        trace = _trace(
+            calls=[
+                _tc(tool="Write", res="permission denied", err=True),
+                _tc(tool="Bash", res="blocked by hook", err=True),
+            ],
+        )
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 2
+        tools = {s.detail["tool_name"] for s in perms}
+        assert tools == {"Write", "Bash"}
+
+
+class TestErrorSequences:
+    def test_single_error_no_signal(self) -> None:
+        trace = _trace(calls=[_tc(err=True)])
+        signals = extract_trace_signals(trace)
+        assert not any(s.signal_type == SignalType.TOOL_ERROR_SEQUENCE for s in signals)
+
+    def test_two_consecutive_is_warning(self) -> None:
+        trace = _trace(calls=[_tc(err=True), _tc(err=True)])
+        signals = extract_trace_signals(trace)
+        seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
+        assert len(seqs) == 1
+        assert seqs[0].severity == Severity.WARNING
+        assert seqs[0].detail["error_count"] == 2
+
+    def test_four_consecutive_is_critical(self) -> None:
+        trace = _trace(calls=[_tc(err=True) for _ in range(4)])
+        signals = extract_trace_signals(trace)
+        seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
+        assert len(seqs) == 1
+        assert seqs[0].severity == Severity.CRITICAL
+        assert seqs[0].detail["error_count"] == 4
+
+    def test_non_consecutive_errors_no_signal(self) -> None:
+        trace = _trace(
+            calls=[_tc(err=True), _tc(err=False), _tc(err=True)],
+        )
+        signals = extract_trace_signals(trace)
+        seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
+        assert seqs == []
+
+    def test_start_end_indices(self) -> None:
+        trace = _trace(
+            calls=[_tc(), _tc(err=True), _tc(err=True), _tc(err=True), _tc()],
+        )
+        signals = extract_trace_signals(trace)
+        seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
+        assert seqs[0].detail["start_index"] == 1
+        assert seqs[0].detail["end_index"] == 3
+
+
+class TestRetryLoop:
+    def test_attempts_two_not_emitted(self) -> None:
+        trace = _trace(
+            calls=[_tc(err=True), _tc(err=True)],
+            sequences=[_rs(attempts=2, indices=[0, 1])],
+        )
+        signals = extract_trace_signals(trace)
+        assert not any(s.signal_type == SignalType.RETRY_LOOP for s in signals)
+
+    def test_attempts_three_varied_inputs_emits_retry(self) -> None:
+        trace = _trace(
+            calls=[
+                _tc(inp="edit line 40", err=True),
+                _tc(inp="edit line 41", err=True),
+                _tc(inp="edit line 42", err=True),
+            ],
+            sequences=[
+                _rs(attempts=3, indices=[0, 1, 2], first_err="Parse error"),
+            ],
+        )
+        signals = extract_trace_signals(trace)
+        loops = [s for s in signals if s.signal_type == SignalType.RETRY_LOOP]
+        assert len(loops) == 1
+        assert loops[0].severity == Severity.WARNING
+        assert loops[0].detail["retry_count"] == 3
+        assert loops[0].detail["first_error_message"] == "Parse error"
+
+    def test_first_error_message_propagates(self) -> None:
+        trace = _trace(
+            calls=[_tc(err=True), _tc(err=True), _tc(err=True)],
+            sequences=[_rs(attempts=3, first_err="connection timeout")],
+        )
+        signals = extract_trace_signals(trace)
+        loops = [s for s in signals if s.signal_type == SignalType.RETRY_LOOP]
+        assert loops[0].detail["first_error_message"] == "connection timeout"
+
+
+class TestStuckPattern:
+    def test_three_identical_is_retry_not_stuck(self) -> None:
+        # attempts=3 is below STUCK threshold (>=4) regardless of identical inputs.
+        trace = _trace(
+            calls=[_tc(inp="ls") for _ in range(3)],
+            sequences=[_rs(attempts=3)],
+        )
+        signals = extract_trace_signals(trace)
+        types = {s.signal_type for s in signals}
+        assert SignalType.RETRY_LOOP in types
+        assert SignalType.STUCK_PATTERN not in types
+
+    def test_four_identical_is_stuck(self) -> None:
+        trace = _trace(
+            calls=[_tc(inp="ls /missing") for _ in range(4)],
+            sequences=[_rs(attempts=4)],
+        )
+        signals = extract_trace_signals(trace)
+        stucks = [s for s in signals if s.signal_type == SignalType.STUCK_PATTERN]
+        assert len(stucks) == 1
+        assert stucks[0].severity == Severity.CRITICAL
+        assert stucks[0].detail["stuck_count"] == 4
+        assert stucks[0].detail["input_summary"] == "ls /missing"
+
+    def test_four_near_identical_is_retry_not_stuck(self) -> None:
+        # One-char drift — passes RETRY's 0.80 similarity but fails STUCK's
+        # exact-match requirement.
+        trace = _trace(
+            calls=[_tc(inp=f"ls /tmp/{i}") for i in range(4)],
+            sequences=[_rs(attempts=4)],
+        )
+        signals = extract_trace_signals(trace)
+        types = {s.signal_type for s in signals}
+        assert SignalType.RETRY_LOOP in types
+        assert SignalType.STUCK_PATTERN not in types
+
+
+class TestMutualExclusion:
+    def test_stuck_does_not_also_emit_retry(self) -> None:
+        trace = _trace(
+            calls=[_tc(inp="stuck") for _ in range(5)],
+            sequences=[_rs(attempts=5)],
+        )
+        signals = extract_trace_signals(trace)
+        types = [s.signal_type for s in signals]
+        assert SignalType.STUCK_PATTERN in types
+        assert SignalType.RETRY_LOOP not in types
+
+    def test_tool_error_sequence_not_emitted_on_covered_indices(self) -> None:
+        # 4 consecutive errors, all covered by a STUCK sequence — no
+        # TOOL_ERROR_SEQUENCE should emit on top of STUCK.
+        trace = _trace(
+            calls=[_tc(inp="x", err=True) for _ in range(4)],
+            sequences=[_rs(attempts=4)],
+        )
+        signals = extract_trace_signals(trace)
+        types = {s.signal_type for s in signals}
+        assert SignalType.STUCK_PATTERN in types
+        assert SignalType.TOOL_ERROR_SEQUENCE not in types
+
+    def test_tool_error_sequence_emits_on_uncovered_errors(self) -> None:
+        # Two uncovered errors followed by a STUCK run: uncovered tail
+        # still triggers TOOL_ERROR_SEQUENCE for its own indices.
+        trace = _trace(
+            calls=[
+                _tc(tool="Read", err=True),
+                _tc(tool="Read", err=True),
+                _tc(inp="stuck", err=True),
+                _tc(inp="stuck", err=True),
+                _tc(inp="stuck", err=True),
+                _tc(inp="stuck", err=True),
+            ],
+            sequences=[_rs(attempts=4, indices=[2, 3, 4, 5])],
+        )
+        signals = extract_trace_signals(trace)
+        types = {s.signal_type for s in signals}
+        assert SignalType.STUCK_PATTERN in types
+        assert SignalType.TOOL_ERROR_SEQUENCE in types
+        seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
+        # Only the uncovered [0, 1] run should be reported.
+        assert seqs[0].detail["error_count"] == 2


### PR DESCRIPTION
## Summary

- Adds 4 new `SignalType` values and an `extract_trace_signals(trace)` function that mines `SubagentTrace` evidence for `TOOL_ERROR_SEQUENCE`, `RETRY_LOOP`, `PERMISSION_FAILURE`, and `STUCK_PATTERN` signals.
- Adds 4 correlation rules (`PermissionFailureRule`, `RetryLoopRule`, `StuckPatternRule`, `ErrorSequenceRule`) that produce trace-backed recommendations on config surfaces (`tools`, `prompt`).
- Wires trace signal extraction into `run_diagnostics` — per invocation with a `.trace`, with a defensive `UNKNOWN_AGENT_TYPE` overwrite from the parent.

## Design decisions

- **STUCK ⊥ RETRY ⊥ TOOL_ERROR_SEQUENCE for the same indices.** Resolves architect's "one observed pattern → one signal" concern. A `covered` set propagates from `_extract_retry_and_stuck` to `_extract_error_sequences`. Documented as an invariant; `TestMutualExclusion` guards regressions.
- **PERMISSION_FAILURE deliberately not in `covered`.** Permission denial produces both a specialized recommendation (grant tool) and the general fallback signal — different remediation axes.
- **`PERMISSION_REGEX` local to `trace_signals.py`.** Does not extend `signals.ERROR_PATTERNS`; the metadata-level `ERROR_PATTERN` contract is untouched.

## Test plan

- [x] 23 new unit tests in `tests/unit/test_trace_signals.py`
- [x] 12 new correlator tests in `tests/unit/test_correlator.py` (4 new classes)
- [x] 3 new wiring tests in `tests/unit/test_diagnostics.py`
- [x] Full suite: 469 passed / 34 deselected (was 431)
- [x] `mypy src/agentfluent/` strict — clean
- [x] `ruff check src/ tests/` — clean

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)