### PR TITLE
feat(diagnostics): add MCP audit rules for unused + missing servers (#118)

### DIFF
--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -451,6 +451,62 @@ class ModelRoutingRule:
 
 
 # Module-level rule registry. Add new rules here.
+class McpAuditRule:
+    """MCP server audit signals -> recommend mcpServers config edit.
+
+    Both ``MCP_UNUSED_SERVER`` and ``MCP_MISSING_SERVER`` land here;
+    the recommendation branches on signal_type to produce the right
+    observation/reason/action. Severity mirrors the signal
+    (INFO for unused, WARNING for missing) so downstream sort by
+    severity keeps advisory notes below actionable warnings.
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type in (
+            SignalType.MCP_UNUSED_SERVER,
+            SignalType.MCP_MISSING_SERVER,
+        )
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        server_name = str(signal.detail.get("server_name", ""))
+
+        if signal.signal_type == SignalType.MCP_UNUSED_SERVER:
+            source_file = str(signal.detail.get("source_file", ""))
+            reason = (
+                "A configured server with no observed usage is either "
+                "unused or inactive — removing it reduces config drift."
+            )
+            action = (
+                f"Remove '{server_name}' from mcpServers in {source_file}, "
+                "or set disabled: true if you expect to use it later."
+            )
+        else:  # MCP_MISSING_SERVER
+            reason = (
+                "Failed calls to an unconfigured MCP server indicate the "
+                "server is expected but not installed in any config "
+                "scope visible to the agent."
+            )
+            action = (
+                f"Add '{server_name}' to ~/.claude.json (user scope) or "
+                ".mcp.json (project scope) so the agent can reach it."
+            )
+
+        return DiagnosticRecommendation(
+            target="mcp",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            config_file=str(signal.detail.get("source_file", "")),
+            signal_types=[signal.signal_type],
+        )
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -461,6 +517,7 @@ RULES: list[CorrelationRule] = [
     StuckPatternRule(),
     ErrorSequenceRule(),
     ModelRoutingRule(),
+    McpAuditRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -35,11 +35,14 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
+from agentfluent.config.models import Severity
 from agentfluent.core.session import index_tool_results_by_id
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 from agentfluent.diagnostics.signals import ERROR_REGEX
 
 if TYPE_CHECKING:
     from agentfluent.agents.models import AgentInvocation
+    from agentfluent.config.models import McpServerConfig
     from agentfluent.core.session import SessionMessage
 
 
@@ -224,3 +227,104 @@ def extract_mcp_usage(
         )
 
     return {server: a.build(server) for server, a in agg.items()}
+
+
+def audit_mcp_servers(
+    usage_by_server: dict[str, McpServerUsage],
+    configured: list[McpServerConfig],
+    *,
+    sessions_analyzed: int,
+) -> list[DiagnosticSignal]:
+    """Compare observed MCP usage against configured servers.
+
+    Emits two signal types:
+
+    - ``MCP_UNUSED_SERVER`` (INFO) — a configured, enabled server with
+      zero observed calls. Advisory: user may want to remove it. Does
+      NOT fire on disabled servers (the user intentionally turned
+      them off).
+    - ``MCP_MISSING_SERVER`` (WARNING) — observed calls reference a
+      server name not in the configured set, AND at least one of
+      those calls failed. The error gate reduces noise: a mystery
+      server whose calls all succeed is unactionable.
+
+    ``sessions_analyzed`` is surfaced in signal detail to help users
+    judge confidence ("0 calls across 50 sessions" is stronger
+    evidence than "0 calls across 2 sessions").
+    """
+    signals: list[DiagnosticSignal] = []
+    signals.extend(_detect_unused_servers(usage_by_server, configured, sessions_analyzed))
+    signals.extend(_detect_missing_servers(usage_by_server, configured, sessions_analyzed))
+    return signals
+
+
+def _detect_unused_servers(
+    usage_by_server: dict[str, McpServerUsage],
+    configured: list[McpServerConfig],
+    sessions_analyzed: int,
+) -> list[DiagnosticSignal]:
+    """Emit MCP_UNUSED_SERVER for configured+enabled servers with 0 calls."""
+    signals: list[DiagnosticSignal] = []
+    for server in configured:
+        if not server.enabled:
+            continue
+        usage = usage_by_server.get(server.server_name)
+        if usage is not None and usage.total_calls > 0:
+            continue
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.MCP_UNUSED_SERVER,
+                severity=Severity.INFO,
+                agent_type="",
+                message=(
+                    f"MCP server '{server.server_name}' is configured in "
+                    f"{server.source_file} but has 0 tool calls across "
+                    f"{sessions_analyzed} analyzed sessions. "
+                    "Consider removing from mcpServers or marking as disabled."
+                ),
+                detail={
+                    "server_name": server.server_name,
+                    "source_file": str(server.source_file),
+                    "configured_tools": server.configured_tools,
+                    "sessions_analyzed": sessions_analyzed,
+                },
+            ),
+        )
+    return signals
+
+
+def _detect_missing_servers(
+    usage_by_server: dict[str, McpServerUsage],
+    configured: list[McpServerConfig],
+    sessions_analyzed: int,
+) -> list[DiagnosticSignal]:
+    """Emit MCP_MISSING_SERVER for observed+failing servers not in config."""
+    configured_names = {s.server_name for s in configured}
+    signals: list[DiagnosticSignal] = []
+    for name, usage in usage_by_server.items():
+        if name in configured_names:
+            continue
+        if usage.error_count == 0:
+            # All calls succeeded — mystery server but not broken.
+            continue
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.MCP_MISSING_SERVER,
+                severity=Severity.WARNING,
+                agent_type="",
+                message=(
+                    f"{usage.error_count} failed calls to "
+                    f"mcp__{name}__* across {sessions_analyzed} sessions, "
+                    f"but no '{name}' server configured. "
+                    "Add to .mcp.json or ~/.claude.json."
+                ),
+                detail={
+                    "server_name": name,
+                    "total_calls": usage.total_calls,
+                    "error_count": usage.error_count,
+                    "unique_tools": usage.unique_tools,
+                    "sessions_analyzed": sessions_analyzed,
+                },
+            ),
+        )
+    return signals

--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -229,6 +229,28 @@ def extract_mcp_usage(
     return {server: a.build(server) for server, a in agg.items()}
 
 
+def _mcp_signal(
+    signal_type: SignalType,
+    severity: Severity,
+    message: str,
+    detail: dict[str, object],
+) -> DiagnosticSignal:
+    """Build an MCP audit signal with the boilerplate prefilled.
+
+    All MCP signals share ``agent_type=""`` (MCP servers aren't scoped
+    to a single agent_type — they're cross-agent concerns). This
+    helper pins that default so callers only specify the varying
+    fields.
+    """
+    return DiagnosticSignal(
+        signal_type=signal_type,
+        severity=severity,
+        agent_type="",
+        message=message,
+        detail=detail,
+    )
+
+
 def audit_mcp_servers(
     usage_by_server: dict[str, McpServerUsage],
     configured: list[McpServerConfig],
@@ -271,25 +293,22 @@ def _detect_unused_servers(
         usage = usage_by_server.get(server.server_name)
         if usage is not None and usage.total_calls > 0:
             continue
-        signals.append(
-            DiagnosticSignal(
-                signal_type=SignalType.MCP_UNUSED_SERVER,
-                severity=Severity.INFO,
-                agent_type="",
-                message=(
-                    f"MCP server '{server.server_name}' is configured in "
-                    f"{server.source_file} but has 0 tool calls across "
-                    f"{sessions_analyzed} analyzed sessions. "
-                    "Consider removing from mcpServers or marking as disabled."
-                ),
-                detail={
-                    "server_name": server.server_name,
-                    "source_file": str(server.source_file),
-                    "configured_tools": server.configured_tools,
-                    "sessions_analyzed": sessions_analyzed,
-                },
+        signals.append(_mcp_signal(
+            signal_type=SignalType.MCP_UNUSED_SERVER,
+            severity=Severity.INFO,
+            message=(
+                f"MCP server '{server.server_name}' is configured in "
+                f"{server.source_file} but has 0 tool calls across "
+                f"{sessions_analyzed} analyzed sessions. "
+                "Consider removing from mcpServers or marking as disabled."
             ),
-        )
+            detail={
+                "server_name": server.server_name,
+                "source_file": str(server.source_file),
+                "configured_tools": server.configured_tools,
+                "sessions_analyzed": sessions_analyzed,
+            },
+        ))
     return signals
 
 
@@ -307,24 +326,21 @@ def _detect_missing_servers(
         if usage.error_count == 0:
             # All calls succeeded — mystery server but not broken.
             continue
-        signals.append(
-            DiagnosticSignal(
-                signal_type=SignalType.MCP_MISSING_SERVER,
-                severity=Severity.WARNING,
-                agent_type="",
-                message=(
-                    f"{usage.error_count} failed calls to "
-                    f"mcp__{name}__* across {sessions_analyzed} sessions, "
-                    f"but no '{name}' server configured. "
-                    "Add to .mcp.json or ~/.claude.json."
-                ),
-                detail={
-                    "server_name": name,
-                    "total_calls": usage.total_calls,
-                    "error_count": usage.error_count,
-                    "unique_tools": usage.unique_tools,
-                    "sessions_analyzed": sessions_analyzed,
-                },
+        signals.append(_mcp_signal(
+            signal_type=SignalType.MCP_MISSING_SERVER,
+            severity=Severity.WARNING,
+            message=(
+                f"{usage.error_count} failed calls to "
+                f"mcp__{name}__* across {sessions_analyzed} sessions, "
+                f"but no '{name}' server configured. "
+                "Add to .mcp.json or ~/.claude.json."
             ),
-        )
+            detail={
+                "server_name": name,
+                "total_calls": usage.total_calls,
+                "error_count": usage.error_count,
+                "unique_tools": usage.unique_tools,
+                "sessions_analyzed": sessions_analyzed,
+            },
+        ))
     return signals

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -28,6 +28,9 @@ class SignalType(StrEnum):
 
     Aggregate-level signals (extracted from per-agent-type rollups):
     - `MODEL_MISMATCH`
+
+    MCP audit signals (configured-vs-observed MCP server usage):
+    - `MCP_UNUSED_SERVER`, `MCP_MISSING_SERVER`
     """
 
     ERROR_PATTERN = "error_pattern"
@@ -38,6 +41,8 @@ class SignalType(StrEnum):
     PERMISSION_FAILURE = "permission_failure"
     STUCK_PATTERN = "stuck_pattern"
     MODEL_MISMATCH = "model_mismatch"
+    MCP_UNUSED_SERVER = "mcp_unused_server"
+    MCP_MISSING_SERVER = "mcp_missing_server"
 
 
 class DiagnosticSignal(BaseModel):

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -375,3 +375,76 @@ class TestModelRoutingCorrelation:
         recs = correlate(signals, None)
         assert len(recs) == 1
         assert recs[0].config_file == ""
+
+
+class TestMcpAuditCorrelation:
+    def _unused_signal(
+        self, server_name: str = "slack", source_file: str = "/home/u/.claude.json",
+    ) -> DiagnosticSignal:
+        return _signal(
+            signal_type=SignalType.MCP_UNUSED_SERVER,
+            severity=Severity.INFO,
+            agent_type="",
+            message=(
+                f"MCP server '{server_name}' is configured in {source_file} "
+                "but has 0 tool calls across 12 analyzed sessions. "
+                "Consider removing from mcpServers or marking as disabled."
+            ),
+            detail={
+                "server_name": server_name,
+                "source_file": source_file,
+                "configured_tools": None,
+                "sessions_analyzed": 12,
+            },
+        )
+
+    def _missing_signal(
+        self, server_name: str = "slack",
+    ) -> DiagnosticSignal:
+        return _signal(
+            signal_type=SignalType.MCP_MISSING_SERVER,
+            severity=Severity.WARNING,
+            agent_type="",
+            message=(
+                f"3 failed calls to mcp__{server_name}__* across 5 sessions, "
+                f"but no '{server_name}' server configured. "
+                "Add to .mcp.json or ~/.claude.json."
+            ),
+            detail={
+                "server_name": server_name,
+                "total_calls": 5,
+                "error_count": 3,
+                "unique_tools": ["send_message"],
+                "sessions_analyzed": 5,
+            },
+        )
+
+    def test_unused_signal_produces_mcp_target_recommendation(self) -> None:
+        recs = correlate([self._unused_signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "mcp"
+        assert rec.severity == Severity.INFO
+        # Action names the server and points at the source file.
+        assert "slack" in rec.action
+        assert "/home/u/.claude.json" in rec.action
+        assert rec.signal_types == [SignalType.MCP_UNUSED_SERVER]
+
+    def test_missing_signal_produces_warning_recommendation(self) -> None:
+        recs = correlate([self._missing_signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "mcp"
+        assert rec.severity == Severity.WARNING
+        assert "slack" in rec.action
+        # Action suggests adding to either user or project config.
+        assert "~/.claude.json" in rec.action or ".mcp.json" in rec.action
+        assert rec.signal_types == [SignalType.MCP_MISSING_SERVER]
+
+    def test_non_mcp_signal_is_not_claimed_by_mcp_rule(self) -> None:
+        # A plain ERROR_PATTERN signal should route through other rules,
+        # not McpAuditRule. If McpAuditRule.matches were too loose this
+        # test would fail.
+        recs = correlate([_signal(keyword="error")])
+        # At least one recommendation; target is NOT "mcp".
+        assert all(r.target != "mcp" for r in recs)

--- a/tests/unit/test_mcp_assessment.py
+++ b/tests/unit/test_mcp_assessment.py
@@ -12,13 +12,17 @@ from typing import Any
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.analytics.pipeline import analyze_session
+from agentfluent.config.models import McpServerConfig, Severity
 from agentfluent.core.session import ContentBlock, SessionMessage
 from agentfluent.diagnostics.mcp_assessment import (
+    McpServerUsage,
     McpToolCall,
+    audit_mcp_servers,
     extract_mcp_calls_from_messages,
     extract_mcp_usage,
     parse_mcp_tool_name,
 )
+from agentfluent.diagnostics.models import SignalType
 from agentfluent.traces.models import SubagentToolCall, SubagentTrace
 from tests._builders import (
     assistant_message,
@@ -26,6 +30,36 @@ from tests._builders import (
     tool_use_block,
     user_message,
 )
+
+
+def _server(
+    name: str = "github",
+    *,
+    enabled: bool = True,
+    source: str = "/home/u/.claude.json",
+    scope: str = "user",
+) -> McpServerConfig:
+    return McpServerConfig(
+        server_name=name,
+        enabled=enabled,
+        source_file=Path(source),
+        scope=scope,  # type: ignore[arg-type]
+    )
+
+
+def _usage(
+    name: str = "github",
+    *,
+    total: int = 1,
+    errors: int = 0,
+    tools: list[str] | None = None,
+) -> McpServerUsage:
+    return McpServerUsage(
+        server_name=name,
+        total_calls=total,
+        unique_tools=tools or ["create_issue"],
+        error_count=errors,
+    )
 
 
 def _assistant_with_mcp(
@@ -285,3 +319,100 @@ class TestAnalyzeSessionWiresInMcpCalls:
     ) -> None:
         result = analyze_session(basic_session_path)
         assert result.mcp_tool_calls == []
+
+
+class TestAuditMcpServers:
+    def test_configured_enabled_unused_fires_info_signal(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={},
+            configured=[_server("slack")],
+            sessions_analyzed=10,
+        )
+        assert len(signals) == 1
+        s = signals[0]
+        assert s.signal_type == SignalType.MCP_UNUSED_SERVER
+        assert s.severity == Severity.INFO
+        assert s.agent_type == ""
+        assert s.detail["server_name"] == "slack"
+        assert s.detail["sessions_analyzed"] == 10
+
+    def test_disabled_server_does_not_fire_unused(self) -> None:
+        # Disabled servers are intentionally off — not a noise source.
+        signals = audit_mcp_servers(
+            usage_by_server={},
+            configured=[_server("slack", enabled=False)],
+            sessions_analyzed=10,
+        )
+        assert signals == []
+
+    def test_used_server_does_not_fire_unused(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={"slack": _usage("slack", total=2)},
+            configured=[_server("slack")],
+            sessions_analyzed=5,
+        )
+        assert signals == []
+
+    def test_observed_with_errors_not_in_config_fires_missing(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={"nonexistent": _usage("nonexistent", total=3, errors=2)},
+            configured=[],
+            sessions_analyzed=5,
+        )
+        assert len(signals) == 1
+        s = signals[0]
+        assert s.signal_type == SignalType.MCP_MISSING_SERVER
+        assert s.severity == Severity.WARNING
+        assert s.detail["server_name"] == "nonexistent"
+        assert s.detail["error_count"] == 2
+
+    def test_observed_without_errors_not_in_config_does_not_fire_missing(
+        self,
+    ) -> None:
+        # Mystery server with all-successful calls — unactionable.
+        signals = audit_mcp_servers(
+            usage_by_server={"mystery": _usage("mystery", total=5, errors=0)},
+            configured=[],
+            sessions_analyzed=5,
+        )
+        assert signals == []
+
+    def test_observed_and_configured_fires_neither(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={"github": _usage("github", total=10, errors=1)},
+            configured=[_server("github")],
+            sessions_analyzed=3,
+        )
+        assert signals == []
+
+    def test_mixed_scenario_emits_per_server_signals(self) -> None:
+        # Four servers: github (used + configured), slack (unused +
+        # configured), unknown (missing + errors), friendly (missing
+        # + no errors).
+        signals = audit_mcp_servers(
+            usage_by_server={
+                "github": _usage("github", total=5, errors=0),
+                "unknown": _usage("unknown", total=3, errors=2),
+                "friendly": _usage("friendly", total=2, errors=0),
+            },
+            configured=[_server("github"), _server("slack")],
+            sessions_analyzed=8,
+        )
+        types = [s.signal_type for s in signals]
+        assert SignalType.MCP_UNUSED_SERVER in types
+        assert SignalType.MCP_MISSING_SERVER in types
+        # github fires nothing; friendly has no errors so it's skipped;
+        # so 2 signals total: slack (unused) + unknown (missing).
+        assert len(signals) == 2
+        by_type = {s.signal_type: s for s in signals}
+        assert by_type[SignalType.MCP_UNUSED_SERVER].detail["server_name"] == "slack"
+        assert by_type[SignalType.MCP_MISSING_SERVER].detail["server_name"] == "unknown"
+
+    def test_sessions_analyzed_is_propagated_to_signal_detail(self) -> None:
+        # Detail field lets the user judge confidence of the finding.
+        signals = audit_mcp_servers(
+            usage_by_server={},
+            configured=[_server("slack")],
+            sessions_analyzed=42,
+        )
+        assert signals[0].detail["sessions_analyzed"] == 42


### PR DESCRIPTION
Third story for Epic #100. Adds the audit primitives and correlator rule that compare observed MCP usage (from #116) against configured servers (from #117).

## Summary

- **2 new `SignalType` values** appended (enum append is safe for existing consumers):
  - `MCP_UNUSED_SERVER` (INFO) — configured + enabled server with 0 observed calls
  - `MCP_MISSING_SERVER` (WARNING) — observed + failing server not in configured set
- **`audit_mcp_servers(usage, configured, sessions_analyzed)`** — orchestrates detection across both branches
- **`McpAuditRule`** in the correlator — matches both signal types, produces `target=\"mcp\"` recommendations
- Severity mirrors the signal so downstream sort-by-severity keeps advisory notes below actionable warnings

## Design decisions (per epic plan)

- **Disabled servers excluded from unused check** — user intentionally turned them off, flagging would be noise.
- **Error-count gate on missing-server** — a mystery server whose calls all succeed is unactionable; only flag when there's a real failure to explain.
- **`sessions_analyzed` in signal detail** — lets the user judge confidence (0/50 vs 0/2).
- **Empty `agent_type` on MCP signals** — MCP is cross-agent; downstream consumers already handle empty agent_type.

## Not in this PR

- Pipeline wiring (#119) — `run_diagnostics` doesn't call `audit_mcp_servers` yet. Next story.
- CLI rendering — reuses the existing target-grouped formatter automatically once wired.

## Test plan

- [x] 8 new audit unit tests (enabled/disabled gate, used/unused branches, error-count gate, mixed scenario, `sessions_analyzed` propagation)
- [x] 3 new correlator tests (unused → target=mcp INFO, missing → target=mcp WARNING, non-MCP signal not claimed by the rule)
- [x] Full unit suite: 630 → 641 passing, 0 regressions
- [x] `ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean (strict mode)

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)