### PR TITLE
feat(diagnostics): populate invocation_id on contributing recommendations (#197)

### DIFF
--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -84,6 +84,15 @@ class AgentInvocation(BaseModel):
         return is_builtin_agent(self.agent_type)
 
     @property
+    def invocation_id(self) -> str:
+        """Stable identifier for this invocation. Prefers ``agent_id``
+        (UUID linking to the subagent trace file); falls back to
+        ``tool_use_id`` (always populated, links to the parent
+        ``tool_use`` block in the session JSONL) when ``agent_id`` is
+        absent (older sessions, interrupted runs)."""
+        return self.agent_id or self.tool_use_id
+
+    @property
     def tokens_per_tool_use(self) -> float | None:
         """Average tokens per tool call. None if data unavailable."""
         if self.total_tokens is not None and self.tool_uses and self.tool_uses > 0:

--- a/src/agentfluent/diagnostics/builtin_actions.py
+++ b/src/agentfluent/diagnostics/builtin_actions.py
@@ -70,6 +70,7 @@ def builtin_recommendation(
         reason=reason,
         action=action,
         agent_type=signal.agent_type,
+        invocation_id=signal.invocation_id,
         config_file="",
         signal_types=[signal.signal_type],
         is_builtin=True,

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -105,6 +105,7 @@ class AccessErrorRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -161,6 +162,7 @@ class ErrorHandlingRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -211,6 +213,7 @@ class TokenOutlierRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -261,6 +264,7 @@ class DurationOutlierRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -312,6 +316,7 @@ class PermissionFailureRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -368,6 +373,7 @@ class RetryLoopRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -415,6 +421,7 @@ class StuckPatternRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -470,6 +477,7 @@ class ErrorSequenceRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -529,6 +537,7 @@ class ModelRoutingRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
@@ -586,6 +595,7 @@ class McpAuditRule:
             reason=reason,
             action=action,
             agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
             config_file=str(signal.detail.get("source_file", "")),
             signal_types=[signal.signal_type],
         )

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -55,6 +55,15 @@ class DiagnosticSignal(BaseModel):
     """Agent this signal is scoped to. ``None`` for cross-cutting signals
     that don't belong to a specific agent (e.g. MCP server audit findings,
     which apply project-wide). Per-agent signals always carry a name."""
+    invocation_id: str | None = None
+    """Identifier of the source agent invocation when the signal is
+    per-invocation (metadata signals, trace signals). ``None`` for
+    cross-cutting signals (MCP audit, model-routing — those operate over
+    the full invocation set or per agent_type, not per single
+    invocation). Populated as ``inv.agent_id`` when available, else
+    ``inv.tool_use_id`` so consumers can grep the source session JSONL
+    or the linked subagent trace file
+    (``<session>/subagents/agent-<id>.jsonl``)."""
     message: str
     detail: dict[str, object] = Field(default_factory=dict)
     """Extensible detail dict for signal-specific data (keyword, snippet,
@@ -87,6 +96,13 @@ class DiagnosticRecommendation(BaseModel):
     """Which agent this recommendation applies to. ``None`` for
     cross-cutting recommendations not scoped to any single agent (e.g.
     MCP server audit findings)."""
+
+    invocation_id: str | None = None
+    """Identifier of the source agent invocation, copied from the
+    contributing ``DiagnosticSignal``. ``None`` for recommendations
+    derived from cross-cutting signals. Lets JSON consumers map a
+    recommendation back to a specific session / subagent trace for
+    drill-down (#197)."""
 
     config_file: str = ""
     """Path to the agent config file, if known."""

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -56,14 +56,8 @@ class DiagnosticSignal(BaseModel):
     that don't belong to a specific agent (e.g. MCP server audit findings,
     which apply project-wide). Per-agent signals always carry a name."""
     invocation_id: str | None = None
-    """Identifier of the source agent invocation when the signal is
-    per-invocation (metadata signals, trace signals). ``None`` for
-    cross-cutting signals (MCP audit, model-routing — those operate over
-    the full invocation set or per agent_type, not per single
-    invocation). Populated as ``inv.agent_id`` when available, else
-    ``inv.tool_use_id`` so consumers can grep the source session JSONL
-    or the linked subagent trace file
-    (``<session>/subagents/agent-<id>.jsonl``)."""
+    """Source ``AgentInvocation.invocation_id`` for per-invocation
+    signals; ``None`` for cross-cutting signals (MCP audit)."""
     message: str
     detail: dict[str, object] = Field(default_factory=dict)
     """Extensible detail dict for signal-specific data (keyword, snippet,
@@ -98,11 +92,9 @@ class DiagnosticRecommendation(BaseModel):
     MCP server audit findings)."""
 
     invocation_id: str | None = None
-    """Identifier of the source agent invocation, copied from the
-    contributing ``DiagnosticSignal``. ``None`` for recommendations
-    derived from cross-cutting signals. Lets JSON consumers map a
-    recommendation back to a specific session / subagent trace for
-    drill-down (#197)."""
+    """Copied from the contributing ``DiagnosticSignal`` so consumers
+    can drill from a recommendation back to a specific session /
+    subagent trace."""
 
     config_file: str = ""
     """Path to the agent config file, if known."""

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -195,7 +195,13 @@ def run_diagnostics(
     for inv in invocations:
         if inv.trace is None:
             continue
-        signals.extend(extract_trace_signals(inv.trace, agent_type=inv.agent_type))
+        signals.extend(
+            extract_trace_signals(
+                inv.trace,
+                agent_type=inv.agent_type,
+                invocation_id=inv.agent_id or inv.tool_use_id,
+            ),
+        )
 
     signals = _dedup_error_patterns(signals)
 

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -199,7 +199,7 @@ def run_diagnostics(
             extract_trace_signals(
                 inv.trace,
                 agent_type=inv.agent_type,
-                invocation_id=inv.agent_id or inv.tool_use_id,
+                invocation_id=inv.invocation_id,
             ),
         )
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -62,6 +62,7 @@ def _extract_error_signals(invocations: list[AgentInvocation]) -> list[Diagnosti
                 signal_type=SignalType.ERROR_PATTERN,
                 severity=severity,
                 agent_type=inv.agent_type,
+                invocation_id=inv.agent_id or inv.tool_use_id,
                 message=f"Agent '{inv.agent_type}' output contains '{keyword}'.",
                 detail={
                     "keyword": keyword,
@@ -96,6 +97,7 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
                     signal_type=SignalType.TOKEN_OUTLIER,
                     severity=Severity.WARNING,
                     agent_type=inv.agent_type,
+                    invocation_id=inv.agent_id or inv.tool_use_id,
                     message=(
                         f"Agent '{inv.agent_type}' has {val:,.0f} tokens/tool_use, "
                         f"{val / mean:.1f}x above the {mean:,.0f} mean."
@@ -136,6 +138,7 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
                     signal_type=SignalType.DURATION_OUTLIER,
                     severity=Severity.WARNING,
                     agent_type=inv.agent_type,
+                    invocation_id=inv.agent_id or inv.tool_use_id,
                     message=(
                         f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
                         f"{val / mean:.1f}x above the {mean / 1000:.1f}s mean."

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -62,7 +62,7 @@ def _extract_error_signals(invocations: list[AgentInvocation]) -> list[Diagnosti
                 signal_type=SignalType.ERROR_PATTERN,
                 severity=severity,
                 agent_type=inv.agent_type,
-                invocation_id=inv.agent_id or inv.tool_use_id,
+                invocation_id=inv.invocation_id,
                 message=f"Agent '{inv.agent_type}' output contains '{keyword}'.",
                 detail={
                     "keyword": keyword,
@@ -97,7 +97,7 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
                     signal_type=SignalType.TOKEN_OUTLIER,
                     severity=Severity.WARNING,
                     agent_type=inv.agent_type,
-                    invocation_id=inv.agent_id or inv.tool_use_id,
+                    invocation_id=inv.invocation_id,
                     message=(
                         f"Agent '{inv.agent_type}' has {val:,.0f} tokens/tool_use, "
                         f"{val / mean:.1f}x above the {mean:,.0f} mean."
@@ -138,7 +138,7 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
                     signal_type=SignalType.DURATION_OUTLIER,
                     severity=Severity.WARNING,
                     agent_type=inv.agent_type,
-                    invocation_id=inv.agent_id or inv.tool_use_id,
+                    invocation_id=inv.invocation_id,
                     message=(
                         f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
                         f"{val / mean:.1f}x above the {mean / 1000:.1f}s mean."

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -96,7 +96,10 @@ def _cap_evidence(
 
 
 def _extract_permission_failures(
-    trace: SubagentTrace, agent_type: str,
+    trace: SubagentTrace,
+    agent_type: str,
+    *,
+    invocation_id: str | None = None,
 ) -> list[DiagnosticSignal]:
     """Emit one PERMISSION_FAILURE signal per unique tool with a denied result."""
     signals: list[DiagnosticSignal] = []
@@ -129,6 +132,7 @@ def _extract_permission_failures(
                 signal_type=SignalType.PERMISSION_FAILURE,
                 severity=Severity.CRITICAL,
                 agent_type=agent_type,
+                invocation_id=invocation_id,
                 message=(
                     f"Subagent '{agent_type}' was denied access to "
                     f"tool '{tool_name}' ({keyword!r})."
@@ -145,7 +149,10 @@ def _extract_permission_failures(
 
 
 def _extract_retry_and_stuck(
-    trace: SubagentTrace, agent_type: str,
+    trace: SubagentTrace,
+    agent_type: str,
+    *,
+    invocation_id: str | None = None,
 ) -> tuple[list[DiagnosticSignal], set[int]]:
     """Emit STUCK_PATTERN or RETRY_LOOP — never both — per `RetrySequence`.
 
@@ -176,9 +183,17 @@ def _extract_retry_and_stuck(
             c.input_summary == calls[0].input_summary for c in calls[1:]
         )
         if is_stuck:
-            signals.append(_build_stuck_signal(agent_type, seq, calls))
+            signals.append(
+                _build_stuck_signal(
+                    agent_type, seq, calls, invocation_id=invocation_id,
+                ),
+            )
         else:
-            signals.append(_build_retry_signal(agent_type, seq, calls))
+            signals.append(
+                _build_retry_signal(
+                    agent_type, seq, calls, invocation_id=invocation_id,
+                ),
+            )
         covered.update(seq.tool_call_indices)
 
     return signals, covered
@@ -188,12 +203,15 @@ def _build_stuck_signal(
     agent_type: str,
     seq: RetrySequence,
     calls: list[SubagentToolCall],
+    *,
+    invocation_id: str | None = None,
 ) -> DiagnosticSignal:
     evidence = _cap_evidence(calls, seq.tool_call_indices)
     return DiagnosticSignal(
         signal_type=SignalType.STUCK_PATTERN,
         severity=Severity.CRITICAL,
         agent_type=agent_type,
+        invocation_id=invocation_id,
         message=(
             f"Subagent '{agent_type}' repeated tool "
             f"'{seq.tool_name}' with identical input {seq.attempts} "
@@ -212,12 +230,15 @@ def _build_retry_signal(
     agent_type: str,
     seq: RetrySequence,
     calls: list[SubagentToolCall],
+    *,
+    invocation_id: str | None = None,
 ) -> DiagnosticSignal:
     evidence = _cap_evidence(calls, seq.tool_call_indices)
     return DiagnosticSignal(
         signal_type=SignalType.RETRY_LOOP,
         severity=Severity.WARNING,
         agent_type=agent_type,
+        invocation_id=invocation_id,
         message=(
             f"Subagent '{agent_type}' retried tool "
             f"'{seq.tool_name}' {seq.attempts} times."
@@ -233,7 +254,11 @@ def _build_retry_signal(
 
 
 def _extract_error_sequences(
-    trace: SubagentTrace, covered: set[int], agent_type: str,
+    trace: SubagentTrace,
+    covered: set[int],
+    agent_type: str,
+    *,
+    invocation_id: str | None = None,
 ) -> list[DiagnosticSignal]:
     """Emit TOOL_ERROR_SEQUENCE for runs of consecutive `is_error=True`
     tool calls that are not already covered by STUCK/RETRY signals.
@@ -272,6 +297,7 @@ def _extract_error_sequences(
                     signal_type=SignalType.TOOL_ERROR_SEQUENCE,
                     severity=severity,
                     agent_type=agent_type,
+                    invocation_id=invocation_id,
                     message=(
                         f"Subagent '{agent_type}' had "
                         f"{len(run_indices)} consecutive tool errors."
@@ -293,6 +319,7 @@ def extract_trace_signals(
     trace: SubagentTrace | None,
     *,
     agent_type: str | None = None,
+    invocation_id: str | None = None,
 ) -> list[DiagnosticSignal]:
     """Extract all trace-level behavior signals from a parsed subagent trace.
 
@@ -306,6 +333,10 @@ def extract_trace_signals(
     to avoid depending on the linker having populated the trace
     (programmatically-constructed or unlinked traces may still hold
     `UNKNOWN_AGENT_TYPE`).
+
+    `invocation_id` is stamped on every emitted signal so consumers can
+    drill from a trace finding back to its parent ``AgentInvocation``
+    (#197). The pipeline passes ``inv.agent_id or inv.tool_use_id``.
     """
     if trace is None or not trace.tool_calls:
         return []
@@ -313,8 +344,18 @@ def extract_trace_signals(
     effective_agent_type = agent_type if agent_type else trace.agent_type
 
     signals: list[DiagnosticSignal] = []
-    signals.extend(_extract_permission_failures(trace, effective_agent_type))
-    retry_stuck, covered = _extract_retry_and_stuck(trace, effective_agent_type)
+    signals.extend(
+        _extract_permission_failures(
+            trace, effective_agent_type, invocation_id=invocation_id,
+        ),
+    )
+    retry_stuck, covered = _extract_retry_and_stuck(
+        trace, effective_agent_type, invocation_id=invocation_id,
+    )
     signals.extend(retry_stuck)
-    signals.extend(_extract_error_sequences(trace, covered, effective_agent_type))
+    signals.extend(
+        _extract_error_sequences(
+            trace, covered, effective_agent_type, invocation_id=invocation_id,
+        ),
+    )
     return signals

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -30,11 +30,13 @@ def _signal(
     keyword: str = "error",
     detail: dict[str, object] | None = None,
     message: str | None = None,
+    invocation_id: str | None = None,
 ) -> DiagnosticSignal:
     return DiagnosticSignal(
         signal_type=signal_type,
         severity=severity,
         agent_type=agent_type,
+        invocation_id=invocation_id,
         message=message or f"Agent '{agent_type}' output contains '{keyword}'.",
         detail=detail if detail is not None else {"keyword": keyword},
     )
@@ -561,3 +563,50 @@ class TestBuiltinAgentBranching:
         model_rec = correlate([_builtin_signal(SignalType.MODEL_MISMATCH)])[0]
         actions = {token_rec.action, retry_rec.action, perm_rec.action, model_rec.action}
         assert len(actions) == 4
+
+
+class TestInvocationIdPropagation:
+    """#197: invocation_id flows from signal to recommendation across rules."""
+
+    def test_access_error_rule_propagates_invocation_id(self) -> None:
+        sig = _signal(keyword="blocked", severity=Severity.CRITICAL,
+                      invocation_id="ag-1")
+        recs = correlate([sig])
+        assert recs and recs[0].invocation_id == "ag-1"
+
+    def test_token_outlier_rule_propagates_invocation_id(self) -> None:
+        sig = _signal(
+            signal_type=SignalType.TOKEN_OUTLIER,
+            detail={"actual_value": 5000, "mean_value": 1000, "ratio": 5.0},
+            invocation_id="ag-outlier",
+        )
+        recs = correlate([sig])
+        assert recs and recs[0].invocation_id == "ag-outlier"
+
+    def test_builtin_recommendation_propagates_invocation_id(self) -> None:
+        sig = _signal(
+            signal_type=SignalType.RETRY_LOOP,
+            severity=Severity.WARNING,
+            agent_type="Explore",
+            detail={"tool_name": "Bash", "retry_count": 3},
+            invocation_id="ag-builtin",
+        )
+        recs = correlate([sig])
+        assert recs and recs[0].invocation_id == "ag-builtin"
+        # Built-in agents get the concern-keyed action template; field
+        # still flows through.
+        assert recs[0].is_builtin
+
+    def test_cross_cutting_signal_carries_none(self) -> None:
+        # MCP audit signals leave invocation_id as None; the propagation
+        # should preserve None on the recommendation.
+        sig = DiagnosticSignal(
+            signal_type=SignalType.MCP_UNUSED_SERVER,
+            severity=Severity.INFO,
+            agent_type="",
+            invocation_id=None,
+            message="MCP server 'slack' is configured but unused.",
+            detail={"server_name": "slack", "source_file": "/etc/cfg.json"},
+        )
+        recs = correlate([sig])
+        assert recs and recs[0].invocation_id is None

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -12,16 +12,19 @@ def _inv(
     total_tokens: int | None = None,
     tool_uses: int | None = None,
     duration_ms: int | None = None,
+    tool_use_id: str = "toolu_01",
+    agent_id: str | None = None,
 ) -> AgentInvocation:
     return AgentInvocation(
         agent_type=agent_type,
         description="test",
         prompt="do something",
-        tool_use_id="toolu_01",
+        tool_use_id=tool_use_id,
         total_tokens=total_tokens,
         tool_uses=tool_uses,
         duration_ms=duration_ms,
         output_text=output_text,
+        agent_id=agent_id,
     )
 
 
@@ -141,3 +144,55 @@ class TestExtractSignals:
         signals = extract_signals(invocations)
         types = {s.signal_type for s in signals}
         assert SignalType.ERROR_PATTERN in types
+
+
+class TestInvocationIdPropagation:
+    """#197: every per-invocation signal carries an invocation_id pointing
+    back to the source AgentInvocation."""
+
+    def test_error_pattern_uses_agent_id_when_present(self) -> None:
+        invocations = [
+            _inv(
+                output_text="Operation blocked.",
+                agent_id="ag-uuid-1",
+                tool_use_id="toolu_99",
+            ),
+        ]
+        signals = extract_signals(invocations)
+        assert signals[0].invocation_id == "ag-uuid-1"
+
+    def test_falls_back_to_tool_use_id_when_agent_id_missing(self) -> None:
+        # Older sessions / interrupted runs lack agent_id; tool_use_id
+        # is always populated and lets consumers locate the parent
+        # tool_use block in the session JSONL.
+        invocations = [
+            _inv(
+                output_text="Operation blocked.",
+                agent_id=None,
+                tool_use_id="toolu_42",
+            ),
+        ]
+        signals = extract_signals(invocations)
+        assert signals[0].invocation_id == "toolu_42"
+
+    def test_token_outlier_signal_carries_invocation_id(self) -> None:
+        invocations = [
+            _inv(total_tokens=1000, tool_uses=10, agent_id="ag-1"),
+            _inv(total_tokens=1000, tool_uses=10, agent_id="ag-2"),
+            _inv(total_tokens=10000, tool_uses=10, agent_id="ag-3"),
+        ]
+        signals = extract_signals(invocations)
+        outlier = next(s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER)
+        # Outlier rule fires for ag-3 (10x the mean, well above 2x threshold).
+        assert outlier.invocation_id == "ag-3"
+
+    def test_duration_outlier_signal_carries_invocation_id(self) -> None:
+        invocations = [
+            _inv(duration_ms=1000, tool_uses=10, agent_id="ag-1"),
+            _inv(duration_ms=1000, tool_uses=10, agent_id="ag-2"),
+            _inv(duration_ms=10000, tool_uses=10, agent_id="ag-slow"),
+        ]
+        signals = extract_signals(invocations)
+        outlier = next(s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER)
+        assert outlier.invocation_id == "ag-slow"
+


### PR DESCRIPTION
## Summary

The single highest-impact data fidelity gap from the codefluent v0.3 CLI review. Adds `invocation_id: str \| None` to `DiagnosticSignal` and `DiagnosticRecommendation`, then threads it through the full signal → correlator → recommendation pipeline so every contributing recommendation can be mapped back to a specific session / subagent trace.

The reviewer's complaint:

> When I tried to investigate the 15 critical \`tool_error_sequence\` events for \`general-purpose\`, every contributing recommendation had \`\"invocation_id\": null\`. There's no way to map a recommendation back to a specific session/invocation. This is the highest-impact data fidelity gap.

## Architecture (architect-approved)

- **Signal source**: per-invocation signals stamp \`invocation_id = inv.agent_id or inv.tool_use_id\`. \`agent_id\` (UUID linking to the subagent trace file) is preferred; \`tool_use_id\` (always populated, links to the parent tool_use block) is the fallback for older sessions or interrupted runs.
- **Trace signals**: \`extract_trace_signals\` takes a new \`invocation_id\` kwarg from the pipeline; all four trace signal types stamp it.
- **Correlator**: every rule's \`recommend()\` copies \`signal.invocation_id\` to \`recommendation.invocation_id\`.
- **Cross-cutting signals** (MCP audit): \`invocation_id=None\` since these don't belong to any single invocation.
- **Deferred to #203 (v0.5)**: trace-level fields like \`tool_call_index\` and \`subagent_path\` per architect review.

## Smoke check on real session JSON

\`\`\`
aggregated rows: 22
contributing recommendations: 194
with invocation_id populated: 193
sample non-null IDs: ['a5916d6836908a066', 'aa7ef64bef357afce', 'a4dcd3901e6a19182']
\`\`\`

The one null is the cross-cutting MCP audit signal, which is correct behavior.

## Test plan

- [x] \`tests/unit/test_signals.py::TestInvocationIdPropagation\` — 4 new tests:
  - error pattern uses \`agent_id\` when present
  - falls back to \`tool_use_id\` when \`agent_id\` missing
  - token outlier signal carries invocation_id
  - duration outlier signal carries invocation_id
- [x] \`tests/unit/test_correlator.py::TestInvocationIdPropagation\` — 4 new tests:
  - access error rule propagates
  - token outlier rule propagates
  - built-in recommendation propagates
  - cross-cutting signal carries None
- [x] Full unit suite: 730 passed (was 720)
- [x] \`uv run ruff check src/ tests/\` — passes
- [x] \`uv run mypy src/agentfluent/\` — passes
- [x] End-to-end smoke check on real session JSON — 193/194 populated as expected

## Architect review

[Plan reviewed on epic #195](https://github.com/frederick-douglas-pearce/agentfluent/issues/195#issuecomment-4324259195). Architect agreed:
- Field name \`invocation_id\` (not \`agent_id\`)
- Defer trace-level fields to #203
- No conflicts with #201 (per-session diagnostics scope, v0.5) or #203 (inline trace excerpts, v0.5)

## Unblocks

- **#203** (inline trace excerpts) — needs invocation_id to know which trace to excerpt
- **#201** (per-session diagnostics scope) — invocation_id enables session-scoped drill-down

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)