### PR TITLE
feat(diagnostics): tailor recommendations for built-in agents (#166)

### DIFF
--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -148,6 +148,7 @@ def aggregate_recommendations(
                 representative_message=_representative_message(
                     recs, count, metric_range,
                 ),
+                is_builtin=recs[0].is_builtin,
                 contributing_recommendations=recs,
             ),
         )

--- a/src/agentfluent/diagnostics/builtin_actions.py
+++ b/src/agentfluent/diagnostics/builtin_actions.py
@@ -1,17 +1,10 @@
 """Recommendation text for built-in agents (#166).
 
-Built-in agents (``Explore``, ``general-purpose``, ``Plan``, ``code-reviewer``,
-``statusline-setup``, ``claude-code-guide`` — see
-``agentfluent.agents.models.BUILTIN_AGENT_TYPES``) have no user-editable
-prompt file, no tool-list config, and no model selector. The generic
-rule templates that tell the user to "edit the agent's prompt in
-~/.claude/agents/<name>.md" are therefore un-actionable for these
-agents.
-
-This module owns the built-in-specific action text and the helper that
-each correlation rule calls when ``is_builtin_agent(signal.agent_type)``
-is true. Kept separate from ``correlator.py`` to keep that file under
-the per-module size convention as the rule count grows.
+Built-in agents have no user-editable prompt file, tool list, or model
+selector, so generic "edit ~/.claude/agents/<name>.md" templates are
+un-actionable. This module owns the concern-keyed action text each
+correlation rule uses when ``is_builtin_agent(signal.agent_type)`` is
+true.
 """
 
 from __future__ import annotations
@@ -57,19 +50,18 @@ def builtin_recommendation(
     *,
     target: str,
     concern: BuiltinConcern,
-    observation: str,
     reason: str,
 ) -> DiagnosticRecommendation:
     """Build a recommendation for a signal whose agent is a built-in.
 
-    Callers (correlation rules) supply the rule-specific ``observation``
-    and ``reason`` text so each recommendation still reads like it came
-    from the source rule; only the ``action`` differs from the custom-
-    agent path. ``is_builtin=True`` is stamped so downstream consumers
-    (JSON output, priority scoring in #172) can distinguish these rows
-    without re-deriving.
+    Callers supply the rule-specific ``reason`` so each recommendation
+    still reads like it came from the source rule; only the ``action``
+    differs from the custom-agent path. ``is_builtin=True`` is stamped
+    so downstream consumers (JSON output, priority scoring in #172) can
+    distinguish these rows without re-deriving.
     """
     action = _BUILTIN_ACTIONS[concern]
+    observation = signal.message
     return DiagnosticRecommendation(
         target=target,
         severity=signal.severity,

--- a/src/agentfluent/diagnostics/builtin_actions.py
+++ b/src/agentfluent/diagnostics/builtin_actions.py
@@ -1,0 +1,84 @@
+"""Recommendation text for built-in agents (#166).
+
+Built-in agents (``Explore``, ``general-purpose``, ``Plan``, ``code-reviewer``,
+``statusline-setup``, ``claude-code-guide`` — see
+``agentfluent.agents.models.BUILTIN_AGENT_TYPES``) have no user-editable
+prompt file, no tool-list config, and no model selector. The generic
+rule templates that tell the user to "edit the agent's prompt in
+~/.claude/agents/<name>.md" are therefore un-actionable for these
+agents.
+
+This module owns the built-in-specific action text and the helper that
+each correlation rule calls when ``is_builtin_agent(signal.agent_type)``
+is true. Kept separate from ``correlator.py`` to keep that file under
+the per-module size convention as the rule count grows.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from agentfluent.diagnostics.models import (
+    DiagnosticRecommendation,
+    DiagnosticSignal,
+)
+
+BuiltinConcern = Literal["scope", "recovery", "tools", "model"]
+
+_BUILTIN_ACTIONS: dict[BuiltinConcern, str] = {
+    "scope": (
+        "Built-in agent — prompt is not user-editable. "
+        "Consider: (a) a custom wrapper subagent that narrows the task scope, "
+        "(b) tightening the delegation prompt passed to this agent, "
+        "or (c) rerouting this task to a different agent."
+    ),
+    "recovery": (
+        "Built-in agent — prompt is not user-editable. "
+        "Add retry bounds or exit conditions to the *delegating* agent's "
+        "prompt, since the built-in agent cannot enforce them itself. "
+        "Alternatively, wrap this call in a custom subagent that owns the "
+        "recovery logic."
+    ),
+    "tools": (
+        "Built-in agent — tool list is not user-editable. "
+        "Route this task to a custom subagent with explicit tool grants, "
+        "or confirm the built-in agent's fixed tool set is actually required."
+    ),
+    "model": (
+        "Built-in agent — model is not user-configurable. "
+        "Create a custom subagent with the recommended model, or reroute "
+        "this task to an existing agent that already uses it."
+    ),
+}
+
+
+def builtin_recommendation(
+    signal: DiagnosticSignal,
+    *,
+    target: str,
+    concern: BuiltinConcern,
+    observation: str,
+    reason: str,
+) -> DiagnosticRecommendation:
+    """Build a recommendation for a signal whose agent is a built-in.
+
+    Callers (correlation rules) supply the rule-specific ``observation``
+    and ``reason`` text so each recommendation still reads like it came
+    from the source rule; only the ``action`` differs from the custom-
+    agent path. ``is_builtin=True`` is stamped so downstream consumers
+    (JSON output, priority scoring in #172) can distinguish these rows
+    without re-deriving.
+    """
+    action = _BUILTIN_ACTIONS[concern]
+    return DiagnosticRecommendation(
+        target=target,
+        severity=signal.severity,
+        message=f"{observation} {reason} {action}".strip(),
+        observation=observation,
+        reason=reason,
+        action=action,
+        agent_type=signal.agent_type,
+        config_file="",
+        signal_types=[signal.signal_type],
+        is_builtin=True,
+    )

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from agentfluent.agents.models import is_builtin_agent
 from agentfluent.config.models import AgentConfig, Severity
+from agentfluent.diagnostics.builtin_actions import builtin_recommendation
 from agentfluent.diagnostics.models import (
     DiagnosticRecommendation,
     DiagnosticSignal,
@@ -43,6 +45,12 @@ class AccessErrorRule:
     ) -> DiagnosticRecommendation:
         observation = signal.message
         reason = "This indicates the agent lacks access to required tools."
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="tools", concern="tools",
+                observation=observation, reason=reason,
+            )
 
         if config and not config.tools and not config.disallowed_tools:
             action = (
@@ -90,6 +98,12 @@ class ErrorHandlingRule:
         observation = signal.message
         reason = "Repeated errors suggest the agent lacks error handling guidance."
 
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="recovery",
+                observation=observation, reason=reason,
+            )
+
         if config and config.prompt_body:
             body_lower = config.prompt_body.lower()
             has_error_guidance = any(
@@ -136,6 +150,12 @@ class TokenOutlierRule:
         observation = signal.message
         reason = "High token usage suggests the agent is exploring broadly."
 
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="scope",
+                observation=observation, reason=reason,
+            )
+
         if config and len(config.tools) > 8:
             action = (
                 f"Consider restricting the tools list in {config.file_path} "
@@ -179,6 +199,12 @@ class DurationOutlierRule:
     ) -> DiagnosticRecommendation:
         observation = signal.message
         reason = "Slow invocations may indicate an overqualified model or unclear task scope."
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="scope",
+                observation=observation, reason=reason,
+            )
 
         if config and config.model and "opus" in config.model.lower():
             action = (
@@ -224,6 +250,12 @@ class PermissionFailureRule:
         tool_name = str(signal.detail.get("tool_name", ""))
         observation = signal.message
         reason = "The subagent was denied access to a tool it attempted to call."
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="tools", concern="tools",
+                observation=observation, reason=reason,
+            )
 
         if config and tool_name and tool_name not in config.tools:
             action = (
@@ -271,6 +303,12 @@ class RetryLoopRule:
             "Repeated retries on the same tool indicate the agent lacks "
             "recovery guidance for failures."
         )
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="recovery",
+                observation=observation, reason=reason,
+            )
 
         if config and config.prompt_body:
             body_lower = config.prompt_body.lower()
@@ -323,6 +361,12 @@ class StuckPatternRule:
             "progress, indicating no exit condition."
         )
 
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="recovery",
+                observation=observation, reason=reason,
+            )
+
         if config:
             action = (
                 f"Add an explicit exit condition or progress check to the "
@@ -362,6 +406,12 @@ class ErrorSequenceRule:
             "Multiple consecutive tool errors suggest the agent lacks "
             "fallback instructions for when a tool call fails."
         )
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="prompt", concern="scope",
+                observation=observation, reason=reason,
+            )
 
         if config and len(config.tools) > 8:
             action = (
@@ -424,6 +474,12 @@ class ModelRoutingRule:
             f"Observed complexity tier is '{complexity}' but the agent is "
             f"configured with {current_model}."
         )
+
+        if is_builtin_agent(signal.agent_type):
+            return builtin_recommendation(
+                signal, target="model", concern="model",
+                observation=observation, reason=reason,
+            )
 
         action_parts = [f"Switch to {recommended_model}"]
         if mismatch_type == "overspec" and isinstance(savings, int | float):

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -11,7 +11,10 @@ from typing import Protocol
 
 from agentfluent.agents.models import is_builtin_agent
 from agentfluent.config.models import AgentConfig, Severity
-from agentfluent.diagnostics.builtin_actions import builtin_recommendation
+from agentfluent.diagnostics.builtin_actions import (
+    BuiltinConcern,
+    builtin_recommendation,
+)
 from agentfluent.diagnostics.models import (
     DiagnosticRecommendation,
     DiagnosticSignal,
@@ -29,10 +32,39 @@ class CorrelationRule(Protocol):
     ) -> DiagnosticRecommendation: ...
 
 
+class _BuiltinBranchingRule(Protocol):
+    """Extension protocol for rules that participate in built-in-agent
+    branching. Rules that target agent-level config (prompt, tools,
+    model) declare ``_builtin_target`` + ``_builtin_concern`` as class
+    attributes; rules with no agent-level counterpart (e.g.,
+    ``McpAuditRule``) do not."""
+
+    _builtin_target: str
+    _builtin_concern: BuiltinConcern
+
+
+def _check_builtin(
+    rule: _BuiltinBranchingRule, signal: DiagnosticSignal, reason: str,
+) -> DiagnosticRecommendation | None:
+    """Return a built-in recommendation when the signal's agent is a
+    built-in, else ``None`` so the caller falls through to the custom
+    path."""
+    if not is_builtin_agent(signal.agent_type):
+        return None
+    return builtin_recommendation(
+        signal,
+        target=rule._builtin_target,
+        concern=rule._builtin_concern,
+        reason=reason,
+    )
+
+
 class AccessErrorRule:
     """Error pattern "blocked"/"permission denied" -> check tool access."""
 
     _KEYWORDS = {"blocked", "permission denied", "don't have access"}
+    _builtin_target = "tools"
+    _builtin_concern: BuiltinConcern = "tools"
 
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         if signal.signal_type != SignalType.ERROR_PATTERN:
@@ -46,11 +78,8 @@ class AccessErrorRule:
         observation = signal.message
         reason = "This indicates the agent lacks access to required tools."
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="tools", concern="tools",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and not config.tools and not config.disallowed_tools:
             action = (
@@ -85,6 +114,8 @@ class ErrorHandlingRule:
     """Error pattern "failed"/"error"/"retry" -> check prompt for error guidance."""
 
     _KEYWORDS = {"failed", "error", "retry", "unable to", "not found", "timed out"}
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "recovery"
 
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         if signal.signal_type != SignalType.ERROR_PATTERN:
@@ -98,11 +129,8 @@ class ErrorHandlingRule:
         observation = signal.message
         reason = "Repeated errors suggest the agent lacks error handling guidance."
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="recovery",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and config.prompt_body:
             body_lower = config.prompt_body.lower()
@@ -141,6 +169,9 @@ class ErrorHandlingRule:
 class TokenOutlierRule:
     """Token outlier -> recommend more focused instructions or tool restriction."""
 
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "scope"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.TOKEN_OUTLIER
 
@@ -150,11 +181,8 @@ class TokenOutlierRule:
         observation = signal.message
         reason = "High token usage suggests the agent is exploring broadly."
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="scope",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and len(config.tools) > 8:
             action = (
@@ -191,6 +219,9 @@ class TokenOutlierRule:
 class DurationOutlierRule:
     """Duration outlier -> check model selection or task scoping."""
 
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "scope"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.DURATION_OUTLIER
 
@@ -200,11 +231,8 @@ class DurationOutlierRule:
         observation = signal.message
         reason = "Slow invocations may indicate an overqualified model or unclear task scope."
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="scope",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and config.model and "opus" in config.model.lower():
             action = (
@@ -241,6 +269,9 @@ class DurationOutlierRule:
 class PermissionFailureRule:
     """PERMISSION_FAILURE -> recommend adding the denied tool to `tools`."""
 
+    _builtin_target = "tools"
+    _builtin_concern: BuiltinConcern = "tools"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.PERMISSION_FAILURE
 
@@ -251,11 +282,8 @@ class PermissionFailureRule:
         observation = signal.message
         reason = "The subagent was denied access to a tool it attempted to call."
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="tools", concern="tools",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and tool_name and tool_name not in config.tools:
             action = (
@@ -292,6 +320,9 @@ class PermissionFailureRule:
 class RetryLoopRule:
     """RETRY_LOOP -> recommend error-recovery guidance in the prompt."""
 
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "recovery"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.RETRY_LOOP
 
@@ -304,11 +335,8 @@ class RetryLoopRule:
             "recovery guidance for failures."
         )
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="recovery",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and config.prompt_body:
             body_lower = config.prompt_body.lower()
@@ -348,6 +376,9 @@ class RetryLoopRule:
 class StuckPatternRule:
     """STUCK_PATTERN -> recommend adding exit conditions to the prompt."""
 
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "recovery"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.STUCK_PATTERN
 
@@ -361,11 +392,8 @@ class StuckPatternRule:
             "progress, indicating no exit condition."
         )
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="recovery",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config:
             action = (
@@ -395,6 +423,9 @@ class StuckPatternRule:
 class ErrorSequenceRule:
     """TOOL_ERROR_SEQUENCE -> recommend fallback instructions or tool review."""
 
+    _builtin_target = "prompt"
+    _builtin_concern: BuiltinConcern = "scope"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.TOOL_ERROR_SEQUENCE
 
@@ -407,11 +438,8 @@ class ErrorSequenceRule:
             "fallback instructions for when a tool call fails."
         )
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="prompt", concern="scope",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         if config and len(config.tools) > 8:
             action = (
@@ -455,6 +483,9 @@ class ModelRoutingRule:
     more, but the tradeoff is quality).
     """
 
+    _builtin_target = "model"
+    _builtin_concern: BuiltinConcern = "model"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
         return signal.signal_type == SignalType.MODEL_MISMATCH
 
@@ -475,11 +506,8 @@ class ModelRoutingRule:
             f"configured with {current_model}."
         )
 
-        if is_builtin_agent(signal.agent_type):
-            return builtin_recommendation(
-                signal, target="model", concern="model",
-                observation=observation, reason=reason,
-            )
+        if rec := _check_builtin(self, signal, reason):
+            return rec
 
         action_parts = [f"Switch to {recommended_model}"]
         if mismatch_type == "overspec" and isinstance(savings, int | float):

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -88,6 +88,14 @@ class DiagnosticRecommendation(BaseModel):
     signal_types: list[SignalType] = Field(default_factory=list)
     """Which signal types contributed to this recommendation."""
 
+    is_builtin: bool = False
+    """True when the agent is one of Claude Code's built-in types
+    (Explore, general-purpose, Plan, etc. — see
+    ``agents.models.BUILTIN_AGENT_TYPES``). Built-in agents have no
+    user-editable prompt/tool/model config, so their recommendations
+    use a different action template. Denormalized onto the model so
+    JSON consumers don't need to re-derive via ``is_builtin_agent()``."""
+
 
 class AggregatedRecommendation(BaseModel):
     """Aggregate of one or more ``DiagnosticRecommendation`` instances that
@@ -116,6 +124,12 @@ class AggregatedRecommendation(BaseModel):
     representative_message: str
     """Aggregated message shown in the default table. For ``count == 1``
     this is the original recommendation text verbatim."""
+
+    is_builtin: bool = False
+    """Mirrors ``DiagnosticRecommendation.is_builtin`` — built-in and
+    custom agents never aggregate together because ``agent_type`` is in
+    the grouping key, so this is constant across
+    ``contributing_recommendations``."""
 
     contributing_recommendations: list[DiagnosticRecommendation] = Field(
         default_factory=list,

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from agentfluent.config.models import AgentConfig, Scope, Severity
 from agentfluent.diagnostics.correlator import correlate as _correlate_pairs
 from agentfluent.diagnostics.models import (
@@ -462,3 +464,110 @@ class TestMcpAuditCorrelation:
         recs = correlate([_signal(keyword="error")])
         # At least one recommendation; target is NOT "mcp".
         assert all(r.target != "mcp" for r in recs)
+
+
+def _builtin_signal(signal_type: SignalType, agent_type: str = "explore") -> DiagnosticSignal:
+    """Build a minimal signal keyed to a built-in agent, supplying detail
+    fields required by specific rules so each rule's ``recommend`` path
+    exits through the built-in branch cleanly."""
+    detail: dict[str, object] = {}
+    if signal_type == SignalType.ERROR_PATTERN:
+        detail = {"keyword": "failed"}
+    elif signal_type == SignalType.PERMISSION_FAILURE:
+        detail = {"tool_name": "Write", "tool_calls": []}
+    elif signal_type == SignalType.RETRY_LOOP:
+        detail = {"tool_name": "Read", "retry_count": 3, "tool_calls": []}
+    elif signal_type == SignalType.STUCK_PATTERN:
+        detail = {"tool_name": "Read", "stuck_count": 4, "tool_calls": []}
+    elif signal_type == SignalType.TOOL_ERROR_SEQUENCE:
+        detail = {"error_count": 2, "start_index": 0, "end_index": 1, "tool_calls": []}
+    elif signal_type == SignalType.MODEL_MISMATCH:
+        detail = {
+            "mismatch_type": "overspec",
+            "current_model": "claude-opus-4-7",
+            "recommended_model": "claude-haiku-4-5",
+            "complexity_tier": "simple",
+            "invocation_count": 5,
+        }
+    return DiagnosticSignal(
+        signal_type=signal_type,
+        severity=Severity.WARNING,
+        agent_type=agent_type,
+        message=f"Agent '{agent_type}' triggered {signal_type.value}.",
+        detail=detail,
+    )
+
+
+class TestBuiltinAgentBranching:
+    """Rules must emit built-in-specific action text (not "edit the prompt
+    in ~/.claude/agents/<name>.md") when ``signal.agent_type`` names a
+    built-in like Explore, general-purpose, or Plan — those agents have
+    no user-editable config files. Issue #166."""
+
+    @pytest.mark.parametrize(
+        ("signal_type", "expected_phrase", "expected_target"),
+        [
+            (SignalType.TOKEN_OUTLIER, "prompt is not user-editable", "prompt"),
+            (SignalType.DURATION_OUTLIER, "prompt is not user-editable", "prompt"),
+            (SignalType.TOOL_ERROR_SEQUENCE, "prompt is not user-editable", "prompt"),
+            (SignalType.RETRY_LOOP, "prompt is not user-editable", "prompt"),
+            (SignalType.STUCK_PATTERN, "prompt is not user-editable", "prompt"),
+            (SignalType.PERMISSION_FAILURE, "tool list is not user-editable", "tools"),
+            (SignalType.MODEL_MISMATCH, "model is not user-configurable", "model"),
+        ],
+    )
+    def test_builtin_agent_gets_non_editable_action_text(
+        self,
+        signal_type: SignalType,
+        expected_phrase: str,
+        expected_target: str,
+    ) -> None:
+        recs = correlate([_builtin_signal(signal_type)])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.is_builtin is True
+        assert rec.config_file == ""
+        assert rec.target == expected_target
+        assert expected_phrase in rec.action
+
+    def test_error_pattern_blocked_keyword_uses_tools_concern(self) -> None:
+        # AccessErrorRule fires on "blocked"; built-ins get tools-concern text.
+        signals = [_signal(keyword="blocked", agent_type="explore")]
+        recs = correlate(signals)
+        assert recs[0].is_builtin is True
+        assert recs[0].target == "tools"
+        assert "tool list is not user-editable" in recs[0].action
+
+    def test_error_pattern_failed_keyword_uses_recovery_concern(self) -> None:
+        # ErrorHandlingRule fires on "failed"; built-ins get recovery text.
+        signals = [_signal(keyword="failed", agent_type="explore")]
+        recs = correlate(signals)
+        assert recs[0].is_builtin is True
+        assert recs[0].target == "prompt"
+        assert "prompt is not user-editable" in recs[0].action
+
+    def test_custom_agent_unchanged_by_builtin_branching(self) -> None:
+        # Regression: a custom agent (agent_type="pm") still routes
+        # through the original config-or-fallback path.
+        signals = [_builtin_signal(SignalType.TOKEN_OUTLIER, agent_type="pm")]
+        recs = correlate(signals, {"pm": _config()})
+        assert len(recs) == 1
+        assert recs[0].is_builtin is False
+        assert "pm.md" in recs[0].config_file
+        assert "not user-editable" not in recs[0].action
+
+    def test_builtin_detection_is_case_insensitive(self) -> None:
+        # agent_type "Explore" (capital E) should still be detected as builtin.
+        signals = [_builtin_signal(SignalType.TOKEN_OUTLIER, agent_type="Explore")]
+        recs = correlate(signals)
+        assert recs[0].is_builtin is True
+
+    def test_all_four_concern_templates_distinct(self) -> None:
+        # Sanity check: the four concern templates produce recognizably
+        # different action text so JSON consumers can tell them apart.
+        token_rec = correlate([_builtin_signal(SignalType.TOKEN_OUTLIER)])[0]
+        retry_rec = correlate([_builtin_signal(SignalType.RETRY_LOOP)])[0]
+        perm_rec = correlate([_builtin_signal(SignalType.PERMISSION_FAILURE)])[0]
+        model_rec = correlate([_builtin_signal(SignalType.MODEL_MISMATCH)])[0]
+        actions = {token_rec.action, retry_rec.action, perm_rec.action, model_rec.action}
+        assert len(actions) == 4

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -467,9 +467,6 @@ class TestMcpAuditCorrelation:
 
 
 def _builtin_signal(signal_type: SignalType, agent_type: str = "explore") -> DiagnosticSignal:
-    """Build a minimal signal keyed to a built-in agent, supplying detail
-    fields required by specific rules so each rule's ``recommend`` path
-    exits through the built-in branch cleanly."""
     detail: dict[str, object] = {}
     if signal_type == SignalType.ERROR_PATTERN:
         detail = {"keyword": "failed"}
@@ -531,7 +528,6 @@ class TestBuiltinAgentBranching:
         assert expected_phrase in rec.action
 
     def test_error_pattern_blocked_keyword_uses_tools_concern(self) -> None:
-        # AccessErrorRule fires on "blocked"; built-ins get tools-concern text.
         signals = [_signal(keyword="blocked", agent_type="explore")]
         recs = correlate(signals)
         assert recs[0].is_builtin is True
@@ -539,7 +535,6 @@ class TestBuiltinAgentBranching:
         assert "tool list is not user-editable" in recs[0].action
 
     def test_error_pattern_failed_keyword_uses_recovery_concern(self) -> None:
-        # ErrorHandlingRule fires on "failed"; built-ins get recovery text.
         signals = [_signal(keyword="failed", agent_type="explore")]
         recs = correlate(signals)
         assert recs[0].is_builtin is True
@@ -547,8 +542,6 @@ class TestBuiltinAgentBranching:
         assert "prompt is not user-editable" in recs[0].action
 
     def test_custom_agent_unchanged_by_builtin_branching(self) -> None:
-        # Regression: a custom agent (agent_type="pm") still routes
-        # through the original config-or-fallback path.
         signals = [_builtin_signal(SignalType.TOKEN_OUTLIER, agent_type="pm")]
         recs = correlate(signals, {"pm": _config()})
         assert len(recs) == 1
@@ -557,14 +550,11 @@ class TestBuiltinAgentBranching:
         assert "not user-editable" not in recs[0].action
 
     def test_builtin_detection_is_case_insensitive(self) -> None:
-        # agent_type "Explore" (capital E) should still be detected as builtin.
         signals = [_builtin_signal(SignalType.TOKEN_OUTLIER, agent_type="Explore")]
         recs = correlate(signals)
         assert recs[0].is_builtin is True
 
     def test_all_four_concern_templates_distinct(self) -> None:
-        # Sanity check: the four concern templates produce recognizably
-        # different action text so JSON consumers can tell them apart.
         token_rec = correlate([_builtin_signal(SignalType.TOKEN_OUTLIER)])[0]
         retry_rec = correlate([_builtin_signal(SignalType.RETRY_LOOP)])[0]
         perm_rec = correlate([_builtin_signal(SignalType.PERMISSION_FAILURE)])[0]

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -222,6 +222,22 @@ class TestEvidencePreservation:
         assert aggregate_recommendations([]) == []
 
 
+class TestBuiltinPropagation:
+    def test_is_builtin_propagates_from_contributing_recommendations(self) -> None:
+        sig, rec = _token_outlier_pair("explore", 4.9)
+        rec = rec.model_copy(update={"is_builtin": True})
+        aggregated = aggregate_recommendations([(sig, rec)])
+        assert aggregated[0].is_builtin is True
+
+    def test_custom_agents_aggregate_with_is_builtin_false(self) -> None:
+        pairs = [
+            _token_outlier_pair("pm", 2.4),
+            _token_outlier_pair("pm", 3.1),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        assert aggregated[0].is_builtin is False
+
+
 class TestAggregationModel:
     def test_aggregated_recommendation_is_pydantic_serializable(self) -> None:
         pairs = [_token_outlier_pair("pm", 3.4)]


### PR DESCRIPTION
Closes #166. Architect-reviewed plan at https://github.com/frederick-douglas-pearce/agentfluent/issues/166#issuecomment-4310961791.

## Summary

Built-in agents (Explore, general-purpose, Plan, code-reviewer, statusline-setup, claude-code-guide) have no user-editable prompt/tool/model config. Before this PR, the correlation rules told users to "edit the agent's prompt in \`~/.claude/agents/<name>.md\`" — un-actionable for built-ins. This PR branches all 9 agent-config-facing rules to emit built-in-specific action text keyed to the rule's concern area.

## Four concern templates

| Concern | Rules | Built-in action text |
|---|---|---|
| scope | TokenOutlier, DurationOutlier, ErrorSequence | "Consider: (a) a custom wrapper subagent that narrows the task scope, (b) tightening the delegation prompt, or (c) rerouting to a different agent." |
| recovery | RetryLoop, StuckPattern, ErrorHandling | "Add retry bounds or exit conditions to the *delegating* agent's prompt, since the built-in agent cannot enforce them itself." |
| tools | AccessError, PermissionFailure | "Route this task to a custom subagent with explicit tool grants, or confirm the built-in agent's fixed tool set is actually required." |
| model | ModelRouting | "Create a custom subagent with the recommended model, or reroute this task to an existing agent that already uses it." |

McpAuditRule is unchanged — it targets MCP server config, not agent config.

## Architect-flagged expansions

The original plan covered 5 rules and one shared template. Architect review expanded to:
- **9 rules** — added ErrorHandlingRule, ModelRoutingRule, AccessErrorRule, PermissionFailureRule (original 5 were TokenOutlier, DurationOutlier, ErrorSequence, RetryLoop, StuckPattern)
- **4 templates, not 1** — retry/stuck signals need recovery guidance, not scope guidance
- **Propagate \`is_builtin\` to AggregatedRecommendation** — trivial one-liner needed for the JSON output AC

## Output sample (agentfluent project)

Before:
\`\`\`
│ Explore │ tools │ critical │ 7 │ Grant the subagent access to 'Bash' in its
│         │       │          │   │ agent configuration, or remove calls...
\`\`\`

After:
\`\`\`
│ Explore │ tools │ critical │ 7 │ Built-in agent — tool list is not
│         │       │          │   │ user-editable. Route this task to a
│         │       │          │   │ custom subagent with explicit tool grants.
\`\`\`

## File size note

The architect flagged \`correlator.py\` (549 lines pre-PR) as approaching the 300-line convention. This PR keeps the rule logic in correlator.py but extracts action-text constants and the \`builtin_recommendation\` helper to a new \`diagnostics/builtin_actions.py\` module — net effect: correlator.py grows by 5 lines per rule (9 × ~5 = 45 lines) but the 4 action templates live outside it.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/agentfluent/\` — clean (48 files)
- [x] \`uv run pytest\` — 718 passing (14 new tests in \`TestBuiltinAgentBranching\` + \`TestBuiltinPropagation\`)
- [x] Manual run on agentfluent project: all 4 concern templates visible in real output; custom agents (pm, architect) still get original text

## Forward compatibility

- **#172 (priority ranking)**: \`is_builtin\` is a clean input for priority scoring. "Built-in + high count" weights toward "create wrapper subagent" as a high-priority fix.
- **#170 (concrete target model)**: \`ModelRoutingRule\` built-in branch doesn't need pricing data, so #170's shared target-selection helper can plug in independently.
- **#168 (verbose YAML subagent draft)**: \`is_builtin=True\` recommendations are a natural trigger for offering a wrapper-subagent draft in verbose mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)