### PR TITLE
docs(schema): document representative_message vs contributing_recommendations[0].message (#209)

### DIFF
--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -130,25 +130,10 @@ class AggregatedRecommendation(BaseModel):
     not expose a comparable scalar (retry counts, permission failures)."""
 
     representative_message: str
-    """The message shown in the default Recommendations table.
-
-    Two distinct shapes depending on ``count``:
-
-    - ``count == 1`` — verbatim copy of
-      ``contributing_recommendations[0].message`` (the raw underlying
-      recommendation). The two fields carry identical text in this case;
-      either is canonical.
-    - ``count > 1`` — synthesized by
-      ``aggregation._representative_message`` as
-      ``"<signal_type>[ (metric_range)]: <action>"``. Reads as a
-      summary of the cluster, not any individual member. The first
-      contributing recommendation's message is still available at
-      ``contributing_recommendations[0].message`` for code that needs
-      the raw form.
-
-    JSON consumers that want the raw signal text should always read
-    ``contributing_recommendations[0].message``.
-    """
+    """The message shown in the default table. Verbatim copy of
+    ``contributing_recommendations[0].message`` when ``count == 1``;
+    a synthesized cluster summary
+    (``"<signal_type>[ (range)]: <action>"``) when ``count > 1``."""
 
     is_builtin: bool = False
     """Mirrors ``DiagnosticRecommendation.is_builtin`` — built-in and
@@ -159,23 +144,11 @@ class AggregatedRecommendation(BaseModel):
     contributing_recommendations: list[DiagnosticRecommendation] = Field(
         default_factory=list,
     )
-    """Raw per-invocation recommendations that were merged into this row.
-
-    Source of truth for the underlying signal text. ``--verbose`` re-
-    renders this list as the unaggregated view without re-running the
-    pipeline. Each element carries the full
-    observation/reason/action/signal_types from the source
-    recommendation — those fields are not denormalized onto the
-    aggregated row.
-
-    Relation to ``representative_message``:
-
-    - When ``count == 1`` the only contributing recommendation's
-      ``message`` is identical to ``representative_message``.
-    - When ``count > 1`` ``representative_message`` is a synthesized
-      cluster summary; the raw per-invocation messages are available
-      here as ``contributing_recommendations[i].message``.
-    """
+    """Raw per-invocation recommendations merged into this row. Source
+    of truth for the underlying signal text; carries the full
+    observation/reason/action/signal_types from each source recommendation
+    (not denormalized onto the aggregated row). ``--verbose`` re-renders
+    this list as the unaggregated view."""
 
 
 class DelegationSuggestion(BaseModel):

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -130,8 +130,25 @@ class AggregatedRecommendation(BaseModel):
     not expose a comparable scalar (retry counts, permission failures)."""
 
     representative_message: str
-    """Aggregated message shown in the default table. For ``count == 1``
-    this is the original recommendation text verbatim."""
+    """The message shown in the default Recommendations table.
+
+    Two distinct shapes depending on ``count``:
+
+    - ``count == 1`` — verbatim copy of
+      ``contributing_recommendations[0].message`` (the raw underlying
+      recommendation). The two fields carry identical text in this case;
+      either is canonical.
+    - ``count > 1`` — synthesized by
+      ``aggregation._representative_message`` as
+      ``"<signal_type>[ (metric_range)]: <action>"``. Reads as a
+      summary of the cluster, not any individual member. The first
+      contributing recommendation's message is still available at
+      ``contributing_recommendations[0].message`` for code that needs
+      the raw form.
+
+    JSON consumers that want the raw signal text should always read
+    ``contributing_recommendations[0].message``.
+    """
 
     is_builtin: bool = False
     """Mirrors ``DiagnosticRecommendation.is_builtin`` — built-in and
@@ -142,12 +159,23 @@ class AggregatedRecommendation(BaseModel):
     contributing_recommendations: list[DiagnosticRecommendation] = Field(
         default_factory=list,
     )
-    """Raw per-invocation recommendations so ``--verbose`` can re-render
-    the unaggregated view without re-running the pipeline. Carries the
-    full observation/reason/action text and source ``signal_types`` for
-    each member of the group — those fields are not denormalized onto
-    this model since ``contributing_recommendations[0]`` is the source
-    of truth."""
+    """Raw per-invocation recommendations that were merged into this row.
+
+    Source of truth for the underlying signal text. ``--verbose`` re-
+    renders this list as the unaggregated view without re-running the
+    pipeline. Each element carries the full
+    observation/reason/action/signal_types from the source
+    recommendation — those fields are not denormalized onto the
+    aggregated row.
+
+    Relation to ``representative_message``:
+
+    - When ``count == 1`` the only contributing recommendation's
+      ``message`` is identical to ``representative_message``.
+    - When ``count > 1`` ``representative_message`` is a synthesized
+      cluster summary; the raw per-invocation messages are available
+      here as ``contributing_recommendations[i].message``.
+    """
 
 
 class DelegationSuggestion(BaseModel):

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -204,6 +204,35 @@ class TestRepresentativeMessage:
         assert any("token_outlier" in m for m in messages)
         assert any("retry_loop" in m for m in messages)
 
+    def test_count_one_message_equals_contributing_zero_message(self) -> None:
+        # #209 contract: when count == 1, representative_message and
+        # contributing_recommendations[0].message carry identical text.
+        # JSON consumers can rely on this when deciding which to read.
+        pairs = [_token_outlier_pair("pm", 3.4)]
+        aggregated = aggregate_recommendations(pairs)
+        agg = aggregated[0]
+        assert agg.count == 1
+        assert agg.representative_message == agg.contributing_recommendations[0].message
+
+    def test_count_gt_one_message_is_synthesized(self) -> None:
+        # #209 contract: when count > 1, representative_message is
+        # synthesized and may differ from contributing_recommendations[0].
+        # Consumers needing the raw signal text must read contributing[0].
+        pairs = [
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 6.7),
+        ]
+        aggregated = aggregate_recommendations(pairs)
+        agg = aggregated[0]
+        assert agg.count == 2
+        # Synthesized form names the signal type explicitly; raw
+        # contributing message starts with the agent's observation.
+        assert agg.representative_message.startswith("token_outlier")
+        # Raw message from the rule, not the synthetic prefix.
+        assert not agg.contributing_recommendations[0].message.startswith(
+            "token_outlier",
+        )
+
 
 class TestSortOrder:
     def test_critical_before_warning(self) -> None:


### PR DESCRIPTION
## Summary

- Expands the docstrings on `AggregatedRecommendation.representative_message` and `AggregatedRecommendation.contributing_recommendations` to make the semantic distinction explicit and discoverable.
- Adds two tests anchoring the contract: `count == 1` → fields carry identical text; `count > 1` → `representative_message` is synthesized and may differ from `contributing_recommendations[0].message`.
- No model field renamed. The rename to `aggregated_message` was considered but the [architect review](https://github.com/frederick-douglas-pearce/agentfluent/issues/195#issuecomment-4324259195) recommended against breaking JSON schema for no user benefit at 0.x.

## What this resolves

The codefluent v0.3 reviewer wrote:

> Some entries had both `representative_message` and `contributing_recommendations[0].message`. They were always identical (or close to it) in the data I saw. Consider documenting which is canonical, or deduplicating. It cost me a minute of \"is one richer than the other?\"

The fields differ when `count > 1` (synthesized cluster summary vs raw per-invocation text) but JSON consumers had no way to know. Now they do — the Pydantic-derived schema includes the explanation, and the new tests enforce the contract.

## Test plan

- [x] `tests/unit/test_recommendation_aggregation.py::TestRepresentativeMessage` — 2 new tests:
  - `test_count_one_message_equals_contributing_zero_message`
  - `test_count_gt_one_message_is_synthesized`
- [x] All existing aggregation tests still pass (4 of 6 in this class were already covering the two paths; new tests anchor the cross-field relationship)
- [x] Full unit suite: 724 passed
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/agentfluent/` — passes

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)