### PR TITLE
docs(readme): document agentfluent[clustering] extra and its consequence (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ uvx agentfluent list
 
 #### Optional extras
 
-- **`agentfluent[clustering]`** — installs `scikit-learn` and enables delegation clustering, which proposes new specialized subagents from recurring `general-purpose` invocations. Without this extra, `agentfluent analyze --diagnostics` still runs all other diagnostics, but `delegation_suggestions` is always empty in JSON output and the "Suggested Subagents" section is omitted from terminal output. Install with `uv tool install 'agentfluent[clustering]'` (or `pip install 'agentfluent[clustering]'`).
+- **`agentfluent[clustering]`** — installs `scikit-learn` and enables delegation clustering, which proposes new specialized subagents from recurring `general-purpose` invocations. Without this extra, `agentfluent analyze --diagnostics` still runs all other diagnostics, but `delegation_suggestions` is always empty in JSON output and the "Suggested Subagents" section is omitted from terminal output. Install with `uv tool install 'agentfluent[clustering]'` or `pip install 'agentfluent[clustering]'`.
 
 ### First run
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ pip install agentfluent
 uvx agentfluent list
 ```
 
+#### Optional extras
+
+- **`agentfluent[clustering]`** — installs `scikit-learn` and enables delegation clustering, which proposes new specialized subagents from recurring `general-purpose` invocations. Without this extra, `agentfluent analyze --diagnostics` still runs all other diagnostics, but `delegation_suggestions` is always empty in JSON output and the "Suggested Subagents" section is omitted from terminal output. Install with `uv tool install 'agentfluent[clustering]'` (or `pip install 'agentfluent[clustering]'`).
+
 ### First run
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an Optional extras subsection under Install explaining what the `agentfluent[clustering]` extra enables and what's lost without it (empty `delegation_suggestions`, no Suggested Subagents section).
- Resolves part 1 of #208 (README docs). Part 2 (JSON `notes` field on empty results) split into a follow-up issue — touches the diagnostics result schema and is out of wave-1 scope.

## Test plan

- [x] `cat README.md` — visually confirm the new subsection lands cleanly between Install and First run
- [x] No code changes, no tests required

Closes part 1 of #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)