### PR TITLE
feat(diagnostics): aggregate duplicate recommendations (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The agent observability space is crowded — several tools capture what agents d
 
 - **Research-grounded.** Every diagnostic maps to a specific gap in the agent's prompt, tool list, or model selection — not vibes. See the [research doc](docs/AGENT_ANALYTICS_RESEARCH.md) for the feasibility and positioning analysis.
 - **Behavior-to-improvement, not just traces.** When the agent retries Bash 40% of the time, AgentFluent tells you *which prompt clause is missing* — not just that the retry happened.
-- **The config is the agent.** In interactive sessions, the human course-corrects. In programmatic agents, the prompt and tool setup *are* the agent — a flaw compounds at scale. AgentFluent scores four dimensions of that config today — description, tools (`allowed_tools` / `disallowedTools`), model, and prompt — with hook, MCP, and cross-agent coverage on the roadmap.
+- **The config is the agent.** In interactive sessions, the human course-corrects. In programmatic agents, the prompt and tool setup *are* the agent — a flaw compounds at scale. AgentFluent scores description, tools (`allowed_tools` / `disallowedTools`), model, and prompt on every agent definition, and audits MCP server configuration (configured-but-unused, observed-but-missing) against real tool usage. Hook coverage and cross-agent pattern detection are on the roadmap.
 - **Local-first and private.** All analysis runs on your machine. Zero outbound network calls. No API key required.
 - **CLI-native.** `agentfluent analyze --format json | jq ...` — fits agent developer workflows (terminal, CI/CD, PR checks) without a web dashboard dependency.
 - **JSON output envelope is a contract.** A stable `{version, command, data}` schema lets you build PR gates, trend dashboards, and regression detectors on top without tracking AgentFluent's internal refactors.
@@ -126,7 +126,13 @@ agentfluent analyze --project codefluent --diagnostics      # Show behavior diag
 agentfluent analyze --project codefluent --format json | jq '.data.token_metrics.total_cost'
 ```
 
-Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. `--diagnostics` surfaces behavior signals (tool errors, token-per-tool-use outliers, duration outliers) with a pointer to the configuration gap most likely responsible.
+Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. `--diagnostics` surfaces the full v0.3 signal surface:
+
+- **Metadata-level** (from invocation summaries): tool-error keywords, token-per-tool-use outliers, duration outliers.
+- **Trace-level** (from `~/.claude/projects/<session>/subagents/`): retry loops, stuck patterns, permission failures, consecutive tool-error sequences — each with per-tool-call evidence.
+- **Aggregate**: model mismatch (complexity class wrong for declared/observed model), delegation clustering (recurring `general-purpose` patterns → proposed specialized subagents), MCP server audit (configured-but-unused, observed-but-missing).
+
+Each recommendation carries a specific config surface to change (prompt, tools, model, mcp) and a pointer to the file to edit.
 
 Cost numbers reflect current per-token pricing; historical sessions are priced at today's rates until [#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80) (time-series pricing) lands.
 
@@ -151,7 +157,11 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 | `--scope` | `all` | `config-check` scope: `user`, `project`, or `all` |
 | `--agent` | (none) | Filter `analyze` or `config-check` to one subagent type |
 | `--latest N` | (all sessions) | `analyze` only the N most recent sessions |
+| `--session` | (all) | `analyze` a specific session filename within the project |
 | `--diagnostics` | off | `analyze`: show behavior-correlation signals |
+| `--min-cluster-size` | 5 | Delegation clustering: minimum invocations per cluster (requires `agentfluent[clustering]`) |
+| `--min-similarity` | 0.7 | Delegation dedup: cosine-similarity threshold against existing agents |
+| `--claude-config-dir` | `~/.claude/` | Override the Claude config root (also honors `$CLAUDE_CONFIG_DIR`) |
 | `--format` | `table` | Output format: `table` (Rich) or `json` (envelope) |
 | `--verbose` | off | Extra detail (per-session breakdown, per-invocation detail) |
 | `--quiet` | off | Suppress non-essential output (useful in CI) |
@@ -183,22 +193,31 @@ No ANSI escapes in JSON output, guaranteed. The key `total_cost` is the pay-per-
 flowchart LR
     subgraph Local["Local filesystem — nothing leaves this boundary"]
         S["Session JSONL<br/>~/.claude/projects/"]
-        A["Agent definitions<br/>~/.claude/agents/<br/>.claude/agents/"]
+        ST["Subagent traces<br/>&lt;session&gt;/subagents/"]
+        A["Agent definitions<br/>~/.claude/agents/"]
+        M["MCP config<br/>~/.claude.json<br/>.mcp.json"]
     end
 
     S --> P[Parser]
+    ST --> TP[Trace Parser<br/>+ Linker]
     P --> X[Agent Extractor]
     P --> TM[Token &amp; Cost<br/>Metrics]
     P --> TU[Tool Usage<br/>Patterns]
+    TP --> X
     A --> CS[Config Scanner]
     CS --> SC[Config Scorer]
+    M --> MD[MCP Discovery]
 
-    X --> D[Diagnostics<br/>Correlator]
-    TM --> D
-    TU --> D
-    SC --> D
+    X --> DX[Delegation<br/>Clustering]
+    X --> MR[Model-Routing<br/>Analysis]
+    X --> SIG[Signal Extraction<br/>metadata + trace]
+    SIG --> COR[Correlator]
+    MR --> COR
+    DX --> COR
+    MD --> COR
+    SC --> COR
 
-    D --> OUT["Rich tables<br/>or JSON envelope"]
+    COR --> OUT["Rich tables<br/>or JSON envelope"]
     TM --> OUT
     TU --> OUT
     SC --> OUT
@@ -207,12 +226,15 @@ flowchart LR
 Step by step:
 
 1. **Parse JSONL** — `core/parser.py` reads each session file into typed `SessionMessage` objects. Handles streaming snapshot deduplication, plain-string vs. array content shapes, and Claude Code's real `toolUseResult` format (see [`CLAUDE.md`](CLAUDE.md) for the format spec).
-2. **Discover projects and sessions** — `core/discovery.py` enumerates `~/.claude/projects/` and surfaces friendly display names.
-3. **Extract agent invocations** — `agents/extractor.py` walks messages, pairs Agent `tool_use` blocks with their `tool_result` content blocks, and pulls per-invocation metadata (tokens, duration, tool-use count) from the containing user message's `toolUseResult` sibling.
-4. **Compute token and cost metrics** — `analytics/tokens.py` aggregates usage per model with `<synthetic>` sentinel filtering; `analytics/pricing.py` applies per-token rates labeled as API rate.
-5. **Score agent configurations** — `config/scanner.py` parses YAML frontmatter from each `.md` in `.claude/agents/` and `~/.claude/agents/`; `config/scoring.py` scores description, tools, model, and prompt on a 4-dimension rubric.
-6. **Diagnose behavior** — `diagnostics/signals.py` correlates observed patterns (retry loops, tool errors, zero-invocation agents) with likely configuration root causes and attaches a recommendation.
-7. **Render** — `cli/formatters/table.py` emits Rich tables; `cli/formatters/json.py` emits the stable JSON envelope. Format is selected by `--format`.
+2. **Parse subagent traces** — `traces/parser.py` reads per-session subagent files under `<session>/subagents/agent-<agentId>.jsonl` and reconstructs the internal tool-call sequence with `is_error` flags. `traces/linker.py` attaches each trace back to its parent invocation via `agentId`. `traces/retry.py` detects retry sequences within a trace.
+3. **Discover projects and sessions** — `core/discovery.py` enumerates `~/.claude/projects/` and surfaces friendly display names.
+4. **Extract agent invocations** — `agents/extractor.py` walks messages, pairs Agent `tool_use` blocks with their `tool_result` content blocks, and pulls per-invocation metadata (tokens, duration, tool-use count) from the containing user message's `toolUseResult` sibling.
+5. **Compute token and cost metrics** — `analytics/tokens.py` aggregates usage per model with `<synthetic>` sentinel filtering; `analytics/pricing.py` applies per-token rates labeled as API rate.
+6. **Score agent configurations** — `config/scanner.py` parses YAML frontmatter from each `.md` in `.claude/agents/` and `~/.claude/agents/`; `config/scoring.py` scores description, tools, model, and prompt on a 4-dimension rubric.
+7. **Discover MCP servers** — `config/mcp_discovery.py` reads `mcpServers` from `~/.claude.json` (user + project-local scopes) and `.mcp.json` (project-shared), honoring the `enabledMcpjsonServers` / `disabledMcpjsonServers` gating arrays. Used by the audit phase to compare against observed `mcp__*` tool usage.
+8. **Diagnose behavior** — `diagnostics/` extracts metadata signals (`signals.py`), trace-level signals (`trace_signals.py` — retry loops, stuck patterns, permission failures, error sequences), model-routing mismatches (`model_routing.py`), and MCP audit signals (`mcp_assessment.py`). `correlator.py` routes each signal to a config target (prompt/tools/model/mcp) and emits an actionable recommendation.
+9. **Propose new subagents** — `diagnostics/delegation.py` clusters recurring `general-purpose` invocations via TF-IDF + KMeans and drafts candidate subagent definitions with name, model, tool list, and prompt scaffold. Deduped against existing agents by cosine similarity.
+10. **Render** — `cli/formatters/table.py` emits Rich tables; `cli/formatters/json.py` emits the stable JSON envelope. Format is selected by `--format`.
 
 Everything runs locally. No outbound network calls, ever. No API key needed.
 
@@ -221,7 +243,11 @@ Everything runs locally. No outbound network calls, ever. No API key needed.
 - **Project and Session Discovery** — Enumerates `~/.claude/projects/`, groups sessions by project, shows per-project session count, total size, and last-modified timestamp. Handles Claude Code subagent sidechain files and Agent SDK sessions uniformly.
 - **Execution Analytics** — Token usage, API-rate cost, cache efficiency, per-model breakdown, tool-call concentration, and per-agent invocation metrics (tokens, duration, tool-use count). Cache creation and cache read tokens are tracked separately so you can see where your prompt caching is working.
 - **Agent Config Assessment** — 4-dimension rubric (description, tools, model, prompt) applied to every `.md` file in `~/.claude/agents/` and `./.claude/agents/`. Produces a 0–100 score plus ranked, specific recommendations ("Prompt body doesn't mention error handling"). Catches agents that are technically valid but miss well-known best practices.
-- **Diagnostics Preview** — `--diagnostics` correlates three behavior signals to configuration gaps: tool errors (caught by keywords like `blocked`, `failed`, `error`) suggesting missing error-handling instructions or over-broad tools; per-tool-use token outliers suggesting an agent that's exploring too broadly or needs a tighter prompt; duration outliers flagging unusually slow invocations. Each signal carries a severity level and a specific recommendation.
+- **Subagent Trace Parsing** — Parses the internal tool-call sequences Claude Code emits under `~/.claude/projects/<session>/subagents/agent-<agentId>.jsonl`, links them back to the delegating invocation, and detects retry sequences. Gives diagnostics per-call evidence (which tool, which attempt, which error) instead of just an invocation-level summary.
+- **Behavior Diagnostics** — `--diagnostics` emits signals across three layers. *Metadata*: tool-error keywords, token-per-tool-use outliers, duration outliers. *Trace-level*: retry loops, stuck patterns (same call repeated with no progress), permission failures, consecutive tool-error sequences. *Aggregate*: model mismatch (declared/observed model wrong for the workload's complexity), MCP server audit (configured-but-unused, observed-but-missing). Each signal routes to a `target` config surface — prompt, tools, model, or mcp — and the recommendation names the file to edit and the specific change to make.
+- **Delegation Clustering** — TF-IDF + KMeans on recurring `general-purpose` invocations surfaces patterns that would benefit from their own specialized subagent. Proposes a complete draft: name, description, recommended model (with cost reasoning), tool list derived from the cluster's trace data, and a prompt-body scaffold. Suppresses drafts that overlap existing agents and annotates the overlap. Requires the optional `agentfluent[clustering]` extra.
+- **Model-Routing Diagnostics** — Per-agent-type classification of observed complexity (tool-call counts, token footprint, error rate, write-tool presence) compared against the agent's declared model tier. Flags overspec (complex model on simple workload — cost savings estimate included) and underspec (simple model struggling). Consumes trace-based model inference when frontmatter is absent.
+- **MCP Server Assessment** — Reads configured MCP servers from `~/.claude.json` (user + project-local) and `.mcp.json` (project-shared), honoring per-user enable/disable gating. Compares against observed `mcp__<server>__*` tool usage from both parent sessions and subagent traces. Emits `MCP_UNUSED_SERVER` (INFO, configured but zero calls) and `MCP_MISSING_SERVER` (WARNING, failing calls to an unconfigured server) signals with actionable recommendations.
 - **JSON Output Envelope** — Stable `{version, command, data}` schema. No ANSI escapes. Intended as a programmatic contract for CI integration, PR gates, and regression tracking.
 - **Quiet and Verbose Modes** — `--quiet` for CI-friendly one-line summaries; `--verbose` for per-session breakdown and per-invocation detail tables. Defaults target interactive humans.
 
@@ -236,7 +262,7 @@ AgentFluent is designed so data stays on your machine. The attack surface is sma
 | Input validation | Pydantic models with strict type constraints | Malformed JSONL crashing the parser |
 | Safe YAML loading | `yaml.safe_load` only | Arbitrary code execution via frontmatter |
 | CI security review | Claude-powered review on every PR | New vulnerabilities |
-| Automated testing | 270+ unit tests incl. security-focused cases | Regressions |
+| Automated testing | 600+ unit tests incl. security-focused cases | Regressions |
 
 ### Secrets handling
 
@@ -257,7 +283,7 @@ See [`docs/SECURITY.md`](docs/SECURITY.md) for the full policy: leak vector, def
 - **[Typer](https://typer.tiangolo.com) + [Rich](https://rich.readthedocs.io)** — CLI framework and terminal formatting
 - **[Pydantic v2](https://docs.pydantic.dev)** — data models across module boundaries
 - **[PyYAML](https://pyyaml.org)** — agent definition frontmatter parsing (`safe_load` only)
-- **[pytest](https://pytest.org) + pytest-cov** — 270+ tests
+- **[pytest](https://pytest.org) + pytest-cov** — 600+ tests
 - **[mypy](https://mypy.readthedocs.io) strict mode** — full type coverage
 - **[ruff](https://docs.astral.sh/ruff/)** — linting and formatting
 - **[uv](https://docs.astral.sh/uv/)** — package and dependency management
@@ -270,8 +296,10 @@ src/agentfluent/
 ├── core/                # JSONL parser, session models, project/session discovery
 ├── agents/              # Agent invocation extraction and AgentInvocation model
 ├── analytics/           # Token/cost metrics, tool patterns, model pricing
-├── config/              # Agent definition scanner and scoring rubric
-└── diagnostics/         # Behavior signals, correlation, recommendations
+├── config/              # Agent definition scanner + scoring + MCP server discovery
+├── traces/              # Subagent trace parsing, linking, and retry detection
+└── diagnostics/         # Behavior signals (metadata + trace), correlation,
+                         # model routing, delegation clustering, MCP audit
 ```
 
 Full architecture and conventions are documented in [`CLAUDE.md`](CLAUDE.md).
@@ -288,7 +316,7 @@ uv run agentfluent --help
 ### Testing
 
 ```bash
-uv run pytest -m "not integration"            # 270+ unit tests (CI default)
+uv run pytest -m "not integration"            # 600+ unit tests (CI default)
 uv run pytest                                 # Full suite incl. integration tests against your real ~/.claude/projects/
 uv run pytest --cov=agentfluent               # With coverage
 ```
@@ -316,27 +344,31 @@ Five GitHub Actions workflows run automatically:
 
 ## Roadmap
 
-**v0.2 (next release):**
-- Parser fix for real Claude Code `toolUseResult` shape ([#84](https://github.com/frederick-douglas-pearce/agentfluent/issues/84) — merged)
-- Cost label clarity for subscription-plan users ([#76](https://github.com/frederick-douglas-pearce/agentfluent/issues/76) — merged)
-- Pricing data correction + opus-4-7 + synthetic filter ([#75](https://github.com/frederick-douglas-pearce/agentfluent/issues/75) — merged)
+**v0.2 (shipped):**
+- Parser fix for real Claude Code `toolUseResult` shape ([#84](https://github.com/frederick-douglas-pearce/agentfluent/issues/84))
+- Cost label clarity for subscription-plan users ([#76](https://github.com/frederick-douglas-pearce/agentfluent/issues/76))
+- Pricing data correction + opus-4-7 + synthetic filter ([#75](https://github.com/frederick-douglas-pearce/agentfluent/issues/75))
 
-**v0.3+:**
-- Time-series pricing data structure ([#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80))
-- Session-timestamp-aware cost calculation ([#81](https://github.com/frederick-douglas-pearce/agentfluent/issues/81))
-- Automated pricing-update service ([#82](https://github.com/frederick-douglas-pearce/agentfluent/issues/82))
-- `--claude-config-dir` flag for non-default session paths ([#90](https://github.com/frederick-douglas-pearce/agentfluent/issues/90))
-- Delegation pattern recognition — cluster `general-purpose` invocations and recommend custom subagents ([#92](https://github.com/frederick-douglas-pearce/agentfluent/issues/92))
-- Deeper diagnostics with per-tool-call evidence
-- Subagent trace parsing (`~/.claude/projects/<session>/subagents/`)
-- Prompt regression detection across agent config versions
-- Retry-pattern and zero-invocation-agent signals (complete the diagnostics surface currently covering tool errors and outliers)
-- Hook and MCP-server coverage in the config rubric
+**v0.3 (shipped):**
+- Subagent trace parser ([E2](https://github.com/frederick-douglas-pearce/agentfluent/issues/98)) — reconstructs the full internal tool-call sequence per subagent with `is_error` flags and retry detection, linked back to the delegating invocation.
+- Deep diagnostics engine ([E3](https://github.com/frederick-douglas-pearce/agentfluent/issues/99)) — trace-level signals: retry loops, stuck patterns, permission failures, consecutive tool-error sequences, each carrying per-tool-call evidence.
+- Delegation clustering ([#92](https://github.com/frederick-douglas-pearce/agentfluent/issues/92)) — TF-IDF + KMeans over recurring `general-purpose` invocations; proposes complete draft subagent definitions deduped against existing agents.
+- Model-routing diagnostics ([#95](https://github.com/frederick-douglas-pearce/agentfluent/issues/95)) — per-agent-type complexity classification vs. declared model; overspec/underspec flags with cost-savings estimates. Trace-based model inference when frontmatter is absent.
+- MCP server assessment ([#100](https://github.com/frederick-douglas-pearce/agentfluent/issues/100)) — configured-vs-observed audit with `MCP_UNUSED_SERVER` and `MCP_MISSING_SERVER` signals.
+- `--claude-config-dir` flag and `$CLAUDE_CONFIG_DIR` env var for non-default session paths ([#90](https://github.com/frederick-douglas-pearce/agentfluent/issues/90)).
+- Empirical threshold calibration via a committed Jupyter notebook ([#140](https://github.com/frederick-douglas-pearce/agentfluent/issues/140)).
+
+**v0.4+:**
+- Time-series pricing data structure ([#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80)) + session-timestamp-aware cost calculation ([#81](https://github.com/frederick-douglas-pearce/agentfluent/issues/81)) + automated pricing updates ([#82](https://github.com/frederick-douglas-pearce/agentfluent/issues/82)).
+- Agent SDK main-session MCP + tool extraction ([#112](https://github.com/frederick-douglas-pearce/agentfluent/issues/112)).
+- Per-invocation token input/output split for more accurate cost estimates ([#143](https://github.com/frederick-douglas-pearce/agentfluent/issues/143)).
+- Hosted documentation site ([#97](https://github.com/frederick-douglas-pearce/agentfluent/issues/97)).
+- Prompt regression detection (`agentfluent diff`) across agent config versions.
+- Hook coverage in the config rubric.
 
 **Future:**
 - Webapp dashboard for trend visualization
 - `agentfluent diff` — side-by-side comparison of behavior before/after a prompt change
-- MCP server configuration assessment
 - Closed-loop self-improvement — use AgentFluent's diagnostic output as a feedback signal the agent itself consumes to propose config edits against its own past sessions
 - Agent ROI reporting — roll up cost, usage, and task-completion signals over time so a business can evaluate whether an optimized agent is worth continuing to run
 
@@ -350,7 +382,7 @@ Browse [open issues](https://github.com/frederick-douglas-pearce/agentfluent/iss
 | **No agent invocations** | Agent invocation rows require the session to actually call a subagent (`Agent` tool_use with a `subagent_type`). A session that never delegated has no agent data to analyze — this is not an error. |
 | **Zero tokens / dashes in Agent Invocations** | If you're on AgentFluent ≤ 0.1.0, this is the [#84 parser bug](https://github.com/frederick-douglas-pearce/agentfluent/issues/84) — upgrade with `uv tool upgrade agentfluent`. |
 | **Python version error** | AgentFluent requires Python 3.12+. Check with `python --version` and upgrade if needed. |
-| **Non-default session path** | If `~/.claude/` is stored somewhere unusual, AgentFluent currently uses the default path only. Custom path support is planned. |
+| **Non-default session path** | Pass `--claude-config-dir /path/to/.claude` or set `$CLAUDE_CONFIG_DIR` before invoking any command. The override applies to project discovery, agent configs, and MCP server discovery together. |
 | **`Malformed JSON at <file>:<line>` warning** | A session file has a corrupted line — usually null bytes left behind when Claude Code was killed mid-write. The parser skips the line and continues; analytics are unaffected. Safe to ignore, or delete the line with `sed -i '<line>d' <file>` to silence the warning. |
 | **Stale tool install after local build** | If `uv tool install --from <path> agentfluent` seems to reuse cached code, run `uv tool uninstall agentfluent && uv cache clean agentfluent` before reinstalling. |
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -267,34 +267,41 @@ def _format_diagnostics_table(
             )
         console.print(sig_table)
 
-    if diag.recommendations:
+    if verbose and diag.recommendations:
         rec_table = Table(title="Recommendations", show_header=True)
         rec_table.add_column("Agent", style="cyan")
         rec_table.add_column("Target")
         rec_table.add_column("Severity")
-        if verbose:
-            rec_table.add_column("Observation")
-            rec_table.add_column("Action")
-        else:
-            rec_table.add_column("Recommendation")
+        rec_table.add_column("Observation")
+        rec_table.add_column("Action")
 
         for rec in diag.recommendations:
             color = SEVERITY_COLORS.get(rec.severity, "white")
-            if verbose:
-                rec_table.add_row(
-                    escape(rec.agent_type),
-                    escape(rec.target),
-                    f"[{color}]{rec.severity.value}[/{color}]",
-                    escape(rec.observation),
-                    escape(rec.action),
-                )
-            else:
-                rec_table.add_row(
-                    escape(rec.agent_type),
-                    escape(rec.target),
-                    f"[{color}]{rec.severity.value}[/{color}]",
-                    escape(rec.message),
-                )
+            rec_table.add_row(
+                escape(rec.agent_type),
+                escape(rec.target),
+                f"[{color}]{rec.severity.value}[/{color}]",
+                escape(rec.observation),
+                escape(rec.action),
+            )
+        console.print(rec_table)
+    elif diag.aggregated_recommendations:
+        rec_table = Table(title="Recommendations", show_header=True)
+        rec_table.add_column("Agent", style="cyan")
+        rec_table.add_column("Target")
+        rec_table.add_column("Severity")
+        rec_table.add_column("Count", justify="right")
+        rec_table.add_column("Recommendation")
+
+        for agg in diag.aggregated_recommendations:
+            color = SEVERITY_COLORS.get(agg.severity, "white")
+            rec_table.add_row(
+                escape(agg.agent_type),
+                escape(agg.target),
+                f"[{color}]{agg.severity.value}[/{color}]",
+                str(agg.count),
+                escape(agg.representative_message),
+            )
         console.print(rec_table)
 
     _format_deep_diagnostics(console, diag, verbose=verbose)

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -1,0 +1,170 @@
+"""Aggregate per-invocation recommendations into distinct findings.
+
+``correlate`` emits one recommendation per matched signal, which produces
+N near-identical rows when N invocations of the same agent trigger the
+same rule (e.g., four Explore invocations each firing TOKEN_OUTLIER).
+The default Recommendations table is far more actionable when those N
+rows collapse to a single aggregated row with an occurrence count and
+(for signal types that carry scalar metrics) a min–max range.
+
+Aggregation happens in the pipeline, after ``correlate``, so every
+output format benefits — not just the table formatter. The raw
+per-invocation list is preserved alongside the aggregated list on
+``DiagnosticsResult`` so ``--verbose`` and JSON consumers can drill in.
+
+NOTE for #166 (built-in vs custom agent differentiation): if that issue
+forks recommendation text within the same ``(agent_type, target,
+signal_type)`` tuple, extend the aggregation key to include whatever
+field carries the fork (e.g., ``config_file`` or a new ``is_builtin``
+flag). Today the 10 existing rules don't fork within the same tuple, so
+the key below is correct.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import (
+    AggregatedRecommendation,
+    DiagnosticRecommendation,
+    DiagnosticSignal,
+    SignalType,
+)
+
+_SEVERITY_RANK: dict[Severity, int] = {
+    Severity.CRITICAL: 3,
+    Severity.WARNING: 2,
+    Severity.INFO: 1,
+}
+
+# Signal types that carry comparable scalar metrics in ``detail``. Only
+# these produce a ``metric_range`` on the aggregated row.
+_SCALAR_METRIC_SIGNALS: frozenset[SignalType] = frozenset(
+    {SignalType.TOKEN_OUTLIER, SignalType.DURATION_OUTLIER},
+)
+
+
+def _aggregation_key(
+    rec: DiagnosticRecommendation,
+) -> tuple[str, str, frozenset[SignalType]]:
+    """Shape key used to group per-invocation recommendations.
+
+    ``target`` is included because ``TokenOutlierRule`` /
+    ``ErrorSequenceRule`` fork to ``tools`` vs ``prompt`` based on config
+    — those should remain distinct aggregated rows.
+    """
+    return (rec.agent_type, rec.target, frozenset(rec.signal_types))
+
+
+def _compute_metric_range(signals: list[DiagnosticSignal]) -> str | None:
+    """Build ``"4.9x–8.0x above 5,064 mean"`` when signals carry ratio data.
+
+    Returns ``None`` for signal types without comparable scalars (retry
+    counts, permission failures) so the aggregated row falls back to a
+    count-only message.
+    """
+    scalar_signals = [s for s in signals if s.signal_type in _SCALAR_METRIC_SIGNALS]
+    if not scalar_signals:
+        return None
+
+    ratios: list[float] = []
+    means: list[float] = []
+    for sig in scalar_signals:
+        ratio = sig.detail.get("ratio")
+        mean = sig.detail.get("mean_value")
+        if isinstance(ratio, (int, float)):
+            ratios.append(float(ratio))
+        if isinstance(mean, (int, float)):
+            means.append(float(mean))
+
+    if not ratios:
+        return None
+
+    lo, hi = min(ratios), max(ratios)
+    if lo == hi:
+        range_text = f"{lo:.1f}x"
+    else:
+        range_text = f"{lo:.1f}x–{hi:.1f}x"
+
+    if means:
+        mean_ref = sum(means) / len(means)
+        return f"{range_text} above {mean_ref:,.0f} mean"
+    return f"{range_text} above mean"
+
+
+def _max_severity(recs: list[DiagnosticRecommendation]) -> Severity:
+    return max(recs, key=lambda r: _SEVERITY_RANK[r.severity]).severity
+
+
+def _representative_message(
+    recs: list[DiagnosticRecommendation],
+    count: int,
+    metric_range: str | None,
+) -> str:
+    """Build the aggregated row's message.
+
+    For ``count == 1`` the original message is returned verbatim so
+    single-invocation findings read identically to the raw table. For
+    ``count > 1`` the message is rebuilt as ``"N invocations[ (range)].
+    <action>"`` using the representative recommendation's ``action`` text
+    (which is constant across duplicates in the same aggregation group).
+    """
+    rep = recs[0]
+    if count == 1:
+        return rep.message
+
+    prefix = f"{count} invocations"
+    if metric_range:
+        prefix = f"{prefix} ({metric_range})"
+
+    if rep.action:
+        return f"{prefix}. {rep.action}"
+    return f"{prefix}."
+
+
+def aggregate_recommendations(
+    pairs: list[tuple[DiagnosticSignal, DiagnosticRecommendation]],
+) -> list[AggregatedRecommendation]:
+    """Group paired ``(signal, recommendation)`` tuples by their shape key.
+
+    Sorted by (severity descending, count descending) so the highest-
+    impact findings surface first in the default table.
+    """
+    groups: dict[
+        tuple[str, str, frozenset[SignalType]],
+        list[tuple[DiagnosticSignal, DiagnosticRecommendation]],
+    ] = defaultdict(list)
+    for signal, rec in pairs:
+        groups[_aggregation_key(rec)].append((signal, rec))
+
+    aggregated: list[AggregatedRecommendation] = []
+    for (agent_type, target, signal_types_set), members in groups.items():
+        signals = [s for s, _ in members]
+        recs = [r for _, r in members]
+        count = len(members)
+        severity = _max_severity(recs)
+        metric_range = _compute_metric_range(signals)
+        rep = recs[0]
+
+        aggregated.append(
+            AggregatedRecommendation(
+                agent_type=agent_type,
+                target=target,
+                severity=severity,
+                signal_types=sorted(signal_types_set, key=lambda s: s.value),
+                count=count,
+                metric_range=metric_range,
+                representative_message=_representative_message(
+                    recs, count, metric_range,
+                ),
+                observation=rep.observation,
+                reason=rep.reason,
+                action=rep.action,
+                contributing_signals=signals,
+                contributing_recommendations=recs,
+            ),
+        )
+
+    aggregated.sort(key=lambda a: (-_SEVERITY_RANK[a.severity], -a.count))
+    return aggregated

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -11,13 +11,6 @@ Aggregation happens in the pipeline, after ``correlate``, so every
 output format benefits — not just the table formatter. The raw
 per-invocation list is preserved alongside the aggregated list on
 ``DiagnosticsResult`` so ``--verbose`` and JSON consumers can drill in.
-
-NOTE for #166 (built-in vs custom agent differentiation): if that issue
-forks recommendation text within the same ``(agent_type, target,
-signal_type)`` tuple, extend the aggregation key to include whatever
-field carries the fork (e.g., ``config_file`` or a new ``is_builtin``
-flag). Today the 10 existing rules don't fork within the same tuple, so
-the key below is correct.
 """
 
 from __future__ import annotations
@@ -64,13 +57,11 @@ def _compute_metric_range(signals: list[DiagnosticSignal]) -> str | None:
     counts, permission failures) so the aggregated row falls back to a
     count-only message.
     """
-    scalar_signals = [s for s in signals if s.signal_type in _SCALAR_METRIC_SIGNALS]
-    if not scalar_signals:
-        return None
-
     ratios: list[float] = []
     means: list[float] = []
-    for sig in scalar_signals:
+    for sig in signals:
+        if sig.signal_type not in _SCALAR_METRIC_SIGNALS:
+            continue
         ratio = sig.detail.get("ratio")
         mean = sig.detail.get("mean_value")
         if isinstance(ratio, (int, float)):
@@ -145,7 +136,6 @@ def aggregate_recommendations(
         count = len(members)
         severity = _max_severity(recs)
         metric_range = _compute_metric_range(signals)
-        rep = recs[0]
 
         aggregated.append(
             AggregatedRecommendation(
@@ -158,10 +148,6 @@ def aggregate_recommendations(
                 representative_message=_representative_message(
                     recs, count, metric_range,
                 ),
-                observation=rep.observation,
-                reason=rep.reason,
-                action=rep.action,
-                contributing_signals=signals,
                 contributing_recommendations=recs,
             ),
         )

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -524,7 +524,7 @@ RULES: list[CorrelationRule] = [
 def correlate(
     signals: list[DiagnosticSignal],
     configs: dict[str, AgentConfig] | None = None,
-) -> list[DiagnosticRecommendation]:
+) -> list[tuple[DiagnosticSignal, DiagnosticRecommendation]]:
     """Map signals to config surfaces and produce recommendations.
 
     Args:
@@ -533,16 +533,20 @@ def correlate(
             When available, recommendations reference specific config files.
 
     Returns:
-        List of actionable recommendations.
+        Paired ``(signal, recommendation)`` tuples — one per matched
+        signal. The pairing is explicit (rather than positional across
+        two lists) so downstream consumers like
+        ``aggregate_recommendations`` can attribute evidence back to the
+        source signal without relying on list-ordering invariants.
     """
-    recommendations: list[DiagnosticRecommendation] = []
+    pairs: list[tuple[DiagnosticSignal, DiagnosticRecommendation]] = []
 
     for signal in signals:
         config = configs.get(signal.agent_type.lower()) if configs else None
 
         for rule in RULES:
             if rule.matches(signal, config):
-                recommendations.append(rule.recommend(signal, config))
+                pairs.append((signal, rule.recommend(signal, config)))
                 break
 
-    return recommendations
+    return pairs

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -117,19 +117,15 @@ class AggregatedRecommendation(BaseModel):
     """Aggregated message shown in the default table. For ``count == 1``
     this is the original recommendation text verbatim."""
 
-    observation: str = ""
-    reason: str = ""
-    action: str = ""
-
-    contributing_signals: list[DiagnosticSignal] = Field(default_factory=list)
-    """Source signals, preserved for verbose drill-down and future
-    consumers (e.g., priority scoring in #172)."""
-
     contributing_recommendations: list[DiagnosticRecommendation] = Field(
         default_factory=list,
     )
     """Raw per-invocation recommendations so ``--verbose`` can re-render
-    the unaggregated view without re-running the pipeline."""
+    the unaggregated view without re-running the pipeline. Carries the
+    full observation/reason/action text and source ``signal_types`` for
+    each member of the group — those fields are not denormalized onto
+    this model since ``contributing_recommendations[0]`` is the source
+    of truth."""
 
 
 class DelegationSuggestion(BaseModel):

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -89,6 +89,49 @@ class DiagnosticRecommendation(BaseModel):
     """Which signal types contributed to this recommendation."""
 
 
+class AggregatedRecommendation(BaseModel):
+    """Aggregate of one or more ``DiagnosticRecommendation`` instances that
+    share the same ``(agent_type, target, signal_types)`` shape.
+
+    Produced by ``diagnostics.aggregation.aggregate_recommendations`` so the
+    default Recommendations table can show distinct findings (with an
+    occurrence count and metric range) instead of N near-identical rows.
+    The raw per-invocation recommendations remain available on
+    ``contributing_recommendations`` for ``--verbose`` and JSON output.
+    """
+
+    agent_type: str
+    target: str
+    severity: Severity
+    signal_types: list[SignalType] = Field(default_factory=list)
+
+    count: int = 1
+    """Number of per-invocation recommendations merged into this row."""
+
+    metric_range: str | None = None
+    """Human-readable metric range for signal types that carry ratio data
+    (TOKEN_OUTLIER, DURATION_OUTLIER). ``None`` for signal types that do
+    not expose a comparable scalar (retry counts, permission failures)."""
+
+    representative_message: str
+    """Aggregated message shown in the default table. For ``count == 1``
+    this is the original recommendation text verbatim."""
+
+    observation: str = ""
+    reason: str = ""
+    action: str = ""
+
+    contributing_signals: list[DiagnosticSignal] = Field(default_factory=list)
+    """Source signals, preserved for verbose drill-down and future
+    consumers (e.g., priority scoring in #172)."""
+
+    contributing_recommendations: list[DiagnosticRecommendation] = Field(
+        default_factory=list,
+    )
+    """Raw per-invocation recommendations so ``--verbose`` can re-render
+    the unaggregated view without re-running the pipeline."""
+
+
 class DelegationSuggestion(BaseModel):
     """A draft subagent definition derived from a cluster of recurring
     ``general-purpose`` delegations.
@@ -147,6 +190,17 @@ class DiagnosticsResult(BaseModel):
 
     signals: list[DiagnosticSignal] = Field(default_factory=list)
     recommendations: list[DiagnosticRecommendation] = Field(default_factory=list)
+    """Raw per-invocation recommendations. One entry per matched signal.
+    Retained alongside ``aggregated_recommendations`` so ``--verbose`` and
+    JSON consumers can drill into unaggregated evidence."""
+
+    aggregated_recommendations: list[AggregatedRecommendation] = Field(
+        default_factory=list,
+    )
+    """Recommendations aggregated by ``(agent_type, target, signal_types)``
+    with occurrence counts and metric ranges. This is the default surface
+    shown in the table formatter."""
+
     subagent_trace_count: int = 0
     """Number of subagent traces that successfully parsed and linked."""
 

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -22,6 +22,7 @@ from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
+from agentfluent.diagnostics.aggregation import aggregate_recommendations
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_CLUSTER_SIZE,
@@ -234,7 +235,9 @@ def run_diagnostics(
                 ),
             )
 
-    recommendations = correlate(signals, configs_by_name)
+    correlated_pairs = correlate(signals, configs_by_name)
+    recommendations = [rec for _, rec in correlated_pairs]
+    aggregated = aggregate_recommendations(correlated_pairs)
 
     subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
 
@@ -256,6 +259,7 @@ def run_diagnostics(
     return DiagnosticsResult(
         signals=signals,
         recommendations=recommendations,
+        aggregated_recommendations=aggregated,
         subagent_trace_count=subagent_trace_count,
         delegation_suggestions=delegation_suggestions,
     )

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -3,8 +3,22 @@
 from pathlib import Path
 
 from agentfluent.config.models import AgentConfig, Scope, Severity
-from agentfluent.diagnostics.correlator import correlate
-from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+from agentfluent.diagnostics.correlator import correlate as _correlate_pairs
+from agentfluent.diagnostics.models import (
+    DiagnosticRecommendation,
+    DiagnosticSignal,
+    SignalType,
+)
+
+
+def correlate(
+    signals: list[DiagnosticSignal],
+    configs: dict[str, AgentConfig] | None = None,
+) -> list[DiagnosticRecommendation]:
+    """Test wrapper: drops the signal side of ``correlate``'s paired return
+    so per-rule assertions can stay focused on recommendation content.
+    Pairing semantics are exercised by the aggregation tests."""
+    return [rec for _, rec in _correlate_pairs(signals, configs)]
 
 
 def _signal(

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -1,0 +1,243 @@
+"""Tests for recommendation aggregation.
+
+Covers the grouping key, count tracking, metric-range synthesis (for
+scalar signal types only), severity-based sort order, and the
+round-trip through ``DiagnosticsResult`` so the raw recommendations
+remain available for verbose drill-down.
+"""
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.aggregation import aggregate_recommendations
+from agentfluent.diagnostics.models import (
+    AggregatedRecommendation,
+    DiagnosticRecommendation,
+    DiagnosticSignal,
+    SignalType,
+)
+
+
+def _token_outlier_pair(
+    agent_type: str,
+    ratio: float,
+    mean_value: float = 5064.0,
+    target: str = "prompt",
+) -> tuple[DiagnosticSignal, DiagnosticRecommendation]:
+    signal = DiagnosticSignal(
+        signal_type=SignalType.TOKEN_OUTLIER,
+        severity=Severity.WARNING,
+        agent_type=agent_type,
+        message=f"Agent '{agent_type}' has high token usage ({ratio:.1f}x).",
+        detail={
+            "ratio": ratio,
+            "actual_value": ratio * mean_value,
+            "mean_value": mean_value,
+        },
+    )
+    rec = DiagnosticRecommendation(
+        target=target,
+        severity=Severity.WARNING,
+        message=(
+            f"Agent '{agent_type}' has {ratio * mean_value:,.0f} tokens/tool_use, "
+            f"{ratio:.1f}x above the {mean_value:,.0f} mean."
+        ),
+        observation=(
+            f"Agent '{agent_type}' uses {ratio * mean_value:,.0f} tokens per call."
+        ),
+        reason="High token usage suggests broad exploration.",
+        action="Add more specific instructions to the agent's prompt.",
+        agent_type=agent_type,
+        signal_types=[SignalType.TOKEN_OUTLIER],
+    )
+    return signal, rec
+
+
+def _retry_loop_pair(
+    agent_type: str,
+    tool_name: str,
+    attempts: int,
+    severity: Severity = Severity.WARNING,
+) -> tuple[DiagnosticSignal, DiagnosticRecommendation]:
+    signal = DiagnosticSignal(
+        signal_type=SignalType.RETRY_LOOP,
+        severity=severity,
+        agent_type=agent_type,
+        message=(
+            f"Subagent '{agent_type}' retried tool '{tool_name}' {attempts} times."
+        ),
+        detail={"tool_name": tool_name, "attempts": attempts},
+    )
+    rec = DiagnosticRecommendation(
+        target="prompt",
+        severity=severity,
+        message=(
+            f"Subagent '{agent_type}' retried tool '{tool_name}' {attempts} times. "
+            "Add explicit retry / fallback guidance."
+        ),
+        observation=(
+            f"Subagent '{agent_type}' retried '{tool_name}' {attempts} times."
+        ),
+        reason="Repeated retries indicate missing recovery guidance.",
+        action="Add fallback guidance to the agent's prompt body.",
+        agent_type=agent_type,
+        signal_types=[SignalType.RETRY_LOOP],
+    )
+    return signal, rec
+
+
+class TestAggregationKey:
+    def test_same_shape_collapses_to_one_row(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 6.7),
+            _token_outlier_pair("Explore", 8.0),
+            _token_outlier_pair("Explore", 5.2),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert len(aggregated) == 1
+        assert aggregated[0].count == 4
+        assert aggregated[0].agent_type == "Explore"
+        assert aggregated[0].target == "prompt"
+
+    def test_different_agents_stay_separate(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("general-purpose", 3.2),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert len(aggregated) == 2
+        by_agent = {a.agent_type: a for a in aggregated}
+        assert by_agent["Explore"].count == 1
+        assert by_agent["general-purpose"].count == 1
+
+    def test_different_target_stays_separate(self) -> None:
+        # Same agent + signal_type but target="tools" vs "prompt" (the
+        # TokenOutlierRule fork); must aggregate as two distinct rows.
+        pairs = [
+            _token_outlier_pair("Explore", 4.9, target="prompt"),
+            _token_outlier_pair("Explore", 5.2, target="prompt"),
+            _token_outlier_pair("Explore", 7.0, target="tools"),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert len(aggregated) == 2
+        targets = {a.target: a.count for a in aggregated}
+        assert targets == {"prompt": 2, "tools": 1}
+
+    def test_different_signal_types_stay_separate(self) -> None:
+        pairs = [
+            _token_outlier_pair("pm", 2.4),
+            _retry_loop_pair("pm", "Read", 3),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert len(aggregated) == 2
+
+
+class TestMetricRange:
+    def test_scalar_signals_produce_range(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9, mean_value=5064.0),
+            _token_outlier_pair("Explore", 6.7, mean_value=5064.0),
+            _token_outlier_pair("Explore", 8.0, mean_value=5064.0),
+            _token_outlier_pair("Explore", 5.2, mean_value=5064.0),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].metric_range == "4.9x–8.0x above 5,064 mean"
+
+    def test_single_invocation_shows_point_not_range(self) -> None:
+        pairs = [_token_outlier_pair("pm", 3.4)]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].metric_range == "3.4x above 5,064 mean"
+
+    def test_non_scalar_signal_has_no_range(self) -> None:
+        pairs = [
+            _retry_loop_pair("architect", "Read", 3),
+            _retry_loop_pair("architect", "Read", 7),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].metric_range is None
+
+
+class TestRepresentativeMessage:
+    def test_single_invocation_preserves_original_message(self) -> None:
+        _, rec = _token_outlier_pair("pm", 3.4)
+        aggregated = aggregate_recommendations([(_, rec)])
+        assert aggregated[0].representative_message == rec.message
+
+    def test_multi_invocation_includes_count_and_range(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 6.7),
+            _token_outlier_pair("Explore", 8.0),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        msg = aggregated[0].representative_message
+        assert msg.startswith("3 invocations (4.9x–8.0x above 5,064 mean).")
+        assert "Add more specific instructions" in msg
+
+    def test_multi_invocation_non_scalar_uses_count_only(self) -> None:
+        pairs = [
+            _retry_loop_pair("architect", "Read", 3),
+            _retry_loop_pair("architect", "Read", 7),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        msg = aggregated[0].representative_message
+        assert msg.startswith("2 invocations.")
+
+
+class TestSortOrder:
+    def test_critical_before_warning(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _retry_loop_pair("architect", "Read", 7, severity=Severity.CRITICAL),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].severity == Severity.CRITICAL
+        assert aggregated[1].severity == Severity.WARNING
+
+    def test_higher_count_sorts_first_within_severity(self) -> None:
+        pairs = [
+            _token_outlier_pair("loner", 3.0),
+            _token_outlier_pair("crowd", 4.0),
+            _token_outlier_pair("crowd", 5.0),
+            _token_outlier_pair("crowd", 6.0),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].agent_type == "crowd"
+        assert aggregated[0].count == 3
+        assert aggregated[1].agent_type == "loner"
+
+
+class TestEvidencePreservation:
+    def test_contributing_signals_and_recs_are_attached(self) -> None:
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 8.0),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        agg = aggregated[0]
+        assert len(agg.contributing_signals) == 2
+        assert len(agg.contributing_recommendations) == 2
+        assert {s.detail["ratio"] for s in agg.contributing_signals} == {4.9, 8.0}
+
+    def test_empty_input_yields_empty_output(self) -> None:
+        assert aggregate_recommendations([]) == []
+
+
+class TestAggregationModel:
+    def test_aggregated_recommendation_is_pydantic_serializable(self) -> None:
+        pairs = [_token_outlier_pair("pm", 3.4)]
+        aggregated = aggregate_recommendations(pairs)
+        # Round-trip through JSON shape to catch any non-serializable fields.
+        dumped = aggregated[0].model_dump(mode="json")
+        assert dumped["agent_type"] == "pm"
+        assert dumped["count"] == 1
+        assert dumped["metric_range"] == "3.4x above 5,064 mean"
+
+    def test_model_instantiates_with_minimal_fields(self) -> None:
+        agg = AggregatedRecommendation(
+            agent_type="pm",
+            target="prompt",
+            severity=Severity.WARNING,
+            representative_message="ok",
+        )
+        assert agg.count == 1
+        assert agg.metric_range is None

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -207,16 +207,16 @@ class TestSortOrder:
 
 
 class TestEvidencePreservation:
-    def test_contributing_signals_and_recs_are_attached(self) -> None:
+    def test_contributing_recommendations_are_attached(self) -> None:
         pairs = [
             _token_outlier_pair("Explore", 4.9),
             _token_outlier_pair("Explore", 8.0),
         ]
         aggregated = aggregate_recommendations(pairs)
         agg = aggregated[0]
-        assert len(agg.contributing_signals) == 2
         assert len(agg.contributing_recommendations) == 2
-        assert {s.detail["ratio"] for s in agg.contributing_signals} == {4.9, 8.0}
+        observations = {r.observation for r in agg.contributing_recommendations}
+        assert len(observations) == 2
 
     def test_empty_input_yields_empty_output(self) -> None:
         assert aggregate_recommendations([]) == []


### PR DESCRIPTION
Closes #165. Architect-reviewed plan at https://github.com/frederick-douglas-pearce/agentfluent/issues/165#issuecomment-4310345700.

## Summary

- Default Recommendations table now collapses N near-identical per-invocation rows into one aggregated row per `(agent, target, signal_types)` shape, with a `Count` column and a metric range for signal types that carry ratio data.
- `--verbose` preserves the raw per-invocation view (Observation / Action columns) for drill-down.
- JSON output emits both `recommendations` (raw) and `aggregated_recommendations` (new).
- `correlate()` now returns paired `(signal, recommendation)` tuples instead of relying on implicit list-order alignment — addresses the `important` fragility the architect review flagged.

## Impact

On `agentfluent analyze --project agentfluent --diagnostics` (9 sessions):
- **Raw recommendations:** 165
- **Aggregated rows:** 23
- **Output length:** 1895 → 789 lines
- **Sorting:** severity desc, then count desc — critical findings surface at the top

Example aggregated row:
```
│ Explore │ prompt │ warning │ 4 │ 4 invocations (4.9x–8.0x above 5,015 mean).
│         │        │         │   │ Consider adding more specific instructions
│         │        │         │   │ to the agent's prompt or restricting its
│         │        │         │   │ tool list.
```

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean (47 files)
- [x] `uv run pytest` — 704 passing (16 new tests in `test_recommendation_aggregation.py`)
- [x] Manual run against agentfluent project: aggregation visible in default table, `--verbose` preserves raw view, `--format json` emits both fields

## Forward compatibility

Per the architect review, the design accommodates upcoming issues without interface changes:
- **#166** (built-in vs custom agent differentiation): natural agent-type separation; code comment in `aggregation.py` flags where to extend the key if needed.
- **#170** (concrete target model in recs): downstream of rule text — aggregation consumes whatever templates produce.
- **#172** (priority ranking / top-N): `AggregatedRecommendation` already exposes `count`, `severity`, `contributing_signals` — the fields a priority scorer needs.

## Unblocks

- **#155** (v0.3 screenshot refresh) — the aggregated view is now clean enough to screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)