### PR TITLE
feat(diagnostics): cross-reference model-mismatch into deduped delegation notes (#113)

### DIFF
--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -475,6 +475,7 @@ def _apply_dedup(
         max_sim = float(sim[i][max_j])
         if max_sim > min_similarity:
             matched_name = existing_configs[max_j].name
+            draft.matched_agent = matched_name
             draft.dedup_note = (
                 f"suppressed — already covered by '{matched_name}' "
                 f"(similarity {max_sim:.2f})"

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -131,6 +131,11 @@ class DelegationSuggestion(BaseModel):
     """Non-empty when the draft overlaps an existing agent config above
     the similarity threshold. Holds the matched agent name + similarity."""
 
+    matched_agent: str = ""
+    """Name of the existing agent that deduped this draft (empty when
+    not deduped). Exposed as a first-class field so cross-reference
+    logic can look up the matched agent without parsing ``dedup_note``."""
+
 
 class DiagnosticsResult(BaseModel):
     """Complete diagnostics output for a session or set of sessions."""

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -60,7 +60,9 @@ def _append_mismatch_phrase(
     Format mirrors `ModelRoutingRule.recommend`'s action text so the
     user sees the same phrasing across the "Suggested Subagents" and
     "Recommendations" surfaces. Omits the savings clause when pricing
-    is unavailable.
+    is unavailable. The original dedup prefix ("suppressed — already
+    covered by ... (similarity ...)") is preserved intact so existing
+    CLI parsing and assertions still hold.
     """
     detail = signal.detail
     matched_name = str(detail.get("current_model", ""))
@@ -77,10 +79,11 @@ def _append_mismatch_phrase(
         clauses.append(
             f"est. savings ${savings:.2f} across {invocation_count} invocations",
         )
-    # Mutate the note in place by appending the new sentence. Keep the
-    # original "suppressed — already covered by ... (similarity ...)"
-    # prefix intact so existing CLI parsing / assertions still hold.
-    return f"{dedup_note}. {'; '.join(clauses)}."
+    # Strip trailing terminal punctuation from the incoming note so the
+    # ". " separator produces a well-formed sentence regardless of the
+    # dedup-note format's current or future shape.
+    prefix = dedup_note.rstrip(" .;")
+    return f"{prefix}. {'; '.join(clauses)}."
 
 
 def _enrich_dedup_with_mismatches(
@@ -95,7 +98,13 @@ def _enrich_dedup_with_mismatches(
     ``dedup_note`` with the mismatch summary so the user sees both
     facts in one place. Non-deduped suggestions and non-mismatch
     signals are ignored.
+
+    Agent names are matched case-insensitively so frontmatter casing
+    (``PM`` in the draft vs ``pm`` in the signal) does not defeat the
+    cross-reference.
     """
+    if not suggestions:
+        return
     mismatches_by_agent: dict[str, DiagnosticSignal] = {
         s.agent_type.lower(): s
         for s in signals

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -52,6 +52,66 @@ TRACE_SIGNAL_TYPES: frozenset[SignalType] = frozenset(
 )
 
 
+def _append_mismatch_phrase(
+    dedup_note: str, signal: DiagnosticSignal,
+) -> str:
+    """Extend a `dedup_note` with the human-readable model-mismatch summary.
+
+    Format mirrors `ModelRoutingRule.recommend`'s action text so the
+    user sees the same phrasing across the "Suggested Subagents" and
+    "Recommendations" surfaces. Omits the savings clause when pricing
+    is unavailable.
+    """
+    detail = signal.detail
+    matched_name = str(detail.get("current_model", ""))
+    recommended = str(detail.get("recommended_model", ""))
+    mismatch_type = str(detail.get("mismatch_type", ""))
+    savings = detail.get("estimated_savings_usd")
+    invocation_count = detail.get("invocation_count", 0)
+
+    clauses = [
+        f"Note: '{signal.agent_type}' is {mismatch_type}'d on {matched_name}",
+        f"consider switching to {recommended}",
+    ]
+    if mismatch_type == "overspec" and isinstance(savings, int | float):
+        clauses.append(
+            f"est. savings ${savings:.2f} across {invocation_count} invocations",
+        )
+    # Mutate the note in place by appending the new sentence. Keep the
+    # original "suppressed — already covered by ... (similarity ...)"
+    # prefix intact so existing CLI parsing / assertions still hold.
+    return f"{dedup_note}. {'; '.join(clauses)}."
+
+
+def _enrich_dedup_with_mismatches(
+    suggestions: list[DelegationSuggestion],
+    signals: list[DiagnosticSignal],
+) -> None:
+    """Append model-mismatch context to deduped suggestions in place.
+
+    When a ``DelegationSuggestion`` was suppressed (``matched_agent``
+    set) because it overlaps an existing agent, and that agent also
+    has a live ``MODEL_MISMATCH`` signal, extend the suggestion's
+    ``dedup_note`` with the mismatch summary so the user sees both
+    facts in one place. Non-deduped suggestions and non-mismatch
+    signals are ignored.
+    """
+    mismatches_by_agent: dict[str, DiagnosticSignal] = {
+        s.agent_type.lower(): s
+        for s in signals
+        if s.signal_type == SignalType.MODEL_MISMATCH
+    }
+    if not mismatches_by_agent:
+        return
+    for sug in suggestions:
+        if not sug.matched_agent:
+            continue
+        mismatch = mismatches_by_agent.get(sug.matched_agent.lower())
+        if mismatch is None:
+            continue
+        sug.dedup_note = _append_mismatch_phrase(sug.dedup_note, mismatch)
+
+
 def _dedup_error_patterns(signals: list[DiagnosticSignal]) -> list[DiagnosticSignal]:
     """Drop metadata ERROR_PATTERN signals for agent_types that already
     have at least one trace-level signal.
@@ -133,6 +193,7 @@ def run_diagnostics(
             min_cluster_size=min_cluster_size,
             min_similarity=min_similarity,
         )
+        _enrich_dedup_with_mismatches(delegation_suggestions, signals)
     else:
         logger.debug(
             "Delegation clustering skipped: scikit-learn not installed. "

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -322,6 +322,19 @@ class TestDedup:
         result = _apply_dedup([draft], configs, min_similarity=0.3)
         assert result[0].dedup_note
         assert "pytest-runner" in result[0].dedup_note
+        # `matched_agent` is populated alongside `dedup_note` so
+        # cross-reference consumers don't have to parse the note string.
+        assert result[0].matched_agent == "pytest-runner"
+
+    def test_non_deduped_suggestion_has_empty_matched_agent(self) -> None:
+        draft = self._draft()
+        configs = [_config(
+            name="database-migrator",
+            description="Manages SQL schema migrations for the payments service",
+        )]
+        result = _apply_dedup([draft], configs, min_similarity=0.7)
+        assert result[0].dedup_note == ""
+        assert result[0].matched_agent == ""
 
     def test_dissimilar_existing_agent_leaves_dedup_note_empty(self) -> None:
         draft = self._draft()

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -428,3 +428,19 @@ class TestCrossReferenceEnrichment:
         signals = [self._mismatch_signal(agent_type="pm")]
         _enrich_dedup_with_mismatches(suggestions, signals)
         assert "claude-haiku-4-5" in suggestions[0].dedup_note
+
+    def test_enrichment_strips_trailing_punctuation_from_dedup_note(self) -> None:
+        # Regression guard: if the dedup_note format ever gains a
+        # trailing period, the appended mismatch phrase should still
+        # produce a well-formed single-sentence output, not "..). Note: ..".
+        suggestions = [
+            self._suggestion(
+                matched_agent="pm",
+                dedup_note="suppressed — already covered by 'pm'.",
+            ),
+        ]
+        signals = [self._mismatch_signal(agent_type="pm")]
+        _enrich_dedup_with_mismatches(suggestions, signals)
+        note = suggestions[0].dedup_note
+        assert ".." not in note  # no double-period from naive concat
+        assert "pm" in note and "claude-haiku-4-5" in note

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -8,9 +8,17 @@ and v0.2 output-shape regression for trace-less sessions.
 import pytest
 
 from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import Severity
 from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
-from agentfluent.diagnostics.models import SignalType
-from agentfluent.diagnostics.pipeline import run_diagnostics
+from agentfluent.diagnostics.models import (
+    DelegationSuggestion,
+    DiagnosticSignal,
+    SignalType,
+)
+from agentfluent.diagnostics.pipeline import (
+    _enrich_dedup_with_mismatches,
+    run_diagnostics,
+)
 from agentfluent.traces.models import (
     RetrySequence,
     SubagentToolCall,
@@ -322,3 +330,101 @@ class TestModelRoutingWiring:
         result = run_diagnostics(invs)
         assert any(s.signal_type == SignalType.MODEL_MISMATCH for s in result.signals)
         assert any(r.target == "model" for r in result.recommendations)
+
+
+class TestCrossReferenceEnrichment:
+    """When a DelegationSuggestion's matched_agent has a live
+    MODEL_MISMATCH signal, its dedup_note is enriched with the
+    mismatch summary so the user sees one consolidated breadcrumb.
+    The standalone MODEL_MISMATCH signal + recommendation are
+    unaffected — they still surface independently in their own
+    section (different user-facing context)."""
+
+    def _mismatch_signal(
+        self,
+        agent_type: str = "pm",
+        mismatch_type: str = "overspec",
+        savings: float | None = 12.50,
+    ) -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.MODEL_MISMATCH,
+            severity=Severity.WARNING,
+            agent_type=agent_type,
+            message=f"{mismatch_type}'d model on {agent_type}",
+            detail={
+                "mismatch_type": mismatch_type,
+                "current_model": "claude-opus-4-7",
+                "recommended_model": "claude-haiku-4-5",
+                "complexity_tier": "simple",
+                "invocation_count": 8,
+                "estimated_savings_usd": savings,
+            },
+        )
+
+    def _suggestion(
+        self,
+        matched_agent: str = "pm",
+        dedup_note: str = "suppressed — already covered by 'pm' (similarity 0.85)",
+    ) -> DelegationSuggestion:
+        return DelegationSuggestion(
+            name="py-tests",
+            description="Handles delegations related to: pytest, tests, run.",
+            model="claude-sonnet-4-6",
+            tools=["Read", "Grep"],
+            prompt_template="You run pytest tests.",
+            confidence="medium",
+            cluster_size=5,
+            cohesion_score=0.7,
+            top_terms=["pytest"],
+            dedup_note=dedup_note,
+            matched_agent=matched_agent,
+        )
+
+    def test_dedup_match_plus_mismatch_enriches_dedup_note(self) -> None:
+        suggestions = [self._suggestion(matched_agent="pm")]
+        signals = [self._mismatch_signal(agent_type="pm")]
+        _enrich_dedup_with_mismatches(suggestions, signals)
+        note = suggestions[0].dedup_note
+        # Original dedup prefix preserved.
+        assert "suppressed" in note
+        assert "pm" in note
+        # Mismatch phrase appended.
+        assert "overspec" in note
+        assert "claude-haiku-4-5" in note
+        assert "12.50" in note  # savings phrase present
+
+    def test_mismatch_without_savings_omits_savings_clause(self) -> None:
+        suggestions = [self._suggestion(matched_agent="pm")]
+        signals = [self._mismatch_signal(agent_type="pm", savings=None)]
+        _enrich_dedup_with_mismatches(suggestions, signals)
+        note = suggestions[0].dedup_note
+        assert "claude-haiku-4-5" in note
+        assert "savings" not in note.lower()
+
+    def test_dedup_match_without_mismatch_leaves_note_unchanged(self) -> None:
+        suggestions = [self._suggestion(matched_agent="pm")]
+        original = suggestions[0].dedup_note
+        # Signal targets a different agent — no cross-reference.
+        signals = [self._mismatch_signal(agent_type="architect")]
+        _enrich_dedup_with_mismatches(suggestions, signals)
+        assert suggestions[0].dedup_note == original
+
+    def test_mismatch_without_matching_dedup_leaves_suggestion_untouched(
+        self,
+    ) -> None:
+        # Suggestion wasn't deduped — matched_agent is "".
+        sug = self._suggestion(matched_agent="", dedup_note="")
+        signals = [self._mismatch_signal(agent_type="pm")]
+        _enrich_dedup_with_mismatches([sug], signals)
+        assert sug.dedup_note == ""
+
+    def test_empty_inputs_are_safe(self) -> None:
+        _enrich_dedup_with_mismatches([], [])
+        _enrich_dedup_with_mismatches([self._suggestion()], [])
+        _enrich_dedup_with_mismatches([], [self._mismatch_signal()])
+
+    def test_case_insensitive_agent_matching(self) -> None:
+        suggestions = [self._suggestion(matched_agent="PM")]
+        signals = [self._mismatch_signal(agent_type="pm")]
+        _enrich_dedup_with_mismatches(suggestions, signals)
+        assert "claude-haiku-4-5" in suggestions[0].dedup_note


### PR DESCRIPTION
## Summary

Option B per the design discussion: when a \`DelegationSuggestion\` is suppressed (matched to an existing agent via dedup) AND that matched agent also has a live \`MODEL_MISMATCH\` signal, enrich the suggestion's \`dedup_note\` with the mismatch summary so the user sees one consolidated breadcrumb.

## Why not the literal D014 merge?

D014's "composite merge on same cluster" scenario **cannot occur in v0.3**:
- #110 only clusters \`general-purpose\` invocations (proposed *new* agents)
- #111 only fires on agents with an explicit \`AgentConfig.model\` (which \`general-purpose\` never has — it's a built-in with no config file)

The two outputs describe different agents by construction. Shipping the literal AC would have been dead code.

The only realistic cross-reference happens through #110's dedup step. When a draft matches an existing agent AND that agent has a mismatch, the user should see both facts in one place — that's what this PR delivers.

## Implementation

- **\`DelegationSuggestion.matched_agent: str\`** — new field populated alongside \`dedup_note\` by \`_apply_dedup\`. Lets downstream consumers match programmatically without parsing strings.
- **\`_enrich_dedup_with_mismatches(suggestions, signals)\`** — pure helper in \`diagnostics/pipeline.py\`. Case-insensitive agent matching; omits savings clause when pricing is unavailable (same contract as \`ModelRoutingRule\`).
- **Wiring** — \`run_diagnostics\` calls it after both outputs exist.
- **No impact on the standalone MODEL_MISMATCH signal/recommendation** — still surfaces independently in the Recommendations section. Enrichment is additive.

## Revisit after #142

Once #142 expands model-routing coverage (trace-based model inference), MODEL_MISMATCH may be able to fire in ways that genuinely overlap a \`DelegationSuggestion\`'s cluster members. Tracked in **#145**.

## Test plan

- [x] 6 new pipeline tests in \`tests/unit/test_diagnostics_pipeline.py::TestCrossReferenceEnrichment\` (enrich happy path, no-savings path, non-matching agent, non-deduped suggestion, empty inputs, case-insensitive)
- [x] 2 updated delegation tests asserting \`matched_agent\` field is populated / empty appropriately
- [x] Full suite: 575 passed / 36 deselected (was 568, +7)
- [x] \`mypy src/agentfluent/\` strict clean
- [x] \`ruff check src/ tests/\` clean
- [x] Dogfood on real sessions: no enrichment visible (requires simultaneous dedup match + mismatch on same agent — rare in real data; unit tests carry the weight)

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)