### PR TITLE
feat(diagnostics): wire MCP audit into run_diagnostics pipeline (#119)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -13,6 +13,7 @@ from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.helpers import format_cost, format_tokens
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
+from agentfluent.config.mcp_discovery import resolve_project_disk_path
 from agentfluent.core.discovery import find_project
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
@@ -181,8 +182,16 @@ def analyze(
     result = analyze_sessions(paths, agent_filter=agent)
 
     all_invocations = [inv for s in result.sessions for inv in s.invocations]
+    all_mcp_calls = [c for s in result.sessions for c in s.mcp_tool_calls]
 
     if all_invocations:
+        # `project_info.path` is the ~/.claude/projects/<slug>/ dir, not
+        # the original project source path. MCP discovery needs the
+        # real path (for .mcp.json and ~/.claude.json:projects[<abs>]
+        # lookups); resolve it via the slug.
+        project_disk_path = resolve_project_disk_path(
+            project_info.slug, claude_config_dir=config_dir,
+        )
         result.diagnostics = run_diagnostics(
             all_invocations,
             min_cluster_size=(
@@ -193,6 +202,9 @@ def analyze(
                 min_similarity if min_similarity is not None
                 else DEFAULT_MIN_SIMILARITY
             ),
+            mcp_tool_calls=all_mcp_calls,
+            claude_config_dir=config_dir,
+            project_dir=project_disk_path,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         console.print(

--- a/src/agentfluent/config/mcp_discovery.py
+++ b/src/agentfluent/config/mcp_discovery.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -122,11 +123,24 @@ def discover_mcp_servers(
     )
 
 
+@lru_cache(maxsize=16)
 def _load_json(path: Path) -> dict[str, Any] | None:
     """Read and decode a JSON object file.
 
     Returns ``None`` for missing files (silent), logs a warning and
     returns ``None`` for malformed JSON or non-object roots.
+
+    Cached per-path for the lifetime of the process. ``~/.claude.json``
+    is read by both ``resolve_project_disk_path`` (CLI) and
+    ``discover_mcp_servers`` (pipeline) during a single
+    ``agentfluent analyze`` invocation; caching eliminates the
+    redundant ~45KB file read + JSON parse. Real usage touches only
+    2 files per invocation (``~/.claude.json`` + the project's
+    ``.mcp.json``); ``maxsize=16`` is 8× headroom — generous for
+    future config sources without inviting unbounded growth. Callers
+    must not mutate the returned dict — it's shared state. Tests that
+    need a fresh read should call ``_load_json.cache_clear()`` in
+    setup.
     """
     if not path.exists():
         return None

--- a/src/agentfluent/config/mcp_discovery.py
+++ b/src/agentfluent/config/mcp_discovery.py
@@ -37,6 +37,38 @@ logger = logging.getLogger(__name__)
 MCP_PROJECT_FILENAME = ".mcp.json"
 
 
+def resolve_project_disk_path(
+    slug: str,
+    claude_config_dir: Path | None,
+) -> Path | None:
+    """Map a ``~/.claude/projects/<slug>/`` directory name back to the
+    original on-disk project path.
+
+    Claude Code stores per-project data in ``~/.claude.json`` keyed by
+    absolute path (e.g., ``/home/user/myproj``). The project directory
+    inside ``~/.claude/projects/`` is a slug-encoded form of that
+    path (``-home-user-myproj``). Direct slug reversal would be lossy
+    for paths containing hyphens, so we look up the slug in the
+    ``projects`` dict keys and match by forward-encoding each
+    candidate absolute path — the unambiguous direction.
+
+    Returns ``None`` when no match is found or ``~/.claude.json`` is
+    missing / malformed. Callers typically degrade gracefully in that
+    case (MCP discovery falls back to user scope only).
+    """
+    claude_json_path = claude_json_for(claude_config_dir)
+    data = _load_json(claude_json_path)
+    if data is None:
+        return None
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        return None
+    for abs_path_str in projects:
+        if str(abs_path_str).replace("/", "-") == slug:
+            return Path(str(abs_path_str))
+    return None
+
+
 def discover_mcp_servers(
     claude_config_dir: Path | None,
     project_dir: Path | None,

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -16,8 +16,10 @@ pattern used elsewhere.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.diagnostics.correlator import correlate
@@ -26,6 +28,11 @@ from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_SIMILARITY,
     SKLEARN_AVAILABLE,
     suggest_delegations,
+)
+from agentfluent.diagnostics.mcp_assessment import (
+    McpToolCall,
+    audit_mcp_servers,
+    extract_mcp_usage,
 )
 from agentfluent.diagnostics.model_routing import extract_model_routing_signals
 from agentfluent.diagnostics.models import (
@@ -153,6 +160,9 @@ def run_diagnostics(
     *,
     min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
     min_similarity: float = DEFAULT_MIN_SIMILARITY,
+    mcp_tool_calls: list[McpToolCall] | None = None,
+    claude_config_dir: Path | None = None,
+    project_dir: Path | None = None,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
@@ -163,6 +173,14 @@ def run_diagnostics(
     general-purpose delegations. ``subagent_trace_count`` on the result
     reflects traces that successfully parsed and linked, not the raw
     filesystem enumeration.
+
+    MCP audit runs when any of three conditions hold: a user has
+    configured MCP servers discovered at ``claude_config_dir`` /
+    ``project_dir``, subagent traces carry MCP tool calls, or
+    ``mcp_tool_calls`` (parent-session MCP calls collected by
+    ``analyze_session``) is non-empty. Silent-skips the whole audit
+    when all three are empty — no noisy "MCP Assessment" section on
+    projects that don't use MCP at all.
     """
     signals = extract_signals(invocations)
 
@@ -189,6 +207,32 @@ def run_diagnostics(
     # Aggregate-level signals (model-routing) use the same config lookup
     # the correlator will read from; fold them in before correlation.
     signals.extend(extract_model_routing_signals(invocations, configs_by_name))
+
+    # MCP audit. Runs only when the caller has provided explicit MCP
+    # context — avoids silently picking up the user's real
+    # ~/.claude.json from programmatic callers (tests, libraries) that
+    # don't opt in. The CLI always passes at least `mcp_tool_calls`
+    # and `claude_config_dir`, so users still get audit by default.
+    # Final silent-skip when audit runs but has no content to avoid a
+    # noisy "MCP Assessment" section on non-MCP projects.
+    mcp_audit_requested = (
+        mcp_tool_calls is not None
+        or claude_config_dir is not None
+        or project_dir is not None
+    )
+    if mcp_audit_requested:
+        mcp_usage = extract_mcp_usage(invocations, mcp_tool_calls)
+        configured_mcp = discover_mcp_servers(
+            claude_config_dir=claude_config_dir, project_dir=project_dir,
+        )
+        if mcp_usage or configured_mcp:
+            signals.extend(
+                audit_mcp_servers(
+                    mcp_usage,
+                    configured_mcp,
+                    sessions_analyzed=len(invocations) or 1,
+                ),
+            )
 
     recommendations = correlate(signals, configs_by_name)
 

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -445,3 +445,67 @@ class TestCrossReferenceEnrichment:
         note = suggestions[0].dedup_note
         assert ".." not in note  # no double-period from naive concat
         assert "pm" in note and "claude-haiku-4-5" in note
+
+
+class TestMcpAuditWiring:
+    """run_diagnostics MCP-audit gate: runs only when caller passes
+    explicit MCP context. Prevents programmatic callers from silently
+    picking up the user's real ~/.claude.json.
+    """
+
+    def test_no_mcp_context_skips_audit(self, tmp_path, monkeypatch) -> None:
+        # Even if a real ~/.claude.json would return servers, a caller
+        # that passes nothing should see no MCP audit output. Redirect
+        # Path.home to an empty dir to also guarantee no accidental read.
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = run_diagnostics([_inv()])
+        assert all(
+            s.signal_type.value not in ("mcp_unused_server", "mcp_missing_server")
+            for s in result.signals
+        )
+
+    def test_mcp_tool_calls_provided_triggers_audit(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        # Even with no configured servers (empty home), providing
+        # mcp_tool_calls that had errors should fire MCP_MISSING_SERVER.
+        from agentfluent.diagnostics.mcp_assessment import McpToolCall
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        calls = [
+            McpToolCall(
+                server_name="unknown_server", tool_name="x", is_error=True,
+            ),
+            McpToolCall(
+                server_name="unknown_server", tool_name="y", is_error=True,
+            ),
+        ]
+        result = run_diagnostics([_inv()], mcp_tool_calls=calls)
+        assert any(
+            s.signal_type == SignalType.MCP_MISSING_SERVER
+            for s in result.signals
+        )
+
+    def test_configured_servers_read_when_claude_config_dir_passed(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        # Passing claude_config_dir is enough to trigger audit even
+        # without mcp_tool_calls — caller opts in explicitly.
+        import json
+
+        claude_root = tmp_path / ".claude"
+        claude_root.mkdir()
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            json.dumps({"mcpServers": {"unused-svc": {"command": "x"}}}),
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        result = run_diagnostics([_inv()], claude_config_dir=claude_root)
+
+        unused = [
+            s for s in result.signals
+            if s.signal_type == SignalType.MCP_UNUSED_SERVER
+        ]
+        assert len(unused) == 1
+        assert unused[0].detail["server_name"] == "unused-svc"

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -5,11 +5,17 @@ backward compatibility of the public `run_diagnostics` import path,
 and v0.2 output-shape regression for trace-less sessions.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 from agentfluent.agents.models import AgentInvocation
-from agentfluent.config.models import Severity
+from agentfluent.config.mcp_discovery import _load_json
+from agentfluent.config.models import AgentConfig, Scope, Severity
 from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
+from agentfluent.diagnostics.delegation import MODEL_OPUS
+from agentfluent.diagnostics.mcp_assessment import McpToolCall
 from agentfluent.diagnostics.models import (
     DelegationSuggestion,
     DiagnosticSignal,
@@ -296,11 +302,6 @@ class TestModelRoutingWiring:
     def test_model_mismatch_signal_produces_target_model_recommendation(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from pathlib import Path
-
-        from agentfluent.config.models import AgentConfig, Scope
-        from agentfluent.diagnostics.delegation import MODEL_OPUS
-
         # 5 "pm" invocations with simple workload but declaring Opus —
         # overspec case. Stub scan_agents to return a config that
         # declares model=Opus; otherwise the agent gets skipped.
@@ -453,25 +454,31 @@ class TestMcpAuditWiring:
     picking up the user's real ~/.claude.json.
     """
 
-    def test_no_mcp_context_skips_audit(self, tmp_path, monkeypatch) -> None:
-        # Even if a real ~/.claude.json would return servers, a caller
-        # that passes nothing should see no MCP audit output. Redirect
-        # Path.home to an empty dir to also guarantee no accidental read.
+    @pytest.fixture(autouse=True)
+    def _isolate_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Redirect Path.home so audit can never accidentally read the
+        # contributor's real ~/.claude.json. Clear _load_json's lru_cache
+        # before and after so tmp_path reuse across tests doesn't return
+        # a stale parsed dict from a prior test's file.
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        _load_json.cache_clear()
+        yield
+        _load_json.cache_clear()
+
+    def test_no_mcp_context_skips_audit(self) -> None:
+        # A caller that passes nothing should see no MCP audit output,
+        # even if a real ~/.claude.json would return servers.
         result = run_diagnostics([_inv()])
         assert all(
             s.signal_type.value not in ("mcp_unused_server", "mcp_missing_server")
             for s in result.signals
         )
 
-    def test_mcp_tool_calls_provided_triggers_audit(
-        self, tmp_path, monkeypatch,
-    ) -> None:
-        # Even with no configured servers (empty home), providing
-        # mcp_tool_calls that had errors should fire MCP_MISSING_SERVER.
-        from agentfluent.diagnostics.mcp_assessment import McpToolCall
-
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    def test_mcp_tool_calls_provided_triggers_audit(self) -> None:
+        # Providing mcp_tool_calls with errors fires MCP_MISSING_SERVER
+        # even with no configured servers.
         calls = [
             McpToolCall(
                 server_name="unknown_server", tool_name="x", is_error=True,
@@ -487,19 +494,16 @@ class TestMcpAuditWiring:
         )
 
     def test_configured_servers_read_when_claude_config_dir_passed(
-        self, tmp_path, monkeypatch,
+        self, tmp_path: Path,
     ) -> None:
         # Passing claude_config_dir is enough to trigger audit even
         # without mcp_tool_calls — caller opts in explicitly.
-        import json
-
         claude_root = tmp_path / ".claude"
         claude_root.mkdir()
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text(
             json.dumps({"mcpServers": {"unused-svc": {"command": "x"}}}),
         )
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
         result = run_diagnostics([_inv()], claude_config_dir=claude_root)
 


### PR DESCRIPTION
Fourth story for Epic #100. Wires extraction (#116), discovery (#117), and audit rules (#118) into the `analyze --diagnostics` pipeline.

## Summary

- **`run_diagnostics`** gains three keyword-only kwargs: `mcp_tool_calls`, `claude_config_dir`, `project_dir`. All default to `None` — additive, no existing callers break.
- **MCP audit gated on explicit caller opt-in**: runs only when the caller provides at least one of the three MCP context kwargs. Prevents programmatic callers (tests, library users) from silently picking up the user's real `~/.claude.json`. The CLI always passes at least two of them, so users get audit automatically.
- **Final silent-skip** inside the gate when audit returns no signals — keeps non-MCP projects clean of an empty \"MCP Assessment\" section.
- **CLI flattens session-level `mcp_tool_calls`** across all analyzed sessions (mirrors the existing `all_invocations` pattern).
- **New `resolve_project_disk_path(slug, claude_config_dir)` helper** in `config/mcp_discovery.py`: `project_info.path` is the `~/.claude/projects/<slug>/` location, not the project source directory we need for `.mcp.json` lookups. The resolver looks up the slug in `~/.claude.json`'s `projects` dict keys — unambiguous direction even for project paths with hyphens (avoids the lossy slug-reversal Architect #1 flagged).

## Why the caller-opt-in gate

Two previously-existing pipeline tests (`test_oserror_in_scan_agents` and `test_empty_invocations`) would have regressed under unconditional MCP discovery — `run_diagnostics([])` would start reading the real home dir. The gate preserves their shape AND makes programmatic use clean.

## Dogfood

Full flow confirmed end-to-end on real data:
- `~/.claude.json` has `mcpServers: {github: ...}` (user scope, configured)
- agentfluent project uses `mcp__github__*` heavily (74+ calls)
- Audit correctly emits **zero MCP signals**: not unused (github IS used), not missing (github IS configured). Pipeline runs, nothing to flag.

## Test plan

- [x] 3 new wiring tests: no-context skip (tests don't leak real config), `mcp_tool_calls`-only trigger produces `MCP_MISSING_SERVER`, `claude_config_dir`-only trigger produces `MCP_UNUSED_SERVER`
- [x] Full unit suite: 641 → 644 passing, 0 regressions
- [x] `ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean (strict mode)
- [x] Dogfood: `agentfluent analyze --project agentfluent --diagnostics` runs end-to-end

## Epic #100 status after this merge

- ✅ #117 (discovery) — PR #156
- ✅ #116 (extraction) — PR #157
- ✅ #118 (audit rules) — PR #158
- ✅ #119 (pipeline) — this PR
- ⏳ #120 (tests) — rolled into each story PR; ticket to close once this lands

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)