### PR TITLE
fix(agents): default to general-purpose when subagent_type missing (#169)

### DIFF
--- a/src/agentfluent/agents/extractor.py
+++ b/src/agentfluent/agents/extractor.py
@@ -22,7 +22,15 @@ def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvoc
             if tool_use.name != "Agent":
                 continue
 
-            agent_type = tool_use.input.get("subagent_type", "unknown")
+            # Claude Code's Agent tool defaults to ``general-purpose`` when
+            # ``subagent_type`` is omitted. Some older Claude Code versions
+            # and some caller-side skills invoked Agent without specifying
+            # the field; the resulting tool_use blocks have no
+            # ``subagent_type`` key even though the invocation ran as
+            # general-purpose. Match the tool's own default rather than
+            # labeling those invocations "unknown" and excluding them from
+            # the general-purpose delegation bucket (#169).
+            agent_type = tool_use.input.get("subagent_type", "general-purpose")
             description = tool_use.input.get("description", "")
             prompt = tool_use.input.get("prompt", "")
 

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -270,3 +270,30 @@ class TestExtractFromConstructedMessages:
         assert inv.duration_ms == 122963
         assert inv.agent_id == "uuid-real"
         assert inv.output_text == "Agent finished successfully."
+
+    def test_missing_subagent_type_defaults_to_general_purpose(self) -> None:
+        # Some caller-side skills and older Claude Code versions invoke
+        # Agent without ``subagent_type``; the tool defaults to
+        # general-purpose under the hood but the logged tool_use block
+        # omits the field. Extractor must match the tool's default
+        # behavior instead of labeling these "unknown" (#169).
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_no_subtype",
+                        name="Agent",
+                        input={
+                            "description": "Code reuse review",
+                            "prompt": "Review the diff at /tmp/simplify.diff.",
+                        },
+                    ),
+                ],
+            ),
+        ]
+        invocations = extract_agent_invocations(messages)
+        assert len(invocations) == 1
+        assert invocations[0].agent_type == "general-purpose"
+        assert invocations[0].is_builtin is True


### PR DESCRIPTION
Closes #169.

## Investigation

Earlier output review flagged 9 agent invocations with \`agent_type = \"unknown\"\` on the agentfluent project (268k tokens, ~7 minutes of runtime). Investigation script (\`/tmp/unknown_agent_investigate.py\` during the session) dumped every Agent tool_use block whose \`subagent_type\` was missing or empty.

**Findings:**

| Property | Value |
|---|---|
| Unknown Agent calls | 9 / 189 (4.8%) |
| Source session | 1 file (\`aab56dbe-780d-...jsonl\`) — all 9 from the same session |
| Input key-set | \`['description', 'prompt']\` — every one, no variation |
| Claude Code version | 2.1.109 / 2.1.110 (other sessions on same versions have the field) |
| Descriptions | "Code reuse review", "Code quality review", "Efficiency review" — all \`/simplify\` skill invocations |

The caller-side \`/simplify\` skill that ran in the affected session invoked the Agent tool without specifying \`subagent_type\`. Anthropic's Agent tool docs say \`general-purpose\` is the default when the field is omitted. The tool ran as general-purpose; the logged tool_use block just reflected what was passed.

## Fix

One-line change in \`agents/extractor.py\`: default to \`\"general-purpose\"\` instead of \`\"unknown\"\`. Matches the Agent tool's own documented default behavior.

\`\`\`python
# before
agent_type = tool_use.input.get(\"subagent_type\", \"unknown\")
# after
agent_type = tool_use.input.get(\"subagent_type\", \"general-purpose\")
\`\`\`

The 9 invocations now fold into the general-purpose bucket where they belong — including being eligible for delegation clustering (previously the cluster pipeline only looks at general-purpose invocations, so these 9 were silently excluded from the candidate pool).

## Before → after (agentfluent project)

| Row | Before | After |
|---|---|---|
| unknown | 9 invocations, 268k tokens | — (removed) |
| general-purpose | 41 invocations | 50 invocations |
| Total | 189 | 189 |

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/agentfluent/\` — clean (48 files)
- [x] \`uv run pytest\` — 737 passing (1 new test: \`test_missing_subagent_type_defaults_to_general_purpose\`)
- [x] Manual run on agentfluent project: \`unknown\` row gone, general-purpose count increased by 9, total unchanged

## Forward compatibility

If a future Claude Code version ever introduces a new Agent variant with a different default, we'd need to revisit. Today the default is documented and stable; matching it here is safer than the alternative (labeling legitimate general-purpose invocations "unknown" and excluding them from clustering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)