### PR TITLE
ci: use RELEASE_PLEASE_PAT so release PRs trigger CI (#193)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Adds `token: \${{ secrets.RELEASE_PLEASE_PAT }}` to the `googleapis/release-please-action@v5` step so release PRs fire `pull_request` events under a PAT (not the default `GITHUB_TOKEN`, which GitHub blocks from triggering downstream workflows).
- One-line change. Resolves the empty-`statusCheckRollup` problem we hit on PR #126 (v0.3.0 release).

## ⚠️ Prerequisite before merge

Create the `RELEASE_PLEASE_PAT` repo secret with these fine-grained PAT scopes:
- Contents: Read and Write
- Pull requests: Read and Write
- Workflows: Read and Write

Without the secret in place, `\${{ secrets.RELEASE_PLEASE_PAT }}` resolves to empty string and the action falls back to the default `GITHUB_TOKEN` (today's behavior). So the change is safe to merge before the secret lands — it just won't have effect until then. **Recommend creating the secret first, then merging.**

## Test plan

- [x] Create `RELEASE_PLEASE_PAT` secret at repo level
- [x] Document PAT expiration in repo notes (so we know when to rotate)
- [x] On next release-please PR (or after a `chore:` commit to `main`), confirm CI / Security Review / Dependabot Auto-Merge fire automatically without manual close/reopen
- [x] Verify release-please still creates and updates release PRs as before (no regression)

Closes #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)