### PR TITLE
fix(schema): agent_type None instead of "" for cross-cutting findings (#207)

### DIFF
--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -16,6 +16,11 @@ SEVERITY_COLORS: dict[Severity, str] = {
     Severity.INFO: "cyan",
 }
 
+GLOBAL_AGENT_LABEL = "(global)"
+"""Display string for cross-cutting findings whose ``agent_type`` is
+``None`` (e.g., MCP audit). JSON output keeps ``null``; tables substitute
+this label."""
+
 CONFIDENCE_COLORS: dict[str, str] = {
     "high": "green",
     "medium": "yellow",

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
     CONFIDENCE_COLORS,
+    GLOBAL_AGENT_LABEL,
     SEVERITY_COLORS,
     average_score,
     format_cost,
@@ -260,7 +261,7 @@ def _format_diagnostics_table(
 
         for sig in diag.signals:
             sig_table.add_row(
-                escape(sig.agent_type or "(global)"),
+                escape(sig.agent_type or GLOBAL_AGENT_LABEL),
                 escape(sig.signal_type.value),
                 severity_cell(sig.severity),
                 escape(sig.message),
@@ -277,7 +278,7 @@ def _format_diagnostics_table(
 
         for rec in diag.recommendations:
             rec_table.add_row(
-                escape(rec.agent_type or "(global)"),
+                escape(rec.agent_type or GLOBAL_AGENT_LABEL),
                 escape(rec.target),
                 severity_cell(rec.severity),
                 escape(rec.observation),
@@ -294,7 +295,7 @@ def _format_diagnostics_table(
 
         for agg in diag.aggregated_recommendations:
             rec_table.add_row(
-                escape(agg.agent_type or "(global)"),
+                escape(agg.agent_type or GLOBAL_AGENT_LABEL),
                 escape(agg.target),
                 severity_cell(agg.severity),
                 str(agg.count),
@@ -347,7 +348,7 @@ def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> No
     color = SEVERITY_COLORS[sig.severity]
     header = (
         f"\n[{color}]{escape(sig.signal_type.value)}[/{color}] "
-        f"[cyan]{escape(sig.agent_type or '(global)')}[/cyan] — {escape(sig.message)}"
+        f"[cyan]{escape(sig.agent_type or GLOBAL_AGENT_LABEL)}[/cyan] — {escape(sig.message)}"
     )
     console.print(header)
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -260,7 +260,7 @@ def _format_diagnostics_table(
 
         for sig in diag.signals:
             sig_table.add_row(
-                escape(sig.agent_type),
+                escape(sig.agent_type or "(global)"),
                 escape(sig.signal_type.value),
                 severity_cell(sig.severity),
                 escape(sig.message),
@@ -277,7 +277,7 @@ def _format_diagnostics_table(
 
         for rec in diag.recommendations:
             rec_table.add_row(
-                escape(rec.agent_type),
+                escape(rec.agent_type or "(global)"),
                 escape(rec.target),
                 severity_cell(rec.severity),
                 escape(rec.observation),
@@ -294,7 +294,7 @@ def _format_diagnostics_table(
 
         for agg in diag.aggregated_recommendations:
             rec_table.add_row(
-                escape(agg.agent_type),
+                escape(agg.agent_type or "(global)"),
                 escape(agg.target),
                 severity_cell(agg.severity),
                 str(agg.count),
@@ -347,7 +347,7 @@ def _render_trace_signal_evidence(console: Console, sig: DiagnosticSignal) -> No
     color = SEVERITY_COLORS[sig.severity]
     header = (
         f"\n[{color}]{escape(sig.signal_type.value)}[/{color}] "
-        f"[cyan]{escape(sig.agent_type)}[/cyan] — {escape(sig.message)}"
+        f"[cyan]{escape(sig.agent_type or '(global)')}[/cyan] — {escape(sig.message)}"
     )
     console.print(header)
 

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -37,18 +37,14 @@ _SCALAR_METRIC_SIGNALS: frozenset[SignalType] = frozenset(
     {SignalType.TOKEN_OUTLIER, SignalType.DURATION_OUTLIER},
 )
 
+# Shape key for grouping per-invocation recommendations. ``agent_type``
+# is ``None`` for cross-cutting recommendations (MCP audit) which form
+# their own group; ``target`` distinguishes rows when one rule forks
+# (e.g. TokenOutlierRule emits to either ``tools`` or ``prompt``).
+type AggregationKey = tuple[str | None, str, frozenset[SignalType]]
 
-def _aggregation_key(
-    rec: DiagnosticRecommendation,
-) -> tuple[str | None, str, frozenset[SignalType]]:
-    """Shape key used to group per-invocation recommendations.
 
-    ``target`` is included because ``TokenOutlierRule`` /
-    ``ErrorSequenceRule`` fork to ``tools`` vs ``prompt`` based on config
-    — those should remain distinct aggregated rows. ``agent_type`` is
-    ``None`` for cross-cutting recommendations (MCP audit) which form
-    their own group key.
-    """
+def _aggregation_key(rec: DiagnosticRecommendation) -> AggregationKey:
     return (rec.agent_type, rec.target, frozenset(rec.signal_types))
 
 
@@ -129,7 +125,7 @@ def aggregate_recommendations(
     impact findings surface first in the default table.
     """
     groups: dict[
-        tuple[str | None, str, frozenset[SignalType]],
+        AggregationKey,
         list[tuple[DiagnosticSignal, DiagnosticRecommendation]],
     ] = defaultdict(list)
     for signal, rec in pairs:

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -40,12 +40,14 @@ _SCALAR_METRIC_SIGNALS: frozenset[SignalType] = frozenset(
 
 def _aggregation_key(
     rec: DiagnosticRecommendation,
-) -> tuple[str, str, frozenset[SignalType]]:
+) -> tuple[str | None, str, frozenset[SignalType]]:
     """Shape key used to group per-invocation recommendations.
 
     ``target`` is included because ``TokenOutlierRule`` /
     ``ErrorSequenceRule`` fork to ``tools`` vs ``prompt`` based on config
-    — those should remain distinct aggregated rows.
+    — those should remain distinct aggregated rows. ``agent_type`` is
+    ``None`` for cross-cutting recommendations (MCP audit) which form
+    their own group key.
     """
     return (rec.agent_type, rec.target, frozenset(rec.signal_types))
 
@@ -127,7 +129,7 @@ def aggregate_recommendations(
     impact findings surface first in the default table.
     """
     groups: dict[
-        tuple[str, str, frozenset[SignalType]],
+        tuple[str | None, str, frozenset[SignalType]],
         list[tuple[DiagnosticSignal, DiagnosticRecommendation]],
     ] = defaultdict(list)
     for signal, rec in pairs:

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -49,7 +49,7 @@ def _check_builtin(
     """Return a built-in recommendation when the signal's agent is a
     built-in, else ``None`` so the caller falls through to the custom
     path."""
-    if not is_builtin_agent(signal.agent_type):
+    if signal.agent_type is None or not is_builtin_agent(signal.agent_type):
         return None
     return builtin_recommendation(
         signal,
@@ -626,7 +626,11 @@ def correlate(
     pairs: list[tuple[DiagnosticSignal, DiagnosticRecommendation]] = []
 
     for signal in signals:
-        config = configs.get(signal.agent_type.lower()) if configs else None
+        config = (
+            configs.get(signal.agent_type.lower())
+            if configs and signal.agent_type
+            else None
+        )
 
         for rule in RULES:
             if rule.matches(signal, config):

--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -237,15 +237,15 @@ def _mcp_signal(
 ) -> DiagnosticSignal:
     """Build an MCP audit signal with the boilerplate prefilled.
 
-    All MCP signals share ``agent_type=""`` (MCP servers aren't scoped
-    to a single agent_type — they're cross-agent concerns). This
-    helper pins that default so callers only specify the varying
-    fields.
+    All MCP signals share ``agent_type=None`` (MCP servers aren't scoped
+    to a single agent_type — they're cross-agent concerns). Renders as
+    ``(global)`` in terminal output and serializes to ``null`` in JSON,
+    making the cross-cutting nature explicit to consumers.
     """
     return DiagnosticSignal(
         signal_type=signal_type,
         severity=severity,
-        agent_type="",
+        agent_type=None,
         message=message,
         detail=detail,
     )

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -51,7 +51,10 @@ class DiagnosticSignal(BaseModel):
 
     signal_type: SignalType
     severity: Severity
-    agent_type: str
+    agent_type: str | None
+    """Agent this signal is scoped to. ``None`` for cross-cutting signals
+    that don't belong to a specific agent (e.g. MCP server audit findings,
+    which apply project-wide). Per-agent signals always carry a name."""
     message: str
     detail: dict[str, object] = Field(default_factory=dict)
     """Extensible detail dict for signal-specific data (keyword, snippet,
@@ -80,8 +83,10 @@ class DiagnosticRecommendation(BaseModel):
     action: str = ""
     """What to change in the config."""
 
-    agent_type: str = ""
-    """Which agent this recommendation applies to."""
+    agent_type: str | None = None
+    """Which agent this recommendation applies to. ``None`` for
+    cross-cutting recommendations not scoped to any single agent (e.g.
+    MCP server audit findings)."""
 
     config_file: str = ""
     """Path to the agent config file, if known."""
@@ -109,7 +114,9 @@ class AggregatedRecommendation(BaseModel):
     ``contributing_recommendations`` for ``--verbose`` and JSON output.
     """
 
-    agent_type: str
+    agent_type: str | None
+    """``None`` for cross-cutting findings; renders as ``(global)`` in
+    terminal output."""
     target: str
     severity: Severity
     signal_types: list[SignalType] = Field(default_factory=list)

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -113,10 +113,14 @@ def _enrich_dedup_with_mismatches(
     """
     if not suggestions:
         return
+    # MODEL_MISMATCH is always per-agent, so agent_type is non-None in
+    # practice. The explicit guard satisfies mypy after #207's schema
+    # change and degrades gracefully if a cross-cutting MODEL_MISMATCH
+    # ever lands.
     mismatches_by_agent: dict[str, DiagnosticSignal] = {
         s.agent_type.lower(): s
         for s in signals
-        if s.signal_type == SignalType.MODEL_MISMATCH
+        if s.signal_type == SignalType.MODEL_MISMATCH and s.agent_type
     }
     if not mismatches_by_agent:
         return

--- a/tests/unit/test_mcp_assessment.py
+++ b/tests/unit/test_mcp_assessment.py
@@ -332,7 +332,7 @@ class TestAuditMcpServers:
         s = signals[0]
         assert s.signal_type == SignalType.MCP_UNUSED_SERVER
         assert s.severity == Severity.INFO
-        assert s.agent_type == ""
+        assert s.agent_type is None
         assert s.detail["server_name"] == "slack"
         assert s.detail["sessions_analyzed"] == 10
 
@@ -416,3 +416,40 @@ class TestAuditMcpServers:
             sessions_analyzed=42,
         )
         assert signals[0].detail["sessions_analyzed"] == 42
+
+
+class TestCrossCuttingAgentTypeIsNone:
+    """MCP audit signals are not scoped to a specific agent (#207).
+
+    Cross-cutting findings carry ``agent_type=None`` rather than the
+    ``""`` empty-string sentinel that read as a stray tab in tooling.
+    """
+
+    def test_unused_server_signal_has_none_agent_type(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={},
+            configured=[_server("slack")],
+            sessions_analyzed=5,
+        )
+        assert signals[0].agent_type is None
+
+    def test_missing_server_signal_has_none_agent_type(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={"missing": _usage("missing", total=5, errors=5)},
+            configured=[],
+            sessions_analyzed=5,
+        )
+        assert signals
+        assert all(s.agent_type is None for s in signals)
+
+    def test_signal_serializes_agent_type_as_null(self) -> None:
+        # JSON consumers should see null, not "" — the reviewer's
+        # complaint was the empty string read as a stray tab when
+        # grouping output by agent.
+        signals = audit_mcp_servers(
+            usage_by_server={},
+            configured=[_server("slack")],
+            sessions_analyzed=5,
+        )
+        dumped = signals[0].model_dump(mode="json")
+        assert dumped["agent_type"] is None


### PR DESCRIPTION
## Summary

- Changes `agent_type: str` to `agent_type: str | None` on `DiagnosticSignal`, `DiagnosticRecommendation`, and `AggregatedRecommendation`.
- MCP audit signals (the only source of cross-cutting findings, at `mcp_assessment.py`) now set `agent_type=None` instead of `""`.
- JSON consumers now see `"agent_type": null`. Table consumers see `(global)` instead of a stray tab.

## Architect-flagged callsites — audited and guarded

Per the [architect review on epic #195](https://github.com/frederick-douglas-pearce/agentfluent/issues/195#issuecomment-4324259195), `agent_type: None` would crash three callers:

| Callsite | Fix |
|---|---|
| `correlator.py:52` `is_builtin_agent(signal.agent_type)` | Guard: return None if `agent_type is None` (cross-cutting → never builtin path) |
| `correlator.py:629` `signal.agent_type.lower()` | Guard: skip config lookup when `agent_type` is None |
| `cli/formatters/table.py` 3 `escape(...agent_type)` callsites | Render `or "(global)"` |

Other callsites (`aggregation.py:50` grouping key, `signals.py:83/121` operating on `AgentInvocation.agent_type`, `pipeline.py:117` filtering MODEL_MISMATCH-only signals) were verified safe.

## Test plan

- [x] `tests/unit/test_mcp_assessment.py::TestCrossCuttingAgentTypeIsNone` — 3 new tests:
  - unused-server signal carries `agent_type is None`
  - missing-server signal carries `agent_type is None`
  - JSON dump serializes `agent_type` as `null`
- [x] Existing MCP test updated: `agent_type == ""` → `agent_type is None`
- [x] Full unit suite: 725 passed (was 720; the diagnostics smoke test caught a missed `escape(sig.agent_type)` callsite during development — now also guarded)
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/agentfluent/` — passes

## Schema migration note for JSON consumers

This is a schema change. JSON consumers that previously did `obj["agent_type"] == ""` to detect cross-cutting findings now must check for `null`. Pre-0.x — no semver break per project convention.

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)