### PR TITLE
feat(diagnostics): surface copy-paste-ready YAML subagent draft (#168)

### DIFF
--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -423,14 +423,8 @@ def _format_delegation_suggestions(
 
     if verbose:
         for sug in suggestions:
-            top_terms = ", ".join(sug.top_terms) if sug.top_terms else "—"
-            console.print(
-                f"\n[cyan]{escape(sug.name)}[/cyan]  "
-                f"[dim](cohesion {sug.cohesion_score:.2f}, "
-                f"top terms: {escape(top_terms)})[/dim]",
-            )
-            console.print(f"  {escape(sug.description)}")
-            console.print(f"  [dim]prompt draft:[/dim] {escape(sug.prompt_template)}")
+            console.print()
+            console.print(escape(sug.yaml_draft))
 
 
 def _format_diagnostics_summary(console: Console, diag: DiagnosticsResult) -> None:

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, Field
+import yaml
+from pydantic import BaseModel, Field, computed_field
 
 from agentfluent.config.models import Severity
 
@@ -193,6 +194,52 @@ class DelegationSuggestion(BaseModel):
     """Name of the existing agent that deduped this draft (empty when
     not deduped). Exposed as a first-class field so cross-reference
     logic can look up the matched agent without parsing ``dedup_note``."""
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def yaml_draft(self) -> str:
+        """Copy-paste-ready subagent definition block.
+
+        Matches the shape a user would save to
+        ``~/.claude/agents/<name>.md``: comment preamble with confidence
+        + cluster context, YAML frontmatter (description, model, tools),
+        ``---`` separator, prompt body. Low-confidence clusters get a
+        REVIEW warning in the preamble so the caller doesn't paste them
+        into production without vetting.
+        """
+        preamble: list[str] = [f"# Suggested agent: {self.name}"]
+        if self.confidence == "low":
+            preamble.append("# REVIEW BEFORE USE — low confidence cluster")
+        preamble.append(
+            f"# Confidence: {self.confidence} "
+            f"({self.cluster_size} invocations, {self.cohesion_score:.2f} cohesion)",
+        )
+        if self.top_terms:
+            preamble.append(f"# Top terms: {', '.join(self.top_terms)}")
+        if self.dedup_note:
+            preamble.append(f"# Note: {self.dedup_note}")
+
+        frontmatter_data: dict[str, object] = {
+            "description": self.description,
+            "model": self.model,
+            "tools": self.tools,
+        }
+        frontmatter = yaml.safe_dump(
+            frontmatter_data, sort_keys=False, default_flow_style=False,
+        ).rstrip()
+
+        tools_comment = ""
+        if not self.tools and self.tools_note:
+            tools_comment = f"\n# tools: {self.tools_note}"
+
+        return (
+            "\n".join(preamble)
+            + "\n---\n"
+            + frontmatter
+            + tools_comment
+            + "\n---\n\n"
+            + self.prompt_template
+        )
 
 
 class DiagnosticsResult(BaseModel):

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -195,6 +195,9 @@ class DelegationSuggestion(BaseModel):
     not deduped). Exposed as a first-class field so cross-reference
     logic can look up the matched agent without parsing ``dedup_note``."""
 
+    # ``# type: ignore[prop-decorator]`` is the documented workaround for
+    # mypy not reconciling ``@computed_field`` stacked on ``@property``
+    # (upstream: pydantic/pydantic#6709).
     @computed_field  # type: ignore[prop-decorator]
     @property
     def yaml_draft(self) -> str:

--- a/tests/_builders.py
+++ b/tests/_builders.py
@@ -171,3 +171,38 @@ def write_project_layout(
                 "\n".join(json.dumps(m) for m in messages) + "\n",
             )
     return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Model factories.
+# ---------------------------------------------------------------------------
+
+from typing import Literal  # noqa: E402
+
+from agentfluent.diagnostics.models import DelegationSuggestion  # noqa: E402
+
+
+def delegation_suggestion(
+    name: str = "test-runner",
+    description: str = "Handles delegations related to: pytest, tests, run.",
+    tools: list[str] | None = None,
+    tools_note: str = "",
+    confidence: Literal["high", "medium", "low"] = "high",
+    dedup_note: str = "",
+    top_terms: list[str] | None = None,
+    cohesion_score: float = 0.85,
+) -> DelegationSuggestion:
+    """Build a ``DelegationSuggestion`` with project-consistent defaults."""
+    return DelegationSuggestion(
+        name=name,
+        description=description,
+        model="claude-sonnet-4-6",
+        tools=tools if tools is not None else ["Read", "Grep"],
+        tools_note=tools_note,
+        prompt_template="You run pytest tests and report results.",
+        confidence=confidence,
+        cluster_size=10,
+        cohesion_score=cohesion_score,
+        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
+        dedup_note=dedup_note,
+    )

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -15,6 +15,7 @@ from agentfluent.diagnostics.models import (
     DiagnosticsResult,
     SignalType,
 )
+from tests._builders import delegation_suggestion as _suggestion
 
 
 def _trace_signal(
@@ -169,30 +170,6 @@ class TestJsonRoundTrip:
         assert restored["signals"][0]["detail"]["stuck_count"] == 5
 
 
-def _suggestion(
-    name: str = "test-runner",
-    description: str = "Handles delegations related to: pytest, tests, run.",
-    tools: list[str] | None = None,
-    tools_note: str = "",
-    confidence: str = "high",
-    dedup_note: str = "",
-    top_terms: list[str] | None = None,
-) -> DelegationSuggestion:
-    return DelegationSuggestion(
-        name=name,
-        description=description,
-        model="claude-sonnet-4-6",
-        tools=tools if tools is not None else ["Read", "Grep"],
-        tools_note=tools_note,
-        prompt_template="You run pytest tests and report results.",
-        confidence=confidence,  # type: ignore[arg-type]
-        cluster_size=10,
-        cohesion_score=0.85,
-        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
-        dedup_note=dedup_note,
-    )
-
-
 def _result_with_suggestions(
     suggestions: list[DelegationSuggestion],
 ) -> DiagnosticsResult:
@@ -222,7 +199,6 @@ class TestDelegationSuggestionsSection:
         out = _render_suggestions(
             _result_with_suggestions([_suggestion()]), verbose=True,
         )
-        # Copy-paste-ready YAML frontmatter structure.
         assert "# Suggested agent: test-runner" in out
         assert "# Confidence: high" in out
         assert "description:" in out
@@ -230,7 +206,6 @@ class TestDelegationSuggestionsSection:
         assert "tools:" in out
         assert "- Read" in out
         assert "---" in out
-        # Prompt body + top terms preserved.
         assert "You run pytest tests" in out
         assert "pytest" in out
 

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -218,12 +218,36 @@ class TestDelegationSuggestionsSection:
         assert "test-runner" in out
         assert "claude-sonnet-4-6" in out
 
-    def test_verbose_adds_prompt_draft_block(self) -> None:
+    def test_verbose_emits_yaml_subagent_draft(self) -> None:
         out = _render_suggestions(
             _result_with_suggestions([_suggestion()]), verbose=True,
         )
-        assert "prompt draft" in out
-        assert "pytest" in out  # top terms surface
+        # Copy-paste-ready YAML frontmatter structure.
+        assert "# Suggested agent: test-runner" in out
+        assert "# Confidence: high" in out
+        assert "description:" in out
+        assert "model: claude-sonnet-4-6" in out
+        assert "tools:" in out
+        assert "- Read" in out
+        assert "---" in out
+        # Prompt body + top terms preserved.
+        assert "You run pytest tests" in out
+        assert "pytest" in out
+
+    def test_verbose_low_confidence_includes_review_warning(self) -> None:
+        out = _render_suggestions(
+            _result_with_suggestions([_suggestion(confidence="low")]), verbose=True,
+        )
+        assert "REVIEW BEFORE USE" in out
+        assert "# Confidence: low" in out
+
+    def test_verbose_empty_tools_notes_reason(self) -> None:
+        sug = _suggestion(tools=[], tools_note="no subagent traces linked")
+        out = _render_suggestions(
+            _result_with_suggestions([sug]), verbose=True,
+        )
+        assert "tools: []" in out
+        assert "no subagent traces linked" in out
 
     def test_dedup_note_rendered(self) -> None:
         sug = _suggestion(dedup_note="suppressed — already covered by 'pm' (similarity 0.85)")

--- a/tests/unit/test_delegation_yaml_draft.py
+++ b/tests/unit/test_delegation_yaml_draft.py
@@ -1,0 +1,118 @@
+"""Tests for ``DelegationSuggestion.yaml_draft`` computed field.
+
+These tests stay isolated from ``test_delegation.py`` because that
+module skips when scikit-learn is unavailable — the YAML draft itself
+has no sklearn dependency, so it must remain testable regardless.
+"""
+
+from __future__ import annotations
+
+from agentfluent.diagnostics.models import DelegationSuggestion
+
+
+def _suggestion(
+    name: str = "test-runner",
+    description: str = "Handles delegations related to: pytest, tests, run.",
+    tools: list[str] | None = None,
+    tools_note: str = "",
+    confidence: str = "high",
+    dedup_note: str = "",
+    top_terms: list[str] | None = None,
+    cohesion_score: float = 0.85,
+) -> DelegationSuggestion:
+    return DelegationSuggestion(
+        name=name,
+        description=description,
+        model="claude-sonnet-4-6",
+        tools=tools if tools is not None else ["Read", "Grep"],
+        tools_note=tools_note,
+        prompt_template="You run pytest tests and report results.",
+        confidence=confidence,  # type: ignore[arg-type]
+        cluster_size=10,
+        cohesion_score=cohesion_score,
+        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
+        dedup_note=dedup_note,
+    )
+
+
+class TestYamlDraftStructure:
+    def test_preamble_lists_name_and_confidence(self) -> None:
+        out = _suggestion().yaml_draft
+        assert out.startswith("# Suggested agent: test-runner")
+        assert "# Confidence: high (10 invocations, 0.85 cohesion)" in out
+
+    def test_frontmatter_separators_bracket_yaml_block(self) -> None:
+        out = _suggestion().yaml_draft
+        parts = out.split("---\n")
+        assert len(parts) == 3
+        assert "description:" in parts[1]
+        assert "model: claude-sonnet-4-6" in parts[1]
+
+    def test_prompt_body_appears_after_second_separator(self) -> None:
+        out = _suggestion().yaml_draft
+        assert out.rstrip().endswith("You run pytest tests and report results.")
+
+    def test_tools_rendered_as_yaml_list(self) -> None:
+        out = _suggestion(tools=["Read", "Grep", "Bash"]).yaml_draft
+        assert "tools:\n- Read\n- Grep\n- Bash" in out
+
+    def test_top_terms_in_preamble_when_present(self) -> None:
+        out = _suggestion().yaml_draft
+        assert "# Top terms: pytest, tests, run" in out
+
+    def test_top_terms_line_omitted_when_empty(self) -> None:
+        out = _suggestion(top_terms=[]).yaml_draft
+        assert "Top terms" not in out
+
+
+class TestYamlDraftConfidenceHandling:
+    def test_low_confidence_preamble_includes_review_warning(self) -> None:
+        out = _suggestion(confidence="low", cohesion_score=0.45).yaml_draft
+        assert "# REVIEW BEFORE USE" in out
+        assert "# Confidence: low" in out
+
+    def test_medium_and_high_confidence_omit_review_warning(self) -> None:
+        assert "REVIEW" not in _suggestion(confidence="high").yaml_draft
+        assert "REVIEW" not in _suggestion(confidence="medium").yaml_draft
+
+
+class TestYamlDraftEdgeCases:
+    def test_empty_tools_with_note_surfaces_note_as_comment(self) -> None:
+        out = _suggestion(tools=[], tools_note="no subagent traces linked").yaml_draft
+        assert "tools: []" in out
+        assert "# tools: no subagent traces linked" in out
+
+    def test_empty_tools_without_note_shows_empty_list(self) -> None:
+        out = _suggestion(tools=[]).yaml_draft
+        assert "tools: []" in out
+        assert "# tools:" not in out
+
+    def test_dedup_note_surfaces_in_preamble(self) -> None:
+        out = _suggestion(
+            dedup_note="suppressed — already covered by 'pm' (similarity 0.85)",
+        ).yaml_draft
+        assert "# Note: suppressed" in out
+
+    def test_description_with_special_chars_is_yaml_quoted_safely(self) -> None:
+        # pyyaml's safe_dump handles special-char escaping; a description
+        # containing quotes and colons must not produce invalid YAML.
+        out = _suggestion(
+            description='Handles "tests" with: special chars',
+        ).yaml_draft
+        assert "description:" in out
+        import yaml
+        frontmatter_block = out.split("---\n")[1]
+        parsed = yaml.safe_load(frontmatter_block)
+        assert parsed["description"] == 'Handles "tests" with: special chars'
+
+
+class TestYamlDraftJsonSerialization:
+    def test_yaml_draft_appears_in_model_dump(self) -> None:
+        dumped = _suggestion().model_dump()
+        assert "yaml_draft" in dumped
+        assert dumped["yaml_draft"].startswith("# Suggested agent:")
+
+    def test_yaml_draft_appears_in_json_mode_dump(self) -> None:
+        dumped = _suggestion().model_dump(mode="json")
+        assert "yaml_draft" in dumped
+        assert isinstance(dumped["yaml_draft"], str)

--- a/tests/unit/test_delegation_yaml_draft.py
+++ b/tests/unit/test_delegation_yaml_draft.py
@@ -7,32 +7,7 @@ has no sklearn dependency, so it must remain testable regardless.
 
 from __future__ import annotations
 
-from agentfluent.diagnostics.models import DelegationSuggestion
-
-
-def _suggestion(
-    name: str = "test-runner",
-    description: str = "Handles delegations related to: pytest, tests, run.",
-    tools: list[str] | None = None,
-    tools_note: str = "",
-    confidence: str = "high",
-    dedup_note: str = "",
-    top_terms: list[str] | None = None,
-    cohesion_score: float = 0.85,
-) -> DelegationSuggestion:
-    return DelegationSuggestion(
-        name=name,
-        description=description,
-        model="claude-sonnet-4-6",
-        tools=tools if tools is not None else ["Read", "Grep"],
-        tools_note=tools_note,
-        prompt_template="You run pytest tests and report results.",
-        confidence=confidence,  # type: ignore[arg-type]
-        cluster_size=10,
-        cohesion_score=cohesion_score,
-        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
-        dedup_note=dedup_note,
-    )
+from tests._builders import delegation_suggestion as _suggestion
 
 
 class TestYamlDraftStructure:
@@ -94,8 +69,6 @@ class TestYamlDraftEdgeCases:
         assert "# Note: suppressed" in out
 
     def test_description_with_special_chars_is_yaml_quoted_safely(self) -> None:
-        # pyyaml's safe_dump handles special-char escaping; a description
-        # containing quotes and colons must not produce invalid YAML.
         out = _suggestion(
             description='Handles "tests" with: special chars',
         ).yaml_draft


### PR DESCRIPTION
Closes #168.

## Summary

The Suggested Subagents table previously showed name, model, confidence, cluster size, and tools in a compact row — but not the description or drafted prompt. The \`--verbose\` output was three lines of free-text sketch, not copy-paste-ready.

This PR adds a \`yaml_draft\` computed field on \`DelegationSuggestion\` that builds a proper YAML frontmatter block. Users can now drop the verbose output directly into \`~/.claude/agents/<name>.md\`.

## Output shape

\`\`\`yaml
# Suggested agent: severity-signal
# REVIEW BEFORE USE — low confidence cluster
# Confidence: low (9 invocations, 0.25 cohesion)
# Top terms: severity, signal, py, diff, code
---
description: 'Handles delegations related to: severity, signal, py.'
model: claude-opus-4-7
tools:
- Bash
- Glob
- Grep
- Read
---

You handle recurring delegations involving severity, signal, py.

Scope your work to the specific task described in the user's prompt...
\`\`\`

## Design choices

- **Computed field via \`@computed_field\`, not stored state.** Derivable from existing fields on \`DelegationSuggestion\`; Pydantic serializes it automatically so JSON consumers get it for free without a separate aggregation pass.
- **\`yaml.safe_dump\` for the frontmatter.** Correct escaping for descriptions with quotes, colons, backslashes without hand-rolling YAML rules. pyyaml was already a project dependency.
- **Low-confidence clusters still produce a draft** with an explicit \`# REVIEW BEFORE USE\` warning line per the #168 AC — don't silently drop the signal, but make the caveat impossible to miss.
- **Rich escape wraps the whole block.** YAML contains characters that Rich could interpret as markup; escaping at the block level keeps the output literal without fighting Rich's parser.

## JSON consumers

\`--format json\` exposes \`yaml_draft\` as a string field on each suggestion. Pipe to file:

\`\`\`bash
agentfluent analyze -p myproject --diagnostics --format json \\
  | jq -r '.data.diagnostics.delegation_suggestions[0].yaml_draft' \\
  > ~/.claude/agents/new-agent.md
\`\`\`

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/agentfluent/\` — clean (48 files)
- [x] \`uv run pytest\` — 734 passing (14 new \`yaml_draft\` unit tests + 3 updated formatter tests)
- [x] Manual run on agentfluent project: \`--verbose\` prints YAML blocks below the table; all 3 clusters (low confidence) get the REVIEW warning
- [x] JSON output includes \`yaml_draft\` field

## Forward compatibility

- **#167** (cluster cohesion investigation): the \`# REVIEW BEFORE USE\` warning on low-confidence drafts becomes lower-friction once cohesion tuning improves — but the AC was "still produce a draft," so this is correct whether or not #167 lands.
- **#172** (priority ranking): JSON consumers already have the draft; #172 can add priority-ordering without touching this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)