### PR TITLE
chore(tests): consolidate JSONL builders into shared tests/_builders.py

### DIFF
--- a/tests/_builders.py
+++ b/tests/_builders.py
@@ -1,0 +1,173 @@
+"""Shared JSONL builders for tests.
+
+Underscore-prefixed so pytest doesn't auto-collect it. Test files import
+these helpers instead of redeclaring their own factories for the same
+JSONL shapes (user messages, assistant messages, content blocks,
+project layouts with subagent traces).
+
+Design: low-level block and message factories compose into higher-level
+shortcuts (``assistant_with_tool_use``, ``user_with_tool_result``,
+``write_project_layout``). Keep each helper independently testable and
+small — prefer composition over parameter bloat.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Low-level content-block factories.
+# ---------------------------------------------------------------------------
+
+
+def tool_use_block(
+    tool_use_id: str,
+    name: str = "Bash",
+    inp: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a ``tool_use`` content-block dict."""
+    return {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp or {}}
+
+
+def tool_result_block(
+    tool_use_id: str,
+    content: str = "ok",
+    *,
+    is_error: bool | None = None,
+) -> dict[str, Any]:
+    """Build a ``tool_result`` content-block dict."""
+    block: dict[str, Any] = {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": content,
+    }
+    if is_error is not None:
+        block["is_error"] = is_error
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Message-level factories.
+# ---------------------------------------------------------------------------
+
+
+def user_message(
+    content: Any,  # noqa: ANN401 — JSONL content is legitimately Any
+    timestamp: str | None = "2026-04-21T10:00:00.000Z",
+    *,
+    tool_use_result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a complete ``user`` message dict.
+
+    ``tool_use_result`` is the camelCase ``toolUseResult`` sibling used
+    when the user message is carrying an Agent-tool result — the linker
+    reads metadata (agentId, agentType, totalTokens, ...) from this
+    field. Omit for plain user text messages.
+    """
+    msg: dict[str, Any] = {
+        "type": "user",
+        "message": {"role": "user", "content": content},
+    }
+    if timestamp is not None:
+        msg["timestamp"] = timestamp
+    if tool_use_result is not None:
+        msg["toolUseResult"] = tool_use_result
+    return msg
+
+
+def assistant_message(
+    content: list[dict[str, Any]],
+    *,
+    message_id: str = "msg_01",
+    timestamp: str | None = "2026-04-21T10:00:01.000Z",
+    usage: dict[str, int] | None = None,
+    model: str = "claude-opus-4-6",
+) -> dict[str, Any]:
+    """Build a complete ``assistant`` message dict."""
+    msg: dict[str, Any] = {
+        "type": "assistant",
+        "message": {
+            "id": message_id,
+            "role": "assistant",
+            "model": model,
+            "content": content,
+        },
+    }
+    if timestamp is not None:
+        msg["timestamp"] = timestamp
+    if usage is not None:
+        msg["message"]["usage"] = usage
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Sequence shortcuts — assistant emits tool_use, user returns tool_result.
+# ---------------------------------------------------------------------------
+
+
+def assistant_with_tool_use(
+    tool_use_id: str,
+    name: str = "Bash",
+    inp: dict[str, Any] | None = None,
+    *,
+    message_id: str = "msg_01",
+    timestamp: str | None = "2026-04-21T10:00:01.000Z",
+    usage: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Assistant message wrapping a single ``tool_use`` content block."""
+    return assistant_message(
+        [tool_use_block(tool_use_id, name, inp)],
+        message_id=message_id, timestamp=timestamp, usage=usage,
+    )
+
+
+def user_with_tool_result(
+    tool_use_id: str,
+    content: str = "ok",
+    *,
+    is_error: bool | None = None,
+    timestamp: str | None = "2026-04-21T10:00:01.500Z",
+    tool_use_result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """User message wrapping a single ``tool_result`` content block."""
+    return user_message(
+        [tool_result_block(tool_use_id, content, is_error=is_error)],
+        timestamp=timestamp,
+        tool_use_result=tool_use_result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Project-layout helper for linker tests.
+# ---------------------------------------------------------------------------
+
+
+def write_project_layout(
+    tmp_path: Path,
+    session_uuid: str,
+    session_messages: list[dict[str, Any]],
+    *,
+    subagent_traces: dict[str, list[dict[str, Any]]] | None = None,
+) -> Path:
+    """Write a session JSONL plus optional subagent trace files under ``tmp_path``.
+
+    ``subagent_traces`` maps ``agent_id`` → list of message dicts; each
+    entry becomes ``<tmp_path>/<session_uuid>/subagents/agent-<agent_id>.jsonl``.
+    Returns ``tmp_path`` itself so the caller can root ``discover_*`` calls
+    at the same directory.
+    """
+    session_path = tmp_path / f"{session_uuid}.jsonl"
+    session_path.write_text(
+        "\n".join(json.dumps(m) for m in session_messages) + "\n",
+    )
+
+    if subagent_traces:
+        subagents_dir = tmp_path / session_uuid / "subagents"
+        subagents_dir.mkdir(parents=True, exist_ok=True)
+        for agent_id, messages in subagent_traces.items():
+            (subagents_dir / f"agent-{agent_id}.jsonl").write_text(
+                "\n".join(json.dumps(m) for m in messages) + "\n",
+            )
+    return tmp_path

--- a/tests/unit/test_traces_linker.py
+++ b/tests/unit/test_traces_linker.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -12,6 +11,13 @@ from agentfluent.analytics.pipeline import analyze_session
 from agentfluent.traces.linker import link_traces
 from agentfluent.traces.models import UNKNOWN_AGENT_TYPE, SubagentTrace
 from agentfluent.traces.parser import parse_subagent_trace
+from tests._builders import (
+    assistant_message,
+    assistant_with_tool_use,
+    user_message,
+    user_with_tool_result,
+    write_project_layout,
+)
 
 WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
 
@@ -178,86 +184,56 @@ def _build_project(
     *,
     include_trace_file: bool,
 ) -> Path:
-    """Create a minimal project layout with optional subagent trace."""
-    session_path = tmp_path / f"{session_uuid}.jsonl"
-    session_path.write_text(
-        json.dumps(
-            {
-                "type": "assistant",
-                "message": {
-                    "id": "msg_1",
-                    "role": "assistant",
-                    "model": "claude-opus-4-6",
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "id": "toolu_1",
-                            "name": "Agent",
-                            "input": {
-                                "subagent_type": "plan",
-                                "description": "Plan work",
-                                "prompt": "Plan the work",
-                            },
-                        },
-                    ],
-                },
-                "timestamp": "2026-04-21T10:00:00.000Z",
-            },
-        )
-        + "\n"
-        + json.dumps(
-            {
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": "toolu_1",
-                            "content": "plan complete",
-                        },
-                    ],
-                },
-                "toolUseResult": {
-                    "agentId": agent_id,
-                    "agentType": "plan",
-                    "totalTokens": 100,
-                },
-                "timestamp": "2026-04-21T10:00:01.000Z",
-            },
-        )
-        + "\n",
-    )
+    """Create a minimal project layout with optional subagent trace.
 
+    Returns the session JSONL path so callers can hand it directly to
+    ``analyze_session``.
+    """
+    session_messages = [
+        assistant_with_tool_use(
+            "toolu_1",
+            name="Agent",
+            inp={
+                "subagent_type": "plan",
+                "description": "Plan work",
+                "prompt": "Plan the work",
+            },
+            message_id="msg_1",
+            timestamp="2026-04-21T10:00:00.000Z",
+        ),
+        user_with_tool_result(
+            "toolu_1",
+            content="plan complete",
+            timestamp="2026-04-21T10:00:01.000Z",
+            tool_use_result={
+                "agentId": agent_id,
+                "agentType": "plan",
+                "totalTokens": 100,
+            },
+        ),
+    ]
+
+    subagent_traces: dict[str, list[dict[str, Any]]] | None = None
     if include_trace_file:
-        subagents_dir = tmp_path / session_uuid / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / f"agent-{agent_id}.jsonl").write_text(
-            json.dumps(
-                {
-                    "type": "user",
-                    "message": {"role": "user", "content": "Plan the work"},
-                    "timestamp": "2026-04-21T10:00:00.100Z",
-                },
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "type": "assistant",
-                    "message": {
-                        "id": "msg_inner",
-                        "role": "assistant",
-                        "model": "claude-opus-4-6",
-                        "content": [{"type": "text", "text": "done"}],
-                        "usage": {"input_tokens": 5, "output_tokens": 2},
-                    },
-                    "timestamp": "2026-04-21T10:00:00.500Z",
-                },
-            )
-            + "\n",
-        )
+        subagent_traces = {
+            agent_id: [
+                user_message(
+                    "Plan the work", timestamp="2026-04-21T10:00:00.100Z",
+                ),
+                assistant_message(
+                    [{"type": "text", "text": "done"}],
+                    message_id="msg_inner",
+                    timestamp="2026-04-21T10:00:00.500Z",
+                    usage={"input_tokens": 5, "output_tokens": 2},
+                ),
+            ],
+        }
 
-    return session_path
+    write_project_layout(
+        tmp_path, session_uuid, session_messages,
+        subagent_traces=subagent_traces,
+    )
+    return tmp_path / f"{session_uuid}.jsonl"
 
 
 class TestPipelineIntegration:

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -16,66 +16,20 @@ from agentfluent.traces.models import (
     SubagentTrace,
 )
 from agentfluent.traces.parser import parse_subagent_trace
+from tests._builders import (
+    assistant_message as _assistant,
+)
+from tests._builders import (
+    tool_result_block as _tool_result,
+)
+from tests._builders import (
+    tool_use_block as _tool_use,
+)
+from tests._builders import (
+    user_message as _user,
+)
 
 WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
-
-
-def _user(
-    content: Any,  # noqa: ANN401
-    timestamp: str | None = "2026-04-21T10:00:00.000Z",
-) -> dict[str, Any]:
-    msg: dict[str, Any] = {
-        "type": "user",
-        "message": {"role": "user", "content": content},
-    }
-    if timestamp is not None:
-        msg["timestamp"] = timestamp
-    return msg
-
-
-def _assistant(
-    content: list[dict[str, Any]],
-    *,
-    message_id: str = "msg_01",
-    timestamp: str | None = "2026-04-21T10:00:01.000Z",
-    usage: dict[str, int] | None = None,
-) -> dict[str, Any]:
-    msg: dict[str, Any] = {
-        "type": "assistant",
-        "message": {
-            "id": message_id,
-            "role": "assistant",
-            "model": "claude-opus-4-6",
-            "content": content,
-        },
-    }
-    if timestamp is not None:
-        msg["timestamp"] = timestamp
-    if usage is not None:
-        msg["message"]["usage"] = usage
-    return msg
-
-
-def _tool_use(
-    tool_use_id: str, name: str = "Bash", inp: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    return {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp or {}}
-
-
-def _tool_result(
-    tool_use_id: str,
-    content: str = "ok",
-    *,
-    is_error: bool | None = None,
-) -> dict[str, Any]:
-    block: dict[str, Any] = {
-        "type": "tool_result",
-        "tool_use_id": tool_use_id,
-        "content": content,
-    }
-    if is_error is not None:
-        block["is_error"] = is_error
-    return block
 
 
 class TestParseSubagentTrace:

--- a/tests/unit/test_traces_retry.py
+++ b/tests/unit/test_traces_retry.py
@@ -14,6 +14,11 @@ from agentfluent.traces.retry import (
     _is_similar_retry,
     detect_retry_sequences,
 )
+from tests._builders import (
+    assistant_with_tool_use,
+    user_message,
+    user_with_tool_result,
+)
 
 WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
 
@@ -231,43 +236,21 @@ class TestParserIntegration:
         Each `tool_calls` tuple is (tool_use_id, tool_name, input, is_error, result).
         """
         lines: list[dict[str, Any]] = [
-            {
-                "type": "user",
-                "message": {"role": "user", "content": "go"},
-                "timestamp": "2026-04-21T10:00:00.000Z",
-            },
+            user_message("go", timestamp="2026-04-21T10:00:00.000Z"),
         ]
         for i, (tool_use_id, name, inp, is_err, result) in enumerate(tool_calls):
             lines.append(
-                {
-                    "type": "assistant",
-                    "message": {
-                        "id": f"msg_{i}",
-                        "role": "assistant",
-                        "model": "claude-opus-4-6",
-                        "content": [
-                            {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp},
-                        ],
-                    },
-                    "timestamp": f"2026-04-21T10:00:{i + 1:02d}.000Z",
-                },
+                assistant_with_tool_use(
+                    tool_use_id, name, inp,
+                    message_id=f"msg_{i}",
+                    timestamp=f"2026-04-21T10:00:{i + 1:02d}.000Z",
+                ),
             )
             lines.append(
-                {
-                    "type": "user",
-                    "message": {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": tool_use_id,
-                                "content": result,
-                                "is_error": is_err,
-                            },
-                        ],
-                    },
-                    "timestamp": f"2026-04-21T10:00:{i + 1:02d}.500Z",
-                },
+                user_with_tool_result(
+                    tool_use_id, result, is_error=is_err,
+                    timestamp=f"2026-04-21T10:00:{i + 1:02d}.500Z",
+                ),
             )
         return write_jsonl("agent-integration.jsonl", lines)
 


### PR DESCRIPTION
## Summary

Resolves #133 — three test files previously redeclared near-identical JSONL factories or built them ad-hoc inline; each round of /simplify during E2 deferred consolidation because each local diff was defensible in isolation. The debt has compounded enough to pay down.

## New \`tests/_builders.py\`

Underscore-prefixed (pytest won't auto-collect). Three layers:

- **Low-level content-block factories**: \`tool_use_block\`, \`tool_result_block\`
- **Message factories**: \`user_message\` (with optional \`tool_use_result\` sibling for Agent tool-result messages), \`assistant_message\`
- **Sequence shortcuts**: \`assistant_with_tool_use\`, \`user_with_tool_result\` — cover the common "assistant emits tool_use, user returns tool_result" pair
- **Project-layout helper**: \`write_project_layout(tmp_path, uuid, msgs, subagent_traces=...)\` — collapses the linker test's ~90-line inline mini-project construction

## Stacks on #148

This PR branches off \`chore/123-agent-invocation-cleanup\` (PR #148) because both touch \`test_traces_linker.py\`. Merge #148 first, then rebase this if needed — the diff is clean either way.

## Callers updated

| File | Change |
|---|---|
| \`test_traces_parser.py\` | Local \`_user\` / \`_assistant\` / \`_tool_use\` / \`_tool_result\` replaced with shared factories via alias imports (in-file body stays identical). |
| \`test_traces_retry.py\` | \`_write_trace_with_calls\` now composes shared shortcuts instead of hand-rolling dicts. |
| \`test_traces_linker.py\` | \`_build_project\` now uses \`write_project_layout\` with typed message lists instead of hand-concatenating JSON strings. |

## Test plan

- [x] No behavior change. 576 unit tests pass unchanged.
- [x] \`mypy src/agentfluent/\` strict clean.
- [x] \`ruff check src/ tests/\` clean.
- [x] Net change: +253 lines / -167 lines (+86 LOC; the new builders module is the bulk, but inline logic in test files is substantially shorter).

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)