### PR TITLE
feat(cli): default --diagnostics on for analyze (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ If you write your own prompts each session, use CodeFluent. If your prompts live
 
 ![Execution Analytics: token usage, per-model cost, tool frequency, and Agent Invocations tables](images/demo-analyze.svg)
 
-**Behavior Diagnostics** — `agentfluent analyze --project <name> --diagnostics`
+**Behavior Diagnostics** — `agentfluent analyze --project <name>` (diagnostics on by default)
 
 ![Behavior Diagnostics: aggregated Recommendations table with Count column and built-in-aware action text](images/demo-diagnostics.svg)
 
-**Suggested Subagents with copy-paste-ready YAML draft** — `agentfluent analyze --project <name> --diagnostics --verbose`
+**Suggested Subagents with copy-paste-ready YAML draft** — `agentfluent analyze --project <name> --verbose`
 
 ![Suggested Subagents: medium-confidence cluster + YAML subagent definition ready to save as ~/.claude/agents/<name>.md](images/demo-subagents.svg)
 
@@ -125,20 +125,20 @@ Lists every Claude Code / Agent SDK project found under `~/.claude/projects/`, w
 ### `agentfluent analyze` — token, cost, and behavior metrics
 
 ```bash
-agentfluent analyze --project codefluent                    # Full project analysis
-agentfluent analyze --project codefluent --agent pm         # Filter to one subagent
-agentfluent analyze --project codefluent --latest 5         # Last 5 sessions only
-agentfluent analyze --project codefluent --diagnostics      # Show behavior diagnostics
-agentfluent analyze --project codefluent --diagnostics -v   # + YAML subagent drafts
+agentfluent analyze --project codefluent                       # Full analysis with behavior diagnostics
+agentfluent analyze --project codefluent --no-diagnostics      # Token + cost only (skip diagnostics pipeline)
+agentfluent analyze --project codefluent --agent pm            # Filter to one subagent
+agentfluent analyze --project codefluent --latest 5            # Last 5 sessions only
+agentfluent analyze --project codefluent -v                    # + YAML subagent drafts
 agentfluent analyze --project codefluent --format json | jq '.data.token_metrics.total_cost'
 
 # Save the top-confidence cluster as a real subagent definition:
-agentfluent analyze --project codefluent --diagnostics --format json \
+agentfluent analyze --project codefluent --format json \
   | jq -r '.data.diagnostics.delegation_suggestions[0].yaml_draft' \
   > ~/.claude/agents/new-agent.md
 ```
 
-Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. `--diagnostics` surfaces the full v0.3 signal surface:
+Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. Behavior diagnostics run by default and surface the full v0.3 signal surface (pass `--no-diagnostics` to skip):
 
 - **Metadata-level** (from invocation summaries): tool-error keywords, token-per-tool-use outliers, duration outliers.
 - **Trace-level** (from `~/.claude/projects/<session>/subagents/`): retry loops, stuck patterns, permission failures, consecutive tool-error sequences — each with per-tool-call evidence.
@@ -170,7 +170,7 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 | `--agent` | (none) | Filter `analyze` or `config-check` to one subagent type |
 | `--latest N` | (all sessions) | `analyze` only the N most recent sessions |
 | `--session` | (all) | `analyze` a specific session filename within the project |
-| `--diagnostics` | off | `analyze`: show behavior-correlation signals |
+| `--diagnostics / --no-diagnostics` | on | `analyze`: behavior-correlation signals (default on; `--no-diagnostics` skips the pipeline) |
 | `--min-cluster-size` | 5 | Delegation clustering: minimum invocations per cluster (requires `agentfluent[clustering]`) |
 | `--min-similarity` | 0.7 | Delegation dedup: cosine-similarity threshold against existing agents |
 | `--claude-config-dir` | `~/.claude/` | Override the Claude config root (also honors `$CLAUDE_CONFIG_DIR`) |

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -105,10 +105,13 @@ def analyze(
         help="Analyze only the N most recent sessions.",
     ),
     diagnostics: bool = typer.Option(
-        False,
-        "--diagnostics",
-        "-d",
-        help="Show detailed behavior diagnostics.",
+        True,
+        "--diagnostics/--no-diagnostics",
+        "-d/-D",
+        help=(
+            "Show detailed behavior diagnostics (default: on). "
+            "Pass --no-diagnostics to skip the diagnostics pipeline."
+        ),
     ),
     format: str = typer.Option(
         "table",
@@ -192,7 +195,7 @@ def analyze(
     all_invocations = [inv for s in result.sessions for inv in s.invocations]
     all_mcp_calls = [c for s in result.sessions for c in s.mcp_tool_calls]
 
-    if all_invocations:
+    if all_invocations and diagnostics:
         # `project_info.path` is the ~/.claude/projects/<slug>/ dir, not
         # the original project source path. MCP discovery needs the
         # real path (for .mcp.json and ~/.claude.json:projects[<abs>]
@@ -215,7 +218,7 @@ def analyze(
             project_dir=project_disk_path,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
-        console.print(
+        err_console.print(
             "[dim]No agent invocations found -- "
             "diagnostics require agent activity.[/dim]"
         )

--- a/tests/unit/cli/test_diagnostics_default.py
+++ b/tests/unit/cli/test_diagnostics_default.py
@@ -9,10 +9,20 @@ the diagnostics pipeline would be overhead.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import typer
 from typer.testing import CliRunner
+
+# Rich/Typer style each char of an option with separate ANSI escapes when
+# FORCE_COLOR is set (CI does this), so a literal substring search fails
+# on raw stdout. Strip color codes before asserting.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 class TestDiagnosticsDefaultOn:
@@ -111,6 +121,6 @@ class TestHelpReflectsDefault:
     ) -> None:
         result = runner.invoke(cli_app, ["analyze", "--help"])
         assert result.exit_code == 0
-        # Strip ANSI / wrapping for substring matching
-        assert "--no-diagnostics" in result.stdout
-        assert "default: on" in result.stdout.lower()
+        plain = _strip_ansi(result.stdout)
+        assert "--no-diagnostics" in plain
+        assert "default: on" in plain.lower()

--- a/tests/unit/cli/test_diagnostics_default.py
+++ b/tests/unit/cli/test_diagnostics_default.py
@@ -1,0 +1,116 @@
+"""Verify #202: --diagnostics defaults to on, --no-diagnostics opts out.
+
+Diagnostics is the core value proposition; running ``agentfluent analyze``
+without flags should surface diagnostic signals automatically. The
+``--no-diagnostics`` opt-out exists for token-only / CI use cases where
+the diagnostics pipeline would be overhead.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestDiagnosticsDefaultOn:
+    def test_no_flag_runs_diagnostics(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--project", "project"])
+        assert result.exit_code == 0
+        assert "Diagnostic Signals" in result.stdout
+
+    def test_explicit_diagnostics_flag_still_works(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        """Backwards compatibility: ``--diagnostics`` still parses and is a no-op
+        relative to the new default."""
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--diagnostics"],
+        )
+        assert result.exit_code == 0
+        assert "Diagnostic Signals" in result.stdout
+
+    def test_no_flag_includes_diagnostics_in_json(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        diagnostics = payload["data"].get("diagnostics")
+        assert diagnostics is not None
+        assert diagnostics.get("signals"), "expected signals in default analyze"
+
+
+class TestNoDiagnosticsOptOut:
+    def test_no_diagnostics_skips_signal_table(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--no-diagnostics"],
+        )
+        assert result.exit_code == 0
+        assert "Diagnostic Signals" not in result.stdout
+
+    def test_no_diagnostics_omits_diagnostics_in_json(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze",
+                "--project", "project",
+                "--no-diagnostics",
+                "--format", "json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        diagnostics = payload["data"].get("diagnostics")
+        assert diagnostics is None
+
+    def test_short_flag_negation(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        """``-D`` is the short form of ``--no-diagnostics``."""
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "-D"],
+        )
+        assert result.exit_code == 0
+        assert "Diagnostic Signals" not in result.stdout
+
+
+class TestHelpReflectsDefault:
+    def test_help_mentions_default_on(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["analyze", "--help"])
+        assert result.exit_code == 0
+        # Strip ANSI / wrapping for substring matching
+        assert "--no-diagnostics" in result.stdout
+        assert "default: on" in result.stdout.lower()


### PR DESCRIPTION
## Summary

- Flips the `--diagnostics` default from off to on in `analyze`. Adds `--no-diagnostics` (short form `-D`) to opt out of the diagnostics pipeline entirely.
- Behavior diagnostics are the core value of `analyze`; making them opt-in buried the product. Per Fred's confirmation in the v0.4 scope review, the codefluent v0.3 reviewer was right: "the whole point of running analyze is to get diagnostics."
- Also routes the "no agent invocations found" hint to stderr so it doesn't clobber JSON output when diagnostics fire against a project with no invocations.
- README updated: examples drop the redundant `--diagnostics`; flag table reflects new default; one example added showing `--no-diagnostics` opt-out.

## ⚠️ Behavior change

`agentfluent analyze --project X` now runs diagnostics by default. Pre-existing scripts that omitted `--diagnostics` will see diagnostic signals in their output. Pass `--no-diagnostics` to preserve the old behavior.

Per Fred: pre-0.x, no semver break — release note suffices. The conventional commit prefix is `feat:` (not `feat!:`).

## Test plan

- [x] `tests/unit/cli/test_diagnostics_default.py` — 7 new tests covering:
  - default-on for table + JSON output
  - explicit `--diagnostics` still parses (back-compat)
  - `--no-diagnostics` skips the pipeline (no diagnostics in JSON, no signal table)
  - short form `-D` works
  - `--help` reflects the new default
- [x] Full unit suite: `uv run pytest -m "not integration"` — 709 passed (fixed 2 regressions in `test_json_output.py` by routing the no-invocations hint to stderr)
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/agentfluent/` — passes

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)