### PR TITLE
feat(diagnostics): integrate trace diagnostics into analyze CLI (#108)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -145,12 +145,9 @@ def analyze(
     result = analyze_sessions(paths, agent_filter=agent)
 
     all_invocations = [inv for s in result.sessions for inv in s.invocations]
-    total_subagent_traces = sum(si.subagent_count for si in session_infos)
 
     if all_invocations:
-        result.diagnostics = run_diagnostics(
-            all_invocations, subagent_trace_count=total_subagent_traces,
-        )
+        result.diagnostics = run_diagnostics(all_invocations)
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         console.print(
             "[dim]No agent invocations found -- "

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -57,3 +57,8 @@ def score_color(score: int) -> str:
 def average_score(scores: list[ConfigScore]) -> int:
     """Integer average of overall_score across agents; 0 for an empty list."""
     return sum(s.overall_score for s in scores) // len(scores) if scores else 0
+
+
+def truncate(text: str, max_len: int) -> str:
+    """Truncate with a trailing ellipsis when the text exceeds max_len."""
+    return text if len(text) <= max_len else text[: max_len - 1] + "…"

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
@@ -219,12 +220,14 @@ def format_analysis_table(
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
                 tools = str(inv.tool_uses) if inv.tool_uses else "-"
                 duration = f"{inv.duration_ms / 1000:.1f}s" if inv.duration_ms else "-"
-                desc = (
-                    inv.description
-                    if len(inv.description) <= 60
-                    else inv.description[:57] + "..."
+                desc = truncate(inv.description, 60)
+                inv_table.add_row(
+                    escape(inv.agent_type),
+                    escape(desc),
+                    tokens,
+                    tools,
+                    duration,
                 )
-                inv_table.add_row(inv.agent_type, desc, tokens, tools, duration)
         console.print(inv_table)
 
     console.print(API_RATE_FOOTNOTE, style="dim")
@@ -256,10 +259,10 @@ def _format_diagnostics_table(
         for sig in diag.signals:
             color = SEVERITY_COLORS.get(sig.severity, "white")
             sig_table.add_row(
-                sig.agent_type,
-                sig.signal_type.value,
+                escape(sig.agent_type),
+                escape(sig.signal_type.value),
                 f"[{color}]{sig.severity.value}[/{color}]",
-                sig.message,
+                escape(sig.message),
             )
         console.print(sig_table)
 
@@ -278,18 +281,18 @@ def _format_diagnostics_table(
             color = SEVERITY_COLORS.get(rec.severity, "white")
             if verbose:
                 rec_table.add_row(
-                    rec.agent_type,
-                    rec.target,
+                    escape(rec.agent_type),
+                    escape(rec.target),
                     f"[{color}]{rec.severity.value}[/{color}]",
-                    rec.observation,
-                    rec.action,
+                    escape(rec.observation),
+                    escape(rec.action),
                 )
             else:
                 rec_table.add_row(
-                    rec.agent_type,
-                    rec.target,
+                    escape(rec.agent_type),
+                    escape(rec.target),
                     f"[{color}]{rec.severity.value}[/{color}]",
-                    rec.message,
+                    escape(rec.message),
                 )
         console.print(rec_table)
 
@@ -328,11 +331,16 @@ def _format_deep_diagnostics(
 
 
 def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> None:
-    """Render one trace signal with its evidence sub-table."""
+    """Render one trace signal with its evidence sub-table.
+
+    All JSONL-sourced strings (agent_type, message, and every evidence
+    dict field) are escaped before being passed to Rich — trace content
+    is untrusted and could otherwise smuggle markup like `[link=…]`.
+    """
     color = SEVERITY_COLORS.get(sig.severity, "white")
     header = (
-        f"\n[{color}]{sig.signal_type.value}[/{color}] "
-        f"[cyan]{sig.agent_type}[/cyan] — {sig.message}"
+        f"\n[{color}]{escape(sig.signal_type.value)}[/{color}] "
+        f"[cyan]{escape(sig.agent_type)}[/cyan] — {escape(sig.message)}"
     )
     console.print(header)
 
@@ -351,11 +359,11 @@ def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> No
         if not isinstance(entry, dict):
             continue
         ev_table.add_row(
-            str(entry.get("index", "")),
-            str(entry.get("tool_name", "")),
-            truncate(str(entry.get("input_summary", "")), 60),
+            escape(str(entry.get("index", ""))),
+            escape(str(entry.get("tool_name", ""))),
+            escape(truncate(str(entry.get("input_summary", "")), 60)),
             "✗" if entry.get("is_error") else "",
-            truncate(str(entry.get("result_summary", "")), 60),
+            escape(truncate(str(entry.get("result_summary", "")), 60)),
         )
     console.print(ev_table)
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from agentfluent.analytics.pipeline import AnalysisResult
     from agentfluent.config.models import ConfigScore
     from agentfluent.core.discovery import ProjectInfo, SessionInfo
-    from agentfluent.diagnostics.models import DiagnosticsResult
+    from agentfluent.diagnostics.models import DiagnosticSignal, DiagnosticsResult
 
 
 def format_projects_table(
@@ -292,11 +292,75 @@ def _format_diagnostics_table(
                 )
         console.print(rec_table)
 
-    if diag.subagent_trace_count > 0:
+    _format_deep_diagnostics(console, diag, verbose=verbose)
+
+
+def _format_deep_diagnostics(
+    console: Console,
+    diag: DiagnosticsResult,
+    *,
+    verbose: bool,
+) -> None:
+    """Render the Deep Diagnostics section with trace-signal evidence.
+
+    Compact summary by default; per-signal evidence sub-tables under
+    --verbose. Emits nothing when no trace-level signals are present.
+    """
+    from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
+
+    trace_signals = [s for s in diag.signals if s.signal_type in TRACE_SIGNAL_TYPES]
+    if not trace_signals:
+        return
+
+    unique_agents = {s.agent_type for s in trace_signals}
+    if not verbose:
         console.print(
-            f"\n[dim]{diag.subagent_trace_count} subagent trace files available. "
-            "Deep diagnostics (per-tool-call analysis) coming in v1.1.[/dim]"
+            f"\n[bold]Deep Diagnostics:[/bold] {len(trace_signals)} trace signal(s) "
+            f"across {len(unique_agents)} subagent(s). "
+            "Use [bold]--verbose[/bold] for per-call evidence."
         )
+        return
+
+    console.print("\n[bold]Deep Diagnostics[/bold]")
+    for sig in trace_signals:
+        _render_trace_signal_evidence(console, sig)
+
+
+def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> None:
+    """Render one trace signal with its evidence sub-table."""
+    color = SEVERITY_COLORS.get(sig.severity, "white")
+    header = (
+        f"\n[{color}]{sig.signal_type.value}[/{color}] "
+        f"[cyan]{sig.agent_type}[/cyan] — {sig.message}"
+    )
+    console.print(header)
+
+    evidence = sig.detail.get("tool_calls", [])
+    if not isinstance(evidence, list) or not evidence:
+        return
+
+    ev_table = Table(show_header=True, box=None, padding=(0, 1))
+    ev_table.add_column("#", style="dim", justify="right")
+    ev_table.add_column("Tool")
+    ev_table.add_column("Input", overflow="fold")
+    ev_table.add_column("Err", justify="center")
+    ev_table.add_column("Result", overflow="fold")
+
+    for entry in evidence:
+        if not isinstance(entry, dict):
+            continue
+        ev_table.add_row(
+            str(entry.get("index", "")),
+            str(entry.get("tool_name", "")),
+            _truncate(str(entry.get("input_summary", "")), 60),
+            "✗" if entry.get("is_error") else "",
+            _truncate(str(entry.get("result_summary", "")), 60),
+        )
+    console.print(ev_table)
+
+
+def _truncate(text: str, max_len: int) -> str:
+    return text if len(text) <= max_len else text[: max_len - 1] + "…"
 
 
 def _format_diagnostics_summary(console: Console, diag: DiagnosticsResult) -> None:

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -21,6 +21,7 @@ from agentfluent.cli.formatters.helpers import (
     format_size,
     format_tokens,
     score_color,
+    truncate,
 )
 
 API_RATE_FOOTNOTE = (
@@ -352,15 +353,11 @@ def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> No
         ev_table.add_row(
             str(entry.get("index", "")),
             str(entry.get("tool_name", "")),
-            _truncate(str(entry.get("input_summary", "")), 60),
+            truncate(str(entry.get("input_summary", "")), 60),
             "✗" if entry.get("is_error") else "",
-            _truncate(str(entry.get("result_summary", "")), 60),
+            truncate(str(entry.get("result_summary", "")), 60),
         )
     console.print(ev_table)
-
-
-def _truncate(text: str, max_len: int) -> str:
-    return text if len(text) <= max_len else text[: max_len - 1] + "…"
 
 
 def _format_diagnostics_summary(console: Console, diag: DiagnosticsResult) -> None:

--- a/src/agentfluent/diagnostics/__init__.py
+++ b/src/agentfluent/diagnostics/__init__.py
@@ -2,59 +2,6 @@
 
 from __future__ import annotations
 
-import logging
+from agentfluent.diagnostics.pipeline import TRACE_SIGNAL_TYPES, run_diagnostics
 
-from agentfluent.agents.models import AgentInvocation
-from agentfluent.config.models import AgentConfig
-from agentfluent.config.scanner import scan_agents
-from agentfluent.diagnostics.correlator import correlate
-from agentfluent.diagnostics.models import DiagnosticsResult
-from agentfluent.diagnostics.signals import extract_signals
-from agentfluent.diagnostics.trace_signals import extract_trace_signals
-
-logger = logging.getLogger(__name__)
-
-
-def run_diagnostics(
-    invocations: list[AgentInvocation],
-    *,
-    subagent_trace_count: int = 0,
-) -> DiagnosticsResult:
-    """Run the full diagnostics pipeline on agent invocations.
-
-    Extracts behavior signals, scans for agent config files, correlates
-    signals with config, and produces recommendations.
-
-    Args:
-        invocations: Extracted agent invocations from session analysis.
-        subagent_trace_count: Number of subagent trace files detected.
-
-    Returns:
-        DiagnosticsResult with signals and recommendations.
-    """
-    signals = extract_signals(invocations)
-
-    # Fold in trace-level signals for any invocation with an attached
-    # subagent trace. Passing agent_type explicitly avoids depending on
-    # the linker having populated trace.agent_type.
-    for inv in invocations:
-        if inv.trace is None:
-            continue
-        signals.extend(extract_trace_signals(inv.trace, agent_type=inv.agent_type))
-
-    # Build config lookup for correlation
-    configs: dict[str, AgentConfig] | None = None
-    try:
-        agent_configs = scan_agents("all")
-        if agent_configs:
-            configs = {c.name.lower(): c for c in agent_configs}
-    except OSError:
-        logger.debug("Could not scan agent config files", exc_info=True)
-
-    recommendations = correlate(signals, configs)
-
-    return DiagnosticsResult(
-        signals=signals,
-        recommendations=recommendations,
-        subagent_trace_count=subagent_trace_count,
-    )
+__all__ = ["TRACE_SIGNAL_TYPES", "run_diagnostics"]

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -1,0 +1,111 @@
+"""Diagnostics orchestration.
+
+Owns the `run_diagnostics` pipeline: extracts metadata-level and
+trace-level signals, deduplicates overlapping metadata error signals
+when strictly-more-informative trace signals cover the same
+`agent_type`, runs correlation against any available agent configs, and
+computes the parsed-trace count surfaced on `DiagnosticsResult`.
+
+Kept separate from `analytics/pipeline.py` to keep the analytics layer
+free of diagnostics imports and to match the one-file-per-concern
+pattern used elsewhere.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import AgentConfig
+from agentfluent.config.scanner import scan_agents
+from agentfluent.diagnostics.correlator import correlate
+from agentfluent.diagnostics.models import (
+    DiagnosticSignal,
+    DiagnosticsResult,
+    SignalType,
+)
+from agentfluent.diagnostics.signals import extract_signals
+from agentfluent.diagnostics.trace_signals import extract_trace_signals
+
+logger = logging.getLogger(__name__)
+
+# Signal types emitted by the trace-level extractor. Used by the dedup
+# pass to identify agent_types whose metadata ERROR_PATTERN signals can
+# be safely suppressed in favor of more-specific trace evidence.
+TRACE_SIGNAL_TYPES: frozenset[SignalType] = frozenset(
+    {
+        SignalType.TOOL_ERROR_SEQUENCE,
+        SignalType.RETRY_LOOP,
+        SignalType.PERMISSION_FAILURE,
+        SignalType.STUCK_PATTERN,
+    },
+)
+
+
+def _dedup_error_patterns(signals: list[DiagnosticSignal]) -> list[DiagnosticSignal]:
+    """Drop metadata ERROR_PATTERN signals for agent_types that already
+    have at least one trace-level signal.
+
+    Trace signals carry specific evidence (which tool, which call index,
+    which keyword) and specific remediation; metadata ERROR_PATTERN is a
+    best-effort keyword scan of the final output. Showing both for the
+    same agent would produce two recommendations for the same underlying
+    issue — one vague, one precise.
+
+    Only `ERROR_PATTERN` is suppressed. `TOKEN_OUTLIER` and
+    `DURATION_OUTLIER` measure different axes and are left alone.
+    """
+    trace_agent_types = {
+        s.agent_type for s in signals if s.signal_type in TRACE_SIGNAL_TYPES
+    }
+    if not trace_agent_types:
+        return signals
+    return [
+        s for s in signals
+        if not (
+            s.signal_type == SignalType.ERROR_PATTERN
+            and s.agent_type in trace_agent_types
+        )
+    ]
+
+
+def run_diagnostics(
+    invocations: list[AgentInvocation],
+) -> DiagnosticsResult:
+    """Run the full diagnostics pipeline on agent invocations.
+
+    Extracts metadata + trace-level signals, dedups overlapping metadata
+    error signals, scans for agent config files, correlates signals
+    with config, and produces recommendations. `subagent_trace_count`
+    on the result reflects traces that successfully parsed and linked,
+    not the raw filesystem enumeration.
+    """
+    signals = extract_signals(invocations)
+
+    # Fold in trace-level signals for any invocation with an attached
+    # subagent trace. Passing agent_type explicitly avoids depending on
+    # the linker having populated trace.agent_type.
+    for inv in invocations:
+        if inv.trace is None:
+            continue
+        signals.extend(extract_trace_signals(inv.trace, agent_type=inv.agent_type))
+
+    signals = _dedup_error_patterns(signals)
+
+    configs: dict[str, AgentConfig] | None = None
+    try:
+        agent_configs = scan_agents("all")
+        if agent_configs:
+            configs = {c.name.lower(): c for c in agent_configs}
+    except OSError:
+        logger.debug("Could not scan agent config files", exc_info=True)
+
+    recommendations = correlate(signals, configs)
+
+    subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
+
+    return DiagnosticsResult(
+        signals=signals,
+        recommendations=recommendations,
+        subagent_trace_count=subagent_trace_count,
+    )

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -105,6 +105,53 @@ class TestDeepDiagnosticsSection:
         assert "stuck_pattern" in out
 
 
+class TestMarkupInjection:
+    """Untrusted JSONL content must not be interpreted as Rich markup.
+
+    Trace data (tool results, subagent summaries) can contain attacker-
+    crafted content like ``[link=https://evil]...[/link]``. If the
+    formatter renders those strings verbatim, Rich interprets the tags
+    and the user sees a phishable hyperlink. All user-data-derived
+    strings must pass through ``rich.markup.escape``.
+    """
+
+    def test_agent_type_with_markup_is_escaped(self) -> None:
+        sig = _trace_signal(agent_type="[link=https://evil]click[/link]")
+        out = _render(_result([sig]), verbose=True)
+        assert "[link=https://evil]" in out  # escaped form renders the tag literally
+        assert "click" in out
+
+    def test_message_with_markup_is_escaped(self) -> None:
+        sig = DiagnosticSignal(
+            signal_type=SignalType.STUCK_PATTERN,
+            severity=Severity.CRITICAL,
+            agent_type="pm",
+            message="injected [bold red]CRITICAL FINDING[/bold red] warning",
+            detail={},
+        )
+        out = _render(_result([sig]), verbose=True)
+        # The bracketed tag must appear literally, not be consumed as markup.
+        assert "[bold red]" in out
+        assert "CRITICAL FINDING" in out
+
+    def test_evidence_fields_with_markup_are_escaped(self) -> None:
+        sig = _trace_signal(detail={
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "tool_name": "Bash",
+                    "input_summary": "[link=https://phish]go[/link]",
+                    "result_summary": "[bold]danger[/bold]",
+                    "is_error": True,
+                },
+            ],
+            "stuck_count": 1,
+        })
+        out = _render(_result([sig]), verbose=True)
+        assert "[link=https://phish]" in out
+        assert "[bold]" in out
+
+
 class TestJsonRoundTrip:
     def test_trace_signal_with_evidence_roundtrips(self) -> None:
         import json

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -1,0 +1,118 @@
+"""Tests for the Deep Diagnostics section of the analyze formatter."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from agentfluent.cli.formatters.table import _format_deep_diagnostics
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import (
+    DiagnosticSignal,
+    DiagnosticsResult,
+    SignalType,
+)
+
+
+def _trace_signal(
+    signal_type: SignalType = SignalType.STUCK_PATTERN,
+    agent_type: str = "pm",
+    detail: dict[str, object] | None = None,
+) -> DiagnosticSignal:
+    return DiagnosticSignal(
+        signal_type=signal_type,
+        severity=Severity.CRITICAL,
+        agent_type=agent_type,
+        message=f"{signal_type.value} on {agent_type}",
+        detail=detail if detail is not None else {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "tool_name": "Bash",
+                    "input_summary": "ls /missing",
+                    "result_summary": "not found",
+                    "is_error": True,
+                },
+            ],
+            "stuck_count": 5,
+        },
+    )
+
+
+def _result(signals: list[DiagnosticSignal]) -> DiagnosticsResult:
+    return DiagnosticsResult(signals=signals, recommendations=[])
+
+
+def _render(diag: DiagnosticsResult, *, verbose: bool) -> str:
+    console = Console(record=True, width=120)
+    _format_deep_diagnostics(console, diag, verbose=verbose)
+    return console.export_text()
+
+
+class TestDeepDiagnosticsSection:
+    def test_absent_when_no_trace_signals(self) -> None:
+        # Only a metadata-level signal — no Deep Diagnostics output.
+        meta_signal = DiagnosticSignal(
+            signal_type=SignalType.ERROR_PATTERN,
+            severity=Severity.WARNING,
+            agent_type="pm",
+            message="error",
+            detail={"keyword": "error"},
+        )
+        out = _render(_result([meta_signal]), verbose=False)
+        assert "Deep Diagnostics" not in out
+
+    def test_compact_summary_by_default(self) -> None:
+        out = _render(_result([_trace_signal()]), verbose=False)
+        assert "Deep Diagnostics" in out
+        assert "1 trace signal" in out
+        assert "--verbose" in out
+
+    def test_compact_summary_counts_unique_agents(self) -> None:
+        signals = [
+            _trace_signal(agent_type="pm"),
+            _trace_signal(agent_type="pm"),
+            _trace_signal(agent_type="architect"),
+        ]
+        out = _render(_result(signals), verbose=False)
+        assert "3 trace signal" in out
+        assert "2 subagent" in out
+
+    def test_verbose_renders_evidence_subtable(self) -> None:
+        out = _render(_result([_trace_signal()]), verbose=True)
+        assert "Deep Diagnostics" in out
+        # Evidence row content should appear.
+        assert "Bash" in out
+        assert "ls /missing" in out
+        # No "--verbose" hint when already verbose.
+        assert "--verbose" not in out
+
+    def test_verbose_renders_multiple_signals(self) -> None:
+        signals = [
+            _trace_signal(signal_type=SignalType.STUCK_PATTERN, agent_type="pm"),
+            _trace_signal(signal_type=SignalType.RETRY_LOOP, agent_type="architect"),
+        ]
+        out = _render(_result(signals), verbose=True)
+        assert "stuck_pattern" in out
+        assert "retry_loop" in out
+        assert "pm" in out
+        assert "architect" in out
+
+    def test_verbose_handles_missing_evidence_gracefully(self) -> None:
+        # A trace signal with no `tool_calls` in detail still renders the
+        # header without crashing on the sub-table.
+        sig = _trace_signal(detail={"stuck_count": 5})
+        out = _render(_result([sig]), verbose=True)
+        assert "stuck_pattern" in out
+
+
+class TestJsonRoundTrip:
+    def test_trace_signal_with_evidence_roundtrips(self) -> None:
+        import json
+
+        diag = _result([_trace_signal()])
+        dumped = diag.model_dump(mode="json")
+        # Re-parse to confirm it's JSON-serializable.
+        restored = json.loads(json.dumps(dumped))
+        assert restored["signals"][0]["signal_type"] == "stuck_pattern"
+        assert restored["signals"][0]["detail"]["tool_calls"][0]["tool_name"] == "Bash"
+        assert restored["signals"][0]["detail"]["stuck_count"] == 5

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -1,0 +1,172 @@
+"""Tests for the diagnostics orchestration pipeline.
+
+Covers: metadata/trace signal dedup, subagent_trace_count semantics,
+and backward compatibility of the public `run_diagnostics` import path.
+"""
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.pipeline import run_diagnostics
+from agentfluent.traces.models import (
+    RetrySequence,
+    SubagentToolCall,
+    SubagentTrace,
+)
+
+
+def _inv(
+    agent_type: str = "pm",
+    output_text: str = "",
+    trace: SubagentTrace | None = None,
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        is_builtin=False,
+        description="test",
+        prompt="do something",
+        tool_use_id="toolu_01",
+        output_text=output_text,
+        trace=trace,
+    )
+
+
+def _stuck_trace(agent_type: str = "pm") -> SubagentTrace:
+    calls = [
+        SubagentToolCall(
+            tool_name="Bash",
+            input_summary="ls /missing",
+            result_summary="not found",
+            is_error=True,
+        )
+        for _ in range(5)
+    ]
+    return SubagentTrace(
+        agent_id="agent-x",
+        agent_type=agent_type,
+        delegation_prompt="find",
+        tool_calls=calls,
+        retry_sequences=[
+            RetrySequence(
+                tool_name="Bash",
+                attempts=5,
+                tool_call_indices=[0, 1, 2, 3, 4],
+                first_error_message="not found",
+                eventual_success=False,
+            ),
+        ],
+    )
+
+
+class TestDedup:
+    def test_metadata_error_pattern_suppressed_when_trace_signal_same_agent_type(
+        self,
+    ) -> None:
+        inv = _inv(
+            agent_type="pm",
+            output_text="The operation failed with a permission denied error.",
+            trace=_stuck_trace(agent_type="pm"),
+        )
+        result = run_diagnostics([inv])
+        by_type = {s.signal_type for s in result.signals}
+        assert SignalType.STUCK_PATTERN in by_type
+        # ERROR_PATTERN for pm is suppressed.
+        assert not any(
+            s.signal_type == SignalType.ERROR_PATTERN and s.agent_type == "pm"
+            for s in result.signals
+        )
+
+    def test_metadata_error_pattern_retained_for_other_agent_type(self) -> None:
+        # agent A has a trace, agent B doesn't; B's metadata signals stay.
+        inv_a = _inv(agent_type="pm", trace=_stuck_trace(agent_type="pm"))
+        inv_b = _inv(agent_type="architect", output_text="permission denied")
+        result = run_diagnostics([inv_a, inv_b])
+        assert any(
+            s.signal_type == SignalType.ERROR_PATTERN and s.agent_type == "architect"
+            for s in result.signals
+        )
+
+    def test_no_trace_signals_all_metadata_retained(self) -> None:
+        inv = _inv(output_text="failed to load the config")
+        result = run_diagnostics([inv])
+        error_signals = [
+            s for s in result.signals if s.signal_type == SignalType.ERROR_PATTERN
+        ]
+        assert len(error_signals) >= 1
+
+    def test_token_outlier_not_suppressed_by_trace_signal(self) -> None:
+        # 'pm' invocations spread such that one clears the 2x-mean outlier
+        # threshold; one of them also carries a trace. TOKEN_OUTLIER must
+        # survive the dedup pass.
+        inv_a = AgentInvocation(
+            agent_type="pm", is_builtin=False, description="a", prompt="a",
+            tool_use_id="t1", output_text="",
+            total_tokens=100, tool_uses=1, trace=_stuck_trace(agent_type="pm"),
+        )
+        inv_b = AgentInvocation(
+            agent_type="pm", is_builtin=False, description="b", prompt="b",
+            tool_use_id="t2", output_text="",
+            total_tokens=100, tool_uses=1,
+        )
+        inv_c = AgentInvocation(
+            agent_type="pm", is_builtin=False, description="c", prompt="c",
+            tool_use_id="t3", output_text="",
+            total_tokens=10_000, tool_uses=1,
+        )
+        result = run_diagnostics([inv_a, inv_b, inv_c])
+        assert any(s.signal_type == SignalType.TOKEN_OUTLIER for s in result.signals)
+        assert any(s.signal_type == SignalType.STUCK_PATTERN for s in result.signals)
+
+    def test_dedup_happens_before_correlation(self) -> None:
+        # An ERROR_PATTERN "permission denied" signal normally triggers
+        # AccessErrorRule. When suppressed by a trace signal, its
+        # recommendation must also be absent.
+        inv = _inv(
+            agent_type="pm",
+            output_text="permission denied when accessing file",
+            trace=_stuck_trace(agent_type="pm"),
+        )
+        result = run_diagnostics([inv])
+        # StuckPatternRule should produce a recommendation for the trace.
+        stuck_recs = [
+            r for r in result.recommendations
+            if r.signal_types == [SignalType.STUCK_PATTERN]
+        ]
+        assert len(stuck_recs) == 1
+        # AccessErrorRule's recommendation (from metadata ERROR_PATTERN)
+        # should NOT appear.
+        assert not any(
+            r.signal_types == [SignalType.ERROR_PATTERN] and r.agent_type == "pm"
+            for r in result.recommendations
+        )
+
+
+class TestSubagentTraceCount:
+    def test_counts_parsed_linked_traces(self) -> None:
+        inv_a = _inv(trace=_stuck_trace())
+        inv_b = _inv(trace=_stuck_trace())
+        result = run_diagnostics([inv_a, inv_b])
+        assert result.subagent_trace_count == 2
+
+    def test_zero_when_no_invocations(self) -> None:
+        result = run_diagnostics([])
+        assert result.subagent_trace_count == 0
+
+    def test_mix_of_linked_and_unlinked(self) -> None:
+        inv_linked = _inv(trace=_stuck_trace())
+        inv_unlinked = _inv(trace=None)
+        result = run_diagnostics([inv_linked, inv_unlinked])
+        assert result.subagent_trace_count == 1
+
+
+class TestBackwardCompatImport:
+    def test_run_diagnostics_importable_from_diagnostics_package(self) -> None:
+        from agentfluent.diagnostics import run_diagnostics as rd_from_pkg
+
+        # Same callable as pipeline.run_diagnostics.
+        assert rd_from_pkg is run_diagnostics
+
+    def test_trace_signal_types_exported(self) -> None:
+        from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
+
+        assert SignalType.STUCK_PATTERN in TRACE_SIGNAL_TYPES
+        assert SignalType.ERROR_PATTERN not in TRACE_SIGNAL_TYPES


### PR DESCRIPTION
## Summary

- Moves `run_diagnostics` into a new `diagnostics/pipeline.py` module (architect-endorsed layout; keeps analytics/ free of diagnostics imports).
- Suppresses metadata `ERROR_PATTERN` signals for any `agent_type` that also has a trace-level signal. Trace signals are strictly more informative; showing both produced two recommendations for the same underlying issue. `TOKEN_OUTLIER` / `DURATION_OUTLIER` are untouched.
- `DiagnosticsResult.subagent_trace_count` now reflects parsed+linked traces, not filesystem enumeration.
- CLI adds a "Deep Diagnostics" section: compact summary by default, per-call evidence sub-tables under `--verbose`.
- JSON output carries trace signals and evidence dicts via Pydantic automatically.

## Dogfood

Ran against real `agentfluent` project sessions. Detected `tool_error_sequence` + `retry_loop` on an `Explore` subagent with 5 consecutive Read failures; compact summary rendered by default, evidence sub-tables under `--verbose`, and JSON output includes the full `detail.tool_calls` list.

## Test plan

- [x] 10 new pipeline tests in \`tests/unit/test_diagnostics_pipeline.py\` (dedup, count semantics, backward-compat imports)
- [x] 7 new formatter tests in \`tests/unit/cli/test_deep_diagnostics_formatting.py\` (section presence, verbose vs compact, JSON round-trip)
- [x] Full suite: 486 passed / 34 deselected (was 469, +17)
- [x] \`mypy src/agentfluent/\` strict — clean
- [x] \`ruff check src/ tests/\` — clean
- [x] Manual CLI verification: terminal default, \`--verbose\`, and \`--format json\` all render the new data correctly on a real project

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)