### PR TITLE
feat(agents): add tester agent for fixing existing pytest failures

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,0 +1,165 @@
+---
+name: tester
+description: >
+  Invoke when one or more pytest tests are failing and the goal is to
+  diagnose and fix the failures. Returns the failure cause and either a
+  proposed minimal Edit (or applied fix) or a clear description of what's
+  wrong if the fix isn't safe to auto-apply. Do NOT invoke for: writing
+  new tests, designing test strategy, refactoring tests, fixing tests
+  that reflect intended new behavior changes, or chasing mypy/ruff/CI
+  failures (those belong to the parent thread). Do NOT invoke before
+  pytest has been run — if no failure has been observed yet, run pytest
+  in the parent thread first and report what failed.
+model: claude-sonnet-4-6
+tools:
+  - Read
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+disallowedTools:
+  - Write
+  - Agent
+  - WebFetch
+  - WebSearch
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+---
+
+You are a focused test-failure diagnostician for the AgentFluent Python
+codebase. Your job is to take a failing pytest run, identify the root
+cause, and either apply a minimal Edit that fixes the failure or
+report back with a precise description of what's wrong if the fix
+isn't safe to auto-apply.
+
+You do one thing well: **fix existing test failures.** You don't write
+new tests. You don't refactor. You don't chase scope. If you finish
+faster than expected, you stop and return — you don't fill the time
+exploring.
+
+## How to work
+
+When invoked, the parent thread should have already given you:
+- The failing test name(s) or pytest output
+- (Optional) hints about the suspected cause
+
+If the prompt doesn't include test output, run pytest yourself with
+the appropriate scope. Default to `uv run pytest -m "not integration"`
+unless the parent specifies otherwise.
+
+### The loop
+
+1. **Read the failing test** to understand the assertion that's
+   breaking. Read its surrounding fixtures if relevant.
+2. **Read the source under test.** The failure is almost always in one
+   of: the test (incorrect expectation), the source (real bug), or a
+   shared fixture (stale data).
+3. **Form a one-sentence diagnosis** of the root cause before editing
+   anything. If you can't, read more context — but bound exploration
+   to ~3 file reads. If you still can't diagnose, return with what
+   you've found.
+4. **Apply the minimum Edit.** Change the smallest amount of code that
+   makes the test pass. Resist the urge to "improve" surrounding code.
+5. **Re-run the failing test** to confirm. Use `uv run pytest <path>::<name>`
+   for fast feedback, then run the full unit suite if the targeted
+   test passes.
+6. **Return a concise summary.**
+
+### Stopping conditions
+
+You **must stop and return** in these cases:
+
+- Two consecutive fix attempts where the targeted test still fails after
+  re-running pytest. (An Edit that applies cleanly but doesn't make the
+  test pass counts — that's a misdiagnosis, not a tool failure.)
+- The failure traces to code that's clearly outside the agentfluent
+  package (e.g., a Pydantic version issue, a typer behavior change).
+- The "fix" would require changing more than ~20 lines, or touching
+  more than 2 files. That's a refactor, not a fix — return for the
+  parent thread to scope.
+- The test appears to encode intended **new** behavior (e.g., the
+  test was just written and is failing because the source hasn't been
+  updated yet). Return — don't change the test to match the source.
+- The failure is environmental (missing dependency, broken venv,
+  database not running). Report and stop.
+
+### Output format
+
+Return this structure to the parent thread:
+
+```
+DIAGNOSIS: <one sentence: what was wrong>
+ACTION: <APPLIED | PROPOSED | RETURNED>
+FILES: <list of files changed or that need attention>
+VERIFICATION: <what you ran to confirm, and the result>
+REASON: <only when ACTION is RETURNED — which stopping condition triggered>
+NOTES: <anything else the parent thread should know>
+```
+
+Use `APPLIED` when you fixed it and confirmed the test passes.
+Use `PROPOSED` when you have a fix but want sign-off (e.g., the change
+touches behavior, not just a typo).
+Use `RETURNED` when you stopped without fixing and need the parent to
+take over. Always include `REASON:` so the parent knows whether to retry
+with more context, escalate to a different agent, or take over directly.
+
+## Project conventions you must follow
+
+The AgentFluent codebase has strict conventions enforced by CI. Your
+fix must respect them:
+
+- **mypy --strict is enabled.** Type annotations are required on
+  public functions. Don't introduce `Any` unless there's no
+  alternative.
+- **Pydantic v2.** Models use `model_config = ConfigDict(extra="...")`.
+  Match the existing pattern in the file you're editing.
+- **Conventional Commits** for any commit messages: `fix:` for bug
+  fixes, `test:` for test-only changes. (You don't commit, but if you
+  describe a commit, use the right prefix.)
+- **No new comments** beyond what's already in the file unless the WHY
+  is genuinely non-obvious. The codebase favors descriptive names over
+  comments.
+- **Don't bypass hooks.** If a pre-commit hook fails, that's a real
+  problem to surface, not work around with `--no-verify`.
+
+## Tool use guidance
+
+- **Read** — for tests, source, and fixtures. Read the failing test
+  first, the source it tests second, and shared fixtures only if
+  needed.
+- **Grep** — for finding usages of a symbol or pattern across the
+  package. Prefer Grep over multiple Reads when chasing a definition.
+- **Edit** — for the minimal fix. One Edit per atomic change; if you
+  need multiple unrelated edits, you're probably out of scope.
+- **Bash** — for `uv run pytest <args>`. Don't run other shell
+  commands unless they're directly part of test verification (e.g.,
+  `uv run mypy <file>` to check that your fix doesn't break the
+  typecheck).
+
+## What "minimal fix" means
+
+A test failed because of one of these patterns. Match your fix to the
+pattern:
+
+- **Off-by-one or boundary bug** in source — fix the boundary.
+- **Stale assertion** in test that no longer matches reality — update
+  the assertion (only if the new behavior is clearly correct; otherwise
+  RETURNED).
+- **Missing case** in source — add the case.
+- **Fixture drift** — update the fixture in `tests/fixtures/` or
+  `tests/_builders.py` to match.
+- **Import error or missing symbol** — fix the import or the export.
+
+If the failure looks like none of these, you may be looking at a
+deeper issue. Diagnose, return, let the parent decide.
+
+## What you do not do
+
+- Write new test cases (different scope; needs a more capable model).
+- Refactor for readability or style.
+- "Improve" code that isn't part of the failing test path.
+- Change CI configuration, hooks, or dependency versions.
+- Fix mypy or ruff failures (they're separate loops).
+- Ask the user clarifying questions — diagnose what you can, return
+  with `RETURNED` if you can't.

--- a/.claude/specs/analysis/2026-04-29-agent-portfolio-analysis.md
+++ b/.claude/specs/analysis/2026-04-29-agent-portfolio-analysis.md
@@ -1,0 +1,299 @@
+# Agent Portfolio Analysis — agentfluent dogfood run
+
+**Date:** 2026-04-29
+**Author:** Claude (Opus 4.7) with Fred Pearce
+**Source:** `uv run agentfluent analyze --project agentfluent` against
+~/.claude/projects/-home-fdpearce-Documents-Projects-git-agentfluent
+**Sessions analyzed:** 11
+**agentfluent version:** v0.4.0 (`a299a8c`)
+
+## Purpose
+
+First dogfood run: use agentfluent's own output to identify high-leverage
+subagents to add to this project. Optimize for development workflow (cheaper,
+faster, more reliable) — not for marketing copy. The output of this run also
+serves as the baseline for measuring impact of subsequent agents we add.
+
+## Method
+
+Ran `analyze` and `analyze --json` against the `agentfluent` project.
+Cross-referenced top-level metrics, agent invocation breakdown, diagnostic
+signals, and clustering suggestions. Spot-checked verbose output for
+representative tool-use evidence.
+
+## Key numbers
+
+**Totals across 11 sessions:**
+
+- Total cost: **$861**
+- Total tokens: **1.33B**
+- API calls: **4,095**
+- Cache efficiency: **98.4%**
+
+**Token distribution (the headline finding):**
+
+- Parent thread: **~99.5%** of tokens (~$855)
+- Subagents combined: **~0.5%** (~$5 across 209 invocations)
+
+This shapes everything else. Subagent costs are not the cost story.
+
+**Agent breakdown:**
+
+| Agent | Calls | Tokens | Avg cost/call | Avg duration/call | tool_error_seqs | retry_loops |
+|---|---|---|---|---|---|---|
+| Explore (built-in) | 92 | 2.7M | $0.02 | 210s | **47** | 26 |
+| general-purpose (built-in) | 62 | 2.1M | $0.02 | 98s | 22 | **29** |
+| pm (custom, opus-4-6) | 26 | 1.1M | $0.03 | **999s** (~16min) | 7 | 5 |
+| architect (custom, opus-4-6) | 22 | 1.1M | $0.03 | 138s | 12 | 9 |
+| Plan (built-in) | 5 | 178k | $0.02 | 132s | 0 | 1 |
+| claude-code-guide (built-in) | 2 | 35k | $0.01 | 32s | 1 | 0 |
+
+**Diagnostic signal totals:**
+
+- 89 `tool_error_sequence`
+- 70 `retry_loop`
+- 15 `permission_failure`
+- 14 `token_outlier`
+- 11 `duration_outlier`
+- 1 `model_mismatch`
+
+**Top retry-prone tools (across all agents):**
+
+- `Read`: 41 retries (Explore=12, general-purpose=19, pm=4, architect=5, Plan=1)
+- `Bash`: 14 retries (mostly Explore=13)
+- `Edit`: 6 retries (general-purpose=6)
+- `mcp__github__get_issue`: 4 retries (architect=3, pm=1)
+
+**Strongest delegation cluster from the clustering pass:**
+
+- `tests-unit` — **medium** confidence, 6 invocations, tools: Bash, Edit, Glob, Grep, Read, Write
+- `py-src` — low, 14 invocations, broader Python source editing
+- `cost-pricing` — low, 5 invocations, includes WebFetch/WebSearch
+- `py-analytics` — low, 10, read-only investigation
+- `code-signal` — low, 10, read-only investigation
+
+## Honest read
+
+**The cost story this data tells is weak.** $5 of $861 is from subagents.
+Adding new subagents will not measurably reduce spend. Any "save N% on cost"
+narrative built on this dataset would collapse under scrutiny.
+
+**The wall-time and reliability story is real.** 70 retry loops + 89
+consecutive-error sequences = a meaningful amount of work happening
+twice. The `pm` agent averaging **16+ minutes per invocation** is the most
+striking single number in the output and deserves its own investigation.
+The aggregate effect on a developer's experience is "agents that feel slow
+or flaky" — and that's something an end-user will notice and care about.
+
+**The strongest delegation signal is `tests-unit`** (medium confidence, 6
+invocations). This is currently routing through `general-purpose`, which
+contributes disproportionately to the retry/error counts. Worth specializing.
+
+**The `py-src` cluster size (14) is the more interesting signal** even at
+low confidence. 14 recurring "edit Python source" invocations *in the
+parent thread* is why the parent dominates token spend. The biggest
+long-term lever may not be "create more subagent flavors" — it may be
+"delegate more of the work currently happening parent-thread."
+
+**`permission_failure` signals are noisy here.** Most "blocked" hits
+come from the secret-blocking PreToolUse hook (CLAUDE.md, see
+`.claude/hooks/block_secret_reads.py`). That's intended behavior, not a
+real failure. Worth filtering or annotating in a future agentfluent
+release.
+
+## Three nuances on the parent-thread offloading thesis
+
+The headline finding (parent thread = 99.5% of spend) suggests an obvious
+fix: offload more work to subagents on cheaper models. That's broadly
+correct but has three real tradeoffs worth surfacing before we act on
+the recommendations below:
+
+**1. Cache efficiency is a hidden tradeoff.** This session's 98.4% cache
+efficiency is exceptional — the parent thread reuses its prompt prefix
+tightly. Each subagent invocation starts fresh, paying full input rate
+on its own (smaller) prefix. Naively offloading many small tasks can
+lose more in cache hits than it saves in cheaper model rates. The win
+concentrates on **larger** offloaded tasks where work-per-call dwarfs
+the prompt-rebuild cost.
+
+**2. Wall-time is a separate axis from dollars.** Max and Pro plan users
+feel the wall-time cost of slow agents but not the dollar cost. API,
+Bedrock, and Vertex users feel both. Same offloading techniques have
+different value props for different audiences. The recommendations and
+narrative should treat these separately.
+
+**3. Delegation has a fixed parent-thread tax.** Every Agent invocation
+costs the parent: the delegation prompt + the returned summary land in
+parent context. For very small tasks (run a one-line bash command, read
+a single file), that tax exceeds the benefit. There's a "right size"
+floor for offloading; below it, parent-thread is the correct choice.
+
+## Recommendations
+
+### Agent 1: `tester` — fix existing test failures (claude-sonnet-4-6)
+
+The strongest signal in the output. Six clustered invocations in
+test-running territory; today they route to `general-purpose` and
+contribute to its 22 tool_error_sequences and 29 retry_loops.
+
+**Scope:** fix existing test failures only. Run pytest, parse the
+failure, read the relevant test + source, propose a minimal Edit. Does
+NOT write new tests (that's a wider scope that needs a more capable
+model and forecloses the eventual Haiku downgrade we want to leave
+open).
+
+**Tools:** `Read, Edit, Bash, Grep` (no Write).
+
+**Model:** `claude-sonnet-4-6` initially. The codebase is Python with
+`mypy --strict` — failure diagnosis sometimes requires reading complex
+type errors. Start conservative; let agentfluent's `model_mismatch`
+signal tell us to downgrade to Haiku once we have observation data.
+
+**Why it'll help:** narrower scope → fewer wandering Read/Glob retries
+on the unit-test path → less wall-time per loop. Cost-side: shifts
+test-loop work from Opus-via-general-purpose to Sonnet-via-tester,
+which is also a meaningful (if small) win.
+
+**Why tester is well-sized for offloading** (per the tradeoffs above):
+test loops involve multiple Read+Bash+Edit cycles per invocation, easily
+clearing the delegation tax. Each test failure is also its own
+relatively contained context, so cache loss vs the parent thread is
+minimal. Both alignments mean tester should produce a measurable
+parent-thread reduction without falling into the small-task trap.
+
+**What to measure (next agentfluent run, after using `tester` for
+several test loops):**
+
+- `general-purpose` invocation count: should drop
+- `tester` should appear with low retry_loop / tool_error_sequence
+  counts (target: zero, realistic: <2)
+- `tester` avg_duration should be substantially below the current
+  general-purpose avg of 98s on test workflows
+- Watch for `model_mismatch: overspec` on `tester` after 3+ invocations
+  — that's the Haiku-downgrade signal
+
+### Agent 2: `gh-watcher` — poll for CI completion (claude-haiku-4-5)
+
+Observed directly in this session: `gh pr checks --watch` polling for
+5+ minutes while the parent thread sat idle and burned cache TTL. Real
+pattern, recurring, doesn't fit any existing agent.
+
+**Scope:** Watch a PR's CI checks until pass/fail and return a concise
+summary. Owns the polling loop so the parent thread can keep working.
+
+**Tools:** `Bash, ScheduleWakeup` (gh-only Bash + sleep — no edit
+surface, minimal blast radius).
+
+**Model:** `claude-haiku-4-5`. Pure I/O orchestration; Haiku is the
+right tier.
+
+**Why it'll help:** parent thread is your most expensive token consumer
+($855 of $861). Anything that lets it work in parallel with CI is
+high-leverage. Different value than `tester`: this saves wall-time and
+parent-thread tokens, where `tester` saves subagent retry waste.
+
+**What to measure:** parent-thread cache_efficiency on PR-cutting
+sessions (should rise — fewer TTL expirations from idle waits).
+
+### Not-a-new-agent recommendation: delegate more `py-src` work
+
+The `py-src` cluster (14 invocations) tells us recurring Python source
+editing is happening parent-thread. This is why parent-thread tokens
+dominate. A focused `py-src` agent on Sonnet 4.6 with
+`[Read, Edit, Grep, Glob, Bash]` would shift the work off the parent.
+
+Holding off until `tester` and `gh-watcher` performance data is in.
+Adding too many agents at once makes attribution impossible.
+
+## Decisions made this session
+
+- **Sequence:** one agent at a time. Build `tester` first; observe for
+  ~1 week of normal use; re-run agentfluent; assess; then build
+  `gh-watcher`. Single-axis change keeps the diff between agentfluent
+  runs interpretable.
+- **`tester` model:** start at Sonnet 4.6, plan to downgrade to Haiku
+  if `model_mismatch: overspec` fires after enough observations.
+- **`tester` scope:** fix existing failures only. No new test
+  authorship.
+- **Doc location:** `.claude/specs/analysis/<date>-*.md`. New
+  subfolder under specs for analysis snapshots; keeps the existing
+  PRD/backlog/decisions structure clean.
+
+## Open questions / followups
+
+- **Why does `pm` average 999s/call?** Worth a per-invocation drill-down
+  separate from this analysis. Could be: (a) genuinely heavy PM tasks,
+  (b) wasted exploration cycles, (c) waiting on user clarification mid-
+  invocation. Currently flagged as a duration_outlier with model
+  recommendation; the model isn't necessarily the issue.
+- **Filtering hook-induced `permission_failure` noise.** The "blocked"
+  signals from the secret-reads hook are intended behavior. Should
+  agentfluent learn to recognize these and downgrade severity / hide
+  by default? Possible v0.5 issue.
+- **`py-src` delegation.** Defer until tester + gh-watcher land and we
+  have a sense of the real impact. If they help meaningfully,
+  py-src delegation is the obvious next step.
+- **Calibration follow-up:** after `tester` is in use, this is a real
+  data point for `model_routing` calibration (#140). The complexity
+  classifier currently classifies every observed agent as "complex" on
+  v0.3 single-dataset calibration — `tester` should classify as
+  "simple" or "moderate" if the thresholds are set sensibly.
+- **Cross-project validation of the parent-thread thesis.** The 99.5%
+  parent-share number is one data point from one developer's workflow.
+  Worth running agentfluent on:
+  - `codefluent` (already in `~/.claude/projects/`, 11 sessions) — same
+    developer, different project. Tests "is this Fred-specific or
+    workflow-stable?"
+  - `sportswear-esg-news-classifier`
+    (`~/Documents/Courses/DataTalksClub/projects/`) — different domain
+    (ML / ESG news classification), pre-subagent maturity stage (no
+    custom agents yet). Tests the thesis at a different point on the
+    developer-tooling adoption curve. Likely shows the thesis even more
+    starkly (no subagents = 100% parent thread by definition).
+
+  Each cross-project run is a chance to refine: where does 99.5%
+  generalize, where doesn't it? Either outcome strengthens the
+  eventual narrative.
+
+## Marketing notes (out of scope, for the eventual blog post)
+
+The product narrative the data supports is **not** "save 50% on cost."
+It's "see what your delegation is silently wasting." The output above is
+genuinely useful in a way developers don't currently have access to —
+nobody's `pm` agent averaging 16 minutes/call gets surfaced anywhere
+else. That's the pitch.
+
+**The parent-thread-bloat angle is the most generalizable thesis.**
+Most Claude Code users (especially newer ones) don't use subagents
+at all, which means 100% of their spend is parent-thread. The story
+"the parent thread is silently expensive — here's how to see what
+your subagents *aren't* doing yet" probably resonates with the
+average user, not just power users. Worth developing further with
+cross-project validation.
+
+**Audience nuance for the dollar-savings sub-narrative.** The
+"save real money" framing applies most cleanly to:
+
+- API customers (paying per-token via Anthropic API)
+- Bedrock and Vertex customers (per-token via cloud bills)
+
+It applies less directly to:
+
+- Pro and Max plan users — feel wall-time cost, not dollar cost
+- Enterprise plans — vary; some seat-based, some token-based
+
+The wall-time-and-reliability angle is the *universal* one. Lead with
+that for broad audiences; lead with dollars when targeting the
+budget-sensitive subset (e.g., engineering leads at API-billed orgs).
+
+Concrete write-up worth doing once `tester` and `gh-watcher` have a few
+weeks of data:
+
+- Before/after retry rates on `general-purpose`
+- Before/after parent-thread token share (target: meaningful drop)
+- Real wall-time savings from `gh-watcher`
+- The story of *what* surfaced in the agentfluent output that we
+  didn't already know — e.g., `pm` duration outlier was genuinely
+  surprising
+
+That's a Show HN-shaped post with verifiable numbers.

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Adds project-scope `tester` agent at `.claude/agents/tester.md` — diagnoses and fixes existing pytest failures, returns minimal Edits, refuses scope creep into new test authorship, mypy/ruff/CI failures, or refactoring.
- Adds the dogfood analysis at `.claude/specs/analysis/2026-04-29-agent-portfolio-analysis.md` that drove this design: 99.5% of tokens parent-thread, three offloading tradeoffs (cache, wall-time vs dollars, delegation tax), and the sequence plan for follow-on agents.
- Mechanical `uv.lock` catch-up to v0.4.0.

## Why this agent first

`agentfluent analyze` flagged a `tests-unit` cluster (medium confidence, 6 invocations) currently routing through `general-purpose`, which contributes disproportionately to its 22 tool_error_sequences and 29 retry_loops. Test loops are well-sized for offloading — multiple Read+Bash+Edit cycles per invocation clear the delegation tax, and per-failure context means cache loss is minimal.

## Design decisions

- **Model: claude-sonnet-4-6** initially. Python codebase with `mypy --strict` sometimes needs to read complex type errors. Plan: downgrade to Haiku 4.5 if `model_mismatch: overspec` fires after observation.
- **Scope: fix existing failures only.** No new test authorship — keeps the work mechanical and leaves the Haiku-downgrade path open. New tests need more reasoning than fixes.
- **Tools: Read, Edit, Bash, Grep, Glob.** No Write. Disallowed: Write, Agent, WebFetch, WebSearch, TaskCreate/Update/List.
- **Project-scope** (not user-scope), because conventions (mypy strict, pytest invocation, Pydantic v2 patterns) are codebase-specific.

## Architect review

Reviewed before commit. Two important concerns addressed:

- Glob added to tools list (was incorrectly omitted; the cluster data showed it was in actual use).
- "Two consecutive failed Edits" stopping condition reworded to disambiguate "Edit tool error" vs "test still fails after re-run" — the latter is the intended trigger.

One suggestion taken: added `REASON:` field to RETURNED output so the parent thread knows which stopping condition fired.

## What we'll measure

After using `tester` for a few days of normal test loops, re-run agentfluent and look for:

- Drop in `general-purpose` invocation count
- `tester` retry_loops / tool_error_sequences low (target: zero, realistic: <2)
- `tester` avg_duration well below current general-purpose 98s/call
- `model_mismatch: overspec` on `tester` after 3+ invocations → Haiku-downgrade signal

## Test plan
- [x] No code changes — no test/lint/typecheck implications
- [x] Agent file is markdown-only; CI's existing `check` workflow validates nothing breaks
- [ ] Manual smoke test on next pytest failure to confirm the agent fires for the right delegation prompts and refuses out-of-scope work

## Pre-merge checklist
- [x] Add the `needs-security-review` label and confirm the security-review workflow passes before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)