### PR TITLE
feat(diagnostics): extract MCP tool usage from traces + parent sessions (#116)

### DIFF
--- a/.claude/specs/plan-116-mcp-extraction.md
+++ b/.claude/specs/plan-116-mcp-extraction.md
@@ -1,0 +1,322 @@
+# Plan — Story #116: Parse MCP tool names from session + trace data
+
+**Parent epic:** #100 ([epic plan](./plan-100-mcp-assessment.md))
+**Depends on:** #117 (merged as PR #156) — `McpServerConfig`, `claude_json_for`
+
+## Context
+
+Extraction story. Discovers observed MCP tool usage from two sources:
+
+1. **Subagent traces** — `SubagentTrace.tool_calls`, which already carry `tool_name` and `is_error` per #101
+2. **Parent-session assistant messages** — `tool_use` blocks in `SessionMessage.content` that happen outside any Agent delegation (observed on real data: `mcp__github__*` calls made directly in the main session)
+
+Outputs `dict[str, McpServerUsage]` aggregating calls, tools, and errors per server. Does not audit — that's #118's job.
+
+## Architectural decision — where does parent-session extraction run?
+
+Currently `AgentInvocation` doesn't retain raw messages after `extract_agent_invocations` consumes them. So MCP calls made at the parent session level are invisible downstream.
+
+**Chosen approach**: add a single-pass extractor function that runs during `analyze_session`, alongside the existing `extract_agent_invocations` call. Output lives on `SessionAnalysis` as a new `mcp_tool_calls` field. Threaded through `AnalysisResult` to `run_diagnostics` via a new kwarg on the existing pipeline.
+
+Rationale:
+- One pass through the `messages` list (already in memory during `analyze_session`), no extra I/O
+- No need to carry raw messages past the analytics layer
+- Clean symmetry with `invocations`: both are "per-session extracted evidence"
+- Preserves the existing per-session → aggregated flow; `run_diagnostics` takes the flattened list the same way it does for invocations
+
+Alternative considered: extract MCP calls only from subagent traces in #116, defer parent-session to a follow-up. Rejected because real-world data shows substantive parent-session MCP usage (`mcp__github__*` on this contributor's sessions) and the audit story (#118) would ship incomplete.
+
+## Scope
+
+**Owns:**
+- `src/agentfluent/diagnostics/mcp_assessment.py` (NEW, ~130 lines) — `parse_mcp_tool_name`, `McpToolCall` dataclass, `McpServerUsage` dataclass, `extract_mcp_calls_from_messages`, `extract_mcp_usage`
+- `src/agentfluent/analytics/pipeline.py` — add `mcp_tool_calls` field on `SessionAnalysis`, populate in `analyze_session`
+- `tests/unit/test_mcp_assessment.py` (NEW, ~15 tests)
+- `tests/fixtures/mcp/` — 2 session fixtures (tool use present; with and without errors)
+
+**Deferred to #118 / #119:**
+- Audit rules (unused / missing signal emission)
+- Pipeline wiring of audit into `run_diagnostics`
+- Any `McpServerConfig` consumption
+
+## Module layout
+
+```
+src/agentfluent/
+├── analytics/
+│   └── pipeline.py          # +mcp_tool_calls on SessionAnalysis + populate in analyze_session
+└── diagnostics/
+    └── mcp_assessment.py    # NEW — extraction + parsing + aggregation
+
+tests/
+├── fixtures/mcp/
+│   ├── session_with_mcp_success.jsonl    # mcp__github__create_issue, all success
+│   └── session_with_mcp_errors.jsonl     # mcp__nonexistent__* with is_error=True
+├── unit/test_mcp_assessment.py           # NEW
+└── unit/test_analytics_pipeline.py       # +1 wiring test (may need creating if absent)
+```
+
+## Public surface
+
+```python
+# diagnostics/mcp_assessment.py
+
+def parse_mcp_tool_name(name: str) -> tuple[str, str] | None: ...
+
+class McpToolCall(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    server_name: str
+    tool_name: str
+    is_error: bool
+
+class McpServerUsage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    server_name: str
+    total_calls: int
+    unique_tools: list[str]   # sorted; from a set internally
+    error_count: int
+
+def extract_mcp_calls_from_messages(
+    messages: list[SessionMessage],
+) -> list[McpToolCall]: ...
+
+def extract_mcp_usage(
+    invocations: list[AgentInvocation],
+    session_mcp_calls: list[McpToolCall] | None = None,
+) -> dict[str, McpServerUsage]: ...
+```
+
+Both models are Pydantic `BaseModel` with `ConfigDict(frozen=True)` — matching every other cross-boundary model in the codebase (`SubagentToolCall`, `AgentInvocation`, `TokenMetrics`). `McpToolCall` rides on `SessionAnalysis.mcp_tool_calls` (which Pydantic serializes), so Pydantic semantics are required. `McpServerUsage` is internal today but kept symmetric with `McpToolCall` for consistency and to avoid a future churn when #118 might bubble it into a signal detail.
+
+## `parse_mcp_tool_name` — split-based parser
+
+Per architect review on the epic plan, use split-based parsing instead of regex. Use FIRST `__` after the `mcp__` prefix as the delimiter (not last) — the last-delimiter approach breaks on leading-underscore tool names like `mcp__srv___internal_sync` where `rfind` would produce `("srv_", "internal_sync")` instead of the correct `("srv", "_internal_sync")`:
+
+```python
+def parse_mcp_tool_name(name: str) -> tuple[str, str] | None:
+    """Split an MCP tool name into (server, tool).
+
+    Returns None for non-MCP names or malformed shapes. Uses the last
+    `__` occurrence as the server/tool delimiter so server names with
+    internal underscores parse correctly (e.g.,
+    `mcp__claude_ai_Gmail__authenticate` → `("claude_ai_Gmail",
+    "authenticate")`).
+
+    Limitation: a server name containing `__` would be fundamentally
+    ambiguous in this format. Documented and not handled.
+    """
+    if not name.startswith("mcp__"):
+        return None
+    rest = name[5:]  # strip "mcp__"
+    idx = rest.find("__")
+    if idx <= 0:
+        return None
+    server, tool = rest[:idx], rest[idx + 2:]
+    if not server or not tool:
+        return None
+    return server, tool
+```
+
+Worked examples — must be covered by tests:
+- `mcp__github__create_issue` → `("github", "create_issue")` ✓
+- `mcp__claude_ai_Gmail__authenticate` → `("claude_ai_Gmail", "authenticate")` ✓
+- `mcp__srv___leading_underscore_tool` → `("srv", "_leading_underscore_tool")` ✓
+- `mcp__github__` → `None` (empty tool)
+- `mcp__` → `None` (empty server)
+- `mcp_github_create` → `None` (missing `__` separator)
+- `Bash` → `None` (not MCP)
+
+## `extract_mcp_calls_from_messages`
+
+Walks `list[SessionMessage]`. For each assistant message, iterate `tool_use_blocks` and match each via `parse_mcp_tool_name`. For matches, pair with the corresponding `tool_result` content block in a later user message (match by `tool_use_id`) to determine `is_error`.
+
+Error detection priority:
+1. `tool_result.is_error == True` → error
+2. `tool_result.is_error` absent AND text matches `ERROR_REGEX` → error (reuse the existing ERROR_REGEX from `diagnostics/signals.py`)
+3. Otherwise → not an error
+
+Missing `tool_result` (e.g., interrupted session) → `is_error=False` (no evidence of failure). Log nothing — interrupted sessions are common and don't warrant a warning per call.
+
+```python
+def extract_mcp_calls_from_messages(
+    messages: list[SessionMessage],
+) -> list[McpToolCall]:
+    # First pass: index tool_result content blocks by tool_use_id.
+    results_by_id: dict[str, tuple[str, bool | None]] = {}
+    for msg in messages:
+        if msg.type != "user":
+            continue
+        for block in msg.content_blocks:
+            if block.type == "tool_result" and block.tool_use_id:
+                results_by_id[block.tool_use_id] = (block.text or "", block.is_error)
+
+    calls: list[McpToolCall] = []
+    for msg in messages:
+        if msg.type != "assistant":
+            continue
+        for tu in msg.tool_use_blocks:
+            parsed = parse_mcp_tool_name(tu.name)
+            if parsed is None:
+                continue
+            server, tool = parsed
+            result_text, explicit_error = results_by_id.get(tu.id, ("", None))
+            if explicit_error is True:
+                is_error = True
+            elif explicit_error is False:
+                is_error = False
+            else:
+                is_error = bool(ERROR_REGEX.search(result_text))
+            calls.append(
+                McpToolCall(server_name=server, tool_name=tool, is_error=is_error),
+            )
+    return calls
+```
+
+## `extract_mcp_usage` — aggregation
+
+Accumulates across both sources:
+
+```python
+def extract_mcp_usage(
+    invocations: list[AgentInvocation],
+    session_mcp_calls: list[McpToolCall] | None = None,
+) -> dict[str, McpServerUsage]:
+    """Aggregate observed MCP tool usage per server.
+
+    Pulls from two sources:
+
+    - Subagent traces attached to invocations
+      (`inv.trace.tool_calls`). Each call's `tool_name` is parsed; if
+      it's an MCP name, counted.
+    - Parent-session MCP calls collected by
+      `extract_mcp_calls_from_messages`, passed in via
+      `session_mcp_calls` (None means "no session-level data").
+
+    Returns an empty dict when no MCP tools appear in either source.
+    """
+    agg: dict[str, _Accumulator] = defaultdict(_Accumulator)
+
+    for inv in invocations:
+        trace = inv.trace
+        if trace is None:
+            continue
+        for call in trace.tool_calls:
+            parsed = parse_mcp_tool_name(call.tool_name)
+            if parsed is None:
+                continue
+            server, tool = parsed
+            agg[server].add(tool, is_error=call.is_error)
+
+    for call in session_mcp_calls or []:
+        agg[call.server_name].add(call.tool_name, is_error=call.is_error)
+
+    return {
+        server: a.build(server) for server, a in agg.items()
+    }
+```
+
+Where `_Accumulator` is a private dataclass tracking `tools: set[str]`, `total_calls: int`, `error_count: int`. Its `.build(server_name)` returns an `McpServerUsage` with `unique_tools` sorted for deterministic output.
+
+## Analytics pipeline wiring
+
+Add field to `SessionAnalysis`:
+
+```python
+class SessionAnalysis(BaseModel):
+    # ... existing fields ...
+    mcp_tool_calls: list[McpToolCall] = Field(default_factory=list)
+```
+
+Populate in `analyze_session` (single additional line near the existing `extract_agent_invocations` call):
+
+```python
+# analytics/pipeline.py, inside analyze_session
+messages = parse_session(path)
+# ... existing token/tool metrics extraction ...
+invocations = extract_agent_invocations(messages)
+# NEW
+mcp_tool_calls = extract_mcp_calls_from_messages(messages)
+# ... rest of pipeline ...
+return SessionAnalysis(
+    # ... existing fields ...
+    mcp_tool_calls=mcp_tool_calls,
+)
+```
+
+Note: `McpToolCall` is a frozen dataclass but Pydantic v2 models serialize dataclasses fine. Validate with a round-trip test if in doubt.
+
+## Tests
+
+### `tests/unit/test_mcp_assessment.py` (~15 tests)
+
+- **`TestParseMcpToolName`** (6)
+  - simple server + tool
+  - server with underscores
+  - tool with leading underscore
+  - empty server (`mcp____tool` → None)
+  - empty tool (`mcp__srv__` → None)
+  - non-MCP prefix → None
+
+- **`TestExtractMcpCallsFromMessages`** (6)
+  - assistant message with mcp__github__create_issue tool_use paired with success tool_result
+  - same pattern but `is_error=True` on tool_result
+  - tool_use without paired tool_result → is_error=False (no evidence)
+  - tool_use with text matching ERROR_REGEX but no `is_error` field → is_error=True
+  - tool_use with explicit `is_error=False` but text containing "error" keyword → is_error=False (explicit field wins; documents ERROR_REGEX fallback's false-positive surface)
+  - non-MCP tool_use blocks ignored (mixed with MCP ones)
+
+- **`TestExtractMcpUsage`** (4)
+  - trace-only path: invocation with trace containing MCP tools, no session calls
+  - session-only path: no invocations, only session_mcp_calls
+  - both sources: aggregated, unique_tools is union (sorted)
+  - empty inputs → empty dict
+
+### `tests/unit/test_analytics_pipeline.py` (+1 test)
+
+- `analyze_session` on a fixture containing MCP tool calls populates `mcp_tool_calls` on the result
+
+### Fixtures
+
+Minimal JSONL:
+
+- **`session_with_mcp_success.jsonl`** — 1 user prompt + 1 assistant with `mcp__github__create_issue` tool_use + 1 user with successful tool_result
+- **`session_with_mcp_errors.jsonl`** — assistant with `mcp__nonexistent__bad_call` tool_use + user with `is_error: true` tool_result
+
+Build via existing `tests/_builders.py` helpers if they cover this shape; otherwise write JSONL inline in test setup.
+
+## Edge cases
+
+- **Mixed MCP and non-MCP tools in same invocation's trace** — only MCP names counted; non-MCP silently skipped (the `parse_mcp_tool_name is None` branch).
+- **Trace-path MCP calls vs session-path MCP calls for the same session** — both paths are scanned; duplication shouldn't occur because a trace is scoped to a subagent, and session-level MCP calls happen outside any trace.
+- **Interrupted session** — tool_use with no paired tool_result → counted as not-error (no evidence of failure, can't assume).
+- **`ERROR_REGEX` match on non-error tool output** — false positive risk. The gate only applies when `is_error` field is absent; if the field is present and False, we trust it. This mirrors the existing metadata-layer ERROR_PATTERN detection.
+- **Tool name with ONE underscore** (e.g., `mcp__srv_tool`) — fails `find("__")` (only one `__`), returns None. Expected: this isn't a valid MCP name.
+
+## Verification
+
+```bash
+uv run pytest tests/unit/test_mcp_assessment.py -v
+uv run pytest tests/unit/test_analytics_pipeline.py -v
+uv run pytest -m "not integration" -q           # full suite: 611 → ~626
+uv run mypy src/agentfluent/
+uv run ruff check src/ tests/
+# Dogfood: extract from real session data
+uv run python -c "from pathlib import Path; from agentfluent.analytics.pipeline import analyze_session; s = analyze_session(Path('~/.claude/projects/<slug>/<uuid>.jsonl').expanduser()); print({c.server_name for c in s.mcp_tool_calls})"
+```
+
+## Definition of done
+
+- `parse_mcp_tool_name` uses `find("__")` split; all 7 worked examples covered by tests
+- `McpToolCall` and `McpServerUsage` dataclasses in `diagnostics/mcp_assessment.py`
+- `extract_mcp_calls_from_messages(messages)` returns list of `McpToolCall`
+- `extract_mcp_usage(invocations, session_mcp_calls=None)` returns aggregated dict
+- `SessionAnalysis.mcp_tool_calls` field populated by `analyze_session`
+- ~15 new tests; ruff + mypy strict clean
+- No regression in 611 existing tests
+
+## Risks
+
+1. **Parent-session MCP calls with no tool_result pair** — rare, but happens in interrupted sessions. Gating on `is_error=False` (no evidence) is the safe default; don't over-count errors.
+2. **`ERROR_REGEX` false positives** — used only when `is_error` is absent. Real data should rarely hit this branch; metadata-layer ERROR_PATTERN detection has the same gate and hasn't shown major FP issues.
+3. **`McpToolCall` on `SessionAnalysis`** — adds a field consumed only by #118 wiring. If #118 gets delayed/cut, this field becomes vestigial. Acceptable — the field is small and doesn't break anything.
+4. **Analytics layer changes touch existing tests** — `SessionAnalysis(...)` constructions in tests may need to accept the new default. Mitigated by making `mcp_tool_calls` default to an empty list.

--- a/src/agentfluent/agents/extractor.py
+++ b/src/agentfluent/agents/extractor.py
@@ -3,20 +3,14 @@
 from __future__ import annotations
 
 from agentfluent.agents.models import AgentInvocation
-from agentfluent.core.session import SessionMessage
+from agentfluent.core.session import SessionMessage, index_tool_results_by_id
 
 
 def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvocation]:
     """Match Agent tool_use blocks to their tool_result content blocks by
     tool_use_id and pull metadata from the result-carrying message.
     """
-    results: dict[str, tuple[SessionMessage, str]] = {}
-
-    for msg in messages:
-        if msg.type == "user":
-            for block in msg.content_blocks:
-                if block.type == "tool_result" and block.tool_use_id:
-                    results[block.tool_use_id] = (msg, block.text or "")
+    results = index_tool_results_by_id(messages)
 
     invocations: list[AgentInvocation] = []
 
@@ -33,7 +27,10 @@ def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvoc
             prompt = tool_use.input.get("prompt", "")
 
             entry = results.get(tool_use.id)
-            container, output_text = entry if entry else (None, "")
+            if entry is not None:
+                container, output_text, _ = entry
+            else:
+                container, output_text = None, ""
 
             total_tokens = None
             tool_uses_count = None

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -30,6 +30,10 @@ from agentfluent.analytics.tools import (
 )
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics.mcp_assessment import (
+    McpToolCall,
+    extract_mcp_calls_from_messages,
+)
 from agentfluent.diagnostics.models import DiagnosticsResult
 from agentfluent.traces.discovery import discover_session_subagents
 from agentfluent.traces.linker import link_traces
@@ -47,6 +51,12 @@ class SessionAnalysis(BaseModel):
     tool_metrics: ToolMetrics
     agent_metrics: AgentMetrics
     invocations: list[AgentInvocation] = Field(default_factory=list)
+    mcp_tool_calls: list[McpToolCall] = Field(default_factory=list)
+    """Parent-session MCP tool calls (those made directly in the main
+    session, outside any Agent delegation). Subagent-trace MCP calls
+    are already captured on ``invocations[i].trace.tool_calls`` and
+    not duplicated here."""
+
     message_count: int = 0
     user_message_count: int = 0
     assistant_message_count: int = 0
@@ -89,6 +99,7 @@ def analyze_session(
         ]
 
     invocations = _link_subagent_traces(invocations, path)
+    mcp_tool_calls = extract_mcp_calls_from_messages(messages)
 
     agent_metrics = compute_agent_metrics(
         invocations, session_total_tokens=token_metrics.total_tokens
@@ -100,6 +111,7 @@ def analyze_session(
         tool_metrics=tool_metrics,
         agent_metrics=agent_metrics,
         invocations=invocations,
+        mcp_tool_calls=mcp_tool_calls,
         message_count=len(messages),
         user_message_count=_count_type(messages, "user"),
         assistant_message_count=_count_type(messages, "assistant"),

--- a/src/agentfluent/config/mcp_discovery.py
+++ b/src/agentfluent/config/mcp_discovery.py
@@ -60,7 +60,11 @@ def discover_mcp_servers(
     JSON logs a warning and skips that file.
     """
     claude_json_path = claude_json_for(claude_config_dir)
-    user_servers = _read_user_mcp_servers(claude_json_path)
+    # Load ~/.claude.json once — it can be tens of KB (accumulates
+    # session state over time) and both user-scope and project-local
+    # readers pull from it.
+    claude_json_data = _load_json(claude_json_path)
+    user_servers = _parse_user_mcp_servers(claude_json_data, claude_json_path)
 
     project_local_servers: list[McpServerConfig] = []
     enabled_whitelist: list[str] | None = None
@@ -72,7 +76,9 @@ def discover_mcp_servers(
             project_local_servers,
             enabled_whitelist,
             disabled_list,
-        ) = _read_project_local_mcp_servers(claude_json_path, project_dir)
+        ) = _parse_project_local_mcp_servers(
+            claude_json_data, claude_json_path, project_dir,
+        )
         project_shared_servers = _read_project_shared_mcp_servers(
             project_dir,
             enabled_whitelist=enabled_whitelist,
@@ -152,23 +158,26 @@ def _parse_server_entries(
     return servers
 
 
-def _read_user_mcp_servers(claude_json_path: Path) -> list[McpServerConfig]:
-    """Read top-level ``mcpServers`` from ``~/.claude.json``."""
-    data = _load_json(claude_json_path)
-    if data is None:
+def _parse_user_mcp_servers(
+    claude_json_data: dict[str, Any] | None,
+    source_file: Path,
+) -> list[McpServerConfig]:
+    """Extract top-level ``mcpServers`` from a pre-loaded ``~/.claude.json``."""
+    if claude_json_data is None:
         return []
     return _parse_server_entries(
-        data.get("mcpServers"),
-        source_file=claude_json_path,
+        claude_json_data.get("mcpServers"),
+        source_file=source_file,
         scope="user",
     )
 
 
-def _read_project_local_mcp_servers(
-    claude_json_path: Path,
+def _parse_project_local_mcp_servers(
+    claude_json_data: dict[str, Any] | None,
+    source_file: Path,
     project_dir: Path,
 ) -> tuple[list[McpServerConfig], list[str] | None, list[str]]:
-    """Read per-project section from ``~/.claude.json``.
+    """Extract per-project section from a pre-loaded ``~/.claude.json``.
 
     Returns ``(servers, enabled_whitelist, disabled_list)`` where
     ``enabled_whitelist`` is ``None`` when the field is absent
@@ -179,11 +188,10 @@ def _read_project_local_mcp_servers(
     The enabled / disabled lists drive project_shared gating — the
     caller passes them to ``_read_project_shared_mcp_servers``.
     """
-    data = _load_json(claude_json_path)
-    if data is None:
+    if claude_json_data is None:
         return [], None, []
 
-    projects = data.get("projects")
+    projects = claude_json_data.get("projects")
     if not isinstance(projects, dict):
         return [], None, []
 
@@ -196,7 +204,7 @@ def _read_project_local_mcp_servers(
 
     servers = _parse_server_entries(
         entry.get("mcpServers"),
-        source_file=claude_json_path,
+        source_file=source_file,
         scope="project_local",
     )
     enabled_raw = entry.get("enabledMcpjsonServers")

--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -124,6 +124,34 @@ class SessionMessage(BaseModel):
         ]
 
 
+def index_tool_results_by_id(
+    messages: list[SessionMessage],
+) -> dict[str, tuple[SessionMessage, str, bool | None]]:
+    """Build a ``tool_use_id → (containing_message, text, is_error)`` index.
+
+    Extracted as a shared helper because multiple consumers walk the
+    same user-message → content-block → tool_result path:
+
+    - ``agents/extractor.py`` pairs each Agent ``tool_use`` with its
+      result to pull ``toolUseResult`` metadata off the container.
+    - ``diagnostics/mcp_assessment.py`` pairs each MCP ``tool_use``
+      with its result to determine ``is_error``.
+
+    Returning the container alongside text and is_error lets each
+    caller pick what it needs without re-walking messages.
+    """
+    results: dict[str, tuple[SessionMessage, str, bool | None]] = {}
+    for msg in messages:
+        if msg.type != "user":
+            continue
+        for block in msg.content_blocks:
+            if block.type == "tool_result" and block.tool_use_id:
+                results[block.tool_use_id] = (
+                    msg, block.text or "", block.is_error,
+                )
+    return results
+
+
 # Message types that the parser should skip
 SKIP_TYPES: frozenset[str] = frozenset(
     {

--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -1,0 +1,230 @@
+"""MCP tool usage extraction and aggregation.
+
+Observed-usage counterpart to ``config/mcp_discovery.py`` (which reads
+configured servers). This module discovers what MCP tools the agent
+*actually called*, from two sources:
+
+- **Subagent traces** — ``SubagentTrace.tool_calls`` carry per-call
+  ``tool_name`` and ``is_error``. Populated by #101's trace parser.
+- **Parent-session assistant messages** — ``tool_use`` content blocks
+  in raw ``SessionMessage`` data, paired with their ``tool_result``
+  content blocks by ``tool_use_id`` to recover the error state.
+  Extracted by ``extract_mcp_calls_from_messages`` during
+  ``analyze_session`` and surfaced via ``SessionAnalysis.mcp_tool_calls``.
+
+Audit logic (comparing observed usage to configured servers) lives in
+#118 — this module does extraction only. The two outputs converge in
+``extract_mcp_usage`` which aggregates per-server.
+
+**Parsing.** MCP tool names follow the ``mcp__<server>__<tool>``
+format. Server names can contain internal underscores
+(e.g., ``claude_ai_Gmail``); tool names can start with an underscore
+(e.g., ``_internal_sync``). Parsing uses ``rfind("__")`` on the
+stripped suffix so the last ``__`` is the server/tool boundary.
+A server name containing ``__`` is fundamentally ambiguous in this
+format — not handled.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+from agentfluent.diagnostics.signals import ERROR_REGEX
+
+if TYPE_CHECKING:
+    from agentfluent.agents.models import AgentInvocation
+    from agentfluent.core.session import SessionMessage
+
+
+_MCP_PREFIX = "mcp__"
+
+
+def parse_mcp_tool_name(name: str) -> tuple[str, str] | None:
+    """Split an MCP tool name into ``(server_name, tool_name)``.
+
+    Returns ``None`` for names that don't match ``mcp__<server>__<tool>``
+    or that have an empty server or tool component. Splits at the
+    FIRST ``__`` after the ``mcp__`` prefix — everything before it is
+    the server (may contain single underscores), everything after is
+    the tool (may start with underscore, may contain ``__``).
+
+    Examples:
+
+    - ``mcp__github__create_issue`` → ``("github", "create_issue")``
+    - ``mcp__claude_ai_Gmail__authenticate`` →
+      ``("claude_ai_Gmail", "authenticate")``
+    - ``mcp__srv___internal_sync`` → ``("srv", "_internal_sync")``
+
+    Limitation: server names containing ``__`` are fundamentally
+    ambiguous in this format — the first ``__`` is treated as the
+    server/tool boundary regardless. Not a real-world concern
+    (observed Claude Code servers like ``github`` and
+    ``claude_ai_Gmail`` don't use ``__``).
+    """
+    if not name.startswith(_MCP_PREFIX):
+        return None
+    rest = name[len(_MCP_PREFIX):]
+    idx = rest.find("__")
+    if idx <= 0:
+        return None
+    server, tool = rest[:idx], rest[idx + 2:]
+    if not server or not tool:
+        return None
+    return server, tool
+
+
+class McpToolCall(BaseModel):
+    """A single observed MCP tool invocation.
+
+    Produced by ``extract_mcp_calls_from_messages`` (parent-session
+    source) and carried on ``SessionAnalysis.mcp_tool_calls``. The
+    trace source keeps using ``SubagentToolCall`` directly — both
+    flow into ``extract_mcp_usage`` for aggregation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    server_name: str
+    tool_name: str
+    is_error: bool
+
+
+class McpServerUsage(BaseModel):
+    """Per-server aggregated MCP usage, output of ``extract_mcp_usage``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    server_name: str
+    total_calls: int
+    unique_tools: list[str]
+    """Sorted for deterministic output — derived from an internal set."""
+
+    error_count: int
+
+
+def extract_mcp_calls_from_messages(
+    messages: list[SessionMessage],
+) -> list[McpToolCall]:
+    """Scan parent-session messages for MCP tool_use / tool_result pairs.
+
+    Pairs each assistant ``tool_use`` with its corresponding user
+    ``tool_result`` by ``tool_use_id`` to determine ``is_error``.
+    Error detection priority:
+
+    1. Explicit ``tool_result.is_error`` (True or False) — trust the
+       field when present.
+    2. Missing ``is_error`` + result text matches ``ERROR_REGEX`` →
+       treat as error. Mirrors the metadata-layer ``ERROR_PATTERN``
+       detection; carries the same false-positive risk and is tested.
+    3. No paired ``tool_result`` at all (interrupted session) →
+       treated as not-error. Absence of evidence is not evidence of
+       failure.
+
+    Non-MCP ``tool_use`` blocks are silently skipped via
+    ``parse_mcp_tool_name`` returning ``None``.
+    """
+    # Index tool_result blocks by tool_use_id. Store (text, is_error)
+    # so the second pass can apply the priority ladder above without
+    # re-walking content_blocks.
+    results_by_id: dict[str, tuple[str, bool | None]] = {}
+    for msg in messages:
+        if msg.type != "user":
+            continue
+        for block in msg.content_blocks:
+            if block.type == "tool_result" and block.tool_use_id:
+                results_by_id[block.tool_use_id] = (
+                    block.text or "",
+                    block.is_error,
+                )
+
+    calls: list[McpToolCall] = []
+    for msg in messages:
+        if msg.type != "assistant":
+            continue
+        for tu in msg.tool_use_blocks:
+            parsed = parse_mcp_tool_name(tu.name)
+            if parsed is None:
+                continue
+            server, tool = parsed
+            result_text, explicit_error = results_by_id.get(tu.id, ("", None))
+            if explicit_error is True:
+                is_error = True
+            elif explicit_error is False:
+                is_error = False
+            else:
+                is_error = bool(ERROR_REGEX.search(result_text))
+            calls.append(
+                McpToolCall(
+                    server_name=server, tool_name=tool, is_error=is_error,
+                ),
+            )
+    return calls
+
+
+class _Accumulator:
+    """Mutable per-server accumulator used during aggregation.
+
+    Not exposed — callers see ``McpServerUsage`` instances produced by
+    ``build``.
+    """
+
+    def __init__(self) -> None:
+        self.tools: set[str] = set()
+        self.total_calls: int = 0
+        self.error_count: int = 0
+
+    def add(self, tool_name: str, *, is_error: bool) -> None:
+        self.tools.add(tool_name)
+        self.total_calls += 1
+        if is_error:
+            self.error_count += 1
+
+    def build(self, server_name: str) -> McpServerUsage:
+        return McpServerUsage(
+            server_name=server_name,
+            total_calls=self.total_calls,
+            unique_tools=sorted(self.tools),
+            error_count=self.error_count,
+        )
+
+
+def extract_mcp_usage(
+    invocations: list[AgentInvocation],
+    session_mcp_calls: list[McpToolCall] | None = None,
+) -> dict[str, McpServerUsage]:
+    """Aggregate observed MCP tool usage per server across both sources.
+
+    - **Trace source**: walks ``inv.trace.tool_calls`` for each
+      invocation with a linked ``SubagentTrace``. Each call's
+      ``tool_name`` is parsed; non-MCP names are skipped.
+    - **Parent-session source**: consumes the already-parsed
+      ``McpToolCall`` list produced by
+      ``extract_mcp_calls_from_messages``.
+
+    Returns an empty dict when no MCP tools appear in either source.
+    Duplicates across sources don't occur in practice — a trace is
+    scoped to a subagent's internal work, while session-level calls
+    happen outside any trace.
+    """
+    agg: dict[str, _Accumulator] = defaultdict(_Accumulator)
+
+    for inv in invocations:
+        trace = inv.trace
+        if trace is None:
+            continue
+        for trace_call in trace.tool_calls:
+            parsed = parse_mcp_tool_name(trace_call.tool_name)
+            if parsed is None:
+                continue
+            server, tool = parsed
+            agg[server].add(tool, is_error=trace_call.is_error)
+
+    for session_call in session_mcp_calls or ():
+        agg[session_call.server_name].add(
+            session_call.tool_name, is_error=session_call.is_error,
+        )
+
+    return {server: a.build(server) for server, a in agg.items()}

--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -19,10 +19,13 @@ Audit logic (comparing observed usage to configured servers) lives in
 **Parsing.** MCP tool names follow the ``mcp__<server>__<tool>``
 format. Server names can contain internal underscores
 (e.g., ``claude_ai_Gmail``); tool names can start with an underscore
-(e.g., ``_internal_sync``). Parsing uses ``rfind("__")`` on the
-stripped suffix so the last ``__`` is the server/tool boundary.
-A server name containing ``__`` is fundamentally ambiguous in this
-format — not handled.
+(e.g., ``_internal_sync``). Parsing uses ``find("__")`` on the
+stripped suffix — the FIRST ``__`` after the ``mcp__`` prefix is the
+server/tool boundary. Last-delimiter splitting would break
+leading-underscore tool names (``srv___internal_sync`` would yield
+``("srv_", "internal_sync")`` instead of ``("srv", "_internal_sync")``).
+Server names containing ``__`` are fundamentally ambiguous in this
+format and aren't handled.
 """
 
 from __future__ import annotations
@@ -32,6 +35,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
+from agentfluent.core.session import index_tool_results_by_id
 from agentfluent.diagnostics.signals import ERROR_REGEX
 
 if TYPE_CHECKING:
@@ -126,19 +130,7 @@ def extract_mcp_calls_from_messages(
     Non-MCP ``tool_use`` blocks are silently skipped via
     ``parse_mcp_tool_name`` returning ``None``.
     """
-    # Index tool_result blocks by tool_use_id. Store (text, is_error)
-    # so the second pass can apply the priority ladder above without
-    # re-walking content_blocks.
-    results_by_id: dict[str, tuple[str, bool | None]] = {}
-    for msg in messages:
-        if msg.type != "user":
-            continue
-        for block in msg.content_blocks:
-            if block.type == "tool_result" and block.tool_use_id:
-                results_by_id[block.tool_use_id] = (
-                    block.text or "",
-                    block.is_error,
-                )
+    results = index_tool_results_by_id(messages)
 
     calls: list[McpToolCall] = []
     for msg in messages:
@@ -149,7 +141,11 @@ def extract_mcp_calls_from_messages(
             if parsed is None:
                 continue
             server, tool = parsed
-            result_text, explicit_error = results_by_id.get(tu.id, ("", None))
+            entry = results.get(tu.id)
+            if entry is not None:
+                _, result_text, explicit_error = entry
+            else:
+                result_text, explicit_error = "", None
             if explicit_error is True:
                 is_error = True
             elif explicit_error is False:

--- a/tests/unit/test_mcp_assessment.py
+++ b/tests/unit/test_mcp_assessment.py
@@ -1,0 +1,287 @@
+"""Tests for MCP usage extraction (diagnostics/mcp_assessment.py).
+
+Covers ``parse_mcp_tool_name``, message-level extraction with its
+tool_use / tool_result pairing + ``is_error`` priority ladder, and
+aggregation across trace and parent-session sources.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.analytics.pipeline import analyze_session
+from agentfluent.core.session import ContentBlock, SessionMessage
+from agentfluent.diagnostics.mcp_assessment import (
+    McpToolCall,
+    extract_mcp_calls_from_messages,
+    extract_mcp_usage,
+    parse_mcp_tool_name,
+)
+from agentfluent.traces.models import SubagentToolCall, SubagentTrace
+from tests._builders import (
+    assistant_message,
+    tool_result_block,
+    tool_use_block,
+    user_message,
+)
+
+
+def _assistant_with_mcp(
+    tool_use_id: str, tool_name: str, *, message_id: str = "msg_a",
+) -> SessionMessage:
+    return SessionMessage(
+        type="assistant",
+        message_id=message_id,
+        content_blocks=[
+            ContentBlock(
+                type="tool_use", id=tool_use_id, name=tool_name, input={},
+            ),
+        ],
+    )
+
+
+def _user_with_result(
+    tool_use_id: str, text: str = "ok", *, is_error: bool | None = None,
+) -> SessionMessage:
+    return SessionMessage(
+        type="user",
+        content_blocks=[
+            ContentBlock(
+                type="tool_result",
+                tool_use_id=tool_use_id,
+                text=text,
+                is_error=is_error,
+            ),
+        ],
+    )
+
+
+def _inv_with_trace(tool_calls: list[SubagentToolCall]) -> AgentInvocation:
+    trace = SubagentTrace(
+        agent_id="ag-1",
+        agent_type="general-purpose",
+        delegation_prompt="p",
+        tool_calls=tool_calls,
+    )
+    return AgentInvocation(
+        agent_type="general-purpose",
+        description="d",
+        prompt="p",
+        tool_use_id="toolu_test",
+        trace=trace,
+    )
+
+
+class TestParseMcpToolName:
+    def test_simple_server_and_tool(self) -> None:
+        assert parse_mcp_tool_name("mcp__github__create_issue") == (
+            "github", "create_issue",
+        )
+
+    def test_server_with_internal_underscores(self) -> None:
+        assert parse_mcp_tool_name("mcp__claude_ai_Gmail__authenticate") == (
+            "claude_ai_Gmail", "authenticate",
+        )
+
+    def test_tool_with_leading_underscore(self) -> None:
+        # First `__` after the prefix delimits server from tool, so
+        # the triple-underscore boundary here leaves `_internal_sync`
+        # as the tool — preserving leading-underscore tool names.
+        assert parse_mcp_tool_name("mcp__srv___internal_sync") == (
+            "srv", "_internal_sync",
+        )
+
+    def test_empty_server_returns_none(self) -> None:
+        # mcp____tool has empty server between the two __ delimiters.
+        assert parse_mcp_tool_name("mcp____tool") is None
+
+    def test_empty_tool_returns_none(self) -> None:
+        assert parse_mcp_tool_name("mcp__srv__") is None
+
+    def test_non_mcp_prefix_returns_none(self) -> None:
+        assert parse_mcp_tool_name("Bash") is None
+        assert parse_mcp_tool_name("mcp_github_create") is None  # single underscore
+        assert parse_mcp_tool_name("") is None
+
+
+class TestExtractMcpCallsFromMessages:
+    def test_success_pair_yields_non_error_call(self) -> None:
+        messages = [
+            _assistant_with_mcp("tu-1", "mcp__github__create_issue"),
+            _user_with_result("tu-1", text="created", is_error=False),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls == [
+            McpToolCall(
+                server_name="github", tool_name="create_issue", is_error=False,
+            ),
+        ]
+
+    def test_explicit_is_error_true_propagates(self) -> None:
+        messages = [
+            _assistant_with_mcp("tu-2", "mcp__github__get_pr"),
+            _user_with_result("tu-2", text="failed", is_error=True),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls[0].is_error is True
+
+    def test_no_paired_result_defaults_to_not_error(self) -> None:
+        messages = [_assistant_with_mcp("tu-3", "mcp__github__create_issue")]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert len(calls) == 1
+        assert calls[0].is_error is False
+
+    def test_error_regex_fallback_when_is_error_absent(self) -> None:
+        messages = [
+            _assistant_with_mcp("tu-4", "mcp__github__read"),
+            _user_with_result(
+                "tu-4", text="unable to reach server", is_error=None,
+            ),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls[0].is_error is True  # "unable to" matches ERROR_REGEX
+
+    def test_explicit_is_error_false_wins_over_error_keyword(self) -> None:
+        # Documents the ERROR_REGEX fallback's limited scope: explicit
+        # is_error=False is trusted even when the text contains an
+        # error keyword. This is the "error" word appearing as normal
+        # content, e.g., "reviewed error handling in the PR."
+        messages = [
+            _assistant_with_mcp("tu-5", "mcp__github__review"),
+            _user_with_result(
+                "tu-5",
+                text="reviewed error handling in the diff",
+                is_error=False,
+            ),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls[0].is_error is False
+
+    def test_non_mcp_tool_use_blocks_ignored(self) -> None:
+        messages = [
+            SessionMessage(
+                type="assistant",
+                message_id="msg_mix",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use", id="tu-6a", name="Bash", input={},
+                    ),
+                    ContentBlock(
+                        type="tool_use",
+                        id="tu-6b",
+                        name="mcp__github__create_issue",
+                        input={},
+                    ),
+                    ContentBlock(
+                        type="tool_use", id="tu-6c", name="Read", input={},
+                    ),
+                ],
+            ),
+            _user_with_result("tu-6b", is_error=False),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert len(calls) == 1
+        assert calls[0].server_name == "github"
+
+
+class TestExtractMcpUsage:
+    def test_trace_only_path(self) -> None:
+        inv = _inv_with_trace([
+            SubagentToolCall(
+                tool_name="mcp__github__create_issue",
+                input_summary="", result_summary="", is_error=False,
+            ),
+            SubagentToolCall(
+                tool_name="mcp__github__get_pr",
+                input_summary="", result_summary="", is_error=True,
+            ),
+            SubagentToolCall(
+                tool_name="Bash",  # non-MCP, should be skipped
+                input_summary="", result_summary="", is_error=False,
+            ),
+        ])
+        usage = extract_mcp_usage([inv])
+        assert "github" in usage
+        gh = usage["github"]
+        assert gh.total_calls == 2
+        assert gh.error_count == 1
+        assert gh.unique_tools == ["create_issue", "get_pr"]
+
+    def test_session_only_path(self) -> None:
+        session_calls = [
+            McpToolCall(server_name="slack", tool_name="send", is_error=False),
+            McpToolCall(server_name="slack", tool_name="send", is_error=True),
+        ]
+        usage = extract_mcp_usage([], session_mcp_calls=session_calls)
+        slack = usage["slack"]
+        assert slack.total_calls == 2
+        assert slack.error_count == 1
+        assert slack.unique_tools == ["send"]
+
+    def test_both_sources_aggregated_per_server(self) -> None:
+        inv = _inv_with_trace([
+            SubagentToolCall(
+                tool_name="mcp__github__create_issue",
+                input_summary="", result_summary="", is_error=False,
+            ),
+        ])
+        session_calls = [
+            McpToolCall(
+                server_name="github", tool_name="get_file", is_error=False,
+            ),
+            McpToolCall(
+                server_name="slack", tool_name="send", is_error=False,
+            ),
+        ]
+        usage = extract_mcp_usage([inv], session_mcp_calls=session_calls)
+        assert set(usage) == {"github", "slack"}
+        assert usage["github"].total_calls == 2
+        # unique_tools is the union across both sources, sorted.
+        assert usage["github"].unique_tools == ["create_issue", "get_file"]
+        assert usage["slack"].total_calls == 1
+
+    def test_empty_inputs_return_empty_dict(self) -> None:
+        assert extract_mcp_usage([]) == {}
+        assert extract_mcp_usage([], session_mcp_calls=[]) == {}
+
+    def test_invocation_without_trace_silently_skipped(self) -> None:
+        inv_no_trace = AgentInvocation(
+            agent_type="general-purpose",
+            description="d",
+            prompt="p",
+            tool_use_id="toolu_x",
+        )
+        assert extract_mcp_usage([inv_no_trace]) == {}
+
+
+class TestAnalyzeSessionWiresInMcpCalls:
+    """End-to-end: analyze_session surfaces MCP calls on SessionAnalysis."""
+
+    def test_analyze_session_populates_mcp_tool_calls(
+        self, write_jsonl: Any, tmp_path: Path,
+    ) -> None:
+        path = write_jsonl(
+            "session_mcp.jsonl",
+            [
+                user_message("kick off"),
+                assistant_message([
+                    tool_use_block(
+                        "tu-mcp", name="mcp__github__create_issue",
+                    ),
+                ]),
+                user_message([tool_result_block("tu-mcp", is_error=False)]),
+            ],
+        )
+        result = analyze_session(path)
+        assert len(result.mcp_tool_calls) == 1
+        assert result.mcp_tool_calls[0].server_name == "github"
+        assert result.mcp_tool_calls[0].tool_name == "create_issue"
+        assert result.mcp_tool_calls[0].is_error is False
+
+    def test_analyze_session_with_no_mcp_tools_yields_empty_list(
+        self, basic_session_path: Path,
+    ) -> None:
+        result = analyze_session(basic_session_path)
+        assert result.mcp_tool_calls == []


### PR DESCRIPTION
Second story for Epic #100. Adds the observed-usage extractor that #118 audit rules will consume.

## Summary

- `parse_mcp_tool_name(name)` — split on the first `__` after `mcp__` prefix. Correctly handles server names with internal underscores (`mcp__claude_ai_Gmail__authenticate` → `(\"claude_ai_Gmail\", \"authenticate\")`) AND tool names with leading underscores (`mcp__srv___internal_sync` → `(\"srv\", \"_internal_sync\")`).
- `extract_mcp_calls_from_messages(messages)` — scans raw `SessionMessage` list for `tool_use` / `tool_result` pairs, determines `is_error` via explicit field → `ERROR_REGEX` fallback → default-False ladder.
- `extract_mcp_usage(invocations, session_mcp_calls=None)` — aggregates from both trace and parent-session sources into `dict[str, McpServerUsage]`.
- `SessionAnalysis.mcp_tool_calls` — new field populated by `analyze_session`, carries parent-session extraction output alongside existing `invocations`.

## Implementation note

Original architect suggestion used `rfind(\"__\")` (last delimiter); tests caught that this breaks leading-underscore tool names. Switched to `find(\"__\")` (first delimiter), which handles both edge cases correctly. Plan updated accordingly.

## Dogfood result

On 8 agentfluent-project sessions this PR extracts **74 `mcp__github__*` calls** (2 with errors) that were previously invisible to any diagnostics. Subagent-trace MCP calls are also captured — the audit story (#118) consumes both sources.

## Test plan

- [x] 19 new unit tests covering: parser edge cases, `is_error` priority ladder (including explicit-False-wins-over-keyword case), trace-only / session-only / mixed aggregation, `analyze_session` wiring
- [x] Full unit suite: 611 → 630 passing, 0 regressions
- [x] `ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean (strict mode)
- [x] Dogfood: `analyze_session` on real JSONL produces expected `mcp_tool_calls`

## Shape for downstream stories

`extract_mcp_usage` is the canonical entrypoint for #118 (audit rules). Signature is additive — positional `invocations`, keyword-only `session_mcp_calls=None`. CLI will flatten via `[c for s in result.sessions for c in s.mcp_tool_calls]` when #119 wires the pipeline.

Closes #116. Architect review at [#116 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/116#issuecomment-4303185400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)