### PR TITLE
fix(diagnostics): name signal type in aggregated message prefix (#181)

### DIFF
--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -97,15 +97,21 @@ def _representative_message(
 
     For ``count == 1`` the original message is returned verbatim so
     single-invocation findings read identically to the raw table. For
-    ``count > 1`` the message is rebuilt as ``"N invocations[ (range)].
-    <action>"`` using the representative recommendation's ``action`` text
-    (which is constant across duplicates in the same aggregation group).
+    ``count > 1`` the message is rebuilt as ``"N <signal_type>
+    invocations[ (range)]. <action>"``. Naming the signal type in the
+    prefix distinguishes rows that share the same ``(agent, target)``
+    but fire on different signals — especially for built-in agents,
+    where multiple signal types route to the same concern template and
+    would otherwise produce near-identical aggregated rows (#181).
     """
     rep = recs[0]
     if count == 1:
         return rep.message
 
-    prefix = f"{count} invocations"
+    if rep.signal_types:
+        prefix = f"{count} {rep.signal_types[0].value} invocations"
+    else:
+        prefix = f"{count} invocations"
     if metric_range:
         prefix = f"{prefix} ({metric_range})"
 

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -162,7 +162,7 @@ class TestRepresentativeMessage:
         aggregated = aggregate_recommendations([(_, rec)])
         assert aggregated[0].representative_message == rec.message
 
-    def test_multi_invocation_includes_count_and_range(self) -> None:
+    def test_multi_invocation_includes_signal_type_count_and_range(self) -> None:
         pairs = [
             _token_outlier_pair("Explore", 4.9),
             _token_outlier_pair("Explore", 6.7),
@@ -170,17 +170,36 @@ class TestRepresentativeMessage:
         ]
         aggregated = aggregate_recommendations(pairs)
         msg = aggregated[0].representative_message
-        assert msg.startswith("3 invocations (4.9x–8.0x above 5,064 mean).")
+        assert msg.startswith(
+            "3 token_outlier invocations (4.9x–8.0x above 5,064 mean).",
+        )
         assert "Add more specific instructions" in msg
 
-    def test_multi_invocation_non_scalar_uses_count_only(self) -> None:
+    def test_multi_invocation_non_scalar_names_signal_type(self) -> None:
         pairs = [
             _retry_loop_pair("architect", "Read", 3),
             _retry_loop_pair("architect", "Read", 7),
         ]
         aggregated = aggregate_recommendations(pairs)
         msg = aggregated[0].representative_message
-        assert msg.startswith("2 invocations.")
+        assert msg.startswith("2 retry_loop invocations.")
+
+    def test_same_agent_target_different_signals_distinguishable(self) -> None:
+        # Anchor the #181 fix: when two aggregated rows share the same
+        # (agent, target) but differ in signal type — common for built-in
+        # agents where multiple signals route to the same concern template
+        # — their representative messages must name the triggering signal
+        # so users can tell the rows apart.
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 8.0),
+            _retry_loop_pair("Explore", "Read", 3),
+            _retry_loop_pair("Explore", "Read", 5),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        messages = {a.representative_message for a in aggregated}
+        assert any("token_outlier" in m for m in messages)
+        assert any("retry_loop" in m for m in messages)
 
 
 class TestSortOrder:


### PR DESCRIPTION
Closes #181. Surfaced during the #155 screenshot review.

## Problem

The aggregated Recommendations table groups by \`(agent, target, frozenset(signal_types))\`, so rows with the same agent + target but different signals are correctly kept distinct. But the aggregated \`representative_message\` dropped the per-invocation observation once \`count > 1\`, replacing it with a generic \`\"N invocations. {action}\"\` prefix. When two different signals both map to the same concern template for built-in agents (#166), the action text is identical, so the rows looked like duplicates.

Example on the agentfluent project (Explore / prompt):

| Severity | Count | Before                                                             | After                                                                       |
|----------|-------|--------------------------------------------------------------------|-----------------------------------------------------------------------------|
| critical | 47    | "47 invocations. Built-in agent — prompt is not user-editable..." | "47 **tool_error_sequence** invocations. Built-in agent — ..."              |
| warning  | 26    | "26 invocations. Built-in agent — prompt is not user-editable..." | "26 **retry_loop** invocations. Built-in agent — ..."                       |

Same story for scalar signals with metric ranges:

    Before: "10 invocations (4.9x–8.0x above 5,064 mean). ..."
    After:  "10 token_outlier invocations (4.9x–8.0x above 5,064 mean). ..."

## Fix

One-line change in \`_representative_message()\` in \`aggregation.py\`: prepend the representative recommendation's \`signal_types[0].value\` to the prefix when \`count > 1\`. Every correlator rule emits one signal type per rec in practice; guard included for the theoretical empty case.

\`count == 1\` paths are untouched — the per-invocation message already names the trigger in its observation.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/agentfluent/\` — clean (48 files)
- [x] \`uv run pytest\` — 738 passing. Existing tests updated for the new prefix shape; new regression guard (\`test_same_agent_target_different_signals_distinguishable\`) anchors the behavior.
- [x] Manual CLI: aggregated rows now name their trigger — "47 tool_error_sequence invocations", "7 permission_failure invocations", etc.

## Follow-up

After merge, rebase #179 and regenerate SVG screenshots so the README reflects the clarified output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)