### PR TITLE
chore(template): split security-review gate into Pre-merge checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,8 @@
 - [ ] Type check clean: `uv run mypy src/agentfluent/`
 - [ ] New/changed behavior has test coverage
 - [ ] Manual smoke test via `uv run agentfluent ...` — required for CLI output changes
+
+## Pre-merge checklist
 - [ ] Add the `needs-security-review` label and confirm the security-review workflow passes before merging
 
 ## Breaking changes


### PR DESCRIPTION
## Summary
- Promotes the `needs-security-review` label step out of the Test plan list (where it read as a dev-time check) into its own **Pre-merge checklist** section, matching the codefluent PR template pattern.
- Two-line change to `.github/PULL_REQUEST_TEMPLATE.md`; no functional change to CI or workflows.

## Why
After security-review was gated on the `needs-security-review` label (#221), forgetting to add the label silently skips the gate. Surfacing it as a distinct merge-time step (rather than co-mingled with `pytest`/`ruff`/`mypy` items) makes the requirement harder to overlook.

## Test plan
- [x] Render the template in a draft PR to verify section ordering reads cleanly
- [x] No code changes — no test/lint/typecheck implications

## Pre-merge checklist
- [x] Add the `needs-security-review` label and confirm the security-review workflow passes before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)