### PR TITLE
feat(diagnostics): add delegation clustering + subagent draft generation (#110)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+clustering = ["scikit-learn>=1.4"]
+
 [project.urls]
 Homepage = "https://github.com/frederick-douglas-pearce/agentfluent"
 Repository = "https://github.com/frederick-douglas-pearce/agentfluent"
@@ -44,6 +47,7 @@ dev = [
     "ruff>=0.11",
     "mypy>=1.15",
     "types-pyyaml>=6.0",
+    "scikit-learn>=1.4",
 ]
 
 [build-system]
@@ -75,3 +79,7 @@ python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = ["sklearn.*"]
+ignore_missing_imports = true

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -20,9 +20,17 @@ BUILTIN_AGENT_TYPES: frozenset[str] = frozenset(
 )
 
 
+GENERAL_PURPOSE_AGENT_TYPE = "general-purpose"
+
+
 def is_builtin_agent(agent_type: str) -> bool:
     """Check if an agent type is a built-in Claude Code agent."""
     return agent_type.lower() in BUILTIN_AGENT_TYPES
+
+
+def is_general_purpose(agent_type: str) -> bool:
+    """Check if an agent type is the built-in ``general-purpose`` agent."""
+    return agent_type.lower() == GENERAL_PURPOSE_AGENT_TYPE
 
 
 class AgentInvocation(BaseModel):

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -16,6 +16,11 @@ from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.core.discovery import find_project
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
+from agentfluent.diagnostics.delegation import (
+    _SKLEARN_AVAILABLE,
+    DEFAULT_MIN_CLUSTER_SIZE,
+    DEFAULT_MIN_SIMILARITY,
+)
 
 ANALYZE_EPILOG = """\
 Examples:
@@ -110,12 +115,43 @@ def analyze(
         "-f",
         help="Output format: table or json.",
     ),
+    min_cluster_size: Optional[int] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--min-cluster-size",
+        help=(
+            "Delegation clustering: minimum invocations per cluster "
+            f"(default {DEFAULT_MIN_CLUSTER_SIZE}). Requires "
+            "agentfluent[clustering]."
+        ),
+    ),
+    min_similarity: Optional[float] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--min-similarity",
+        help=(
+            "Delegation dedup: cosine similarity threshold against existing "
+            f"agents (default {DEFAULT_MIN_SIMILARITY}). Requires "
+            "agentfluent[clustering]."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
     """Analyze agent sessions for token usage, cost, and behavior diagnostics."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
+    # Fail fast if the user explicitly asked for clustering-tuning behavior
+    # but the optional extra is not installed. When both flags are left at
+    # their defaults (None), clustering is silently skipped if sklearn is
+    # absent — the lean install stays usable.
+    if (
+        min_cluster_size is not None or min_similarity is not None
+    ) and not _SKLEARN_AVAILABLE:
+        err_console.print(
+            "[red]Error:[/red] Delegation clustering requires scikit-learn. "
+            "Install with: [bold]uv pip install 'agentfluent[clustering]'[/bold]",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
 
     config_dir: Path | None = ctx.obj.claude_config_dir if ctx.obj else None
 
@@ -147,7 +183,17 @@ def analyze(
     all_invocations = [inv for s in result.sessions for inv in s.invocations]
 
     if all_invocations:
-        result.diagnostics = run_diagnostics(all_invocations)
+        result.diagnostics = run_diagnostics(
+            all_invocations,
+            min_cluster_size=(
+                min_cluster_size if min_cluster_size is not None
+                else DEFAULT_MIN_CLUSTER_SIZE
+            ),
+            min_similarity=(
+                min_similarity if min_similarity is not None
+                else DEFAULT_MIN_SIMILARITY
+            ),
+        )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         console.print(
             "[dim]No agent invocations found -- "

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -17,9 +17,9 @@ from agentfluent.core.discovery import find_project
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
 from agentfluent.diagnostics.delegation import (
-    _SKLEARN_AVAILABLE,
     DEFAULT_MIN_CLUSTER_SIZE,
     DEFAULT_MIN_SIMILARITY,
+    SKLEARN_AVAILABLE,
 )
 
 ANALYZE_EPILOG = """\
@@ -146,7 +146,7 @@ def analyze(
     # absent — the lean install stays usable.
     if (
         min_cluster_size is not None or min_similarity is not None
-    ) and not _SKLEARN_AVAILABLE:
+    ) and not SKLEARN_AVAILABLE:
         err_console.print(
             "[red]Error:[/red] Delegation clustering requires scikit-learn. "
             "Install with: [bold]uv pip install 'agentfluent[clustering]'[/bold]",

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -16,6 +16,12 @@ SEVERITY_COLORS: dict[Severity, str] = {
     Severity.INFO: "cyan",
 }
 
+CONFIDENCE_COLORS: dict[str, str] = {
+    "high": "green",
+    "medium": "yellow",
+    "low": "red",
+}
+
 
 def format_cost(cost: float) -> str:
     """Format a dollar cost for display."""

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -297,6 +297,7 @@ def _format_diagnostics_table(
         console.print(rec_table)
 
     _format_deep_diagnostics(console, diag, verbose=verbose)
+    _format_delegation_suggestions(console, diag, verbose=verbose)
 
 
 def _format_deep_diagnostics(
@@ -366,6 +367,65 @@ def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> No
             escape(truncate(str(entry.get("result_summary", "")), 60)),
         )
     console.print(ev_table)
+
+
+def _format_delegation_suggestions(
+    console: Console,
+    diag: DiagnosticsResult,
+    *,
+    verbose: bool,
+) -> None:
+    """Render the "Suggested Subagents" section.
+
+    Compact table by default: one row per suggestion with name, model,
+    confidence, size, tools summary, dedup note. Verbose adds the
+    synthesized prompt + top-terms block under each row.
+
+    All JSONL-derived fields (name, description, tools, dedup note)
+    pass through ``escape`` before hitting Rich — trace content is
+    untrusted and could smuggle markup.
+    """
+    suggestions = diag.delegation_suggestions
+    if not suggestions:
+        return
+
+    console.print("\n[bold]Suggested Subagents[/bold]")
+    sug_table = Table(show_header=True, title_style="")
+    sug_table.add_column("Name", style="cyan")
+    sug_table.add_column("Model")
+    sug_table.add_column("Confidence")
+    sug_table.add_column("Cluster size", justify="right")
+    sug_table.add_column("Tools")
+    sug_table.add_column("Note")
+
+    confidence_colors = {"high": "green", "medium": "yellow", "low": "red"}
+    for sug in suggestions:
+        color = confidence_colors.get(sug.confidence, "white")
+        tools_display = (
+            ", ".join(sug.tools) if sug.tools
+            else escape(sug.tools_note) or "[dim]—[/dim]"
+        )
+        note = escape(sug.dedup_note) if sug.dedup_note else ""
+        sug_table.add_row(
+            escape(sug.name),
+            escape(sug.model),
+            f"[{color}]{sug.confidence}[/{color}]",
+            str(sug.cluster_size),
+            escape(tools_display) if sug.tools else tools_display,
+            note,
+        )
+    console.print(sug_table)
+
+    if verbose:
+        for sug in suggestions:
+            top_terms = ", ".join(sug.top_terms) if sug.top_terms else "—"
+            console.print(
+                f"\n[cyan]{escape(sug.name)}[/cyan]  "
+                f"[dim](cohesion {sug.cohesion_score:.2f}, "
+                f"top terms: {escape(top_terms)})[/dim]",
+            )
+            console.print(f"  {escape(sug.description)}")
+            console.print(f"  [dim]prompt draft:[/dim] {escape(sug.prompt_template)}")
 
 
 def _format_diagnostics_summary(console: Console, diag: DiagnosticsResult) -> None:

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -15,6 +15,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
+    CONFIDENCE_COLORS,
     SEVERITY_COLORS,
     average_score,
     format_cost,
@@ -398,9 +399,8 @@ def _format_delegation_suggestions(
     sug_table.add_column("Tools")
     sug_table.add_column("Note")
 
-    confidence_colors = {"high": "green", "medium": "yellow", "low": "red"}
     for sug in suggestions:
-        color = confidence_colors.get(sug.confidence, "white")
+        color = CONFIDENCE_COLORS.get(sug.confidence, "white")
         tools_display = (
             ", ".join(sug.tools) if sug.tools
             else escape(sug.tools_note) or "[dim]—[/dim]"

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -9,7 +9,7 @@ list of ``DelegationSuggestion`` records that surface on
 scikit-learn is an **optional extra** (``agentfluent[clustering]``).
 Users who only run ``agentfluent analyze`` without clustering flags do
 not need to install it. The top-level try/except sets
-``_SKLEARN_AVAILABLE``; direct callers of the public functions here
+``SKLEARN_AVAILABLE``; direct callers of the public functions here
 get a clear ``SklearnMissingError`` instead of an ImportError. The
 pipeline silently skips clustering when unavailable; the CLI surfaces
 an error + non-zero exit when a user explicitly passes a clustering
@@ -25,7 +25,7 @@ import logging
 import re
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 try:
@@ -36,10 +36,11 @@ try:
     from sklearn.metrics import silhouette_score
     from sklearn.metrics.pairwise import cosine_similarity
 
-    _SKLEARN_AVAILABLE = True
+    SKLEARN_AVAILABLE = True
 except ImportError:  # pragma: no cover — exercised via the install-path test
-    _SKLEARN_AVAILABLE = False
+    SKLEARN_AVAILABLE = False
 
+from agentfluent.agents.models import is_general_purpose
 from agentfluent.diagnostics.models import DelegationSuggestion
 
 if TYPE_CHECKING:
@@ -56,6 +57,8 @@ DEFAULT_MIN_SIMILARITY = 0.7
 _SILHOUETTE_K_MAX = 10        # upper bound on silhouette-selected k
 _SMALL_N_THRESHOLD = 10       # below this, force k=2 without silhouette
 _FORCED_SMALL_K = 2
+_KMEANS_RANDOM_STATE = 42     # default seed for reproducible clustering
+_KMEANS_N_INIT = 10           # KMeans restarts; higher resists bad local minima
 _CONFIDENCE_HIGH_SIZE = 10
 _CONFIDENCE_HIGH_COHESION = 0.8
 _CONFIDENCE_MEDIUM_COHESION = 0.6
@@ -90,25 +93,8 @@ class DelegationCluster:
 ConfidenceTier = Literal["high", "medium", "low"]
 
 
-@dataclass
-class AgentDraft:
-    """Internal: the synthesized draft before it becomes a DelegationSuggestion."""
-
-    name: str
-    description: str
-    model: str
-    tools: list[str]
-    tools_note: str
-    prompt_template: str
-    confidence: ConfidenceTier
-    cluster_size: int
-    cohesion_score: float
-    top_terms: list[str]
-    dedup_note: str = field(default="")
-
-
 def _require_sklearn() -> None:
-    if not _SKLEARN_AVAILABLE:
+    if not SKLEARN_AVAILABLE:
         raise SklearnMissingError(
             "Install agentfluent[clustering] to enable delegation analysis.",
         )
@@ -128,9 +114,26 @@ def _filter_candidates(
     """Keep general-purpose invocations with enough text to cluster on."""
     return [
         inv for inv in invocations
-        if inv.agent_type.lower() == "general-purpose"
+        if is_general_purpose(inv.agent_type)
         and _combined_text_tokens(inv) >= MIN_TEXT_TOKENS
     ]
+
+
+def _fit_kmeans(
+    embeddings: np.ndarray,
+    n_clusters: int,
+    *,
+    random_state: int = _KMEANS_RANDOM_STATE,
+    n_init: int = _KMEANS_N_INIT,
+) -> np.ndarray:
+    """Fit KMeans and return labels as a concrete ndarray.
+
+    Thin wrapper that fixes the ``random_state`` / ``n_init`` defaults
+    (both tunable via kwargs) and converts sklearn's ``Any``-typed
+    ``fit_predict`` return value to an ndarray so mypy stays strict.
+    """
+    km = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=n_init)
+    return np.asarray(km.fit_predict(embeddings))
 
 
 def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
@@ -142,19 +145,16 @@ def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
     refit.
     """
     if n_samples < _SMALL_N_THRESHOLD:
-        km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
-        return np.asarray(km.fit_predict(embeddings))
+        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     k_upper = min(_SILHOUETTE_K_MAX, n_samples // 5)
     if k_upper < 2:
-        km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
-        return np.asarray(km.fit_predict(embeddings))
+        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     best_labels: np.ndarray | None = None
     best_score = -1.0
     for k in range(2, k_upper + 1):
-        km = KMeans(n_clusters=k, random_state=42, n_init=10)
-        labels = np.asarray(km.fit_predict(embeddings))
+        labels = _fit_kmeans(embeddings, k)
         if len(set(labels)) < 2:
             continue
         score = silhouette_score(embeddings, labels)
@@ -176,8 +176,7 @@ def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
         )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
-            return np.asarray(km.fit_predict(embeddings))
+            return _fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     return best_labels
 
@@ -224,14 +223,19 @@ def _all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
     non-probabilistic output. Detecting this case lets us emit a clear
     warning instead of silently producing zero clusters or sklearn
     convergence noise.
+
+    Densifies once and compares rows to row 0 with a vectorized numpy
+    equality check. A single ``toarray()`` + broadcast is ~O(n × features);
+    faster and more predictable than a row-by-row densify loop, and
+    avoids sparse-sparse ``!=`` short-circuit quirks across scipy
+    versions.
     """
     if tfidf_matrix.shape[0] <= 1:
         return True
-    first = tfidf_matrix[0].toarray()
-    for i in range(1, tfidf_matrix.shape[0]):
-        if not np.array_equal(tfidf_matrix[i].toarray(), first):
-            return False
-    return True
+    # sklearn TfidfVectorizer returns a scipy sparse matrix, not a
+    # numpy ndarray — no type stubs for scipy.sparse in this project.
+    dense = tfidf_matrix.toarray()  # type: ignore[attr-defined]
+    return bool((dense == dense[0]).all())
 
 
 def _build_single_cluster(
@@ -409,14 +413,14 @@ def _classify_confidence(cluster_size: int, cohesion: float) -> ConfidenceTier:
     return "low"
 
 
-def generate_draft(cluster: DelegationCluster) -> AgentDraft:
+def generate_draft(cluster: DelegationCluster) -> DelegationSuggestion:
     """Synthesize a draft subagent definition from a cluster."""
     tools = _collect_tools_from_traces(cluster.members)
     tools_note = (
         "" if tools
         else "# run with newer session data for tool recommendations"
     )
-    return AgentDraft(
+    return DelegationSuggestion(
         name=_synthesize_name(cluster.top_terms),
         description=_synthesize_description(cluster.top_terms),
         model=_classify_model(tools, cluster.members),
@@ -443,10 +447,10 @@ def _config_text(config: AgentConfig) -> str:
 
 
 def _apply_dedup(
-    drafts: list[AgentDraft],
+    drafts: list[DelegationSuggestion],
     existing_configs: list[AgentConfig],
     min_similarity: float,
-) -> list[AgentDraft]:
+) -> list[DelegationSuggestion]:
     """Mark drafts whose description+prompt is too close to any existing
     agent config. Deduped drafts are NOT removed from the output — they
     ship with a ``dedup_note`` so users see what was suppressed and why.
@@ -479,22 +483,6 @@ def _apply_dedup(
     return drafts
 
 
-def _draft_to_suggestion(draft: AgentDraft) -> DelegationSuggestion:
-    return DelegationSuggestion(
-        name=draft.name,
-        description=draft.description,
-        model=draft.model,
-        tools=draft.tools,
-        tools_note=draft.tools_note,
-        prompt_template=draft.prompt_template,
-        confidence=draft.confidence,
-        cluster_size=draft.cluster_size,
-        cohesion_score=draft.cohesion_score,
-        top_terms=draft.top_terms,
-        dedup_note=draft.dedup_note,
-    )
-
-
 def suggest_delegations(
     invocations: list[AgentInvocation],
     *,
@@ -515,4 +503,4 @@ def suggest_delegations(
     drafts = [generate_draft(c) for c in clusters]
     if existing_configs:
         drafts = _apply_dedup(drafts, existing_configs, min_similarity)
-    return [_draft_to_suggestion(d) for d in drafts]
+    return drafts

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -1,0 +1,518 @@
+"""Delegation clustering + subagent draft generation.
+
+Clusters ``general-purpose`` agent invocations by their
+``description + prompt`` text using TF-IDF → LSA → KMeans, then
+synthesizes a draft subagent definition for each cluster. Output is a
+list of ``DelegationSuggestion`` records that surface on
+``DiagnosticsResult.delegation_suggestions``.
+
+scikit-learn is an **optional extra** (``agentfluent[clustering]``).
+Users who only run ``agentfluent analyze`` without clustering flags do
+not need to install it. The top-level try/except sets
+``_SKLEARN_AVAILABLE``; direct callers of the public functions here
+get a clear ``SklearnMissingError`` instead of an ImportError. The
+pipeline silently skips clustering when unavailable; the CLI surfaces
+an error + non-zero exit when a user explicitly passes a clustering
+flag but the extra is missing.
+
+See issue #139 for the plan to strip this conditional machinery once
+a second sklearn-dependent feature lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import warnings
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+try:
+    import numpy as np
+    from sklearn.cluster import KMeans
+    from sklearn.decomposition import TruncatedSVD
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.metrics import silhouette_score
+    from sklearn.metrics.pairwise import cosine_similarity
+
+    _SKLEARN_AVAILABLE = True
+except ImportError:  # pragma: no cover — exercised via the install-path test
+    _SKLEARN_AVAILABLE = False
+
+from agentfluent.diagnostics.models import DelegationSuggestion
+
+if TYPE_CHECKING:
+    from agentfluent.agents.models import AgentInvocation
+    from agentfluent.config.models import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+# Module-level tunables. Override via function kwargs or CLI flags.
+MIN_TEXT_TOKENS = 20          # combined description + prompt below this is filtered
+LSA_COMPONENTS = 50
+DEFAULT_MIN_CLUSTER_SIZE = 5
+DEFAULT_MIN_SIMILARITY = 0.7
+_SILHOUETTE_K_MAX = 10        # upper bound on silhouette-selected k
+_SMALL_N_THRESHOLD = 10       # below this, force k=2 without silhouette
+_FORCED_SMALL_K = 2
+_CONFIDENCE_HIGH_SIZE = 10
+_CONFIDENCE_HIGH_COHESION = 0.8
+_CONFIDENCE_MEDIUM_COHESION = 0.6
+_TOOL_READ_ONLY = frozenset(
+    {"Read", "Grep", "Glob", "WebFetch", "WebSearch", "LS"},
+)
+_TOOL_HEAVY_WRITE = frozenset({"Write", "Edit", "Bash", "NotebookEdit"})
+_HEAVY_TOKEN_THRESHOLD = 20_000
+_TOP_TERMS_COUNT = 5
+_PROMPT_BODY_SNIPPET_CHARS = 500
+
+# Model tiers for draft generation. Kept as module constants so later
+# releases can bump to newer Claude versions in one place.
+MODEL_HAIKU = "claude-haiku-4-5"
+MODEL_SONNET = "claude-sonnet-4-6"
+MODEL_OPUS = "claude-opus-4-7"
+
+
+class SklearnMissingError(RuntimeError):
+    """Raised when clustering is invoked but scikit-learn is not installed."""
+
+
+@dataclass
+class DelegationCluster:
+    """Internal: a KMeans cluster of general-purpose invocations."""
+
+    members: list[AgentInvocation]
+    top_terms: list[str]
+    cohesion_score: float
+
+
+ConfidenceTier = Literal["high", "medium", "low"]
+
+
+@dataclass
+class AgentDraft:
+    """Internal: the synthesized draft before it becomes a DelegationSuggestion."""
+
+    name: str
+    description: str
+    model: str
+    tools: list[str]
+    tools_note: str
+    prompt_template: str
+    confidence: ConfidenceTier
+    cluster_size: int
+    cohesion_score: float
+    top_terms: list[str]
+    dedup_note: str = field(default="")
+
+
+def _require_sklearn() -> None:
+    if not _SKLEARN_AVAILABLE:
+        raise SklearnMissingError(
+            "Install agentfluent[clustering] to enable delegation analysis.",
+        )
+
+
+def _combined_text(inv: AgentInvocation) -> str:
+    return f"{inv.description} {inv.prompt}"
+
+
+def _combined_text_tokens(inv: AgentInvocation) -> int:
+    return len(_combined_text(inv).split())
+
+
+def _filter_candidates(
+    invocations: list[AgentInvocation],
+) -> list[AgentInvocation]:
+    """Keep general-purpose invocations with enough text to cluster on."""
+    return [
+        inv for inv in invocations
+        if inv.agent_type.lower() == "general-purpose"
+        and _combined_text_tokens(inv) >= MIN_TEXT_TOKENS
+    ]
+
+
+def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
+    """Return KMeans labels from the k that scores highest on silhouette.
+
+    For n < 10, silhouette's useful k-range collapses (e.g. k_upper=1) —
+    force k=2 and do a single fit. Otherwise, sweep k and keep the
+    labels from the best-scoring fit so we avoid a redundant final-k
+    refit.
+    """
+    if n_samples < _SMALL_N_THRESHOLD:
+        km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
+        return np.asarray(km.fit_predict(embeddings))
+
+    k_upper = min(_SILHOUETTE_K_MAX, n_samples // 5)
+    if k_upper < 2:
+        km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
+        return np.asarray(km.fit_predict(embeddings))
+
+    best_labels: np.ndarray | None = None
+    best_score = -1.0
+    for k in range(2, k_upper + 1):
+        km = KMeans(n_clusters=k, random_state=42, n_init=10)
+        labels = np.asarray(km.fit_predict(embeddings))
+        if len(set(labels)) < 2:
+            continue
+        score = silhouette_score(embeddings, labels)
+        if score > best_score:
+            best_score = score
+            best_labels = labels
+
+    # Degenerate fallback: every k collapsed to a single cluster. Rare,
+    # but possible with near-identical embeddings that survived row
+    # de-dup but lose variance after LSA. Log it so the anomaly is
+    # observable, then force k=2 and suppress the resulting
+    # convergence warning.
+    if best_labels is None:
+        logger.info(
+            "KMeans produced no multi-cluster solution for %d samples; "
+            "falling back to k=2. Input may have near-zero variance "
+            "after TF-IDF + LSA reduction.",
+            n_samples,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            km = KMeans(n_clusters=_FORCED_SMALL_K, random_state=42, n_init=10)
+            return np.asarray(km.fit_predict(embeddings))
+
+    return best_labels
+
+
+def _mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
+    """Average pairwise cosine similarity within a cluster — our cohesion proxy."""
+    if len(cluster_embeddings) < 2:
+        return 1.0
+    sim = cosine_similarity(cluster_embeddings)
+    # Exclude the diagonal (self-sim=1) to avoid biasing toward 1.0.
+    n = sim.shape[0]
+    total = (sim.sum() - n) / (n * n - n)
+    return float(total)
+
+
+def _top_tfidf_terms(
+    tfidf_matrix: np.ndarray,
+    member_indices: list[int],
+    terms: np.ndarray,
+    top_n: int = _TOP_TERMS_COUNT,
+) -> list[str]:
+    member_vecs = tfidf_matrix[member_indices]
+    mean_scores = member_vecs.mean(axis=0)
+    mean_array = np.asarray(mean_scores).ravel()
+    top_idx = mean_array.argsort()[::-1][:top_n]
+    return [str(terms[i]) for i in top_idx if mean_array[i] > 0]
+
+
+def _group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
+    """Single-pass grouping of sample indices by their cluster label."""
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i, lab in enumerate(labels):
+        groups[int(lab)].append(i)
+    return groups
+
+
+def _all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
+    """Detect an anomaly: byte-identical TF-IDF rows across all members.
+
+    Agent-generated prompts are probabilistic; identical rows across
+    multiple invocations is very unlikely in real data. When it does
+    happen, it usually points upstream — duplicate session records,
+    an invocation-extraction bug, or a parent agent producing
+    non-probabilistic output. Detecting this case lets us emit a clear
+    warning instead of silently producing zero clusters or sklearn
+    convergence noise.
+    """
+    if tfidf_matrix.shape[0] <= 1:
+        return True
+    first = tfidf_matrix[0].toarray()
+    for i in range(1, tfidf_matrix.shape[0]):
+        if not np.array_equal(tfidf_matrix[i].toarray(), first):
+            return False
+    return True
+
+
+def _build_single_cluster(
+    candidates: list[AgentInvocation],
+    tfidf_matrix: np.ndarray,
+    terms: np.ndarray,
+) -> DelegationCluster:
+    """Build one cluster holding every candidate — the answer when
+    every TF-IDF row is identical. Cohesion is 1.0 by definition
+    (all members share the same vector)."""
+    all_indices = list(range(len(candidates)))
+    return DelegationCluster(
+        members=list(candidates),
+        top_terms=_top_tfidf_terms(tfidf_matrix, all_indices, terms),
+        cohesion_score=1.0,
+    )
+
+
+def cluster_delegations(
+    invocations: list[AgentInvocation],
+    *,
+    min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
+) -> list[DelegationCluster]:
+    """Group general-purpose invocations into clusters of similar delegations.
+
+    Raises ``SklearnMissingError`` when scikit-learn is not installed.
+    Returns ``[]`` if there are not enough candidates or all are filtered
+    out by the minimum-text-length guard.
+    """
+    _require_sklearn()
+
+    candidates = _filter_candidates(invocations)
+    if len(candidates) < min_cluster_size:
+        return []
+
+    texts = [_combined_text(inv) for inv in candidates]
+    tfidf = TfidfVectorizer(stop_words="english", max_features=500)
+    tfidf_matrix = tfidf.fit_transform(texts)
+    terms = tfidf.get_feature_names_out()
+
+    # Anomaly: if every row is identical, surface the upstream issue and
+    # return a single cluster. Clustering algorithms below would either
+    # emit confusing convergence warnings or silently produce no output.
+    if _all_rows_identical(tfidf_matrix):
+        logger.warning(
+            "Delegation clustering: all %d TF-IDF rows are identical — "
+            "this is unusual for real agent data. Check for duplicate "
+            "invocation records or upstream extraction bugs.",
+            tfidf_matrix.shape[0],
+        )
+        return [_build_single_cluster(candidates, tfidf_matrix, terms)]
+
+    # LSA dimensionality reduction — skip gracefully if we do not have
+    # enough features or samples to support TruncatedSVD.
+    n_components = min(
+        LSA_COMPONENTS, tfidf_matrix.shape[1] - 1, len(candidates) - 1,
+    )
+    if n_components >= 2:
+        with warnings.catch_warnings():
+            # TruncatedSVD can raise a RuntimeWarning on near-zero
+            # variance input; the degenerate-fallback in
+            # _cluster_embeddings already handles the output path.
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            lsa = TruncatedSVD(n_components=n_components, random_state=42)
+            embeddings = lsa.fit_transform(tfidf_matrix)
+    else:
+        embeddings = tfidf_matrix.toarray()
+
+    labels = _cluster_embeddings(embeddings, len(candidates))
+    groups = _group_indices_by_label(labels)
+
+    clusters: list[DelegationCluster] = []
+    for _label, member_indices in sorted(groups.items()):
+        if len(member_indices) < min_cluster_size:
+            continue
+        members = [candidates[i] for i in member_indices]
+        cluster_embeddings = embeddings[member_indices]
+        cohesion = _mean_pairwise_cosine(cluster_embeddings)
+        top_terms = _top_tfidf_terms(tfidf_matrix, member_indices, terms)
+        clusters.append(
+            DelegationCluster(
+                members=members,
+                top_terms=top_terms,
+                cohesion_score=cohesion,
+            ),
+        )
+    return clusters
+
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]")
+
+
+def _synthesize_name(top_terms: list[str]) -> str:
+    """Build a kebab-case agent name from the top TF-IDF terms.
+
+    Prefers the first two terms when available; otherwise falls back to
+    a generic placeholder. Not unique across clusters — the caller is
+    expected to show these as *drafts*, not final names.
+    """
+    cleaned = [_SLUG_STRIP_RE.sub("", t.lower().replace("_", "-")) for t in top_terms]
+    cleaned = [c for c in cleaned if c]
+    if not cleaned:
+        return "custom-agent"
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return f"{cleaned[0]}-{cleaned[1]}"
+
+
+def _synthesize_description(top_terms: list[str]) -> str:
+    if not top_terms:
+        return "Handles a recurring delegation pattern."
+    terms_list = ", ".join(top_terms[:3])
+    return f"Handles delegations related to: {terms_list}."
+
+
+def _synthesize_prompt(top_terms: list[str], members: list[AgentInvocation]) -> str:
+    """Generic prompt scaffold anchored on the cluster's top terms.
+
+    Intentionally minimal — users will refine before committing. The
+    scaffold references the top terms so it feels purposeful rather
+    than boilerplate.
+    """
+    terms_list = ", ".join(top_terms[:3]) if top_terms else "this task"
+    example_descs = [m.description for m in members[:2] if m.description]
+    examples_block = ""
+    if example_descs:
+        examples_block = "\n\nExample delegations observed:\n" + "\n".join(
+            f"- {d}" for d in example_descs
+        )
+    return (
+        f"You handle recurring delegations involving {terms_list}.\n\n"
+        "Scope your work to the specific task described in the user's "
+        "prompt. Return concise, structured output."
+        f"{examples_block}"
+    )
+
+
+def _collect_tools_from_traces(members: list[AgentInvocation]) -> list[str]:
+    tools: set[str] = set()
+    for m in members:
+        if m.trace is not None:
+            tools.update(m.trace.unique_tool_names)
+    return sorted(tools)
+
+
+def _mean_tokens(members: list[AgentInvocation]) -> float:
+    values = [m.total_tokens for m in members if m.total_tokens is not None]
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _classify_model(tools: list[str], members: list[AgentInvocation]) -> str:
+    """Pick a model tier based on the tool mix + observed token burn.
+
+    - All read-only tools → haiku (cheap, fast)
+    - Contains heavy-write tools + high average tokens → opus
+    - Default → sonnet
+    """
+    if not tools:
+        return MODEL_SONNET
+    tool_set = set(tools)
+    if tool_set and tool_set <= _TOOL_READ_ONLY:
+        return MODEL_HAIKU
+    if tool_set & _TOOL_HEAVY_WRITE and _mean_tokens(members) > _HEAVY_TOKEN_THRESHOLD:
+        return MODEL_OPUS
+    return MODEL_SONNET
+
+
+def _classify_confidence(cluster_size: int, cohesion: float) -> ConfidenceTier:
+    if cluster_size >= _CONFIDENCE_HIGH_SIZE and cohesion >= _CONFIDENCE_HIGH_COHESION:
+        return "high"
+    if cohesion >= _CONFIDENCE_MEDIUM_COHESION:
+        return "medium"
+    return "low"
+
+
+def generate_draft(cluster: DelegationCluster) -> AgentDraft:
+    """Synthesize a draft subagent definition from a cluster."""
+    tools = _collect_tools_from_traces(cluster.members)
+    tools_note = (
+        "" if tools
+        else "# run with newer session data for tool recommendations"
+    )
+    return AgentDraft(
+        name=_synthesize_name(cluster.top_terms),
+        description=_synthesize_description(cluster.top_terms),
+        model=_classify_model(tools, cluster.members),
+        tools=tools,
+        tools_note=tools_note,
+        prompt_template=_synthesize_prompt(cluster.top_terms, cluster.members),
+        confidence=_classify_confidence(len(cluster.members), cluster.cohesion_score),
+        cluster_size=len(cluster.members),
+        cohesion_score=cluster.cohesion_score,
+        top_terms=list(cluster.top_terms),
+    )
+
+
+def _config_text(config: AgentConfig) -> str:
+    """Pick the text to dedup against: description, or prompt_body snippet.
+
+    ``AgentConfig.description`` is often empty in real configs (YAML
+    frontmatter isn't always populated). Fall back to a prompt_body
+    prefix so dedup still finds obvious overlaps.
+    """
+    if config.description:
+        return config.description
+    return config.prompt_body[:_PROMPT_BODY_SNIPPET_CHARS]
+
+
+def _apply_dedup(
+    drafts: list[AgentDraft],
+    existing_configs: list[AgentConfig],
+    min_similarity: float,
+) -> list[AgentDraft]:
+    """Mark drafts whose description+prompt is too close to any existing
+    agent config. Deduped drafts are NOT removed from the output — they
+    ship with a ``dedup_note`` so users see what was suppressed and why.
+    """
+    if not existing_configs:
+        return drafts
+    draft_texts = [f"{d.description} {d.prompt_template}" for d in drafts]
+    config_texts = [_config_text(c) for c in existing_configs]
+    # TF-IDF needs at least one non-empty text per document; skip dedup
+    # entirely if all the config texts are empty.
+    if not any(t.strip() for t in config_texts):
+        return drafts
+    vectorizer = TfidfVectorizer(stop_words="english")
+    corpus = draft_texts + config_texts
+    matrix = vectorizer.fit_transform(corpus)
+    draft_vecs = matrix[: len(drafts)]
+    config_vecs = matrix[len(drafts) :]
+    sim = cosine_similarity(draft_vecs, config_vecs)
+    for i, draft in enumerate(drafts):
+        if sim.shape[1] == 0:
+            break
+        max_j = int(sim[i].argmax())
+        max_sim = float(sim[i][max_j])
+        if max_sim > min_similarity:
+            matched_name = existing_configs[max_j].name
+            draft.dedup_note = (
+                f"suppressed — already covered by '{matched_name}' "
+                f"(similarity {max_sim:.2f})"
+            )
+    return drafts
+
+
+def _draft_to_suggestion(draft: AgentDraft) -> DelegationSuggestion:
+    return DelegationSuggestion(
+        name=draft.name,
+        description=draft.description,
+        model=draft.model,
+        tools=draft.tools,
+        tools_note=draft.tools_note,
+        prompt_template=draft.prompt_template,
+        confidence=draft.confidence,
+        cluster_size=draft.cluster_size,
+        cohesion_score=draft.cohesion_score,
+        top_terms=draft.top_terms,
+        dedup_note=draft.dedup_note,
+    )
+
+
+def suggest_delegations(
+    invocations: list[AgentInvocation],
+    *,
+    existing_configs: list[AgentConfig] | None = None,
+    min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
+    min_similarity: float = DEFAULT_MIN_SIMILARITY,
+) -> list[DelegationSuggestion]:
+    """End-to-end: cluster + draft + dedup → list of DelegationSuggestion.
+
+    Raises ``SklearnMissingError`` when scikit-learn is not installed.
+    """
+    _require_sklearn()
+    clusters = cluster_delegations(
+        invocations, min_cluster_size=min_cluster_size,
+    )
+    if not clusters:
+        return []
+    drafts = [generate_draft(c) for c in clusters]
+    if existing_configs:
+        drafts = _apply_dedup(drafts, existing_configs, min_similarity)
+    return [_draft_to_suggestion(d) for d in drafts]

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -1,13 +1,15 @@
-"""Data models for diagnostics: signals and recommendations.
+"""Data models for diagnostics: signals, recommendations, and delegation drafts.
 
-These models are the output of the diagnostics pipeline. DiagnosticSignal
-represents an observed behavior pattern; DiagnosticRecommendation maps
-that signal to an actionable config change.
+DiagnosticSignal represents an observed behavior pattern;
+DiagnosticRecommendation maps that signal to an actionable config
+change; DelegationSuggestion is the draft for a brand-new subagent
+proposed by clustering recurring general-purpose delegations.
 """
 
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -78,10 +80,61 @@ class DiagnosticRecommendation(BaseModel):
     """Which signal types contributed to this recommendation."""
 
 
+class DelegationSuggestion(BaseModel):
+    """A draft subagent definition derived from a cluster of recurring
+    ``general-purpose`` delegations.
+
+    Produced by the delegation clustering pipeline in
+    ``agentfluent.diagnostics.delegation``. Deduped suggestions (those
+    already covered by an existing agent config) are retained in output
+    with a populated ``dedup_note`` so the user sees what was suppressed
+    and why, rather than having the signal silently dropped.
+    """
+
+    name: str
+    """Kebab-case agent name synthesized from the cluster's top terms."""
+
+    description: str
+    """One-line description synthesized from top terms."""
+
+    model: str
+    """Recommended Claude model ID (haiku / sonnet / opus)."""
+
+    tools: list[str] = Field(default_factory=list)
+    """Union of tools observed in the cluster's subagent traces. Empty
+    when no traces were linked to the member invocations."""
+
+    tools_note: str = ""
+    """Diagnostic note when ``tools`` cannot be derived (e.g., older
+    sessions lacking trace capture)."""
+
+    prompt_template: str
+    """Draft prompt scaffold anchored on the cluster's top terms."""
+
+    confidence: Literal["high", "medium", "low"]
+    """Confidence tier based on cluster size + cohesion."""
+
+    cluster_size: int
+    """How many invocations formed this cluster."""
+
+    cohesion_score: float
+    """Mean pairwise cosine similarity within the cluster."""
+
+    top_terms: list[str] = Field(default_factory=list)
+    """Top TF-IDF terms that characterize the cluster."""
+
+    dedup_note: str = ""
+    """Non-empty when the draft overlaps an existing agent config above
+    the similarity threshold. Holds the matched agent name + similarity."""
+
+
 class DiagnosticsResult(BaseModel):
     """Complete diagnostics output for a session or set of sessions."""
 
     signals: list[DiagnosticSignal] = Field(default_factory=list)
     recommendations: list[DiagnosticRecommendation] = Field(default_factory=list)
     subagent_trace_count: int = 0
-    """Number of subagent trace files detected (teaser for v1.1)."""
+    """Number of subagent traces that successfully parsed and linked."""
+
+    delegation_suggestions: list[DelegationSuggestion] = Field(default_factory=list)
+    """Draft subagent definitions proposed by the clustering pipeline."""

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -22,9 +22,9 @@ from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.delegation import (
-    _SKLEARN_AVAILABLE,
     DEFAULT_MIN_CLUSTER_SIZE,
     DEFAULT_MIN_SIMILARITY,
+    SKLEARN_AVAILABLE,
     suggest_delegations,
 )
 from agentfluent.diagnostics.models import (
@@ -120,7 +120,7 @@ def run_diagnostics(
     subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
 
     delegation_suggestions: list[DelegationSuggestion] = []
-    if _SKLEARN_AVAILABLE:
+    if SKLEARN_AVAILABLE:
         delegation_suggestions = suggest_delegations(
             invocations,
             existing_configs=agent_configs or None,

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -3,8 +3,10 @@
 Owns the `run_diagnostics` pipeline: extracts metadata-level and
 trace-level signals, deduplicates overlapping metadata error signals
 when strictly-more-informative trace signals cover the same
-`agent_type`, runs correlation against any available agent configs, and
-computes the parsed-trace count surfaced on `DiagnosticsResult`.
+`agent_type`, runs correlation against any available agent configs,
+computes the parsed-trace count, and (when scikit-learn is installed)
+proposes draft subagent definitions from clustered general-purpose
+delegations.
 
 Kept separate from `analytics/pipeline.py` to keep the analytics layer
 free of diagnostics imports and to match the one-file-per-concern
@@ -19,7 +21,14 @@ from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.diagnostics.correlator import correlate
+from agentfluent.diagnostics.delegation import (
+    _SKLEARN_AVAILABLE,
+    DEFAULT_MIN_CLUSTER_SIZE,
+    DEFAULT_MIN_SIMILARITY,
+    suggest_delegations,
+)
 from agentfluent.diagnostics.models import (
+    DelegationSuggestion,
     DiagnosticSignal,
     DiagnosticsResult,
     SignalType,
@@ -71,14 +80,19 @@ def _dedup_error_patterns(signals: list[DiagnosticSignal]) -> list[DiagnosticSig
 
 def run_diagnostics(
     invocations: list[AgentInvocation],
+    *,
+    min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
+    min_similarity: float = DEFAULT_MIN_SIMILARITY,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
     Extracts metadata + trace-level signals, dedups overlapping metadata
     error signals, scans for agent config files, correlates signals
-    with config, and produces recommendations. `subagent_trace_count`
-    on the result reflects traces that successfully parsed and linked,
-    not the raw filesystem enumeration.
+    with config, produces recommendations, and (when scikit-learn is
+    installed) proposes draft subagent definitions from clustered
+    general-purpose delegations. ``subagent_trace_count`` on the result
+    reflects traces that successfully parsed and linked, not the raw
+    filesystem enumeration.
     """
     signals = extract_signals(invocations)
 
@@ -92,20 +106,36 @@ def run_diagnostics(
 
     signals = _dedup_error_patterns(signals)
 
-    configs: dict[str, AgentConfig] | None = None
+    agent_configs: list[AgentConfig] = []
     try:
-        agent_configs = scan_agents("all")
-        if agent_configs:
-            configs = {c.name.lower(): c for c in agent_configs}
+        agent_configs = list(scan_agents("all"))
     except OSError:
         logger.debug("Could not scan agent config files", exc_info=True)
 
-    recommendations = correlate(signals, configs)
+    configs_by_name = (
+        {c.name.lower(): c for c in agent_configs} if agent_configs else None
+    )
+    recommendations = correlate(signals, configs_by_name)
 
     subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
+
+    delegation_suggestions: list[DelegationSuggestion] = []
+    if _SKLEARN_AVAILABLE:
+        delegation_suggestions = suggest_delegations(
+            invocations,
+            existing_configs=agent_configs or None,
+            min_cluster_size=min_cluster_size,
+            min_similarity=min_similarity,
+        )
+    else:
+        logger.debug(
+            "Delegation clustering skipped: scikit-learn not installed. "
+            "Install agentfluent[clustering] to enable.",
+        )
 
     return DiagnosticsResult(
         signals=signals,
         recommendations=recommendations,
         subagent_trace_count=subagent_trace_count,
+        delegation_suggestions=delegation_suggestions,
     )

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from agentfluent.cli.formatters.table import _format_deep_diagnostics
+from agentfluent.cli.formatters.table import (
+    _format_deep_diagnostics,
+    _format_delegation_suggestions,
+)
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import (
+    DelegationSuggestion,
     DiagnosticSignal,
     DiagnosticsResult,
     SignalType,
@@ -163,3 +167,94 @@ class TestJsonRoundTrip:
         assert restored["signals"][0]["signal_type"] == "stuck_pattern"
         assert restored["signals"][0]["detail"]["tool_calls"][0]["tool_name"] == "Bash"
         assert restored["signals"][0]["detail"]["stuck_count"] == 5
+
+
+def _suggestion(
+    name: str = "test-runner",
+    description: str = "Handles delegations related to: pytest, tests, run.",
+    tools: list[str] | None = None,
+    tools_note: str = "",
+    confidence: str = "high",
+    dedup_note: str = "",
+    top_terms: list[str] | None = None,
+) -> DelegationSuggestion:
+    return DelegationSuggestion(
+        name=name,
+        description=description,
+        model="claude-sonnet-4-6",
+        tools=tools if tools is not None else ["Read", "Grep"],
+        tools_note=tools_note,
+        prompt_template="You run pytest tests and report results.",
+        confidence=confidence,  # type: ignore[arg-type]
+        cluster_size=10,
+        cohesion_score=0.85,
+        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
+        dedup_note=dedup_note,
+    )
+
+
+def _result_with_suggestions(
+    suggestions: list[DelegationSuggestion],
+) -> DiagnosticsResult:
+    return DiagnosticsResult(delegation_suggestions=suggestions)
+
+
+def _render_suggestions(diag: DiagnosticsResult, *, verbose: bool) -> str:
+    console = Console(record=True, width=140)
+    _format_delegation_suggestions(console, diag, verbose=verbose)
+    return console.export_text()
+
+
+class TestDelegationSuggestionsSection:
+    def test_absent_when_no_suggestions(self) -> None:
+        out = _render_suggestions(_result_with_suggestions([]), verbose=False)
+        assert "Suggested Subagents" not in out
+
+    def test_table_rendered_when_suggestions_present(self) -> None:
+        out = _render_suggestions(
+            _result_with_suggestions([_suggestion()]), verbose=False,
+        )
+        assert "Suggested Subagents" in out
+        assert "test-runner" in out
+        assert "claude-sonnet-4-6" in out
+
+    def test_verbose_adds_prompt_draft_block(self) -> None:
+        out = _render_suggestions(
+            _result_with_suggestions([_suggestion()]), verbose=True,
+        )
+        assert "prompt draft" in out
+        assert "pytest" in out  # top terms surface
+
+    def test_dedup_note_rendered(self) -> None:
+        sug = _suggestion(dedup_note="suppressed — already covered by 'pm' (similarity 0.85)")
+        out = _render_suggestions(
+            _result_with_suggestions([sug]), verbose=False,
+        )
+        assert "suppressed" in out
+        assert "pm" in out
+
+    def test_tools_note_rendered_when_no_tools(self) -> None:
+        sug = _suggestion(tools=[], tools_note="# run with newer session data")
+        out = _render_suggestions(
+            _result_with_suggestions([sug]), verbose=False,
+        )
+        assert "newer session data" in out
+
+
+class TestDelegationMarkupInjection:
+    """Trace-derived strings in delegation suggestions must be Rich-escaped,
+    same contract as TestMarkupInjection above."""
+
+    def test_name_with_markup_is_escaped(self) -> None:
+        sug = _suggestion(name="[link=https://evil]click[/link]")
+        out = _render_suggestions(
+            _result_with_suggestions([sug]), verbose=False,
+        )
+        assert "[link=https://evil]" in out
+
+    def test_dedup_note_with_markup_is_escaped(self) -> None:
+        sug = _suggestion(dedup_note="[bold red]CRITICAL[/bold red]")
+        out = _render_suggestions(
+            _result_with_suggestions([sug]), verbose=False,
+        )
+        assert "[bold red]" in out

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -21,7 +21,6 @@ from agentfluent.diagnostics.delegation import (  # noqa: E402
     MODEL_HAIKU,
     MODEL_OPUS,
     MODEL_SONNET,
-    AgentDraft,
     DelegationCluster,
     SklearnMissingError,
     _apply_dedup,
@@ -32,6 +31,7 @@ from agentfluent.diagnostics.delegation import (  # noqa: E402
     generate_draft,
     suggest_delegations,
 )
+from agentfluent.diagnostics.models import DelegationSuggestion  # noqa: E402
 from agentfluent.traces.models import SubagentToolCall, SubagentTrace  # noqa: E402
 
 
@@ -297,8 +297,10 @@ class TestClassifyHelpers:
 
 
 class TestDedup:
-    def _draft(self, description: str = "run pytest suite") -> AgentDraft:
-        return AgentDraft(
+    def _draft(
+        self, description: str = "run pytest suite",
+    ) -> DelegationSuggestion:
+        return DelegationSuggestion(
             name="test-runner",
             description=description,
             model=MODEL_SONNET,
@@ -413,13 +415,13 @@ class TestSklearnMissing:
     def test_cluster_delegations_raises_when_sklearn_unavailable(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(delegation, "_SKLEARN_AVAILABLE", False)
+        monkeypatch.setattr(delegation, "SKLEARN_AVAILABLE", False)
         with pytest.raises(SklearnMissingError, match="agentfluent\\[clustering\\]"):
             cluster_delegations(_TEST_INVS)
 
     def test_suggest_delegations_raises_when_sklearn_unavailable(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(delegation, "_SKLEARN_AVAILABLE", False)
+        monkeypatch.setattr(delegation, "SKLEARN_AVAILABLE", False)
         with pytest.raises(SklearnMissingError):
             suggest_delegations(_TEST_INVS)

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -1,0 +1,425 @@
+"""Tests for delegation clustering, draft generation, and dedup.
+
+scikit-learn is an optional extra; tests are skipped wholesale when
+it's not installed (``pytest.importorskip``) and the dedicated
+"sklearn-missing" tests stub the module flag to exercise the error
+path without uninstalling anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("sklearn")
+
+from agentfluent.agents.models import AgentInvocation  # noqa: E402
+from agentfluent.config.models import AgentConfig, Scope  # noqa: E402
+from agentfluent.diagnostics import delegation  # noqa: E402
+from agentfluent.diagnostics.delegation import (  # noqa: E402
+    MODEL_HAIKU,
+    MODEL_OPUS,
+    MODEL_SONNET,
+    AgentDraft,
+    DelegationCluster,
+    SklearnMissingError,
+    _apply_dedup,
+    _classify_confidence,
+    _classify_model,
+    _collect_tools_from_traces,
+    cluster_delegations,
+    generate_draft,
+    suggest_delegations,
+)
+from agentfluent.traces.models import SubagentToolCall, SubagentTrace  # noqa: E402
+
+
+def _inv(
+    agent_type: str = "general-purpose",
+    description: str = "",
+    prompt: str = "",
+    total_tokens: int | None = None,
+    trace: SubagentTrace | None = None,
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        is_builtin=agent_type.lower() == "general-purpose",
+        description=description,
+        prompt=prompt,
+        tool_use_id="toolu_" + description[:10],
+        total_tokens=total_tokens,
+        trace=trace,
+    )
+
+
+def _trace_with_tools(tools: list[str]) -> SubagentTrace:
+    calls = [
+        SubagentToolCall(tool_name=t, input_summary="x", result_summary="ok")
+        for t in tools
+    ]
+    return SubagentTrace(
+        agent_id="agent-x",
+        agent_type="general-purpose",
+        delegation_prompt="",
+        tool_calls=calls,
+    )
+
+
+def _config(
+    name: str = "existing-agent",
+    description: str = "",
+    prompt_body: str = "",
+) -> AgentConfig:
+    return AgentConfig(
+        name=name,
+        file_path=Path(f"/home/user/.claude/agents/{name}.md"),
+        scope=Scope.USER,
+        description=description,
+        prompt_body=prompt_body,
+    )
+
+
+# Two distinct delegation patterns, 5 invocations each — TF-IDF should
+# separate these cleanly. Each combined description + prompt clears the
+# MIN_TEXT_TOKENS filter (20 tokens). The default threshold itself is
+# tracked for empirical calibration in #140; these fixtures test
+# algorithm correctness at the current setting, not the threshold choice.
+_TEST_INVS = [
+    _inv(
+        description="run the pytest suite and report failures",
+        prompt=(
+            "execute pytest on the tests directory report failures coverage "
+            "and any slow tests collect output pytest fixtures markers"
+        ),
+    ),
+    _inv(
+        description="run unit tests with pytest and coverage",
+        prompt=(
+            "invoke pytest for the unit tests collect coverage metrics "
+            "report slow failures fixtures markers output across the suite"
+        ),
+    ),
+    _inv(
+        description="execute pytest test runner on suite",
+        prompt=(
+            "run pytest against the testing folder capture output report "
+            "failures fixtures markers coverage slow tests across the suite"
+        ),
+    ),
+    _inv(
+        description="pytest execution request for full suite",
+        prompt=(
+            "please run pytest over the entire testing directory report "
+            "failures coverage markers fixtures output slow tests collect"
+        ),
+    ),
+    _inv(
+        description="test suite pytest run with coverage",
+        prompt=(
+            "kick off pytest across the test modules return results "
+            "coverage markers fixtures output failures slow tests collect"
+        ),
+    ),
+    _inv(
+        description="parse session JSONL file extract tool_use",
+        prompt=(
+            "read the claude JSONL session file extract tool_use content "
+            "blocks from assistant messages parse metadata timestamps model"
+        ),
+    ),
+    _inv(
+        description="read JSONL session data for parsing",
+        prompt=(
+            "parse a session JSONL surface the assistant tool_use "
+            "invocations extract metadata timestamps model content blocks"
+        ),
+    ),
+    _inv(
+        description="process session JSONL file extraction",
+        prompt=(
+            "extract tool_use blocks from the claude session JSONL "
+            "parse assistant message metadata timestamps model content"
+        ),
+    ),
+    _inv(
+        description="session parser task JSONL extraction",
+        prompt=(
+            "read the JSONL session parse assistant messages for tool "
+            "calls extract metadata timestamps model content blocks"
+        ),
+    ),
+    _inv(
+        description="JSONL parsing delegation session file",
+        prompt=(
+            "open the session JSONL file extract the tool_use content "
+            "blocks parse assistant messages metadata timestamps model"
+        ),
+    ),
+]
+
+
+class TestClusterDelegations:
+    def test_below_min_cluster_size_returns_empty(self) -> None:
+        # Three invs, min=5 → empty.
+        invs = _TEST_INVS[:3]
+        assert cluster_delegations(invs, min_cluster_size=5) == []
+
+    def test_filters_non_general_purpose(self) -> None:
+        invs = [_inv(agent_type="pm", description="x", prompt="y z w " * 10)]
+        assert cluster_delegations(invs) == []
+
+    def test_filters_short_text(self) -> None:
+        # 2 tokens combined — below MIN_TEXT_TOKENS.
+        invs = [
+            _inv(description="x", prompt="y")
+            for _ in range(10)
+        ]
+        assert cluster_delegations(invs) == []
+
+    def test_two_well_separated_patterns_form_two_clusters(self) -> None:
+        clusters = cluster_delegations(_TEST_INVS, min_cluster_size=3)
+        assert len(clusters) == 2
+        for c in clusters:
+            assert len(c.members) >= 3
+
+    def test_small_n_forces_k_equals_two(self) -> None:
+        # 7 invocations — below _SMALL_N_THRESHOLD (10). k forced to 2.
+        # Confirm we don't crash and we produce ≤ 2 clusters.
+        invs = _TEST_INVS[:7]
+        clusters = cluster_delegations(invs, min_cluster_size=3)
+        assert len(clusters) <= 2
+
+    def test_below_min_cluster_size_after_filter_returns_empty(self) -> None:
+        # Mix of general-purpose + non-matching: only 2 general-purpose
+        # candidates pass the filter, below min.
+        invs = [
+            _inv(description="run pytest unit tests with coverage", prompt="x y z"),
+            _inv(description="run pytest unit tests with coverage", prompt="x y z"),
+            _inv(agent_type="architect", description="design", prompt="x y z" * 10),
+        ]
+        assert cluster_delegations(invs, min_cluster_size=5) == []
+
+
+class TestGenerateDraft:
+    def _cluster(
+        self,
+        top_terms: list[str] | None = None,
+        members: list[AgentInvocation] | None = None,
+        cohesion: float = 0.85,
+    ) -> DelegationCluster:
+        # Use `is None` rather than `or` so an explicitly-empty
+        # `top_terms=[]` reaches the cluster (needed to exercise the
+        # fallback-name path in _synthesize_name).
+        return DelegationCluster(
+            members=members if members is not None else [_inv(description="d", prompt="p")] * 10,
+            top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
+            cohesion_score=cohesion,
+        )
+
+    def test_synthesizes_name_from_top_terms(self) -> None:
+        draft = generate_draft(self._cluster(top_terms=["pytest", "runner"]))
+        assert draft.name == "pytest-runner"
+
+    def test_empty_top_terms_fallback_name(self) -> None:
+        draft = generate_draft(self._cluster(top_terms=[]))
+        assert draft.name == "custom-agent"
+
+    def test_read_only_traces_recommend_haiku(self) -> None:
+        members = [
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read", "Grep"])),
+        ] * 5
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.model == MODEL_HAIKU
+        assert draft.tools == ["Grep", "Read"]
+
+    def test_write_heavy_high_tokens_recommend_opus(self) -> None:
+        members = [
+            _inv(
+                description="d", prompt="p",
+                total_tokens=50_000,
+                trace=_trace_with_tools(["Write", "Edit", "Bash"]),
+            ),
+        ] * 5
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.model == MODEL_OPUS
+
+    def test_default_to_sonnet(self) -> None:
+        # Mix of read + write but low tokens.
+        members = [
+            _inv(
+                description="d", prompt="p",
+                total_tokens=5_000,
+                trace=_trace_with_tools(["Read", "Write"]),
+            ),
+        ] * 5
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.model == MODEL_SONNET
+
+    def test_no_traces_emits_tools_note(self) -> None:
+        members = [_inv(description="d", prompt="p", trace=None)] * 5
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.tools == []
+        assert "newer session data" in draft.tools_note
+
+    def test_confidence_high(self) -> None:
+        members = [_inv()] * 12
+        draft = generate_draft(self._cluster(members=members, cohesion=0.85))
+        assert draft.confidence == "high"
+
+    def test_confidence_medium(self) -> None:
+        members = [_inv()] * 6
+        draft = generate_draft(self._cluster(members=members, cohesion=0.65))
+        assert draft.confidence == "medium"
+
+    def test_confidence_low(self) -> None:
+        members = [_inv()] * 5
+        draft = generate_draft(self._cluster(members=members, cohesion=0.4))
+        assert draft.confidence == "low"
+
+
+class TestClassifyHelpers:
+    def test_mean_tokens_empty_list(self) -> None:
+        # Helper exercised indirectly via _classify_model with no token data.
+        members = [_inv(total_tokens=None)] * 3
+        assert _classify_model(["Write"], members) == MODEL_SONNET
+
+    def test_classify_confidence_size_guard(self) -> None:
+        # size < 10 even with high cohesion → medium, not high.
+        assert _classify_confidence(9, 0.95) == "medium"
+
+    def test_collect_tools_dedups_across_traces(self) -> None:
+        members = [
+            _inv(trace=_trace_with_tools(["Read", "Grep"])),
+            _inv(trace=_trace_with_tools(["Grep", "Bash"])),
+        ]
+        assert _collect_tools_from_traces(members) == ["Bash", "Grep", "Read"]
+
+
+class TestDedup:
+    def _draft(self, description: str = "run pytest suite") -> AgentDraft:
+        return AgentDraft(
+            name="test-runner",
+            description=description,
+            model=MODEL_SONNET,
+            tools=[],
+            tools_note="",
+            prompt_template="You run pytest tests and report results.",
+            confidence="medium",
+            cluster_size=5,
+            cohesion_score=0.7,
+            top_terms=["pytest"],
+        )
+
+    def test_similar_existing_agent_marks_dedup_note(self) -> None:
+        draft = self._draft()
+        configs = [_config(
+            name="pytest-runner",
+            description="Runs pytest suite and reports test results",
+        )]
+        result = _apply_dedup([draft], configs, min_similarity=0.3)
+        assert result[0].dedup_note
+        assert "pytest-runner" in result[0].dedup_note
+
+    def test_dissimilar_existing_agent_leaves_dedup_note_empty(self) -> None:
+        draft = self._draft()
+        configs = [_config(
+            name="database-migrator",
+            description="Manages SQL schema migrations for the payments service",
+        )]
+        result = _apply_dedup([draft], configs, min_similarity=0.7)
+        assert result[0].dedup_note == ""
+
+    def test_falls_back_to_prompt_body_when_description_empty(self) -> None:
+        draft = self._draft()
+        # Description empty; prompt_body carries the matching signal —
+        # deliberately overlapping the draft's "run pytest tests and
+        # report results" phrasing.
+        configs = [_config(
+            name="pytest-runner",
+            description="",
+            prompt_body="You run pytest tests and report results from the test suite.",
+        )]
+        result = _apply_dedup([draft], configs, min_similarity=0.3)
+        assert "pytest-runner" in result[0].dedup_note
+
+    def test_empty_existing_configs_passes_through(self) -> None:
+        draft = self._draft()
+        result = _apply_dedup([draft], [], min_similarity=0.7)
+        assert result[0].dedup_note == ""
+
+    def test_all_empty_config_texts_skip_dedup(self) -> None:
+        draft = self._draft()
+        # Both description and prompt_body empty on every config.
+        configs = [_config(name="empty1"), _config(name="empty2")]
+        result = _apply_dedup([draft], configs, min_similarity=0.7)
+        assert result[0].dedup_note == ""
+
+
+class TestSuggestDelegations:
+    def test_end_to_end_produces_suggestions(self) -> None:
+        suggestions = suggest_delegations(_TEST_INVS, min_cluster_size=3)
+        assert len(suggestions) >= 1
+        # Every suggestion carries a name, description, model, confidence.
+        for s in suggestions:
+            assert s.name
+            assert s.description
+            assert s.model in {MODEL_HAIKU, MODEL_SONNET, MODEL_OPUS}
+            assert s.confidence in {"high", "medium", "low"}
+
+    def test_no_general_purpose_returns_empty(self) -> None:
+        invs = [
+            _inv(agent_type="pm", description="d " * 10, prompt="p " * 10)
+            for _ in range(10)
+        ]
+        assert suggest_delegations(invs) == []
+
+
+class TestIdenticalRowsAnomaly:
+    """Byte-identical delegation text across all invocations is unusual
+    for real agent data (parent agents are probabilistic). We detect it
+    upfront, log a WARNING so the anomaly is observable, and emit a
+    single cluster holding all members rather than letting sklearn
+    produce convergence noise."""
+
+    def _identical_invs(self, n: int = 10) -> list[AgentInvocation]:
+        # Identical prompt across all N — simulates an upstream bug
+        # producing duplicate records, not a realistic use case.
+        shared_prompt = (
+            "read the session JSONL file extract tool_use blocks "
+            "parse assistant messages metadata timestamps model content"
+        )
+        return [
+            _inv(description="extract tool_use blocks from session", prompt=shared_prompt)
+            for _ in range(n)
+        ]
+
+    def test_identical_rows_produces_single_cluster(self) -> None:
+        clusters = cluster_delegations(self._identical_invs())
+        assert len(clusters) == 1
+        assert len(clusters[0].members) == 10
+
+    def test_identical_rows_logs_warning(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level("WARNING", logger="agentfluent.diagnostics.delegation"):
+            cluster_delegations(self._identical_invs())
+        assert any(
+            "identical" in rec.message.lower() for rec in caplog.records
+        )
+
+
+class TestSklearnMissing:
+    def test_cluster_delegations_raises_when_sklearn_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(delegation, "_SKLEARN_AVAILABLE", False)
+        with pytest.raises(SklearnMissingError, match="agentfluent\\[clustering\\]"):
+            cluster_delegations(_TEST_INVS)
+
+    def test_suggest_delegations_raises_when_sklearn_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(delegation, "_SKLEARN_AVAILABLE", False)
+        with pytest.raises(SklearnMissingError):
+            suggest_delegations(_TEST_INVS)

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -271,7 +271,7 @@ class TestDelegationSuggestions:
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(
-            "agentfluent.diagnostics.pipeline._SKLEARN_AVAILABLE", False,
+            "agentfluent.diagnostics.pipeline.SKLEARN_AVAILABLE", False,
         )
         # Silent skip — no raise, no suggestions, other output intact.
         result = run_diagnostics(self._GP_INVS)

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -224,3 +224,55 @@ class TestV02Regression:
         assert result.signals == []
         assert result.recommendations == []
         assert result.subagent_trace_count == 0
+
+
+class TestDelegationSuggestions:
+    """Pipeline wiring for the clustering feature. Real clustering
+    behavior is covered in test_delegation.py; this class just confirms
+    the suggestions surface on DiagnosticsResult and that the sklearn-
+    unavailable path is silently skipped (not raised)."""
+
+    # 10 general-purpose delegations representing a single recurring
+    # pattern — reading + summarizing different files. Each has distinct
+    # text (as a real parent agent would generate) but shares the
+    # dominant content words. Combined length clears MIN_TEXT_TOKENS.
+    _GP_INVS = [
+        AgentInvocation(
+            agent_type="general-purpose",
+            is_builtin=True,
+            description=f"read file {target} and summarize",
+            prompt=(
+                f"Read the file {target} from the repository and produce "
+                "a concise summary of the main functions, classes, and "
+                f"dependencies. Focus on the public surface of {target}."
+            ),
+            tool_use_id=f"tool_{i}",
+        )
+        for i, target in enumerate([
+            "auth/tokens.py",
+            "auth/sessions.py",
+            "db/migrations.py",
+            "db/schema.py",
+            "api/handlers.py",
+            "api/routes.py",
+            "core/config.py",
+            "core/logging.py",
+            "utils/strings.py",
+            "utils/paths.py",
+        ])
+    ]
+
+    def test_pipeline_populates_delegation_suggestions(self) -> None:
+        pytest.importorskip("sklearn")
+        result = run_diagnostics(self._GP_INVS)
+        assert len(result.delegation_suggestions) >= 1
+
+    def test_pipeline_empty_suggestions_when_sklearn_missing(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline._SKLEARN_AVAILABLE", False,
+        )
+        # Silent skip — no raise, no suggestions, other output intact.
+        result = run_diagnostics(self._GP_INVS)
+        assert result.delegation_suggestions == []

--- a/uv.lock
+++ b/uv.lock
@@ -13,12 +13,18 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+clustering = [
+    { name = "scikit-learn" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-learn" },
     { name = "types-pyyaml" },
 ]
 
@@ -27,8 +33,10 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14.0" },
+    { name = "scikit-learn", marker = "extra == 'clustering'", specifier = ">=1.4" },
     { name = "typer", specifier = ">=0.15" },
 ]
+provides-extras = ["clustering"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -36,6 +44,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.11" },
+    { name = "scikit-learn", specifier = ">=1.4" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
@@ -172,6 +181,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +320,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]
@@ -545,12 +624,126 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New \`diagnostics/delegation.py\` module: TF-IDF → LSA → KMeans clustering of \`general-purpose\` invocations, draft synthesis (name, description, tools, model tier, prompt scaffold, confidence), and cosine-similarity dedup against existing agent configs.
- scikit-learn added as an **optional extra** (\`agentfluent[clustering]\`) per architect concern. Lean install works without it; clustering is silently skipped when missing, explicit flags fail fast with install hint. Tech-debt #139 tracks stripping this once a second sklearn feature lands.
- New \`DelegationSuggestion\` Pydantic model on \`DiagnosticsResult.delegation_suggestions\`. JSON serialization is free via Pydantic.
- New \"Suggested Subagents\" CLI section: compact table by default, per-suggestion prompt drafts + top-terms block under \`--verbose\`. All JSONL-sourced fields pass through \`rich.markup.escape\` (consistent with #136's security fix).
- Model recommendations use current Claude 4.x aliases: \`claude-haiku-4-5\`, \`claude-sonnet-4-6\`, \`claude-opus-4-7\`.

## Architect concerns addressed

| Concern | Handling |
|---|---|
| scikit-learn size footprint (#1) | Optional extra + \`_SKLEARN_AVAILABLE\` flag + #139 follow-up for eventual simplification |
| K auto-selection edge case (#2) | \`n < 10\` forces k=2; silhouette sweep skipped |
| Tool list derivation fallback (#3) | \`tools_note\` populated when no traces are linked |
| TF-IDF on short text (#4) | \`MIN_TEXT_TOKENS=20\` filter; calibration tracked in #140 |
| Composite with #95 (#5) | Deferred to #113 per D013 |
| AgentInvocation dataclass (#6) | Resolved in E2 |

## Notable implementation calls

- **Identical TF-IDF rows treated as anomaly, not feature.** Agent-generated prompts are probabilistic; identical rows across invocations usually signal upstream bugs (duplicate extraction, parent-agent problem). Detected upfront, logged at WARNING level, single-cluster output.
- **Single silhouette sweep, no redundant final-k refit.** The sweep's best-scoring labels are returned directly instead of re-fitting KMeans with the chosen k outside the loop.
- **Deduped drafts retained with \`dedup_note\`, not removed.** AC said "suppress + emit INFO note" — read as "keep in output with note" rather than silent omission, so users see what was suppressed and why.
- **Dedup falls back to \`AgentConfig.prompt_body\`** when the frontmatter description is empty (common in real configs).
- **Parameter calibration deferred to #140** — thresholds (MIN_TEXT_TOKENS, DEFAULT_MIN_CLUSTER_SIZE, DEFAULT_MIN_SIMILARITY, confidence tier boundaries) are architect/spec guesses; #140 plans empirical validation against real project data.

## Dogfood

Ran against 3 recent \`agentfluent\` sessions. Detected a \`py-tests\` cluster of 8 invocations with correct tool union (Bash, Glob, Grep, Read) and sensible \`claude-opus-4-7\` recommendation (write-heavy tools + high token average).

## Test plan

- [x] 29 new tests in \`tests/unit/test_delegation.py\` (clustering, draft synthesis, dedup, identical-rows anomaly, sklearn-missing)
- [x] 2 new pipeline wiring tests in \`tests/unit/test_diagnostics_pipeline.py\`
- [x] 7 new formatter tests in \`tests/unit/cli/test_deep_diagnostics_formatting.py\` (Suggested Subagents section + markup injection regression)
- [x] Full suite: 534 passed / 36 deselected (was 486, +48)
- [x] \`mypy src/agentfluent/\` strict clean (43 source files)
- [x] \`ruff check src/ tests/\` clean
- [x] Manual CLI verification: default, \`--verbose\`, real project data

## Follow-ups filed

- #139 — strip sklearn-optional plumbing when a second sklearn feature lands
- #140 — empirically validate clustering parameter constants against real session data

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)