### PR TITLE
fix(cli): route parse warnings to stderr with WARNING prefix (#206)

### DIFF
--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -24,6 +25,25 @@ from agentfluent.core.session import (
 
 logger = logging.getLogger(__name__)
 
+_MAX_WARN_LINE_CHARS = 100
+
+
+def _emit_parse_warning(path: Path, line_num: int, reason: str, line: str) -> None:
+    """Print a parse-time warning to stderr and mirror to the logger.
+
+    Stderr emission uses a ``WARNING:`` prefix and truncates the offending
+    line to ``_MAX_WARN_LINE_CHARS`` so the user can decide whether to
+    investigate without flooding the terminal. Flushed before the caller
+    writes to stdout so the warning never lands inside a Rich table.
+    """
+    snippet = line.strip()
+    if len(snippet) > _MAX_WARN_LINE_CHARS:
+        snippet = snippet[:_MAX_WARN_LINE_CHARS] + "..."
+    snippet = snippet.replace("\x00", "\\x00")
+    message = f"WARNING: {reason} at {path.name}:{line_num}: {snippet}"
+    print(message, file=sys.stderr, flush=True)
+    logger.warning("%s at %s:%d", reason, path.name, line_num)
+
 
 def iter_raw_messages(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
     """Iterate a JSONL file, yielding (line_num, data) for analytical messages.
@@ -38,9 +58,11 @@ def iter_raw_messages(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
     originating line even though some lines were skipped. Callers that
     don't need it can unpack as ``for _, data in ...``.
 
-    Silently skips: missing files, empty files, empty lines, malformed
-    JSON (warn-logged), non-object JSON (warn-logged), and any message
-    whose ``type`` is in ``SKIP_TYPES`` or is missing.
+    Silently skips: missing files, empty files, empty lines, and any
+    message whose ``type`` is in ``SKIP_TYPES`` or is missing. Malformed
+    JSON and non-object JSON lines emit a ``WARNING:``-prefixed line to
+    stderr (with the offending content truncated to
+    ``_MAX_WARN_LINE_CHARS``) and continue.
     """
     if not path.exists():
         logger.warning("Session file not found: %s", path)
@@ -58,11 +80,11 @@ def iter_raw_messages(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
             try:
                 data = json.loads(line)
             except json.JSONDecodeError:
-                logger.warning("Malformed JSON at %s:%d", path.name, line_num)
+                _emit_parse_warning(path, line_num, "Malformed JSON", line)
                 continue
 
             if not isinstance(data, dict):
-                logger.warning("Non-object JSON at %s:%d", path.name, line_num)
+                _emit_parse_warning(path, line_num, "Non-object JSON", line)
                 continue
 
             msg_type = data.get("type")

--- a/tests/unit/cli/test_parse_warnings.py
+++ b/tests/unit/cli/test_parse_warnings.py
@@ -1,0 +1,39 @@
+"""Issue #206: parse-time warnings must reach stderr (with `WARNING:`
+prefix and truncated line context) and never interleave with the table
+on stdout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+def test_list_sessions_routes_parse_warning_to_stderr(
+    runner: CliRunner,
+    cli_app: typer.Typer,
+    populated_home: Path,
+) -> None:
+    """Append a malformed line to the seeded session and confirm:
+
+    - the warning lands on stderr with the `WARNING:` prefix and includes
+      the session filename, line number, and a snippet of the bad line
+    - stdout still renders the Sessions table (and the warning text does
+      not appear inside it)
+    """
+    project_dir = populated_home / "projects" / "-home-user-test-project"
+    session_path = project_dir / "session-1.jsonl"
+    bad_line = "this line is not valid json at all\n"
+    with session_path.open("a") as f:
+        f.write(bad_line)
+
+    result = runner.invoke(cli_app, ["list", "--project", "project"])
+
+    assert result.exit_code == 0
+    assert "WARNING: Malformed JSON" in result.stderr
+    assert "session-1.jsonl" in result.stderr
+    assert "this line is not valid json at all" in result.stderr
+    assert "Sessions" in result.stdout
+    assert "WARNING:" not in result.stdout

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from agentfluent.core.parser import iter_raw_messages, parse_session
 from agentfluent.core.session import SessionMessage
 
@@ -155,6 +157,75 @@ class TestMalformedInput:
     def test_nonexistent_file(self, tmp_path: Path) -> None:
         messages = parse_session(tmp_path / "does-not-exist.jsonl")
         assert messages == []
+
+
+class TestParseWarningsToStderr:
+    """Issue #206: parse warnings must reach stderr with a `WARNING:` prefix
+    and include the truncated offending line so the user can decide whether
+    to investigate. Stdout must stay clean for piping/redirection.
+    """
+
+    def test_malformed_json_writes_to_stderr_with_prefix(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = tmp_path / "session-uuid.jsonl"
+        path.write_text(
+            '{"type": "user"}\n'
+            'this line is not valid json at all\n'
+            '{"type": "assistant"}\n',
+        )
+
+        parse_session(path)
+        captured = capsys.readouterr()
+
+        assert captured.out == ""
+        assert captured.err.startswith("WARNING:")
+        assert "Malformed JSON" in captured.err
+        assert "session-uuid.jsonl:2" in captured.err
+        assert "this line is not valid json at all" in captured.err
+
+    def test_non_object_json_writes_to_stderr_with_prefix(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = tmp_path / "arr.jsonl"
+        path.write_text('{"type": "user"}\n["not", "an", "object"]\n')
+
+        parse_session(path)
+        captured = capsys.readouterr()
+
+        assert captured.out == ""
+        assert "WARNING: Non-object JSON" in captured.err
+        assert "arr.jsonl:2" in captured.err
+        assert '["not", "an", "object"]' in captured.err
+
+    def test_long_line_truncated_to_100_chars(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        long_garbage = "x" * 500
+        path = tmp_path / "long.jsonl"
+        path.write_text(long_garbage + "\n")
+
+        parse_session(path)
+        captured = capsys.readouterr()
+
+        assert "..." in captured.err
+        # Header text plus 100 chars of payload plus the ellipsis; the raw
+        # 500-char line must not appear in full.
+        assert long_garbage not in captured.err
+        assert ("x" * 100) in captured.err
+        assert ("x" * 101) not in captured.err
+
+    def test_no_warning_for_clean_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        path = tmp_path / "clean.jsonl"
+        path.write_text('{"type": "user"}\n{"type": "assistant"}\n')
+
+        parse_session(path)
+        captured = capsys.readouterr()
+
+        assert captured.out == ""
+        assert captured.err == ""
 
 
 class TestToolUseResultOnUserMessage:


### PR DESCRIPTION
## Summary

- Adds `_emit_parse_warning` helper in `core/parser.py` that writes `WARNING: <reason> at <file>:<line>: <snippet>` to stderr (flushed) and mirrors via `logger.warning`.
- Both warning sites in `iter_raw_messages` (malformed JSON, non-object JSON) route through it. Single emission point covers both `parse_session` and the subagent trace parser.
- Lines longer than 100 chars are truncated; null bytes (the common cause of malformed lines per README) are escaped to `\x00`.
- Resolves the parse warning interleaving with `agentfluent list`'s Rich table output.

## Test plan

- [x] `tests/unit/test_parser.py::TestParseWarningsToStderr` — 4 new tests:
  - stderr/stdout separation for malformed JSON
  - stderr/stdout separation for non-object JSON
  - 100-char truncation
  - no warning emitted for clean files
- [x] `tests/unit/cli/test_parse_warnings.py` — CLI-level test that appends a malformed line, runs `agentfluent list --project project`, asserts the warning lands on stderr and the table renders cleanly on stdout
- [x] All 34 parser + CLI parse-warning tests pass
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/agentfluent/` — passes
- [x] `agentfluent list --project X 2>/dev/null` now shows clean stdout (manual smoke check)

Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)