### PR TITLE
feat(diagnostics): subtract idle gaps from duration for outlier detection (#230)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -197,9 +197,27 @@ Agent 'Explore' has 40,288 tokens/tool_use, 8.0x above the 5,064 mean.
 **Short:** An invocation takes far longer per tool call than the agent's typical run.
 
 **Detail:** Same threshold as `token_outlier` (`OUTLIER_THRESHOLD = 2.0x` the
-per-agent mean) but on `duration_per_tool_use`. Often co-occurs with
-`token_outlier`. When it appears alone, the agent is making slow tool
-calls (network latency, large file reads) rather than over-thinking.
+per-agent mean) but on `active_duration_per_tool_use` --
+wall-clock duration with detected idle gaps subtracted. Often
+co-occurs with `token_outlier`. When it appears alone, the agent
+is making slow tool calls (network latency, large file reads)
+rather than over-thinking.
+
+**Active vs wall-clock duration (#230).** When a tool call sits
+pending user approval -- the IDE prompts to allow a `Write`, an
+MCP call, etc., and the user is AFK -- the wall-clock duration
+inflates without any agent work happening. AgentFluent detects
+these idle periods per-trace
+(`gap > max(10 * median, 5 minutes)`) and exposes both
+`duration_ms` (raw wall-clock) and `active_duration_ms` (idle
+subtracted) on subagent traces. Outlier detection uses the
+active variant when a trace is linked, so an agent that "looked
+slow" only because the user was away no longer false-positive
+flags. When no trace is linked (older sessions), detection
+falls back to raw `duration_per_tool_use`. The Claude Code JSONL
+has no native marker for approval-pending state -- see
+`anthropics/claude-code#55240` for the upstream proposal that
+would replace the heuristic with structural detection.
 
 **Example:**
 
@@ -209,7 +227,7 @@ Agent 'pm' has 45.2s/tool_use, 3.1x above the 14.6s mean.
 
 **Severity:** warning
 
-**Threshold:** 2.0x mean (OUTLIER_THRESHOLD)
+**Threshold:** 2.0x mean (OUTLIER_THRESHOLD), computed on active_duration_per_tool_use
 
 **Recommendation target:** `prompt`
 

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -107,17 +107,19 @@ class AgentInvocation(BaseModel):
         return None
 
     @property
+    def idle_gap_ms(self) -> int | None:
+        """Idle time deducted to compute ``active_duration_ms``. ``None``
+        when no trace is linked or the trace couldn't compute it."""
+        if self.trace is None:
+            return None
+        return self.trace.idle_gap_ms
+
+    @property
     def active_duration_ms(self) -> int | None:
         """Wall-clock duration with detected idle gaps subtracted.
 
-        Delegates to the linked subagent trace's ``active_duration_ms``
-        when available. Returns ``None`` when no trace is linked or the
-        trace lacked the timestamp data needed to compute idle gaps —
-        callers should fall back to ``duration_ms`` in that case.
-
-        See ``traces.parser._compute_idle_gap_ms`` for the heuristic and
-        ``scripts/calibration/threshold_validation.ipynb`` Section 11
-        for the empirical justification.
+        ``None`` when no trace is linked or the trace lacked timestamp
+        data; callers should fall back to ``duration_ms`` in that case.
         """
         if self.trace is None:
             return None
@@ -125,14 +127,8 @@ class AgentInvocation(BaseModel):
 
     @property
     def active_duration_per_tool_use(self) -> float | None:
-        """Average active duration (ms) per tool call.
-
-        Prefers the trace's ``active_duration_ms`` (idle gaps removed);
-        falls back to ``duration_per_tool_use`` (raw wall-clock) when
-        no trace is linked. Outlier detection should call this rather
-        than ``duration_per_tool_use`` to avoid attributing user-input
-        wait time to agent work (#230).
-        """
+        """Average active duration (ms) per tool call. Falls back to
+        ``duration_per_tool_use`` when no trace is linked."""
         active = self.active_duration_ms
         if active is not None and self.tool_uses and self.tool_uses > 0:
             return active / self.tool_uses

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -105,3 +105,35 @@ class AgentInvocation(BaseModel):
         if self.duration_ms is not None and self.tool_uses and self.tool_uses > 0:
             return self.duration_ms / self.tool_uses
         return None
+
+    @property
+    def active_duration_ms(self) -> int | None:
+        """Wall-clock duration with detected idle gaps subtracted.
+
+        Delegates to the linked subagent trace's ``active_duration_ms``
+        when available. Returns ``None`` when no trace is linked or the
+        trace lacked the timestamp data needed to compute idle gaps —
+        callers should fall back to ``duration_ms`` in that case.
+
+        See ``traces.parser._compute_idle_gap_ms`` for the heuristic and
+        ``scripts/calibration/threshold_validation.ipynb`` Section 11
+        for the empirical justification.
+        """
+        if self.trace is None:
+            return None
+        return self.trace.active_duration_ms
+
+    @property
+    def active_duration_per_tool_use(self) -> float | None:
+        """Average active duration (ms) per tool call.
+
+        Prefers the trace's ``active_duration_ms`` (idle gaps removed);
+        falls back to ``duration_per_tool_use`` (raw wall-clock) when
+        no trace is linked. Outlier detection should call this rather
+        than ``duration_per_tool_use`` to avoid attributing user-input
+        wait time to agent work (#230).
+        """
+        active = self.active_duration_ms
+        if active is not None and self.tool_uses and self.tool_uses > 0:
+            return active / self.tool_uses
+        return self.duration_per_tool_use

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -232,15 +232,16 @@ def format_analysis_table(
             for inv in s.invocations:
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
                 tools = str(inv.tool_uses) if inv.tool_uses else "-"
-                # Display "active (wall)" when active duration is meaningfully
-                # less than wall-clock — surfaces approval-wait time without
-                # cluttering the row when no idle gap was detected.
+                # Display "active (wall)" when the trace flagged real idle
+                # time (>0 ms). Comparing inv.active_duration_ms vs
+                # inv.duration_ms directly produces false positives — the
+                # two come from different sources (trace JSONL timestamps
+                # vs parent toolUseResult.totalDurationMs) and disagree by
+                # a few ms even when no idle was detected.
+                idle_ms = inv.trace.idle_gap_ms if inv.trace is not None else None
                 if inv.duration_ms is None:
                     duration = "-"
-                elif (
-                    inv.active_duration_ms is not None
-                    and inv.active_duration_ms < inv.duration_ms
-                ):
+                elif idle_ms and idle_ms > 0 and inv.active_duration_ms is not None:
                     duration = (
                         f"{inv.active_duration_ms / 1000:.1f}s "
                         f"({inv.duration_ms / 1000:.1f}s wall)"

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -232,7 +232,21 @@ def format_analysis_table(
             for inv in s.invocations:
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
                 tools = str(inv.tool_uses) if inv.tool_uses else "-"
-                duration = f"{inv.duration_ms / 1000:.1f}s" if inv.duration_ms else "-"
+                # Display "active (wall)" when active duration is meaningfully
+                # less than wall-clock — surfaces approval-wait time without
+                # cluttering the row when no idle gap was detected.
+                if inv.duration_ms is None:
+                    duration = "-"
+                elif (
+                    inv.active_duration_ms is not None
+                    and inv.active_duration_ms < inv.duration_ms
+                ):
+                    duration = (
+                        f"{inv.active_duration_ms / 1000:.1f}s "
+                        f"({inv.duration_ms / 1000:.1f}s wall)"
+                    )
+                else:
+                    duration = f"{inv.duration_ms / 1000:.1f}s"
                 desc = truncate(inv.description, 60)
                 inv_table.add_row(
                     escape(inv.agent_type),

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -232,16 +232,13 @@ def format_analysis_table(
             for inv in s.invocations:
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
                 tools = str(inv.tool_uses) if inv.tool_uses else "-"
-                # Display "active (wall)" when the trace flagged real idle
-                # time (>0 ms). Comparing inv.active_duration_ms vs
-                # inv.duration_ms directly produces false positives — the
-                # two come from different sources (trace JSONL timestamps
-                # vs parent toolUseResult.totalDurationMs) and disagree by
-                # a few ms even when no idle was detected.
-                idle_ms = inv.trace.idle_gap_ms if inv.trace is not None else None
+                # Gate on idle_gap_ms, not (active vs duration) diff:
+                # the two come from different sources (JSONL timestamps
+                # vs parent toolUseResult) and disagree by ~ms even when
+                # no idle was detected.
                 if inv.duration_ms is None:
                     duration = "-"
-                elif idle_ms and idle_ms > 0 and inv.active_duration_ms is not None:
+                elif inv.idle_gap_ms and inv.active_duration_ms is not None:
                     duration = (
                         f"{inv.active_duration_ms / 1000:.1f}s "
                         f"({inv.duration_ms / 1000:.1f}s wall)"

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -114,12 +114,18 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
 
 
 def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
-    """Detect invocations with unusually high duration."""
+    """Detect invocations with unusually high duration.
+
+    Uses ``active_duration_per_tool_use`` (idle gaps removed when a
+    subagent trace is linked) so user-approval wait time isn't
+    attributed to the agent. Falls back to raw ``duration_per_tool_use``
+    on invocations without trace data (#230).
+    """
     signals: list[DiagnosticSignal] = []
 
     by_type: dict[str, list[AgentInvocation]] = defaultdict(list)
     for inv in invocations:
-        if inv.duration_per_tool_use is not None:
+        if inv.active_duration_per_tool_use is not None:
             by_type[inv.agent_type.lower()].append(inv)
 
     for agent_type, group in by_type.items():
@@ -127,12 +133,14 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
             continue
 
         values = [
-            inv.duration_per_tool_use for inv in group if inv.duration_per_tool_use is not None
+            inv.active_duration_per_tool_use
+            for inv in group
+            if inv.active_duration_per_tool_use is not None
         ]
         mean = sum(values) / len(values)
 
         for inv in group:
-            val = inv.duration_per_tool_use
+            val = inv.active_duration_per_tool_use
             if val is not None and val > mean * OUTLIER_THRESHOLD:
                 signals.append(DiagnosticSignal(
                     signal_type=SignalType.DURATION_OUTLIER,

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -114,12 +114,10 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
 
 
 def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
-    """Detect invocations with unusually high duration.
+    """Detect invocations with unusually high active duration per tool call.
 
-    Uses ``active_duration_per_tool_use`` (idle gaps removed when a
-    subagent trace is linked) so user-approval wait time isn't
-    attributed to the agent. Falls back to raw ``duration_per_tool_use``
-    on invocations without trace data (#230).
+    Uses ``active_duration_per_tool_use`` so user-approval wait time
+    isn't attributed to the agent.
     """
     signals: list[DiagnosticSignal] = []
 

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -145,12 +145,30 @@
     An invocation takes far longer per tool call than the agent's typical run.
   long: |
     Same threshold as `token_outlier` (`OUTLIER_THRESHOLD = 2.0x` the
-    per-agent mean) but on `duration_per_tool_use`. Often co-occurs with
-    `token_outlier`. When it appears alone, the agent is making slow tool
-    calls (network latency, large file reads) rather than over-thinking.
+    per-agent mean) but on `active_duration_per_tool_use` --
+    wall-clock duration with detected idle gaps subtracted. Often
+    co-occurs with `token_outlier`. When it appears alone, the agent
+    is making slow tool calls (network latency, large file reads)
+    rather than over-thinking.
+
+    **Active vs wall-clock duration (#230).** When a tool call sits
+    pending user approval -- the IDE prompts to allow a `Write`, an
+    MCP call, etc., and the user is AFK -- the wall-clock duration
+    inflates without any agent work happening. AgentFluent detects
+    these idle periods per-trace
+    (`gap > max(10 * median, 5 minutes)`) and exposes both
+    `duration_ms` (raw wall-clock) and `active_duration_ms` (idle
+    subtracted) on subagent traces. Outlier detection uses the
+    active variant when a trace is linked, so an agent that "looked
+    slow" only because the user was away no longer false-positive
+    flags. When no trace is linked (older sessions), detection
+    falls back to raw `duration_per_tool_use`. The Claude Code JSONL
+    has no native marker for approval-pending state -- see
+    `anthropics/claude-code#55240` for the upstream proposal that
+    would replace the heuristic with structural detection.
   example: "Agent 'pm' has 45.2s/tool_use, 3.1x above the 14.6s mean."
   severity_range: warning
-  threshold: 2.0x mean (OUTLIER_THRESHOLD)
+  threshold: 2.0x mean (OUTLIER_THRESHOLD), computed on active_duration_per_tool_use
   recommendation_target: prompt
   related: [token_outlier, model_mismatch]
 

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -38,6 +38,13 @@ class SubagentToolCall(BaseModel):
     ``RESULT_SUMMARY_MAX_CHARS`` constants; the model itself does not
     enforce those limits so fixtures and replay tools can construct
     untruncated instances.
+
+    ``timestamp`` is the assistant ``tool_use`` message timestamp;
+    ``result_timestamp`` is the matching user ``tool_result`` message
+    timestamp. Both Optional because: pre-trace-capture sessions, the
+    pairing miss case, and programmatically-constructed instances.
+    The pair is what enables idle-gap detection (#230) — the gap
+    between them is the per-call elapsed time observable in the JSONL.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -48,6 +55,7 @@ class SubagentToolCall(BaseModel):
     is_error: bool = False
     usage: Usage = Field(default_factory=Usage)
     timestamp: datetime | None = None
+    result_timestamp: datetime | None = None
 
 
 class RetrySequence(BaseModel):
@@ -103,6 +111,21 @@ class SubagentTrace(BaseModel):
     total_retries: int = 0
     usage: Usage = Field(default_factory=Usage)
     duration_ms: int | None = None
+    idle_gap_ms: int | None = None
+    """Sum of per-call gaps flagged as idle by the per-trace heuristic
+    in ``traces.parser._compute_idle_gap_ms`` (#230). ``None`` when no
+    paired tool calls have both timestamps; ``0`` when computable but
+    no gap met the threshold. The Claude Code JSONL has no marker for
+    the wait condition, so this is structurally a workaround — see
+    ``anthropics/claude-code#55240`` for the upstream proposal that
+    would make this unnecessary."""
+
+    active_duration_ms: int | None = None
+    """``duration_ms - idle_gap_ms`` when both are populated; ``None``
+    otherwise. Downstream consumers (e.g., outlier detection) should
+    prefer this over ``duration_ms`` to avoid attributing user-input
+    wait time to agent work."""
+
     source_file: Path | None = None
 
     model: str | None = None

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from agentfluent.core.session import Usage
 
@@ -43,8 +43,6 @@ class SubagentToolCall(BaseModel):
     ``result_timestamp`` is the matching user ``tool_result`` message
     timestamp. Both Optional because: pre-trace-capture sessions, the
     pairing miss case, and programmatically-constructed instances.
-    The pair is what enables idle-gap detection (#230) — the gap
-    between them is the per-call elapsed time observable in the JSONL.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -112,19 +110,9 @@ class SubagentTrace(BaseModel):
     usage: Usage = Field(default_factory=Usage)
     duration_ms: int | None = None
     idle_gap_ms: int | None = None
-    """Sum of per-call gaps flagged as idle by the per-trace heuristic
-    in ``traces.parser._compute_idle_gap_ms`` (#230). ``None`` when no
-    paired tool calls have both timestamps; ``0`` when computable but
-    no gap met the threshold. The Claude Code JSONL has no marker for
-    the wait condition, so this is structurally a workaround — see
-    ``anthropics/claude-code#55240`` for the upstream proposal that
-    would make this unnecessary."""
-
-    active_duration_ms: int | None = None
-    """``duration_ms - idle_gap_ms`` when both are populated; ``None``
-    otherwise. Downstream consumers (e.g., outlier detection) should
-    prefer this over ``duration_ms`` to avoid attributing user-input
-    wait time to agent work."""
+    """Sum of per-call gaps flagged as idle by ``traces.parser._compute_idle_gap_ms``.
+    ``None`` when fewer than two paired tool calls have both timestamps;
+    ``0`` when computable but no gap met the threshold."""
 
     source_file: Path | None = None
 
@@ -136,6 +124,20 @@ class SubagentTrace(BaseModel):
     when the agent's ``AgentConfig`` doesn't declare a model explicitly —
     which is the common case for Claude Code subagents that inherit the
     parent session's model."""
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def active_duration_ms(self) -> int | None:
+        """Wall-clock duration with detected idle gaps subtracted.
+
+        ``None`` when ``duration_ms`` or ``idle_gap_ms`` is ``None``.
+        Clamped at zero to guard against any pathological case where
+        summed idle gaps exceed wall-clock span (overlapping calls,
+        clock skew, future heuristic changes).
+        """
+        if self.duration_ms is None or self.idle_gap_ms is None:
+            return None
+        return max(self.duration_ms - self.idle_gap_ms, 0)
 
     @cached_property
     def unique_tool_names(self) -> set[str]:

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -22,6 +22,7 @@ populates ``retry_sequences`` / ``total_retries`` before returning.
 from __future__ import annotations
 
 import json
+import statistics
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,22 @@ from agentfluent.traces.models import (
     SubagentTrace,
 )
 from agentfluent.traces.retry import detect_retry_sequences
+
+# Idle-gap heuristic constants (#230). A per-call gap (tool_use to
+# tool_result) is flagged as idle when:
+#   gap_ms > max(IDLE_GAP_K * median(all_gaps_in_trace), IDLE_GAP_FLOOR_MS)
+#
+# Empirical justification lives in scripts/calibration/threshold_validation.ipynb
+# Section 11. At the chosen values, all 12 obviously-stuck traces in the
+# v0.4.0 dogfood dataset are caught (100% recall). Floor anchors on the
+# prompt-cache TTL boundary; k forward-protects against future workloads
+# with higher baseline tool latency.
+#
+# The Claude Code JSONL has no structural marker for approval-pending
+# state — see anthropics/claude-code#55240 for the upstream proposal
+# that would let us replace the heuristic with structural detection.
+IDLE_GAP_K = 10
+IDLE_GAP_FLOOR_MS = 300_000  # 5 minutes
 
 
 def _truncate_input(input_dict: dict[str, Any] | None) -> str:
@@ -114,18 +131,24 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
     blocks (in user messages) by ``tool_use_id`` and build
     ``SubagentToolCall`` entries.
 
+    ``timestamp`` is sourced from the assistant ``tool_use`` message;
+    ``result_timestamp`` from the user ``tool_result`` message. The
+    pair enables per-call elapsed-time computation, which the
+    ``_compute_idle_gap_ms`` heuristic uses to flag approval-wait
+    intervals (#230).
+
     Per-call ``Usage`` is left at default zero: the JSONL shape provides
     one ``usage`` per assistant message but a single message can carry
     multiple ``tool_use`` blocks, so faithful per-call token attribution
     is not possible. Trace-level ``usage`` is the source of truth.
     """
-    results: dict[str, ContentBlock] = {}
+    results: dict[str, tuple[ContentBlock, SessionMessage]] = {}
     for msg in messages:
         if msg.type != "user":
             continue
         for block in msg.content_blocks:
             if block.type == "tool_result" and block.tool_use_id:
-                results[block.tool_use_id] = block
+                results[block.tool_use_id] = (block, msg)
 
     tool_calls: list[SubagentToolCall] = []
     for msg in messages:
@@ -134,9 +157,16 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
         for block in msg.content_blocks:
             if block.type != "tool_use" or block.id is None:
                 continue
-            result_block = results.get(block.id)
-            is_error = _detect_is_error(result_block) if result_block else False
-            result_text = result_block.text if result_block else None
+            entry = results.get(block.id)
+            if entry is not None:
+                result_block, result_msg = entry
+                is_error = _detect_is_error(result_block)
+                result_text = result_block.text
+                result_ts = result_msg.timestamp
+            else:
+                is_error = False
+                result_text = None
+                result_ts = None
             tool_calls.append(
                 SubagentToolCall(
                     tool_name=block.name or "",
@@ -144,9 +174,45 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
                     result_summary=_truncate_result(result_text),
                     is_error=is_error,
                     timestamp=msg.timestamp,
+                    result_timestamp=result_ts,
                 ),
             )
     return tool_calls
+
+
+def _compute_idle_gap_ms(tool_calls: list[SubagentToolCall]) -> int | None:
+    """Sum per-call gaps (``tool_use`` to ``tool_result``) flagged as idle.
+
+    Per-trace self-calibrating heuristic: a gap is idle when it exceeds
+    both ``IDLE_GAP_K × median(all_gaps_in_trace)`` and the absolute
+    ``IDLE_GAP_FLOOR_MS`` (whichever is larger). Returns ``None`` when
+    fewer than two paired calls have both timestamps — too little data
+    to compute a meaningful per-trace median, and a single isolated
+    long gap can't be distinguished from "this is just how slow this
+    tool runs" without context.
+
+    The JSONL has no marker for the wait condition; see the module
+    docstring's reference to anthropics/claude-code#55240 for the
+    upstream proposal that would replace this with structural detection.
+    """
+    gaps_ms: list[float] = []
+    for tc in tool_calls:
+        if tc.timestamp is None or tc.result_timestamp is None:
+            continue
+        delta = (tc.result_timestamp - tc.timestamp).total_seconds() * 1000
+        if delta < 0:
+            # Out-of-order timestamps (clock skew, parsing artifact);
+            # don't synthesize work that didn't happen.
+            continue
+        gaps_ms.append(delta)
+
+    if len(gaps_ms) < 2:
+        return None
+
+    median_gap = statistics.median(gaps_ms)
+    threshold = max(IDLE_GAP_K * median_gap, float(IDLE_GAP_FLOOR_MS))
+    idle_total = sum(g for g in gaps_ms if g > threshold)
+    return int(round(idle_total))
 
 
 def parse_subagent_trace(path: Path) -> SubagentTrace:
@@ -176,6 +242,13 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
     messages = parse_session(path)
     tool_calls = _pair_tool_calls(messages)
     retry_sequences = detect_retry_sequences(tool_calls)
+    duration_ms = _compute_duration_ms(messages)
+    idle_gap_ms = _compute_idle_gap_ms(tool_calls)
+    active_duration_ms = (
+        max(duration_ms - idle_gap_ms, 0)
+        if duration_ms is not None and idle_gap_ms is not None
+        else None
+    )
 
     return SubagentTrace(
         agent_id=agent_id,
@@ -186,7 +259,9 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
         total_errors=sum(1 for tc in tool_calls if tc.is_error),
         total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
         usage=_sum_usage(messages),
-        duration_ms=_compute_duration_ms(messages),
+        duration_ms=duration_ms,
+        idle_gap_ms=idle_gap_ms,
+        active_duration_ms=active_duration_ms,
         source_file=path.resolve(),
         model=_first_assistant_model(messages),
     )

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import statistics
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -39,21 +40,14 @@ from agentfluent.traces.models import (
 )
 from agentfluent.traces.retry import detect_retry_sequences
 
-# Idle-gap heuristic constants (#230). A per-call gap (tool_use to
-# tool_result) is flagged as idle when:
-#   gap_ms > max(IDLE_GAP_K * median(all_gaps_in_trace), IDLE_GAP_FLOOR_MS)
-#
-# Empirical justification lives in scripts/calibration/threshold_validation.ipynb
-# Section 11. At the chosen values, all 12 obviously-stuck traces in the
-# v0.4.0 dogfood dataset are caught (100% recall). Floor anchors on the
-# prompt-cache TTL boundary; k forward-protects against future workloads
-# with higher baseline tool latency.
-#
-# The Claude Code JSONL has no structural marker for approval-pending
-# state — see anthropics/claude-code#55240 for the upstream proposal
-# that would let us replace the heuristic with structural detection.
+# Idle-gap heuristic: a per-call (tool_use → tool_result) gap counts
+# as idle when gap_ms > max(IDLE_GAP_K * median_gap_in_trace, IDLE_GAP_FLOOR_MS).
+# Calibrated in scripts/calibration/threshold_validation.ipynb §11
+# (100% recall on 12 stuck traces in v0.4.0 dogfood data). Floor
+# anchors on the 5-min prompt-cache TTL boundary; k forward-protects
+# against future workloads with higher baseline tool latency.
 IDLE_GAP_K = 10
-IDLE_GAP_FLOOR_MS = 300_000  # 5 minutes
+IDLE_GAP_FLOOR_MS = 300_000
 
 
 def _truncate_input(input_dict: dict[str, Any] | None) -> str:
@@ -131,24 +125,18 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
     blocks (in user messages) by ``tool_use_id`` and build
     ``SubagentToolCall`` entries.
 
-    ``timestamp`` is sourced from the assistant ``tool_use`` message;
-    ``result_timestamp`` from the user ``tool_result`` message. The
-    pair enables per-call elapsed-time computation, which the
-    ``_compute_idle_gap_ms`` heuristic uses to flag approval-wait
-    intervals (#230).
-
     Per-call ``Usage`` is left at default zero: the JSONL shape provides
     one ``usage`` per assistant message but a single message can carry
     multiple ``tool_use`` blocks, so faithful per-call token attribution
     is not possible. Trace-level ``usage`` is the source of truth.
     """
-    results: dict[str, tuple[ContentBlock, SessionMessage]] = {}
+    results: dict[str, tuple[ContentBlock, datetime | None]] = {}
     for msg in messages:
         if msg.type != "user":
             continue
         for block in msg.content_blocks:
             if block.type == "tool_result" and block.tool_use_id:
-                results[block.tool_use_id] = (block, msg)
+                results[block.tool_use_id] = (block, msg.timestamp)
 
     tool_calls: list[SubagentToolCall] = []
     for msg in messages:
@@ -159,10 +147,9 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
                 continue
             entry = results.get(block.id)
             if entry is not None:
-                result_block, result_msg = entry
+                result_block, result_ts = entry
                 is_error = _detect_is_error(result_block)
                 result_text = result_block.text
-                result_ts = result_msg.timestamp
             else:
                 is_error = False
                 result_text = None
@@ -183,17 +170,14 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
 def _compute_idle_gap_ms(tool_calls: list[SubagentToolCall]) -> int | None:
     """Sum per-call gaps (``tool_use`` to ``tool_result``) flagged as idle.
 
-    Per-trace self-calibrating heuristic: a gap is idle when it exceeds
-    both ``IDLE_GAP_K × median(all_gaps_in_trace)`` and the absolute
-    ``IDLE_GAP_FLOOR_MS`` (whichever is larger). Returns ``None`` when
-    fewer than two paired calls have both timestamps — too little data
-    to compute a meaningful per-trace median, and a single isolated
-    long gap can't be distinguished from "this is just how slow this
-    tool runs" without context.
+    Returns ``None`` when fewer than two paired calls have both
+    timestamps — too little data to compute a meaningful per-trace
+    median, and a single isolated long gap can't be distinguished from
+    "this is just how slow this tool runs" without context.
 
-    The JSONL has no marker for the wait condition; see the module
-    docstring's reference to anthropics/claude-code#55240 for the
-    upstream proposal that would replace this with structural detection.
+    The Claude Code JSONL has no structural marker for approval-pending
+    state; this heuristic is a workaround. See anthropics/claude-code#55240
+    for the upstream proposal that would replace it with structural detection.
     """
     gaps_ms: list[float] = []
     for tc in tool_calls:
@@ -242,13 +226,6 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
     messages = parse_session(path)
     tool_calls = _pair_tool_calls(messages)
     retry_sequences = detect_retry_sequences(tool_calls)
-    duration_ms = _compute_duration_ms(messages)
-    idle_gap_ms = _compute_idle_gap_ms(tool_calls)
-    active_duration_ms = (
-        max(duration_ms - idle_gap_ms, 0)
-        if duration_ms is not None and idle_gap_ms is not None
-        else None
-    )
 
     return SubagentTrace(
         agent_id=agent_id,
@@ -259,9 +236,8 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
         total_errors=sum(1 for tc in tool_calls if tc.is_error),
         total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
         usage=_sum_usage(messages),
-        duration_ms=duration_ms,
-        idle_gap_ms=idle_gap_ms,
-        active_duration_ms=active_duration_ms,
+        duration_ms=_compute_duration_ms(messages),
+        idle_gap_ms=_compute_idle_gap_ms(tool_calls),
         source_file=path.resolve(),
         model=_first_assistant_model(messages),
     )

--- a/tests/unit/cli/test_active_duration_display.py
+++ b/tests/unit/cli/test_active_duration_display.py
@@ -1,0 +1,146 @@
+"""Verbose Per-Invocation Detail rendering for active vs wall duration (#230).
+
+Regression coverage for the bug spotted during PR #234 review: dual
+``X.Xs (Y.Ys wall)`` formatting was firing for invocations with
+``trace.idle_gap_ms == 0`` because ``trace.duration_ms`` (computed from
+JSONL message timestamps) and ``inv.duration_ms`` (from the parent
+``toolUseResult.totalDurationMs``) disagree by a few milliseconds even
+when no idle gap was detected. Display logic must gate on the
+authoritative ``idle_gap_ms`` signal, not on a cross-source comparison.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.console import Console
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.analytics.agent_metrics import AgentMetrics, AgentTypeMetrics
+from agentfluent.analytics.pipeline import AnalysisResult, SessionAnalysis
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.cli.formatters.table import format_analysis_table
+from agentfluent.traces.models import SubagentTrace
+
+
+def _trace(*, duration_ms: int, idle_gap_ms: int) -> SubagentTrace:
+    return SubagentTrace(
+        agent_id="abc",
+        agent_type="pm",
+        delegation_prompt="x",
+        duration_ms=duration_ms,
+        idle_gap_ms=idle_gap_ms,
+        active_duration_ms=duration_ms - idle_gap_ms,
+    )
+
+
+def _invocation(
+    agent_type: str,
+    *,
+    description: str,
+    parent_duration_ms: int,
+    trace: SubagentTrace | None,
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        description=description,
+        prompt="run",
+        tool_use_id=f"toolu_{description}",
+        total_tokens=1000,
+        tool_uses=10,
+        duration_ms=parent_duration_ms,
+        trace=trace,
+    )
+
+
+def _make_result(invocations: list[AgentInvocation]) -> AnalysisResult:
+    am = AgentMetrics(
+        total_invocations=len(invocations),
+        by_agent_type={
+            "pm": AgentTypeMetrics(
+                agent_type="pm",
+                is_builtin=False,
+                invocation_count=len(invocations),
+                total_tokens=sum((i.total_tokens or 0) for i in invocations),
+                total_duration_ms=sum((i.duration_ms or 0) for i in invocations),
+            ),
+        },
+    )
+    session = SessionAnalysis(
+        session_path=Path("session-1.jsonl"),
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=am,
+        invocations=invocations,
+    )
+    return AnalysisResult(sessions=[session], agent_metrics=am)
+
+
+def _render(result: AnalysisResult) -> str:
+    console = Console(record=True, width=200, force_terminal=False)
+    format_analysis_table(console, result, verbose=True)
+    return console.export_text()
+
+
+def test_idle_gap_renders_active_wall_dual_format() -> None:
+    inv = _invocation(
+        "pm",
+        description="with-idle",
+        parent_duration_ms=1_834_000,
+        trace=_trace(duration_ms=1_834_000, idle_gap_ms=1_452_000),
+    )
+    output = _render(_make_result([inv]))
+    # 382s active vs 1834s wall → both numbers shown with "wall" suffix.
+    assert "382.0s (1834.0s wall)" in output
+
+
+def test_zero_idle_gap_renders_bare_duration() -> None:
+    # Regression: parent duration_ms=343_500 but trace.duration_ms=343_491
+    # (a 9ms ms-level disagreement between sources). With idle_gap_ms=0,
+    # the dual format must NOT fire — anything different would be the
+    # spurious "343.5s (343.5s wall)" rendering the fix targeted.
+    parent_ms = 343_500
+    trace = SubagentTrace(
+        agent_id="abc",
+        agent_type="pm",
+        delegation_prompt="x",
+        duration_ms=343_491,  # Slightly < parent_ms; not real idle.
+        idle_gap_ms=0,
+        active_duration_ms=343_491,
+    )
+    inv = _invocation(
+        "pm",
+        description="no-idle",
+        parent_duration_ms=parent_ms,
+        trace=trace,
+    )
+    output = _render(_make_result([inv]))
+    assert "343.5s" in output
+    assert "wall" not in output
+
+
+def test_no_trace_renders_bare_duration() -> None:
+    inv = _invocation(
+        "pm",
+        description="no-trace",
+        parent_duration_ms=120_000,
+        trace=None,
+    )
+    output = _render(_make_result([inv]))
+    assert "120.0s" in output
+    assert "wall" not in output
+
+
+def test_missing_duration_renders_dash() -> None:
+    inv = AgentInvocation(
+        agent_type="pm",
+        description="interrupted",
+        prompt="run",
+        tool_use_id="toolu_x",
+        duration_ms=None,
+    )
+    output = _render(_make_result([inv]))
+    # Look for "interrupted" row's Duration column showing "-"
+    rows = [line for line in output.splitlines() if "interrupted" in line]
+    assert any(" - " in row or row.rstrip().endswith("-") for row in rows)

--- a/tests/unit/cli/test_active_duration_display.py
+++ b/tests/unit/cli/test_active_duration_display.py
@@ -1,12 +1,9 @@
-"""Verbose Per-Invocation Detail rendering for active vs wall duration (#230).
+"""Active vs wall duration rendering in the verbose Per-Invocation table.
 
-Regression coverage for the bug spotted during PR #234 review: dual
-``X.Xs (Y.Ys wall)`` formatting was firing for invocations with
-``trace.idle_gap_ms == 0`` because ``trace.duration_ms`` (computed from
-JSONL message timestamps) and ``inv.duration_ms`` (from the parent
-``toolUseResult.totalDurationMs``) disagree by a few milliseconds even
-when no idle gap was detected. Display logic must gate on the
-authoritative ``idle_gap_ms`` signal, not on a cross-source comparison.
+Display gates on ``idle_gap_ms`` (authoritative), not on a cross-source
+comparison of ``active_duration_ms`` vs ``duration_ms`` — the two come
+from different sources (JSONL timestamps vs parent toolUseResult) and
+disagree by ~ms even when no idle was detected.
 """
 
 from __future__ import annotations
@@ -31,7 +28,6 @@ def _trace(*, duration_ms: int, idle_gap_ms: int) -> SubagentTrace:
         delegation_prompt="x",
         duration_ms=duration_ms,
         idle_gap_ms=idle_gap_ms,
-        active_duration_ms=duration_ms - idle_gap_ms,
     )
 
 
@@ -96,28 +92,26 @@ def test_idle_gap_renders_active_wall_dual_format() -> None:
 
 
 def test_zero_idle_gap_renders_bare_duration() -> None:
-    # Regression: parent duration_ms=343_500 but trace.duration_ms=343_491
-    # (a 9ms ms-level disagreement between sources). With idle_gap_ms=0,
-    # the dual format must NOT fire — anything different would be the
-    # spurious "343.5s (343.5s wall)" rendering the fix targeted.
-    parent_ms = 343_500
+    # Regression: parent duration_ms=343_500, trace.duration_ms=343_491
+    # (~9ms cross-source disagreement). With idle_gap_ms=0 the dual
+    # format must NOT fire.
     trace = SubagentTrace(
         agent_id="abc",
         agent_type="pm",
         delegation_prompt="x",
-        duration_ms=343_491,  # Slightly < parent_ms; not real idle.
+        duration_ms=343_491,
         idle_gap_ms=0,
-        active_duration_ms=343_491,
     )
     inv = _invocation(
         "pm",
         description="no-idle",
-        parent_duration_ms=parent_ms,
+        parent_duration_ms=343_500,
         trace=trace,
     )
     output = _render(_make_result([inv]))
-    assert "343.5s" in output
-    assert "wall" not in output
+    rows = [line for line in output.splitlines() if "no-idle" in line]
+    assert any("343.5s" in r for r in rows)
+    assert all("wall" not in r for r in rows)
 
 
 def test_no_trace_renders_bare_duration() -> None:
@@ -128,8 +122,9 @@ def test_no_trace_renders_bare_duration() -> None:
         trace=None,
     )
     output = _render(_make_result([inv]))
-    assert "120.0s" in output
-    assert "wall" not in output
+    rows = [line for line in output.splitlines() if "no-trace" in line]
+    assert any("120.0s" in r for r in rows)
+    assert all("wall" not in r for r in rows)
 
 
 def test_missing_duration_renders_dash() -> None:

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -89,14 +89,12 @@ class TestAgentInvocation:
 
 
 class TestActiveDuration:
-    """`active_duration_ms` and `active_duration_per_tool_use` (#230).
-
-    Active duration delegates to a linked subagent trace; falls back
-    to the raw duration when no trace is linked.
-    """
+    """`active_duration_ms` / `active_duration_per_tool_use` delegate
+    to a linked subagent trace; fall back to raw duration when no
+    trace is linked."""
 
     @staticmethod
-    def _trace(active_ms: int | None) -> object:
+    def _trace(*, idle_gap_ms: int | None) -> object:
         from agentfluent.traces.models import SubagentTrace
 
         return SubagentTrace(
@@ -104,26 +102,27 @@ class TestActiveDuration:
             agent_type="pm",
             delegation_prompt="x",
             duration_ms=120_000,
-            idle_gap_ms=120_000 - active_ms if active_ms is not None else None,
-            active_duration_ms=active_ms,
+            idle_gap_ms=idle_gap_ms,
         )
 
     def test_no_trace_falls_back_to_duration(self) -> None:
-        inv = _full_invocation()  # No trace linked
+        inv = _full_invocation()
         assert inv.active_duration_ms is None
+        assert inv.idle_gap_ms is None
         assert inv.active_duration_per_tool_use == inv.duration_per_tool_use
 
     def test_trace_with_active_duration(self) -> None:
         inv = _full_invocation()
-        inv.trace = self._trace(active_ms=60_000)  # type: ignore[assignment]
-        assert inv.active_duration_ms == 60_000
+        inv.trace = self._trace(idle_gap_ms=60_000)  # type: ignore[assignment]
+        assert inv.idle_gap_ms == 60_000
+        assert inv.active_duration_ms == 60_000  # 120_000 - 60_000
         assert inv.active_duration_per_tool_use == 60_000 / 14
 
-    def test_trace_without_active_duration_falls_back(self) -> None:
-        # Trace exists but couldn't compute active_duration_ms (e.g.,
-        # too few paired tool calls). Fall back to raw duration.
+    def test_trace_without_idle_gap_falls_back(self) -> None:
+        # Trace exists but couldn't compute idle_gap (too few paired
+        # tool calls). active_duration_ms is None → fall back to raw.
         inv = _full_invocation()
-        inv.trace = self._trace(active_ms=None)  # type: ignore[assignment]
+        inv.trace = self._trace(idle_gap_ms=None)  # type: ignore[assignment]
         assert inv.active_duration_ms is None
         assert inv.active_duration_per_tool_use == inv.duration_per_tool_use
 
@@ -136,5 +135,5 @@ class TestActiveDuration:
             tool_uses=0,
             duration_ms=5000,
         )
-        inv.trace = self._trace(active_ms=2000)  # type: ignore[assignment]
+        inv.trace = self._trace(idle_gap_ms=3000)  # type: ignore[assignment]
         assert inv.active_duration_per_tool_use is None

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -86,3 +86,55 @@ class TestAgentInvocation:
         inv = _full_invocation()
         restored = AgentInvocation.model_validate_json(inv.model_dump_json())
         assert restored == inv
+
+
+class TestActiveDuration:
+    """`active_duration_ms` and `active_duration_per_tool_use` (#230).
+
+    Active duration delegates to a linked subagent trace; falls back
+    to the raw duration when no trace is linked.
+    """
+
+    @staticmethod
+    def _trace(active_ms: int | None) -> object:
+        from agentfluent.traces.models import SubagentTrace
+
+        return SubagentTrace(
+            agent_id="abc",
+            agent_type="pm",
+            delegation_prompt="x",
+            duration_ms=120_000,
+            idle_gap_ms=120_000 - active_ms if active_ms is not None else None,
+            active_duration_ms=active_ms,
+        )
+
+    def test_no_trace_falls_back_to_duration(self) -> None:
+        inv = _full_invocation()  # No trace linked
+        assert inv.active_duration_ms is None
+        assert inv.active_duration_per_tool_use == inv.duration_per_tool_use
+
+    def test_trace_with_active_duration(self) -> None:
+        inv = _full_invocation()
+        inv.trace = self._trace(active_ms=60_000)  # type: ignore[assignment]
+        assert inv.active_duration_ms == 60_000
+        assert inv.active_duration_per_tool_use == 60_000 / 14
+
+    def test_trace_without_active_duration_falls_back(self) -> None:
+        # Trace exists but couldn't compute active_duration_ms (e.g.,
+        # too few paired tool calls). Fall back to raw duration.
+        inv = _full_invocation()
+        inv.trace = self._trace(active_ms=None)  # type: ignore[assignment]
+        assert inv.active_duration_ms is None
+        assert inv.active_duration_per_tool_use == inv.duration_per_tool_use
+
+    def test_zero_tool_uses_returns_none(self) -> None:
+        inv = AgentInvocation(
+            agent_type="pm",
+            description="x",
+            prompt="x",
+            tool_use_id="t",
+            tool_uses=0,
+            duration_ms=5000,
+        )
+        inv.trace = self._trace(active_ms=2000)  # type: ignore[assignment]
+        assert inv.active_duration_per_tool_use is None

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -145,8 +145,7 @@ class TestDurationOutlierDetection:
             agent_type="pm",
             delegation_prompt="x",
             duration_ms=50000,
-            idle_gap_ms=40000,
-            active_duration_ms=10000,  # Same active rate as the others
+            idle_gap_ms=40000,  # active = 10000ms, same per-tool rate as peers
         )
 
         signals = extract_signals([normal_a, normal_b, slow_wall])

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -130,6 +130,29 @@ class TestDurationOutlierDetection:
         outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
         assert len(outliers) == 0
 
+    def test_uses_active_duration_when_trace_present(self) -> None:
+        # #230: outlier detection should compare active_duration_per_tool_use.
+        # Without #230's fix, the third invocation's wall-clock 50000ms would
+        # flag as an outlier; with the fix, its active duration of 1000ms (the
+        # other 49 seconds were idle wait) puts it in line with peers.
+        from agentfluent.traces.models import SubagentTrace
+
+        normal_a = _inv(duration_ms=10000, tool_uses=10, agent_id="ag-1")
+        normal_b = _inv(duration_ms=10000, tool_uses=10, agent_id="ag-2")
+        slow_wall = _inv(duration_ms=50000, tool_uses=10, agent_id="ag-3")
+        slow_wall.trace = SubagentTrace(
+            agent_id="t3",
+            agent_type="pm",
+            delegation_prompt="x",
+            duration_ms=50000,
+            idle_gap_ms=40000,
+            active_duration_ms=10000,  # Same active rate as the others
+        )
+
+        signals = extract_signals([normal_a, normal_b, slow_wall])
+        outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
+        assert outliers == []  # Wall-clock outlier is rescued by active duration
+
 
 class TestExtractSignals:
     def test_empty_invocations(self) -> None:

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -458,3 +458,156 @@ class TestAggregateCounts:
     # later shipped in #104. See `test_traces_retry.py` for comprehensive
     # retry-sequence tests; the obsolete "total_retries_is_zero" placeholder
     # was removed when the parser-merge fix for #153 exposed it.)
+
+
+class TestResultTimestamp:
+    """`SubagentToolCall.result_timestamp` captured from the user message
+    that carried the matching `tool_result` block (#230)."""
+
+    def test_paired_call_captures_both_timestamps(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                _assistant(
+                    [_tool_use("t1", "Bash")],
+                    timestamp="2026-04-21T10:00:01.000Z",
+                ),
+                _user(
+                    [_tool_result("t1", "ok")],
+                    timestamp="2026-04-21T10:00:01.500Z",
+                ),
+            ],
+        )
+        tc = parse_subagent_trace(path).tool_calls[0]
+        assert tc.timestamp == datetime(2026, 4, 21, 10, 0, 1, tzinfo=UTC)
+        assert tc.result_timestamp == datetime(2026, 4, 21, 10, 0, 1, 500_000, tzinfo=UTC)
+
+    def test_orphan_tool_use_has_no_result_timestamp(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [_user("go"), _assistant([_tool_use("t1", "Read")])],
+        )
+        tc = parse_subagent_trace(path).tool_calls[0]
+        assert tc.result_timestamp is None
+
+
+class TestIdleGapDetection:
+    """`SubagentTrace.idle_gap_ms` / `active_duration_ms` (#230).
+
+    Heuristic: per-call gap > max(IDLE_GAP_K * median, IDLE_GAP_FLOOR_MS)
+    counts as idle. The floor is 5 minutes (300_000 ms) and dominates
+    in tests where median tool latency is small.
+    """
+
+    @staticmethod
+    def _pair(
+        tool_id: str,
+        use_ts: str,
+        result_ts: str,
+    ) -> list[dict[str, Any]]:
+        # Unique message_id per assistant message — the parser merges
+        # snapshots that share an id, which would collapse these into one.
+        return [
+            _assistant(
+                [_tool_use(tool_id, "Bash")],
+                message_id=f"msg_{tool_id}",
+                timestamp=use_ts,
+            ),
+            _user([_tool_result(tool_id, "ok")], timestamp=result_ts),
+        ]
+
+    def test_no_paired_calls_returns_none(self, write_jsonl: WriteJSONL) -> None:
+        # Orphan tool_use with no result → no paired gap → cannot compute
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [_user("go"), _assistant([_tool_use("t1", "Read")])],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.idle_gap_ms is None
+        assert trace.active_duration_ms is None
+
+    def test_single_paired_call_returns_none(self, write_jsonl: WriteJSONL) -> None:
+        # 1 paired call < 2 minimum for per-trace median → indeterminate
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                *self._pair("t1", "2026-04-21T10:00:01.000Z", "2026-04-21T10:00:02.000Z"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.idle_gap_ms is None
+        assert trace.active_duration_ms is None
+
+    def test_short_gaps_no_idle(self, write_jsonl: WriteJSONL) -> None:
+        # Several fast tool calls — every gap below the 5-min floor
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                *self._pair("t1", "2026-04-21T10:00:01.000Z", "2026-04-21T10:00:02.000Z"),
+                *self._pair("t2", "2026-04-21T10:00:03.000Z", "2026-04-21T10:00:04.000Z"),
+                *self._pair("t3", "2026-04-21T10:00:05.000Z", "2026-04-21T10:00:06.500Z"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.idle_gap_ms == 0
+        assert trace.active_duration_ms == trace.duration_ms
+
+    def test_long_gap_above_floor_flagged(self, write_jsonl: WriteJSONL) -> None:
+        # Two short calls + one 10-minute gap — floor binds, k×median doesn't
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                *self._pair("t1", "2026-04-21T10:00:01.000Z", "2026-04-21T10:00:02.000Z"),
+                *self._pair("t2", "2026-04-21T10:00:03.000Z", "2026-04-21T10:13:03.000Z"),
+                *self._pair("t3", "2026-04-21T10:13:04.000Z", "2026-04-21T10:13:05.000Z"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        # The 13-minute gap (780_000 ms) is the only one above the floor
+        assert trace.idle_gap_ms == 780_000
+        assert trace.duration_ms is not None
+        assert trace.active_duration_ms is not None
+        assert trace.active_duration_ms == trace.duration_ms - 780_000
+
+    def test_clock_skew_negative_gap_ignored(self, write_jsonl: WriteJSONL) -> None:
+        # tool_result timestamp before tool_use timestamp — clock skew or
+        # a parsing artifact. Should not contribute synthetic work.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                *self._pair("t1", "2026-04-21T10:00:10.000Z", "2026-04-21T10:00:09.000Z"),
+                *self._pair("t2", "2026-04-21T10:00:11.000Z", "2026-04-21T10:00:12.000Z"),
+            ],
+        )
+        # One valid gap remains → fewer than 2 → returns None
+        trace = parse_subagent_trace(path)
+        assert trace.idle_gap_ms is None
+
+    def test_active_duration_clamped_at_zero(self, write_jsonl: WriteJSONL) -> None:
+        # Defensive: if idle_gap_ms ever exceeds duration_ms (e.g., due
+        # to overlapping calls or a future heuristic change), don't
+        # report a negative active_duration.
+        from agentfluent.traces.parser import _compute_idle_gap_ms
+
+        # Real data here: assert the parser's clamp logic via a
+        # constructed scenario — durations larger than the wall span
+        # can't happen via real JSONL, so we just exercise the public
+        # parser path and confirm the property holds in practice.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
+                *self._pair("t1", "2026-04-21T10:00:01.000Z", "2026-04-21T10:00:02.000Z"),
+                *self._pair("t2", "2026-04-21T10:00:03.000Z", "2026-04-21T10:13:03.000Z"),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.active_duration_ms is not None
+        assert trace.active_duration_ms >= 0
+        # Sanity: helper is callable and returns an int when 2+ paired gaps exist.
+        assert isinstance(_compute_idle_gap_ms(trace.tool_calls), int)

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -588,26 +588,17 @@ class TestIdleGapDetection:
         trace = parse_subagent_trace(path)
         assert trace.idle_gap_ms is None
 
-    def test_active_duration_clamped_at_zero(self, write_jsonl: WriteJSONL) -> None:
-        # Defensive: if idle_gap_ms ever exceeds duration_ms (e.g., due
-        # to overlapping calls or a future heuristic change), don't
-        # report a negative active_duration.
-        from agentfluent.traces.parser import _compute_idle_gap_ms
+    def test_active_duration_clamped_at_zero(self) -> None:
+        # If idle_gap_ms ever exceeds duration_ms (overlapping calls,
+        # future heuristic change), active_duration_ms must clamp at 0
+        # rather than going negative.
+        from agentfluent.traces.models import SubagentTrace
 
-        # Real data here: assert the parser's clamp logic via a
-        # constructed scenario — durations larger than the wall span
-        # can't happen via real JSONL, so we just exercise the public
-        # parser path and confirm the property holds in practice.
-        path = write_jsonl(
-            "agent-x.jsonl",
-            [
-                _user("go", timestamp="2026-04-21T10:00:00.000Z"),
-                *self._pair("t1", "2026-04-21T10:00:01.000Z", "2026-04-21T10:00:02.000Z"),
-                *self._pair("t2", "2026-04-21T10:00:03.000Z", "2026-04-21T10:13:03.000Z"),
-            ],
+        trace = SubagentTrace(
+            agent_id="x",
+            agent_type="pm",
+            delegation_prompt="x",
+            duration_ms=1000,
+            idle_gap_ms=5000,
         )
-        trace = parse_subagent_trace(path)
-        assert trace.active_duration_ms is not None
-        assert trace.active_duration_ms >= 0
-        # Sanity: helper is callable and returns an int when 2+ paired gaps exist.
-        assert isinstance(_compute_idle_gap_ms(trace.tool_calls), int)
+        assert trace.active_duration_ms == 0


### PR DESCRIPTION
Closes #230.

## Summary

Implements the heuristic from PR #233 / Section 11 of the calibration notebook. Adds idle-gap detection at parse time and switches outlier detection to compare active duration (idle subtracted) rather than raw wall-clock.

## Headline dogfood result

| Agent | n | wall avg | active avg | idle share |
|---|---:|---:|---:|---:|
| pm | 27 | **1159.6s** | **162.2s** | **86%** |
| Explore | 92 | 307.2s | 67.7s | 78% |
| general-purpose | 62 | 108.9s | 84.2s | 23% |
| architect | 25 | 155.2s | 155.2s | 0% |
| Plan | 5 | 132.3s | 132.3s | 0% |

The 999s/call mystery is resolved: pm drops from ~19 min/call wall-clock to ~2.7 min/call active. Agents that don't use approval-gated tools (architect, Plan) show 0% idle share — the heuristic correctly attributes nothing to them. Explore's 78% idle was previously invisible.

## Data model changes

- **`SubagentToolCall.result_timestamp`** — pairs with existing `timestamp` to make per-call elapsed time observable.
- **`SubagentTrace.idle_gap_ms`, `SubagentTrace.active_duration_ms`** — per-trace self-calibrating heuristic: \`gap > max(IDLE_GAP_K * median(gaps_in_trace), IDLE_GAP_FLOOR_MS)\`. Defaults: \`k=10\`, \`floor=300_000ms\` (5 min, prompt-cache TTL anchor).
- **`AgentInvocation.active_duration_ms`** (property) — delegates to linked trace; \`None\` when no trace.
- **`AgentInvocation.active_duration_per_tool_use`** (property) — prefers active; falls back to raw \`duration_per_tool_use\` when no trace.

## Outlier detection

\`_extract_duration_outliers\` now reads \`active_duration_per_tool_use\`. Backward-compatible: older sessions without trace data keep the old wall-clock behavior.

## CLI surfacing

Per-Invocation Detail (verbose) shows \`active (wall)\` when active is meaningfully less than wall-clock; bare wall-clock otherwise.

## Glossary

\`duration_outlier\` entry updated; \`docs/GLOSSARY.md\` regenerated.

## Tests

13 new unit tests:
- \`test_traces_parser.py\`: \`TestResultTimestamp\` (2), \`TestIdleGapDetection\` (6) — including clock-skew handling, single-pair indeterminate case, \`active_duration\` clamp at 0.
- \`test_agent_models.py\`: \`TestActiveDuration\` (4) — fallback semantics.
- \`test_signals.py\`: \`test_uses_active_duration_when_trace_present\` (1) — outlier rescue when wall-clock would have falsely flagged.

All 810 tests pass; ruff + mypy clean.

## Limitations

The Claude Code JSONL has no native marker for approval-pending state. This heuristic is a workaround. Filed upstream as [anthropics/claude-code#55240](https://github.com/anthropics/claude-code/issues/55240) — if that lands, the entire heuristic gets replaced with structural detection.

## Test plan

- [x] \`uv run pytest -m \"not integration\"\` — 810 passed
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run mypy src/agentfluent/\` clean
- [x] Dogfood run shows pm wall avg 1159.6s → active avg 162.2s
- [x] Reviewer spot-checks JSON output of \`agentfluent analyze --json\` for new fields
- [x] Reviewer spot-checks verbose CLI table shows \`active (wall)\` formatting

## Sequencing

Per architect review: this PR must merge before #186 Phase 2 (outlier method migration to IQR). Calibrating the new outlier method against \`duration_ms\` would defeat the purpose; #186 Phase 2 should pick up after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)