### PR TITLE
test(cli): add CI-level smoke tests for trace-based diagnostics output

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -10,6 +11,11 @@ import typer
 from typer.testing import CliRunner
 
 from agentfluent.cli.main import app
+from tests._builders import (
+    assistant_with_tool_use,
+    user_with_tool_result,
+    write_project_layout,
+)
 
 
 @pytest.fixture()
@@ -63,5 +69,95 @@ def populated_home(isolated_home: Path, fixtures_dir: Path) -> Path:
 
     agent_file = isolated_home / "agents" / "well-configured.md"
     shutil.copy(fixtures_dir / "agents" / "well_configured.md", agent_file)
+
+    return isolated_home
+
+
+def _load_jsonl(path: Path) -> list[dict[str, object]]:
+    """Load a JSONL file as a list of dict records, skipping blanks."""
+    return [
+        json.loads(line) for line in path.read_text().splitlines() if line.strip()
+    ]
+
+
+@pytest.fixture()
+def populated_home_with_traces(
+    isolated_home: Path, fixtures_dir: Path,
+) -> Path:
+    """Isolated home with a session that carries linked subagent traces
+    exhibiting errors and retries.
+
+    Built programmatically via ``tests._builders.write_project_layout``
+    so the session-to-trace agentId links are explicit. The trace
+    content is loaded from the checked-in retry/stuck fixtures under
+    ``tests/fixtures/subagents/`` — those already exhibit the error
+    and retry shapes we need to exercise the full diagnostic pipeline.
+    """
+    project_dir = isolated_home / "projects" / "-home-user-test-project"
+    project_dir.mkdir()
+
+    # Two Agent invocations: pm (with a retry-pattern trace) and
+    # Explore (with a stuck-pattern trace). agentIds deliberately
+    # avoid an "agent-" prefix so the on-disk filenames stay clean.
+    session_messages = [
+        assistant_with_tool_use(
+            "toolu_pm1",
+            name="Agent",
+            inp={
+                "subagent_type": "pm",
+                "description": "Review backlog",
+                "prompt": "Review the backlog and create issues.",
+            },
+            message_id="msg_01pm",
+            timestamp="2026-04-21T10:00:00.000Z",
+        ),
+        user_with_tool_result(
+            "toolu_pm1",
+            content="Reviewed backlog.",
+            timestamp="2026-04-21T10:02:00.000Z",
+            tool_use_result={
+                "agentId": "pm-run-1",
+                "agentType": "pm",
+                "totalDurationMs": 120000,
+                "totalTokens": 30000,
+                "totalToolUseCount": 10,
+            },
+        ),
+        assistant_with_tool_use(
+            "toolu_ex1",
+            name="Agent",
+            inp={
+                "subagent_type": "Explore",
+                "description": "Map package structure",
+                "prompt": "Find all Python files and summarize.",
+            },
+            message_id="msg_02ex",
+            timestamp="2026-04-21T10:03:00.000Z",
+        ),
+        user_with_tool_result(
+            "toolu_ex1",
+            content="Mapped package structure.",
+            timestamp="2026-04-21T10:05:00.000Z",
+            tool_use_result={
+                "agentId": "explore-run-1",
+                "agentType": "Explore",
+                "totalDurationMs": 90000,
+                "totalTokens": 15000,
+                "totalToolUseCount": 5,
+            },
+        ),
+    ]
+
+    subagent_traces = {
+        "pm-run-1": _load_jsonl(fixtures_dir / "subagents" / "agent-retry.jsonl"),
+        "explore-run-1": _load_jsonl(
+            fixtures_dir / "subagents" / "agent-stuck.jsonl",
+        ),
+    }
+
+    write_project_layout(
+        project_dir, "session-1", session_messages,
+        subagent_traces=subagent_traces,
+    )
 
     return isolated_home

--- a/tests/unit/cli/test_diagnostics_smoke.py
+++ b/tests/unit/cli/test_diagnostics_smoke.py
@@ -1,0 +1,110 @@
+"""CLI smoke tests for trace-based diagnostics output.
+
+Complements the unit-level coverage in ``test_diagnostics_pipeline.py``
+by exercising the full CLI → ``run_diagnostics`` → formatter chain
+against a fixture project that carries linked subagent traces.
+Runs in CI (not skipped), no dependency on real ``~/.claude/projects/``
+data.
+
+See issue #138 for why this lives alongside #109's unit-level
+integration tests instead of replacing them: unit tests guard the
+function-level contracts, smoke tests guard the end-to-end rendering
+pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestDiagnosticsCLISmoke:
+    """Runs `agentfluent analyze --project project --diagnostics` against
+    a project with linked subagent traces. The fixture session has two
+    Agent invocations (pm + Explore) whose agentIds link to subagent
+    trace files exhibiting retry and stuck-pattern behavior."""
+
+    def test_exits_zero_and_shows_signal_table(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--diagnostics"],
+        )
+        assert result.exit_code == 0
+        # The Diagnostic Signals table always renders above the deep-
+        # diagnostics summary when any signal exists.
+        assert "Diagnostic Signals" in result.stdout
+
+    def test_trace_signals_surface_on_diagnostics_flag(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--diagnostics"],
+        )
+        assert result.exit_code == 0
+        # Either retry_loop (from agent-retry.jsonl) or stuck_pattern
+        # (from agent-stuck.jsonl) should appear. Check both types of
+        # evidence leaked through.
+        assert "retry_loop" in result.stdout or "stuck_pattern" in result.stdout
+
+    def test_verbose_renders_deep_diagnostics_section(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--diagnostics", "--verbose"],
+        )
+        assert result.exit_code == 0
+        assert "Deep Diagnostics" in result.stdout
+
+    def test_json_output_includes_trace_signal_detail(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze",
+                "--project", "project",
+                "--diagnostics",
+                "--format", "json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        signals = payload["data"]["diagnostics"]["signals"]
+        trace_types = {"retry_loop", "stuck_pattern", "tool_error_sequence",
+                       "permission_failure"}
+        trace_signals = [s for s in signals if s["signal_type"] in trace_types]
+        assert trace_signals, "expected at least one trace-level signal"
+        # Evidence is the contract #108 promised and #113 depends on.
+        assert "tool_calls" in trace_signals[0]["detail"]
+
+    def test_traceless_project_still_works(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+    ) -> None:
+        """Regression guard: a project without subagent traces (the
+        pre-#108 shape) must not crash the diagnostics path."""
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--diagnostics"],
+        )
+        assert result.exit_code == 0
+        # No trace signals, so no Deep Diagnostics section.
+        assert "Deep Diagnostics" not in result.stdout


### PR DESCRIPTION
## Summary

Closes #138 by adding CI-level smoke tests that exercise the full \`agentfluent analyze --project X --diagnostics\` chain end-to-end against fixture data. Complements (doesn't replace) the unit-level \`run_diagnostics\` coverage from #109.

## Stacks on #149

Depends on the shared builders added in #133 (\`assistant_with_tool_use\`, \`user_with_tool_result\`, \`write_project_layout\`). Merge #149 first, then rebase this if needed.

## New fixture: \`populated_home_with_traces\`

Added in \`tests/unit/cli/conftest.py\` alongside the existing \`populated_home\`. Builds a two-invocation session (pm + Explore) programmatically via the shared builders. Each invocation's \`agentId\` links to a subagent trace file whose content is loaded from the checked-in retry/stuck fixtures under \`tests/fixtures/subagents/\` — those already exhibit the error and retry shapes the diagnostic pipeline detects.

## New smoke tests

Five tests in \`tests/unit/cli/test_diagnostics_smoke.py\`:

- Exit zero + Diagnostic Signals table renders with \`--diagnostics\`
- Trace-level signal types (\`retry_loop\` / \`stuck_pattern\`) surface through the pipeline
- \`--verbose\` renders the "Deep Diagnostics" section
- \`--format json\` includes \`detail.tool_calls\` on trace signals (the contract #108 promised and #113 depends on)
- Regression guard: a traceless project (pre-#108 shape) still completes diagnostics without crashing, no Deep Diagnostics section

## Test plan

- [x] 5 new smoke tests in \`tests/unit/cli/test_diagnostics_smoke.py\`
- [x] Full suite: 581 passed / 36 deselected (was 576, +5)
- [x] \`mypy src/agentfluent/\` strict clean
- [x] \`ruff check src/ tests/\` clean

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)