### PR TITLE
chore: track v0.4 scope review spec; ignore agent worktrees

### DIFF
--- a/.claude/specs/v0.4-scope-review.md
+++ b/.claude/specs/v0.4-scope-review.md
@@ -1,0 +1,150 @@
+# v0.4.0 Scope Review
+
+**Date:** 2026-04-25
+**Author:** PM Agent
+**Milestone:** [v0.4.0](https://github.com/frederick-douglas-pearce/agentfluent/milestone/2)
+**Status:** Awaiting Fred's decisions
+
+---
+
+## Executive Summary
+
+The v0.4.0 milestone currently holds **26 open issues** from five distinct sources: glossary PRD (3), release infrastructure (1), review-driven epic (14 + the epic itself), delegation-draft improvements (3), parent-thread offload (1), cost-scope clarification (1), outlier recalibration (2), and a JSONL drift monitoring skill (1). This is roughly 3x too much for a single release by a solo developer. I recommend **keeping 12 issues** (a tight, coherent release themed around "data fidelity + CLI ergonomics + glossary"), **deferring 11 to v0.5**, and **deferring 3 further**. The two biggest cuts are `agentfluent diff` (#199) and parent-thread offload (#189) -- both high-value features that deserve their own release rather than competing for v0.4 bandwidth. The review-driven epic's P1 items are a mix of quick wins (keep) and medium-effort features (defer); the reviewer's priorities are mostly sound but over-optimistic about what fits in one release.
+
+---
+
+## Triage Table
+
+| # | Title | Source | Reviewer P | Rec | Rationale |
+|---|-------|--------|-----------|-----|-----------|
+| **195** | epic: v0.4 review-driven polish | review | -- | **Keep** | Epic container; stays open until children resolve |
+| **196** | `--json` alias for `--format json` | review | P0 | **Keep** | Genuine paper-cut, XS effort, blocks nothing |
+| **197** | Populate `invocation_id` on recommendations | review | P0 | **Keep** | Real data-fidelity gap the reviewer demonstrated with evidence. Enables #203 |
+| **200** | Surface `total_cost_usd` on `by_agent_type` | review | P1 | **Keep** | XS effort, high user value -- cost is the lingua franca |
+| **202** | `--diagnostics` default-on | review | P1 | **Keep** | Correct call. Diagnostics IS the product. Small change, needs release note |
+| **207** | `agent_type ""` sentinel | review | P3 | **Keep** | XS schema fix, prevents downstream confusion. Do with #197 |
+| **206** | Parse warnings to stderr | review | P3 | **Keep** | XS fix, prevents confusing mid-table output |
+| **208** | README note on `[clustering]` extra | review | P3 | **Keep** | Pure docs, 10-minute fix |
+| **209** | Deduplicate `representative_message` | review | P3 | **Keep** | XS schema cleanup, do alongside #197 |
+| **193** | release-please PAT CI config | infra | -- | **Keep** | Infrastructure; unblocks automated releases for v0.4 itself |
+| **190** | Glossary Phase 1 (static markdown) | glossary PRD | -- | **Keep** | Low-risk, high value for first-time users. No code complexity |
+| **191** | Glossary Phase 2 (`explain` subcommand) | glossary PRD | -- | **Keep** | Completes the glossary surface. Depends on #190 content |
+| **192** | Glossary Phase 3 (inline hints) | glossary PRD | -- | **Defer further** | PRD itself recommends deferral. No usage signal yet |
+| **198** | Markdown report export | review | P1 | **Defer v0.5** | Real value (reviewer hand-built a report), but M effort. Better after #202 and #205 settle the output |
+| **199** | `agentfluent diff` | review | P1 | **Defer v0.5** | Headline feature for v0.5, not a polish item. Needs design: storage model, CI semantics, schema stability. The reviewer even flagged open questions |
+| **201** | Per-session diagnostics scope | review | P1 | **Defer v0.5** | M effort, touches the diagnostics pipeline deeply. Better after #197 lands (invocation_id enables session-scoped drill-down) |
+| **205** | `--severity` filter | review | P2 | **Defer v0.5** | Nice UX, but `jq` works today. Low urgency. Natural companion to #198 |
+| **203** | Inline trace excerpts on critical findings | review | P2 | **Defer v0.5** | Depends on #197 (needs invocation_id to know which trace to excerpt). S effort. Ship after the data-fidelity foundation |
+| **204** | `list` table: cost column + JSON | review | P2 | **Defer v0.5** | Requires wiring cost computation into the list path. S effort, nice but not v0.4 |
+| **189** | Parent-thread offload candidates | pre-review | high | **Defer v0.5** | Strategically important but epic-sized (multi-PR). Deserves its own scope review. Listed in README roadmap as v0.4+ but too big to bundle here |
+| **186** | Outlier detection recalibration | pre-review | -- | **Defer v0.5** | Research-grade work (distribution analysis + threshold tuning). Complements #187. Good v0.5 pair |
+| **187** | Distribution context in verbose output | pre-review | -- | **Defer v0.5** | Depends on #186. Ships naturally after recalibration |
+| **188** | Cost by Model scope clarification | pre-review | medium | **Defer v0.5** | Phase 1 (title/footer note) is XS but Phase 2 (subagent cost attribution) is M. Defer the pair; Phase 1 could be a v0.4 stretch if time allows |
+| **185** | Delegation drafts: unified model classifier | pre-review | medium | **Defer v0.5** | Good refactor (eliminates inconsistent model advice) but not user-facing urgency. Natural companion to #184 |
+| **184** | Delegation drafts: minimal tools list | pre-review | medium | **Defer v0.5** | Improves draft quality. Depends on #185 being settled. v0.5 delegation-improvement theme |
+| **183** | Delegation drafts: skill-aware provenance | pre-review | medium | **Defer further** | Requires building a skill scanner -- novel infrastructure. The provenance problem is real but affects a narrow use case (skill-originated clusters). v0.6+ |
+| **164** | JSONL format drift monitoring skill | pre-review | -- | **Defer further** | Defensive infrastructure, not user-facing. The skill is external to the package. Important but non-urgent -- format hasn't drifted yet. v0.6+ |
+
+---
+
+## Recommended v0.4 Scope (12 issues)
+
+### Dependency Graph
+
+```
+#193 (release-please)         -- independent, do first
+#196 (--json alias)           -- independent, do anytime
+#206 (parse warnings stderr)  -- independent, do anytime
+#208 (README clustering note) -- independent, do anytime
+#202 (diagnostics default-on) -- independent, do early (affects testing of everything else)
+#200 (cost on by_agent_type)  -- independent, do anytime
+#207 (agent_type sentinel)    -- independent, do with #197
+#209 (dedup rep_message)      -- independent, do with #197
+
+#197 (invocation_id)          -- upstream of #203 (deferred), but standalone value
+#190 (glossary Phase 1)       -- upstream of #191
+#191 (glossary Phase 2)       -- depends on #190
+#195 (epic container)         -- closes when children close
+```
+
+### Recommended Implementation Order
+
+**Wave 1 -- Quick wins (1-2 days)**
+1. **#193** -- release-please PAT config. Unblocks automated v0.4 release.
+2. **#196** -- `--json` alias. Two lines per command, high-visibility fix.
+3. **#206** -- Parse warnings to stderr. Tiny fix, immediate quality improvement.
+4. **#208** -- README clustering note. 10-minute docs fix.
+5. **#202** -- `--diagnostics` default-on. Small behavior change, but do early so all subsequent testing uses the new default. Needs release note.
+
+**Wave 2 -- Data fidelity (2-3 days)**
+6. **#200** -- Surface `total_cost_usd` on `by_agent_type`. XS analytics addition.
+7. **#207** -- `agent_type ""` to sentinel. Schema fix.
+8. **#209** -- Deduplicate `representative_message` vs first contributing rec.
+9. **#197** -- Populate `invocation_id`. The most significant data-fidelity work in v0.4. Thread `invocation_id` through the signal/correlator/recommendation chain.
+
+**Wave 3 -- Glossary (3-5 days)**
+10. **#190** -- Write `docs/GLOSSARY.md` with P0/P1/P2 terms. Content-heavy, no code.
+11. **#191** -- Build `terms.yaml` + `agentfluent explain` subcommand + CI drift check. Code work depends on #190 content being reviewed.
+
+**Closeout**
+12. **#195** -- Close epic when all kept children are done. Update epic body to reflect deferred items.
+
+---
+
+## Pushback Section
+
+### #199 -- `agentfluent diff`: Defer, not a polish item
+
+The reviewer called this "the single highest-ROI feature I'd push forward from the Future section." That may be true over a 6-month horizon, but it is a **new subcommand with design decisions** (storage model, baseline management, CI exit codes, schema stability guarantees). It is explicitly listed under "Future" in the MVP PRD and under "v0.4+" in the README roadmap. Shipping it as a hastily-scoped polish item in v0.4 risks a weak first impression. **Recommendation:** Make this the headline feature of v0.5, with a proper PM spec and architect review. The JSON envelope contract (#197, #207, #209 fixes) landing in v0.4 actually builds the foundation `diff` needs.
+
+### #189 -- Parent-thread offload: Defer, epic-sized
+
+The README roadmap lists this as the "dominant cost lever" for v0.4+, which is accurate, but the issue body itself acknowledges it is "likely a multi-PR effort" that "could be split into an epic later." That is the right call. This is a new diagnostics layer (extraction, clustering, cost estimation, recommendation surface, calibration) -- comparable in scope to the v0.3 subagent trace parser. It needs its own epic, stories, and potentially a PRD. **Recommendation:** Scope as the headline feature of v0.5 alongside `diff`.
+
+### #202 -- `--diagnostics` default-on: Keep, but flag as breaking
+
+The reviewer is right that diagnostics IS the product. However, this is a behavior change for existing scripts. The issue body says "confirmed by Fred" -- I trust that. Ship it with a `BREAKING CHANGE:` conventional commit prefix or at minimum a prominent release note. The `--no-diagnostics` opt-out covers the CI use case.
+
+### #164 -- JSONL drift monitoring skill: Defer further
+
+This is defensive infrastructure, not user-facing value. It is also an *external skill* (lives in `~/.claude/skills/`, not in the agentfluent package). The JSONL format has not drifted since the project started, and the existing `extra="ignore"` + `try/except` pattern degrades gracefully when it does. The skill is worth building eventually but competes for attention with features users actually see. **Recommendation:** v0.6+ or whenever a format drift actually causes a production break.
+
+### #183 -- Skill-aware provenance: Defer further
+
+Building a skill scanner is novel infrastructure with a narrow use case (clusters that originate from skills). The provenance problem is real but affects a small subset of delegation suggestions. The fix ("also edit your skill") is communicable via documentation or a manual note without infrastructure. **Recommendation:** v0.6+ after the delegation draft quality improvements (#184, #185) land.
+
+### Review-driven P3 items (#206, #207, #208, #209): Keep all
+
+The reviewer rated these P3, which might suggest deferral. I disagree -- these are all XS effort (minutes to hours) with disproportionate quality impact. Empty-string `agent_type` is a schema bug. Parse warnings on stdout is a correctness bug. The README omission is actively confusing users (the reviewer's `delegation_suggestions: []` confusion). Ship them all in Wave 1.
+
+### Review-driven items that overlap existing backlog
+
+The epic (#195) already notes three overlaps:
+- **TL;DR / `--top N` mode** -- covered by #172 (priority ranking + top-N summary). Not milestoned to v0.4. **Recommendation:** Milestone #172 to v0.5; it composes well with #198 (Markdown report) and #205 (severity filter).
+- **Token-outlier reference population** -- covered by #187 (distribution context). Deferred to v0.5 above.
+- **Outlier recalibration** -- covered by #186. Deferred to v0.5 above.
+
+No duplicate issues need closing.
+
+---
+
+## Open Questions for Fred
+
+1. **#202 as breaking change:** Should this carry a `feat!:` conventional commit (triggers major version bump in release-please) or just a `feat:` with a release note? At 0.x, semver says any minor bump can break, but the optics matter for users who `uv tool upgrade`.
+
+2. **#188 Phase 1 as v0.4 stretch:** The title/footer clarification ("Cost by Model -- Parent Session") is genuinely a one-line change. Worth including as a stretch item in v0.4, or cleaner to defer the whole issue?
+
+3. **Glossary open questions from prd-glossary.md:** The PRD lists 4 critical-path questions (authoritative term list source, threshold citation style, YAML location, Phase 3 disposition). These need answers before #190/#191 implementation begins. Can you respond on the issues or should I summarize them here?
+
+4. **v0.5 theme confirmation:** My implicit assumption is v0.5 = "diff + parent-thread offload + delegation draft quality + outlier recalibration." Does that match your thinking, or do you want to split those across v0.5 and v0.6?
+
+---
+
+## Summary Counts
+
+| Disposition | Count | Issues |
+|-------------|-------|--------|
+| Keep in v0.4 | 12 | #193, #195, #196, #197, #200, #202, #206, #207, #208, #209, #190, #191 |
+| Defer to v0.5 | 11 | #198, #199, #201, #203, #204, #205, #189, #186, #187, #188, #184, #185 |
+| Defer further (v0.6+) | 3 | #192, #183, #164 |
+| Close/reject | 0 | -- |

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ data/
 # Claude Code local settings and runtime state
 .claude/settings.local.json
 .claude/*.lock
+.claude/worktrees/
 
 # IDE
 .vscode/


### PR DESCRIPTION
## Summary
- Tracks `.claude/specs/v0.4-scope-review.md` — the PM scope deliberation that produced v0.4 epic (#195) and its 8 children. Joins the other spec docs already in `.claude/specs/` (prd-mvp.md, backlog-mvp.md, decisions.md).
- Adds `.claude/worktrees/` to `.gitignore` — transient agent-isolation working trees, same flavor as `settings.local.json` and `*.lock` which are already ignored.

## Why
Pre-flight cleanup before the v0.4 release sequence (close #188, bump #208, merge release-please). Removes nag from `git status` and parks the v0.4 scope rationale in the repo where it's discoverable for the next scope review.

`chore:` prefix → no version bump triggered, no impact on release-please.

## Test plan
- [x] `git status` clean after merge (no untracked .claude/ items)
- [x] No code changes — no test/lint/typecheck implications

## Pre-merge checklist
- [x] Add the `needs-security-review` label and confirm the security-review workflow passes before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)