### PR TITLE
chore(agents): convert AgentInvocation.is_builtin to computed property

### DIFF
--- a/src/agentfluent/agents/extractor.py
+++ b/src/agentfluent/agents/extractor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agentfluent.agents.models import AgentInvocation, is_builtin_agent
+from agentfluent.agents.models import AgentInvocation
 from agentfluent.core.session import SessionMessage
 
 
@@ -49,7 +49,6 @@ def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvoc
             invocations.append(
                 AgentInvocation(
                     agent_type=agent_type,
-                    is_builtin=is_builtin_agent(agent_type),
                     description=description,
                     prompt=prompt,
                     tool_use_id=tool_use.id,

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -51,19 +51,16 @@ class AgentInvocation(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     agent_type: str
-    """Agent type (e.g., 'pm', 'Explore', 'Plan')."""
-
-    is_builtin: bool
-    """Whether this is a built-in Claude Code agent."""
+    """Agent type (e.g., 'pm', 'explore', 'plan'). Case varies in real
+    data; ``is_builtin_agent`` normalizes for comparison."""
 
     description: str
-    """The description passed to the Agent tool."""
-
     prompt: str
-    """The delegation prompt sent to the agent."""
 
     tool_use_id: str
-    """The tool_use ID linking this invocation to its tool_result."""
+    """Links this invocation back to the assistant message's ``tool_use``
+    block so downstream code can join the delegation call with its
+    result. Required; always populated by the extractor."""
 
     # From tool_result metadata (may be None if no metadata or agent was interrupted)
     total_tokens: int | None = None
@@ -73,12 +70,18 @@ class AgentInvocation(BaseModel):
 
     # From tool_result content
     output_text: str = ""
-    """The agent's final summary/output text."""
 
     # Attached by trace linking when a matching subagent file exists; `None`
     # otherwise (e.g., older sessions predating trace capture). Serves as the
     # evidence layer for trace-level diagnostics.
     trace: SubagentTrace | None = None
+
+    @property
+    def is_builtin(self) -> bool:
+        """Whether this invocation's agent type is a built-in Claude Code
+        agent. Derived on access from ``agent_type`` + ``BUILTIN_AGENT_TYPES``
+        so the answer stays in sync if the set is updated."""
+        return is_builtin_agent(self.agent_type)
 
     @property
     def tokens_per_tool_use(self) -> float | None:

--- a/tests/unit/test_agent_metrics.py
+++ b/tests/unit/test_agent_metrics.py
@@ -6,14 +6,12 @@ from agentfluent.analytics.agent_metrics import compute_agent_metrics
 
 def _invocation(
     agent_type: str = "pm",
-    is_builtin: bool = False,
     total_tokens: int | None = 10000,
     tool_uses: int | None = 5,
     duration_ms: int | None = 30000,
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=is_builtin,
         description="test",
         prompt="do something",
         tool_use_id="toolu_01",
@@ -50,8 +48,8 @@ class TestComputeAgentMetrics:
 
     def test_multiple_types(self) -> None:
         invocations = [
-            _invocation(agent_type="pm", is_builtin=False),
-            _invocation(agent_type="Explore", is_builtin=True),
+            _invocation(agent_type="pm"),
+            _invocation(agent_type="Explore"),
         ]
         metrics = compute_agent_metrics(invocations)
         assert len(metrics.by_agent_type) == 2
@@ -145,8 +143,8 @@ class TestAgentTokenPercentage:
 class TestBuiltinVsCustom:
     def test_all_builtin(self) -> None:
         invocations = [
-            _invocation(agent_type="Explore", is_builtin=True),
-            _invocation(agent_type="Plan", is_builtin=True),
+            _invocation(agent_type="Explore"),
+            _invocation(agent_type="Plan"),
         ]
         metrics = compute_agent_metrics(invocations)
         assert metrics.builtin_invocations == 2
@@ -154,8 +152,8 @@ class TestBuiltinVsCustom:
 
     def test_all_custom(self) -> None:
         invocations = [
-            _invocation(agent_type="pm", is_builtin=False),
-            _invocation(agent_type="reviewer", is_builtin=False),
+            _invocation(agent_type="pm"),
+            _invocation(agent_type="reviewer"),
         ]
         metrics = compute_agent_metrics(invocations)
         assert metrics.builtin_invocations == 0
@@ -163,8 +161,8 @@ class TestBuiltinVsCustom:
 
     def test_case_insensitive_grouping(self) -> None:
         invocations = [
-            _invocation(agent_type="Explore", is_builtin=True),
-            _invocation(agent_type="explore", is_builtin=True),
+            _invocation(agent_type="Explore"),
+            _invocation(agent_type="explore"),
         ]
         metrics = compute_agent_metrics(invocations)
         assert len(metrics.by_agent_type) == 1

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -27,7 +27,6 @@ class TestIsBuiltinAgent:
 def _full_invocation() -> AgentInvocation:
     return AgentInvocation(
         agent_type="pm",
-        is_builtin=False,
         description="Review backlog",
         prompt="Create issues",
         tool_use_id="toolu_01ABC",
@@ -48,7 +47,6 @@ class TestAgentInvocation:
     def test_without_metadata(self) -> None:
         inv = AgentInvocation(
             agent_type="pm",
-            is_builtin=False,
             description="Review backlog",
             prompt="Create issues",
             tool_use_id="toolu_01ABC",
@@ -61,7 +59,6 @@ class TestAgentInvocation:
     def test_zero_tool_uses(self) -> None:
         inv = AgentInvocation(
             agent_type="pm",
-            is_builtin=False,
             description="test",
             prompt="test",
             tool_use_id="toolu_01",
@@ -72,15 +69,18 @@ class TestAgentInvocation:
         assert inv.tokens_per_tool_use is None
         assert inv.duration_per_tool_use is None
 
-    def test_builtin_classification(self) -> None:
-        inv = AgentInvocation(
-            agent_type="Explore",
-            is_builtin=True,
-            description="Search code",
-            prompt="Find files",
-            tool_use_id="toolu_01",
+    def test_builtin_classification_derived_from_agent_type(self) -> None:
+        # Property is computed from agent_type via is_builtin_agent,
+        # so callers can't pass a stale value — the set is the source
+        # of truth.
+        explore = AgentInvocation(
+            agent_type="Explore", description="d", prompt="p", tool_use_id="t1",
         )
-        assert inv.is_builtin is True
+        custom = AgentInvocation(
+            agent_type="pm", description="d", prompt="p", tool_use_id="t2",
+        )
+        assert explore.is_builtin is True
+        assert custom.is_builtin is False
 
     def test_json_round_trip(self) -> None:
         inv = _full_invocation()

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -44,7 +44,6 @@ def _inv(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=agent_type.lower() == "general-purpose",
         description=description,
         prompt=prompt,
         tool_use_id="toolu_" + description[:10],

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -17,7 +17,6 @@ def _inv(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=False,
         description="test",
         prompt="do something",
         tool_use_id="toolu_01",

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -33,7 +33,6 @@ def _inv(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=False,
         description="test",
         prompt="do something",
         tool_use_id="toolu_01",
@@ -110,17 +109,17 @@ class TestDedup:
         # threshold; one of them also carries a trace. TOKEN_OUTLIER must
         # survive the dedup pass.
         inv_a = AgentInvocation(
-            agent_type="pm", is_builtin=False, description="a", prompt="a",
+            agent_type="pm", description="a", prompt="a",
             tool_use_id="t1", output_text="",
             total_tokens=100, tool_uses=1, trace=_stuck_trace(agent_type="pm"),
         )
         inv_b = AgentInvocation(
-            agent_type="pm", is_builtin=False, description="b", prompt="b",
+            agent_type="pm", description="b", prompt="b",
             tool_use_id="t2", output_text="",
             total_tokens=100, tool_uses=1,
         )
         inv_c = AgentInvocation(
-            agent_type="pm", is_builtin=False, description="c", prompt="c",
+            agent_type="pm", description="c", prompt="c",
             tool_use_id="t3", output_text="",
             total_tokens=10_000, tool_uses=1,
         )
@@ -247,7 +246,6 @@ class TestDelegationSuggestions:
     _GP_INVS = [
         AgentInvocation(
             agent_type="general-purpose",
-            is_builtin=True,
             description=f"read file {target} and summarize",
             prompt=(
                 f"Read the file {target} from the repository and produce "
@@ -318,7 +316,6 @@ class TestModelRoutingWiring:
         invs = [
             AgentInvocation(
                 agent_type="pm",
-                is_builtin=False,
                 description="task",
                 prompt="do it",
                 tool_use_id=f"t{i}",

--- a/tests/unit/test_model_routing.py
+++ b/tests/unit/test_model_routing.py
@@ -36,7 +36,6 @@ def _inv(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=False,
         description="test",
         prompt="do something",
         tool_use_id=f"tool_{agent_type}",

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -15,7 +15,6 @@ def _inv(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=False,
         description="test",
         prompt="do something",
         tool_use_id="toolu_01",

--- a/tests/unit/test_traces_linker.py
+++ b/tests/unit/test_traces_linker.py
@@ -24,7 +24,6 @@ def _invocation(
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
-        is_builtin=True,
         description="",
         prompt="",
         tool_use_id=tool_use_id,


### PR DESCRIPTION
## Summary

Addresses all three findings from #123 (filed during #122's simplify pass):

1. **\`is_builtin\` → \`@property\`** — was a boolean field populated at construction time via \`is_builtin_agent(agent_type)\`; two sources of truth for the same question. Converting to a computed property removes the stale-state risk if \`BUILTIN_AGENT_TYPES\` is ever updated. The extractor and 8 test files no longer pass the kwarg.
2. **Low-value field docstrings removed** from \`is_builtin\`, \`description\`, \`prompt\`, \`output_text\` (they restated field names). Kept the ones that earn their place (\`agent_type\` example list, \`tool_use_id\` join-key invariant, new \`is_builtin\` derivation note).
3. **Casing aligned in \`agent_type\` docstring** — example list now lowercase (\`'pm', 'explore', 'plan'\`), matching \`BUILTIN_AGENT_TYPES\`.

## Behavior impact

None. \`AgentInvocation.is_builtin\` returns the same value for every existing use; \`extra="ignore"\` on the model meant even the stale kwarg path would have been silently swallowed. The property removes the sharp edge.

## Test plan

- [x] One new test replaces \`test_builtin_classification\` with \`test_builtin_classification_derived_from_agent_type\` — asserts the property derives correctly for both a builtin (\`Explore\`) and a custom (\`pm\`) type, locking the no-stale-state invariant.
- [x] 576 unit tests pass (unchanged count).
- [x] \`mypy src/agentfluent/\` strict clean.
- [x] \`ruff check src/ tests/\` clean.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)