### PR TITLE
chore(ci): bump release-please-action to v5 (Node 24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

\`googleapis/release-please-action@v5.0.0\` shipped 2026-04-22 with Node 24 as the sole breaking change. Bumping \`@v4\` → \`@v5\` in \`.github/workflows/release-please.yml\` removes the Node 20 deprecation annotation we saw on the v0.2.0 release run and lands before the forced Node 24 default on 2026-06-02.

## Validation

- Other workflow actions (\`actions/checkout@v6\`, \`astral-sh/setup-uv@v7\`, \`pypa/gh-action-pypi-publish@release/v1\`) are already Node 24 compatible — no other changes needed.
- The release-please-action v5 release notes list exactly one breaking change: the Node upgrade. No config or input changes required.
- The next release PR run will confirm the annotation is gone.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)