### PR TITLE
fix(diagnostics): recalibrate cluster confidence thresholds (#167)

### DIFF
--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -72,16 +72,18 @@ _SMALL_N_THRESHOLD = 10       # below this, force k=2 without silhouette
 _FORCED_SMALL_K = 2
 _KMEANS_RANDOM_STATE = 42     # default seed for reproducible clustering
 _KMEANS_N_INIT = 10           # KMeans restarts; higher resists bad local minima
-# Confidence tier boundaries: #140's calibration (post-#153 parser
-# fix) observed cluster cohesion on real data runs 0.19–0.79, mostly
-# 0.33–0.47. Only ~12% of clusters reach MEDIUM (0.6); none reach
-# HIGH (0.8). Semantic review confirmed the clusters ARE coherent
-# patterns — these thresholds are simply calibrated above what real
-# TF-IDF on agent delegations yields. Candidate for lowering to
-# ~0.3 medium / ~0.5 high once multi-contributor data confirms.
+# Confidence tier boundaries: calibrated against two real-world
+# datasets (agentfluent: 5 clusters, cohesion 0.26–0.46; codefluent:
+# 2 clusters, cohesion 0.16–0.31) in the #167 investigation. Clusters
+# are genuinely finding task families, but free-text delegation
+# prompts have enough variance that real-world cohesion rarely
+# exceeds 0.5 even for coherent groupings. Semantic review:
+# cohesion ≥ 0.35 reliably surfaces recognizable patterns (PR reviews,
+# mode flags); below that lives loose thematic grouping that still
+# warrants a REVIEW BEFORE USE caveat (#168's YAML draft warning).
 _CONFIDENCE_HIGH_SIZE = 10
-_CONFIDENCE_HIGH_COHESION = 0.8
-_CONFIDENCE_MEDIUM_COHESION = 0.6
+_CONFIDENCE_HIGH_COHESION = 0.50
+_CONFIDENCE_MEDIUM_COHESION = 0.35
 _TOOL_READ_ONLY = frozenset(
     {"Read", "Grep", "Glob", "WebFetch", "WebSearch", "LS"},
 )

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -289,17 +289,35 @@ class TestGenerateDraft:
 
     def test_confidence_high(self) -> None:
         members = [_inv()] * 12
-        draft = generate_draft(self._cluster(members=members, cohesion=0.85))
+        draft = generate_draft(self._cluster(members=members, cohesion=0.55))
         assert draft.confidence == "high"
 
     def test_confidence_medium(self) -> None:
         members = [_inv()] * 6
-        draft = generate_draft(self._cluster(members=members, cohesion=0.65))
+        draft = generate_draft(self._cluster(members=members, cohesion=0.40))
         assert draft.confidence == "medium"
 
     def test_confidence_low(self) -> None:
         members = [_inv()] * 5
-        draft = generate_draft(self._cluster(members=members, cohesion=0.4))
+        draft = generate_draft(self._cluster(members=members, cohesion=0.25))
+        assert draft.confidence == "low"
+
+    def test_realistic_cohesion_045_is_medium(self) -> None:
+        # Anchors the #167 calibration: a well-formed agentfluent-style
+        # cluster (cohesion 0.46, size 5 — quiet/json/verbose mode
+        # reviews) must land in MEDIUM, not LOW, under the updated
+        # thresholds. Regression guard against silently reverting the
+        # calibration.
+        members = [_inv()] * 5
+        draft = generate_draft(self._cluster(members=members, cohesion=0.46))
+        assert draft.confidence == "medium"
+
+    def test_realistic_cohesion_028_stays_low(self) -> None:
+        # The flip side: loose thematic groupings (cohesion 0.28, like
+        # the agentfluent "simplify-reviews" cluster) stay LOW so the
+        # YAML draft's REVIEW BEFORE USE warning still fires.
+        members = [_inv()] * 6
+        draft = generate_draft(self._cluster(members=members, cohesion=0.28))
         assert draft.confidence == "low"
 
 


### PR DESCRIPTION
Closes #167. Full investigation at https://github.com/frederick-douglas-pearce/agentfluent/issues/167#issuecomment-4311170702.

## Summary

Delegation clustering was always producing LOW-confidence clusters, even when the clusters were finding genuine task families. Root cause: confidence thresholds (0.6 MEDIUM, 0.8 HIGH) were calibrated above what real-world TF-IDF on free-text delegation prompts yields. The existing calibration comment explicitly predicted this would need adjusting once multi-contributor data was available.

## Investigation data

Two real datasets:

| Dataset | Candidates | Clusters | Cohesion range |
|---|---|---|---|
| agentfluent | 41 | 5 | 0.26 – 0.46 |
| codefluent | 15 | 2 | 0.16 – 0.31 |

Under old thresholds: 0 of 7 clusters reach MEDIUM. All the legitimate task families (PR reviews, mode flag reviews) were stuck at LOW.

## Threshold changes

| Tier | Old | New | Rationale |
|---|---|---|---|
| MEDIUM | cohesion ≥ 0.60 | cohesion ≥ 0.35 | Catches genuine task families like agentfluent's PR reviews (0.40) and CLI mode reviews (0.46). Conservative vs calibration comment's predicted 0.30 — leaves codefluent's loose research-tasks cluster (0.16) in LOW. |
| HIGH | size ≥ 10 AND cohesion ≥ 0.80 | size ≥ 10 AND cohesion ≥ 0.50 | Still aspirational. Real data rarely exceeds 0.50 even for coherent groupings, so HIGH stays meaningful. Size guard retained. |
| LOW | cohesion < 0.60 | cohesion < 0.35 | Loose groupings stay LOW — they still get #168's YAML \`# REVIEW BEFORE USE\` warning. |

## Real-world impact

Before: agentfluent's 5 clusters all LOW.
After: 2 of 5 MEDIUM (PR-tool-result reviews, quiet/json-mode reviews). 3 remain LOW — they're genuinely loose thematic groupings and the review warning is appropriate.

You now have 2 actionable medium-confidence candidates for new subagents per run on agentfluent data.

## Intentionally not changed

- **Sentence-transformer vectorization** — deferred per #92 to v0.4 if TF-IDF accuracy becomes a blocker. Current signal is fine after calibration.
- **KMeans → hierarchical clustering** — investigation showed KMeans is finding the right patterns; the issue was threshold calibration, not algorithm choice.
- **TF-IDF hyperparameters** (max_features=500, unigrams, no stemming) — observed output is fine once thresholds match the distribution.
- **CLI threshold override flags** — YAGNI. Users who want stricter filtering can key on \`confidence == "high"\` in JSON output.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/agentfluent/\` — clean (48 files)
- [x] \`uv run pytest\` — 736 passing (4 test fixtures adjusted, 2 new regression-guard tests added)
- [x] Manual CLI run on agentfluent: expected 2 MEDIUM + 3 LOW; observed 2 MEDIUM + 3 LOW
- [x] Regression guards (\`test_realistic_cohesion_045_is_medium\`, \`test_realistic_cohesion_028_stays_low\`) anchor the calibration to specific observed values so silent reversion would fail

## Unblocks

- **#155** (README screenshots) — the v0.3 diagnostics output now produces actionable recommendations + actionable cluster suggestions at medium confidence, which is what the screenshots should show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)