### PR TITLE
feat(cli): accept --json as alias for --format json (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 | `--min-cluster-size` | 5 | Delegation clustering: minimum invocations per cluster (requires `agentfluent[clustering]`) |
 | `--min-similarity` | 0.7 | Delegation dedup: cosine-similarity threshold against existing agents |
 | `--claude-config-dir` | `~/.claude/` | Override the Claude config root (also honors `$CLAUDE_CONFIG_DIR`) |
-| `--format` | `table` | Output format: `table` (Rich) or `json` (envelope) |
+| `--format` | `table` | Output format: `table` (Rich) or `json` (envelope). Shortcut: `--json` (equivalent to `--format json`) |
 | `--verbose` | off | Extra detail: per-session breakdown, per-invocation detail, raw (un-aggregated) recommendations, and YAML subagent drafts for suggested clusters |
 | `--quiet` | off | Suppress non-essential output (useful in CI) |
 
@@ -182,7 +182,7 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 
 **Default (table):** Rich-rendered tables in the terminal, designed to be readable at a glance. Colors auto-adapt to terminal theme.
 
-**JSON envelope (`--format json`):** Stable schema `{version, command, data}` intended as a contract — pipe to `jq`, integrate with CI, build regression gates on top. Example:
+**JSON envelope (`--format json`, or the shortcut `--json`):** Stable schema `{version, command, data}` intended as a contract — pipe to `jq`, integrate with CI, build regression gates on top. Example:
 
 ```json
 {

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -114,7 +114,12 @@ def analyze(
         "table",
         "--format",
         "-f",
-        help="Output format: table or json.",
+        help="Output format: table or json. Shortcut: --json.",
+    ),
+    json_flag: bool = typer.Option(
+        False,
+        "--json",
+        help="Shortcut for --format json. Overrides --format when set.",
     ),
     min_cluster_size: Optional[int] = typer.Option(  # noqa: UP007, UP045
         None,
@@ -140,6 +145,9 @@ def analyze(
     """Analyze agent sessions for token usage, cost, and behavior diagnostics."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
+    if json_flag:
+        format = "json"
 
     # Fail fast if the user explicitly asked for clustering-tuning behavior
     # but the optional extra is not installed. When both flags are left at

--- a/src/agentfluent/cli/commands/config_check.py
+++ b/src/agentfluent/cli/commands/config_check.py
@@ -78,7 +78,12 @@ def config_check(
         "table",
         "--format",
         "-f",
-        help="Output format: table or json.",
+        help="Output format: table or json. Shortcut: --json.",
+    ),
+    json_flag: bool = typer.Option(
+        False,
+        "--json",
+        help="Shortcut for --format json. Overrides --format when set.",
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
@@ -86,6 +91,9 @@ def config_check(
     """Scan agent definitions and score them against best practices."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
+    if json_flag:
+        format = "json"
 
     if scope not in ("user", "project", "all"):
         err_console.print(f"[red]Invalid scope:[/red] {scope}")

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -154,7 +154,12 @@ def list_cmd(
         "table",
         "--format",
         "-f",
-        help="Output format: 'table' or 'json'.",
+        help="Output format: 'table' or 'json'. Shortcut: --json.",
+    ),
+    json_flag: bool = typer.Option(
+        False,
+        "--json",
+        help="Shortcut for --format json. Overrides --format when set.",
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
@@ -162,6 +167,8 @@ def list_cmd(
     """List available projects, or sessions within a project."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+    if json_flag:
+        format = "json"
     config_dir = ctx.obj.claude_config_dir if ctx.obj else None
     if project:
         if format == "json":

--- a/tests/unit/cli/test_json_alias.py
+++ b/tests/unit/cli/test_json_alias.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import typer
 from typer.testing import CliRunner
+
+# Rich/Typer style each character of an option with separate ANSI escapes
+# when FORCE_COLOR is set (CI does this), so a literal "--json" substring
+# search fails on raw stdout. Strip color codes before asserting.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 class TestJsonAliasMatchesFormatJson:
@@ -85,18 +95,18 @@ class TestJsonAliasInHelp:
     ) -> None:
         result = runner.invoke(cli_app, ["list", "--help"])
         assert result.exit_code == 0
-        assert "--json" in result.stdout
+        assert "--json" in _strip_ansi(result.stdout)
 
     def test_analyze_help(
         self, runner: CliRunner, cli_app: typer.Typer,
     ) -> None:
         result = runner.invoke(cli_app, ["analyze", "--help"])
         assert result.exit_code == 0
-        assert "--json" in result.stdout
+        assert "--json" in _strip_ansi(result.stdout)
 
     def test_config_check_help(
         self, runner: CliRunner, cli_app: typer.Typer,
     ) -> None:
         result = runner.invoke(cli_app, ["config-check", "--help"])
         assert result.exit_code == 0
-        assert "--json" in result.stdout
+        assert "--json" in _strip_ansi(result.stdout)

--- a/tests/unit/cli/test_json_alias.py
+++ b/tests/unit/cli/test_json_alias.py
@@ -1,0 +1,102 @@
+"""--json shortcut: must match --format json output (#196)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestJsonAliasMatchesFormatJson:
+    """`--json` produces byte-identical output to `--format json`."""
+
+    def test_list_projects(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        canonical = runner.invoke(cli_app, ["list", "--format", "json"])
+        alias = runner.invoke(cli_app, ["list", "--json"])
+        assert canonical.exit_code == 0
+        assert alias.exit_code == 0
+        assert alias.stdout == canonical.stdout
+
+    def test_list_sessions(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        canonical = runner.invoke(
+            cli_app, ["list", "--project", "project", "--format", "json"],
+        )
+        alias = runner.invoke(cli_app, ["list", "--project", "project", "--json"])
+        assert canonical.exit_code == 0
+        assert alias.exit_code == 0
+        assert alias.stdout == canonical.stdout
+
+    def test_analyze(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        canonical = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--format", "json"],
+        )
+        alias = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--json"],
+        )
+        assert canonical.exit_code == 0
+        assert alias.exit_code == 0
+        assert alias.stdout == canonical.stdout
+
+    def test_config_check(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        canonical = runner.invoke(
+            cli_app, ["config-check", "--scope", "user", "--format", "json"],
+        )
+        alias = runner.invoke(
+            cli_app, ["config-check", "--scope", "user", "--json"],
+        )
+        assert canonical.exit_code == 0
+        assert alias.exit_code == 0
+        assert alias.stdout == canonical.stdout
+
+
+class TestJsonAliasOverridesFormat:
+    """`--json` wins when both flags are present (documented precedence)."""
+
+    def test_analyze_json_overrides_table(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze",
+                "--project", "project",
+                "--format", "table",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.stdout.lstrip().startswith("{")
+
+
+class TestJsonAliasInHelp:
+    """--help text mentions the alias on each subcommand."""
+
+    def test_list_help(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--help"])
+        assert result.exit_code == 0
+        assert "--json" in result.stdout
+
+    def test_analyze_help(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--help"])
+        assert result.exit_code == 0
+        assert "--json" in result.stdout
+
+    def test_config_check_help(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["config-check", "--help"])
+        assert result.exit_code == 0
+        assert "--json" in result.stdout


### PR DESCRIPTION
## Summary

- Adds `--json` boolean flag to `analyze`, `config-check`, and `list` subcommands. When set, overrides `--format` and forces JSON output.
- Help text on each subcommand mentions the alias.
- README flag table and JSON-envelope paragraph describe the shortcut while keeping `--format json` as the canonical form in examples.
- Resolves the most-cited paper cut from the codefluent v0.3 review.

## Precedence

`--json` wins over `--format`. Documented in flag help and tested.

## Test plan

- [x] `tests/unit/cli/test_json_alias.py` — 8 new tests, all passing:
  - byte-identical stdout between `--json` and `--format json` on all three commands
  - `--json` overrides `--format table`
  - `--json` appears in `--help` for each subcommand
- [x] `uv run ruff check src/ tests/unit/cli/test_json_alias.py` — passes
- [x] `uv run mypy src/agentfluent/` — passes (48 source files)

## Note on README overlap with #210

This branch was developed in parallel with #210 (clustering extra docs). The README edits land in different sections so the merge should be clean, but flagging for awareness.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)