### PR TITLE
feat(signals): IQR-based outlier detection (#186) + extractor consolidation (#235)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -172,21 +172,29 @@ in USD, two decimals.
 **Short:** An invocation consumes far more tokens per tool call than the agent's
 typical run.
 
-**Detail:** Triggered when `tokens_per_tool_use` exceeds `OUTLIER_THRESHOLD` x the
-per-agent-type mean. Computed across all invocations of the same agent
-type within the analyzed sessions, so two invocations of `pm` are needed
-before any can be flagged. Indicates the agent is over-fetching context,
+**Detail:** Triggered when `tokens_per_tool_use` exceeds the Tukey IQR threshold:
+`Q3 + 1.5 × IQR` of the per-agent-type distribution (where Q3 is
+the 75th percentile and IQR = Q3 - Q1). Computed across all
+invocations of the same agent type within the analyzed sessions;
+detection requires at least `OUTLIER_MIN_SAMPLE` invocations (4)
+and IQR > 0. Indicates the agent is over-fetching context,
 exploring unfocused, or being given an ambiguous prompt.
+
+The detection method is robust to right-skewed distributions
+(which agent token usage typically is), unlike a mean-ratio rule
+that gets pulled by its own outliers. The signal `detail` carries
+distribution context (`median_value`, `q3_value`, `iqr_value`,
+`p95_value`, `threshold_value`, `excess_iqrs`).
 
 **Example:**
 
 ```
-Agent 'Explore' has 40,288 tokens/tool_use, 8.0x above the 5,064 mean.
+Agent 'Explore' has 40,288 tokens/tool_use, 7.2×IQR above Q3 of 5,064.
 ```
 
 **Severity:** warning
 
-**Threshold:** 2.0x mean (OUTLIER_THRESHOLD)
+**Threshold:** Q3 + 1.5 × IQR (Tukey rule), per-agent-type
 
 **Recommendation target:** `prompt`
 
@@ -196,12 +204,13 @@ Agent 'Explore' has 40,288 tokens/tool_use, 8.0x above the 5,064 mean.
 
 **Short:** An invocation takes far longer per tool call than the agent's typical run.
 
-**Detail:** Same threshold as `token_outlier` (`OUTLIER_THRESHOLD = 2.0x` the
-per-agent mean) but on `active_duration_per_tool_use` --
-wall-clock duration with detected idle gaps subtracted. Often
-co-occurs with `token_outlier`. When it appears alone, the agent
-is making slow tool calls (network latency, large file reads)
-rather than over-thinking.
+**Detail:** Same Tukey IQR threshold as `token_outlier` (`val > Q3 + 1.5 × IQR`)
+but on `active_duration_per_tool_use` -- wall-clock duration with
+detected idle gaps subtracted. Requires at least `OUTLIER_MIN_SAMPLE`
+invocations (4) and IQR > 0 in the per-agent-type distribution.
+Often co-occurs with `token_outlier`. When it appears alone, the
+agent is making slow tool calls (network latency, large file
+reads) rather than over-thinking.
 
 **Active vs wall-clock duration (#230).** When a tool call sits
 pending user approval -- the IDE prompts to allow a `Write`, an
@@ -222,12 +231,12 @@ would replace the heuristic with structural detection.
 **Example:**
 
 ```
-Agent 'pm' has 45.2s/tool_use, 3.1x above the 14.6s mean.
+Agent 'pm' has 45.2s/tool_use, 3.1×IQR above Q3 of 14.6s.
 ```
 
 **Severity:** warning
 
-**Threshold:** 2.0x mean (OUTLIER_THRESHOLD), computed on active_duration_per_tool_use
+**Threshold:** Q3 + 1.5 × IQR (Tukey rule), computed on active_duration_per_tool_use
 
 **Recommendation target:** `prompt`
 

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -49,37 +49,30 @@ def _aggregation_key(rec: DiagnosticRecommendation) -> AggregationKey:
 
 
 def _compute_metric_range(signals: list[DiagnosticSignal]) -> str | None:
-    """Build ``"4.9x–8.0x above 5,064 mean"`` when signals carry ratio data.
+    """Build ``"3.2×–6.8×IQR above Q3"`` when signals carry IQR-based data.
 
     Returns ``None`` for signal types without comparable scalars (retry
     counts, permission failures) so the aggregated row falls back to a
     count-only message.
     """
-    ratios: list[float] = []
-    means: list[float] = []
+    excesses: list[float] = []
     for sig in signals:
         if sig.signal_type not in _SCALAR_METRIC_SIGNALS:
             continue
-        ratio = sig.detail.get("ratio")
-        mean = sig.detail.get("mean_value")
-        if isinstance(ratio, (int, float)):
-            ratios.append(float(ratio))
-        if isinstance(mean, (int, float)):
-            means.append(float(mean))
+        excess = sig.detail.get("excess_iqrs")
+        if isinstance(excess, (int, float)):
+            excesses.append(float(excess))
 
-    if not ratios:
+    if not excesses:
         return None
 
-    lo, hi = min(ratios), max(ratios)
+    lo, hi = min(excesses), max(excesses)
     if lo == hi:
-        range_text = f"{lo:.1f}x"
+        range_text = f"{lo:.1f}×IQR"
     else:
-        range_text = f"{lo:.1f}x–{hi:.1f}x"
+        range_text = f"{lo:.1f}×–{hi:.1f}×IQR"
 
-    if means:
-        mean_ref = sum(means) / len(means)
-        return f"{range_text} above {mean_ref:,.0f} mean"
-    return f"{range_text} above mean"
+    return f"{range_text} above Q3"
 
 
 def _max_severity(recs: list[DiagnosticRecommendation]) -> Severity:

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -7,6 +7,7 @@ and duration outliers.
 from __future__ import annotations
 
 import re
+import statistics
 from collections import defaultdict
 from collections.abc import Callable
 
@@ -39,7 +40,15 @@ ERROR_REGEX = re.compile(
 # Map matched text back to severity
 _KEYWORD_SEVERITY: dict[str, Severity] = {kw.lower(): sev for kw, sev in ERROR_PATTERNS}
 
-OUTLIER_THRESHOLD = 2.0
+OUTLIER_IQR_MULTIPLIER = 1.5
+"""Tukey-style IQR multiplier: ``threshold = Q3 + k * IQR``. Calibrated
+in scripts/calibration/threshold_validation.ipynb §10."""
+
+OUTLIER_MIN_SAMPLE = 4
+"""Minimum invocations per agent type before IQR detection runs.
+``statistics.quantiles(n=4)`` requires ≥ 4 data points; below that,
+Q3/IQR aren't computable. Larger samples produce more stable estimates
+but the absolute floor is set here."""
 
 
 def _extract_error_signals(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
@@ -80,15 +89,17 @@ def _detect_outliers(
     *,
     accessor: Callable[[AgentInvocation], float | None],
     signal_type: SignalType,
-    format_message: Callable[[AgentInvocation, float, float], str],
+    format_message: Callable[[AgentInvocation, float, float, float], str],
 ) -> list[DiagnosticSignal]:
-    """Generic per-agent-type outlier detector.
+    """Generic per-agent-type outlier detector (Tukey IQR rule).
 
-    Groups invocations by agent type, computes the mean of ``accessor``
+    Groups invocations by agent type, computes Q1/Q3/IQR of ``accessor``
     values per group, and emits a ``DiagnosticSignal`` for each value
-    exceeding ``mean * OUTLIER_THRESHOLD``. Callers supply a
-    ``format_message`` that receives ``(invocation, value, mean)`` and
-    returns the human-readable signal message.
+    exceeding ``Q3 + OUTLIER_IQR_MULTIPLIER * IQR``. Skips groups where
+    ``len(group) < OUTLIER_MIN_SAMPLE`` or where ``IQR <= 0`` (degenerate
+    distribution — can't establish "outlier" sensibly).
+
+    Callers supply ``format_message(inv, value, q3, iqr)``.
     """
     signals: list[DiagnosticSignal] = []
 
@@ -98,28 +109,43 @@ def _detect_outliers(
             by_type[inv.agent_type.lower()].append(inv)
 
     for group in by_type.values():
-        if len(group) < 2:
+        if len(group) < OUTLIER_MIN_SAMPLE:
             continue
 
         values = [v for v in (accessor(inv) for inv in group) if v is not None]
-        mean = sum(values) / len(values)
+        q1, median_val, q3 = statistics.quantiles(values, n=4)
+        iqr = q3 - q1
+        if iqr <= 0:
+            continue
+        threshold = q3 + OUTLIER_IQR_MULTIPLIER * iqr
+        # P95 as auxiliary distribution context. Tautological at very
+        # small n (becomes the max), but useful at n >= ~10.
+        sorted_vals = sorted(values)
+        p95_idx = max(0, min(len(sorted_vals) - 1, int(round(0.95 * (len(sorted_vals) - 1)))))
+        p95 = sorted_vals[p95_idx]
 
         for inv in group:
             val = accessor(inv)
-            if val is not None and val > mean * OUTLIER_THRESHOLD:
-                signals.append(DiagnosticSignal(
-                    signal_type=signal_type,
-                    severity=Severity.WARNING,
-                    agent_type=inv.agent_type,
-                    invocation_id=inv.invocation_id,
-                    message=format_message(inv, val, mean),
-                    detail={
-                        "actual_value": val,
-                        "mean_value": mean,
-                        "ratio": round(val / mean, 1),
-                        "tool_use_id": inv.tool_use_id,
-                    },
-                ))
+            if val is None or val <= threshold:
+                continue
+            excess_iqrs = (val - q3) / iqr
+            signals.append(DiagnosticSignal(
+                signal_type=signal_type,
+                severity=Severity.WARNING,
+                agent_type=inv.agent_type,
+                invocation_id=inv.invocation_id,
+                message=format_message(inv, val, q3, iqr),
+                detail={
+                    "actual_value": val,
+                    "median_value": median_val,
+                    "q3_value": q3,
+                    "iqr_value": iqr,
+                    "p95_value": p95,
+                    "threshold_value": threshold,
+                    "excess_iqrs": round(excess_iqrs, 2),
+                    "tool_use_id": inv.tool_use_id,
+                },
+            ))
 
     return signals
 
@@ -130,9 +156,9 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
         invocations,
         accessor=lambda i: i.tokens_per_tool_use,
         signal_type=SignalType.TOKEN_OUTLIER,
-        format_message=lambda inv, val, mean: (
+        format_message=lambda inv, val, q3, iqr: (
             f"Agent '{inv.agent_type}' has {val:,.0f} tokens/tool_use, "
-            f"{val / mean:.1f}x above the {mean:,.0f} mean."
+            f"{(val - q3) / iqr:.1f}×IQR above Q3 of {q3:,.0f}."
         ),
     )
 
@@ -147,9 +173,9 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
         invocations,
         accessor=lambda i: i.active_duration_per_tool_use,
         signal_type=SignalType.DURATION_OUTLIER,
-        format_message=lambda inv, val, mean: (
+        format_message=lambda inv, val, q3, iqr: (
             f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
-            f"{val / mean:.1f}x above the {mean / 1000:.1f}s mean."
+            f"{(val - q3) / iqr:.1f}×IQR above Q3 of {q3 / 1000:.1f}s."
         ),
     )
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Callable
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.models import Severity
@@ -74,34 +75,44 @@ def _extract_error_signals(invocations: list[AgentInvocation]) -> list[Diagnosti
     return signals
 
 
-def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
-    """Detect invocations with unusually high token consumption."""
+def _detect_outliers(
+    invocations: list[AgentInvocation],
+    *,
+    accessor: Callable[[AgentInvocation], float | None],
+    signal_type: SignalType,
+    format_message: Callable[[AgentInvocation, float, float], str],
+) -> list[DiagnosticSignal]:
+    """Generic per-agent-type outlier detector.
+
+    Groups invocations by agent type, computes the mean of ``accessor``
+    values per group, and emits a ``DiagnosticSignal`` for each value
+    exceeding ``mean * OUTLIER_THRESHOLD``. Callers supply a
+    ``format_message`` that receives ``(invocation, value, mean)`` and
+    returns the human-readable signal message.
+    """
     signals: list[DiagnosticSignal] = []
 
     by_type: dict[str, list[AgentInvocation]] = defaultdict(list)
     for inv in invocations:
-        if inv.tokens_per_tool_use is not None:
+        if accessor(inv) is not None:
             by_type[inv.agent_type.lower()].append(inv)
 
-    for agent_type, group in by_type.items():
+    for group in by_type.values():
         if len(group) < 2:
             continue
 
-        values = [inv.tokens_per_tool_use for inv in group if inv.tokens_per_tool_use is not None]
+        values = [v for v in (accessor(inv) for inv in group) if v is not None]
         mean = sum(values) / len(values)
 
         for inv in group:
-            val = inv.tokens_per_tool_use
+            val = accessor(inv)
             if val is not None and val > mean * OUTLIER_THRESHOLD:
                 signals.append(DiagnosticSignal(
-                    signal_type=SignalType.TOKEN_OUTLIER,
+                    signal_type=signal_type,
                     severity=Severity.WARNING,
                     agent_type=inv.agent_type,
                     invocation_id=inv.invocation_id,
-                    message=(
-                        f"Agent '{inv.agent_type}' has {val:,.0f} tokens/tool_use, "
-                        f"{val / mean:.1f}x above the {mean:,.0f} mean."
-                    ),
+                    message=format_message(inv, val, mean),
                     detail={
                         "actual_value": val,
                         "mean_value": mean,
@@ -111,6 +122,19 @@ def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[Diagnost
                 ))
 
     return signals
+
+
+def _extract_token_outliers(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
+    """Detect invocations with unusually high token consumption."""
+    return _detect_outliers(
+        invocations,
+        accessor=lambda i: i.tokens_per_tool_use,
+        signal_type=SignalType.TOKEN_OUTLIER,
+        format_message=lambda inv, val, mean: (
+            f"Agent '{inv.agent_type}' has {val:,.0f} tokens/tool_use, "
+            f"{val / mean:.1f}x above the {mean:,.0f} mean."
+        ),
+    )
 
 
 def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:
@@ -119,45 +143,15 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
     Uses ``active_duration_per_tool_use`` so user-approval wait time
     isn't attributed to the agent.
     """
-    signals: list[DiagnosticSignal] = []
-
-    by_type: dict[str, list[AgentInvocation]] = defaultdict(list)
-    for inv in invocations:
-        if inv.active_duration_per_tool_use is not None:
-            by_type[inv.agent_type.lower()].append(inv)
-
-    for agent_type, group in by_type.items():
-        if len(group) < 2:
-            continue
-
-        values = [
-            inv.active_duration_per_tool_use
-            for inv in group
-            if inv.active_duration_per_tool_use is not None
-        ]
-        mean = sum(values) / len(values)
-
-        for inv in group:
-            val = inv.active_duration_per_tool_use
-            if val is not None and val > mean * OUTLIER_THRESHOLD:
-                signals.append(DiagnosticSignal(
-                    signal_type=SignalType.DURATION_OUTLIER,
-                    severity=Severity.WARNING,
-                    agent_type=inv.agent_type,
-                    invocation_id=inv.invocation_id,
-                    message=(
-                        f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
-                        f"{val / mean:.1f}x above the {mean / 1000:.1f}s mean."
-                    ),
-                    detail={
-                        "actual_value": val,
-                        "mean_value": mean,
-                        "ratio": round(val / mean, 1),
-                        "tool_use_id": inv.tool_use_id,
-                    },
-                ))
-
-    return signals
+    return _detect_outliers(
+        invocations,
+        accessor=lambda i: i.active_duration_per_tool_use,
+        signal_type=SignalType.DURATION_OUTLIER,
+        format_message=lambda inv, val, mean: (
+            f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
+            f"{val / mean:.1f}x above the {mean / 1000:.1f}s mean."
+        ),
+    )
 
 
 def extract_signals(invocations: list[AgentInvocation]) -> list[DiagnosticSignal]:

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -128,14 +128,22 @@
     An invocation consumes far more tokens per tool call than the agent's
     typical run.
   long: |
-    Triggered when `tokens_per_tool_use` exceeds `OUTLIER_THRESHOLD` x the
-    per-agent-type mean. Computed across all invocations of the same agent
-    type within the analyzed sessions, so two invocations of `pm` are needed
-    before any can be flagged. Indicates the agent is over-fetching context,
+    Triggered when `tokens_per_tool_use` exceeds the Tukey IQR threshold:
+    `Q3 + 1.5 × IQR` of the per-agent-type distribution (where Q3 is
+    the 75th percentile and IQR = Q3 - Q1). Computed across all
+    invocations of the same agent type within the analyzed sessions;
+    detection requires at least `OUTLIER_MIN_SAMPLE` invocations (4)
+    and IQR > 0. Indicates the agent is over-fetching context,
     exploring unfocused, or being given an ambiguous prompt.
-  example: "Agent 'Explore' has 40,288 tokens/tool_use, 8.0x above the 5,064 mean."
+
+    The detection method is robust to right-skewed distributions
+    (which agent token usage typically is), unlike a mean-ratio rule
+    that gets pulled by its own outliers. The signal `detail` carries
+    distribution context (`median_value`, `q3_value`, `iqr_value`,
+    `p95_value`, `threshold_value`, `excess_iqrs`).
+  example: "Agent 'Explore' has 40,288 tokens/tool_use, 7.2×IQR above Q3 of 5,064."
   severity_range: warning
-  threshold: 2.0x mean (OUTLIER_THRESHOLD)
+  threshold: Q3 + 1.5 × IQR (Tukey rule), per-agent-type
   recommendation_target: prompt
   related: [duration_outlier, stuck_pattern, target_prompt]
 
@@ -144,12 +152,13 @@
   short: |
     An invocation takes far longer per tool call than the agent's typical run.
   long: |
-    Same threshold as `token_outlier` (`OUTLIER_THRESHOLD = 2.0x` the
-    per-agent mean) but on `active_duration_per_tool_use` --
-    wall-clock duration with detected idle gaps subtracted. Often
-    co-occurs with `token_outlier`. When it appears alone, the agent
-    is making slow tool calls (network latency, large file reads)
-    rather than over-thinking.
+    Same Tukey IQR threshold as `token_outlier` (`val > Q3 + 1.5 × IQR`)
+    but on `active_duration_per_tool_use` -- wall-clock duration with
+    detected idle gaps subtracted. Requires at least `OUTLIER_MIN_SAMPLE`
+    invocations (4) and IQR > 0 in the per-agent-type distribution.
+    Often co-occurs with `token_outlier`. When it appears alone, the
+    agent is making slow tool calls (network latency, large file
+    reads) rather than over-thinking.
 
     **Active vs wall-clock duration (#230).** When a tool call sits
     pending user approval -- the IDE prompts to allow a `Write`, an
@@ -166,9 +175,9 @@
     has no native marker for approval-pending state -- see
     `anthropics/claude-code#55240` for the upstream proposal that
     would replace the heuristic with structural detection.
-  example: "Agent 'pm' has 45.2s/tool_use, 3.1x above the 14.6s mean."
+  example: "Agent 'pm' has 45.2s/tool_use, 3.1×IQR above Q3 of 14.6s."
   severity_range: warning
-  threshold: 2.0x mean (OUTLIER_THRESHOLD), computed on active_duration_per_tool_use
+  threshold: Q3 + 1.5 × IQR (Tukey rule), computed on active_duration_per_tool_use
   recommendation_target: prompt
   related: [token_outlier, model_mismatch]
 

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -577,7 +577,15 @@ class TestInvocationIdPropagation:
     def test_token_outlier_rule_propagates_invocation_id(self) -> None:
         sig = _signal(
             signal_type=SignalType.TOKEN_OUTLIER,
-            detail={"actual_value": 5000, "mean_value": 1000, "ratio": 5.0},
+            detail={
+                "actual_value": 5000,
+                "median_value": 1000,
+                "q3_value": 1500,
+                "iqr_value": 500,
+                "p95_value": 5000,
+                "threshold_value": 2250,
+                "excess_iqrs": 7.0,
+            },
             invocation_id="ag-outlier",
         )
         recs = correlate([sig])

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -111,25 +111,28 @@ class TestDedup:
         assert len(error_signals) >= 1
 
     def test_token_outlier_not_suppressed_by_trace_signal(self) -> None:
-        # 'pm' invocations spread such that one clears the 2x-mean outlier
-        # threshold; one of them also carries a trace. TOKEN_OUTLIER must
-        # survive the dedup pass.
-        inv_a = AgentInvocation(
+        # IQR-based detection (#186 P2) needs OUTLIER_MIN_SAMPLE peers
+        # to compute Q3/IQR. One outlier carries a trace; TOKEN_OUTLIER
+        # must survive the dedup pass alongside STUCK_PATTERN.
+        peers = [
+            AgentInvocation(
+                agent_type="pm", description=f"p{i}", prompt="x",
+                tool_use_id=f"t-peer-{i}", output_text="",
+                total_tokens=100 + 10 * i, tool_uses=1,
+            )
+            for i in range(9)
+        ]
+        with_trace = AgentInvocation(
             agent_type="pm", description="a", prompt="a",
-            tool_use_id="t1", output_text="",
-            total_tokens=100, tool_uses=1, trace=_stuck_trace(agent_type="pm"),
+            tool_use_id="t-trace", output_text="",
+            total_tokens=200, tool_uses=1, trace=_stuck_trace(agent_type="pm"),
         )
-        inv_b = AgentInvocation(
-            agent_type="pm", description="b", prompt="b",
-            tool_use_id="t2", output_text="",
-            total_tokens=100, tool_uses=1,
-        )
-        inv_c = AgentInvocation(
+        outlier_inv = AgentInvocation(
             agent_type="pm", description="c", prompt="c",
-            tool_use_id="t3", output_text="",
-            total_tokens=10_000, tool_uses=1,
+            tool_use_id="t-outlier", output_text="",
+            total_tokens=100_000, tool_uses=1,
         )
-        result = run_diagnostics([inv_a, inv_b, inv_c])
+        result = run_diagnostics([*peers, with_trace, outlier_inv])
         assert any(s.signal_type == SignalType.TOKEN_OUTLIER for s in result.signals)
         assert any(s.signal_type == SignalType.STUCK_PATTERN for s in result.signals)
 

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -18,30 +18,36 @@ from agentfluent.diagnostics.models import (
 
 def _token_outlier_pair(
     agent_type: str,
-    ratio: float,
-    mean_value: float = 5064.0,
+    excess_iqrs: float,
+    q3_value: float = 5064.0,
+    iqr_value: float = 1000.0,
     target: str = "prompt",
 ) -> tuple[DiagnosticSignal, DiagnosticRecommendation]:
+    actual = q3_value + excess_iqrs * iqr_value
     signal = DiagnosticSignal(
         signal_type=SignalType.TOKEN_OUTLIER,
         severity=Severity.WARNING,
         agent_type=agent_type,
-        message=f"Agent '{agent_type}' has high token usage ({ratio:.1f}x).",
+        message=f"Agent '{agent_type}' has high token usage ({excess_iqrs:.1f}×IQR).",
         detail={
-            "ratio": ratio,
-            "actual_value": ratio * mean_value,
-            "mean_value": mean_value,
+            "excess_iqrs": excess_iqrs,
+            "actual_value": actual,
+            "median_value": q3_value - iqr_value / 2,
+            "q3_value": q3_value,
+            "iqr_value": iqr_value,
+            "p95_value": actual,
+            "threshold_value": q3_value + 1.5 * iqr_value,
         },
     )
     rec = DiagnosticRecommendation(
         target=target,
         severity=Severity.WARNING,
         message=(
-            f"Agent '{agent_type}' has {ratio * mean_value:,.0f} tokens/tool_use, "
-            f"{ratio:.1f}x above the {mean_value:,.0f} mean."
+            f"Agent '{agent_type}' has {actual:,.0f} tokens/tool_use, "
+            f"{excess_iqrs:.1f}×IQR above Q3 of {q3_value:,.0f}."
         ),
         observation=(
-            f"Agent '{agent_type}' uses {ratio * mean_value:,.0f} tokens per call."
+            f"Agent '{agent_type}' uses {actual:,.0f} tokens per call."
         ),
         reason="High token usage suggests broad exploration.",
         action="Add more specific instructions to the agent's prompt.",
@@ -134,18 +140,18 @@ class TestAggregationKey:
 class TestMetricRange:
     def test_scalar_signals_produce_range(self) -> None:
         pairs = [
-            _token_outlier_pair("Explore", 4.9, mean_value=5064.0),
-            _token_outlier_pair("Explore", 6.7, mean_value=5064.0),
-            _token_outlier_pair("Explore", 8.0, mean_value=5064.0),
-            _token_outlier_pair("Explore", 5.2, mean_value=5064.0),
+            _token_outlier_pair("Explore", 4.9),
+            _token_outlier_pair("Explore", 6.7),
+            _token_outlier_pair("Explore", 8.0),
+            _token_outlier_pair("Explore", 5.2),
         ]
         aggregated = aggregate_recommendations(pairs)
-        assert aggregated[0].metric_range == "4.9x–8.0x above 5,064 mean"
+        assert aggregated[0].metric_range == "4.9×–8.0×IQR above Q3"
 
     def test_single_invocation_shows_point_not_range(self) -> None:
         pairs = [_token_outlier_pair("pm", 3.4)]
         aggregated = aggregate_recommendations(pairs)
-        assert aggregated[0].metric_range == "3.4x above 5,064 mean"
+        assert aggregated[0].metric_range == "3.4×IQR above Q3"
 
     def test_non_scalar_signal_has_no_range(self) -> None:
         pairs = [
@@ -171,7 +177,7 @@ class TestRepresentativeMessage:
         aggregated = aggregate_recommendations(pairs)
         msg = aggregated[0].representative_message
         assert msg.startswith(
-            "token_outlier (4.9x–8.0x above 5,064 mean):",
+            "token_outlier (4.9×–8.0×IQR above Q3):",
         )
         assert "Add more specific instructions" in msg
         # Count is in its own column — must not be duplicated in the prefix.
@@ -297,7 +303,7 @@ class TestAggregationModel:
         dumped = aggregated[0].model_dump(mode="json")
         assert dumped["agent_type"] == "pm"
         assert dumped["count"] == 1
-        assert dumped["metric_range"] == "3.4x above 5,064 mean"
+        assert dumped["metric_range"] == "3.4×IQR above Q3"
 
     def test_model_instantiates_with_minimal_fields(self) -> None:
         agg = AggregatedRecommendation(

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -76,38 +76,51 @@ class TestErrorPatternDetection:
 
 
 class TestTokenOutlierDetection:
+    """IQR-based detection (#186 P2): val > Q3 + 1.5*IQR. Requires
+    OUTLIER_MIN_SAMPLE invocations and IQR > 0 to fire."""
+
     def test_detects_outlier(self) -> None:
+        # Spread of 50–130 tokens/use + one clear outlier at 1000.
+        # Q1≈67.5, Q3≈122.5, IQR≈55, threshold≈205 — 1000 fires.
         invocations = [
-            _inv(total_tokens=1000, tool_uses=10),  # 100 tokens/use
-            _inv(total_tokens=1000, tool_uses=10),  # 100 tokens/use
-            _inv(total_tokens=5000, tool_uses=10),  # 500 tokens/use (5x mean ~233)
-        ]
+            _inv(total_tokens=500 + 100 * i, tool_uses=10) for i in range(9)
+        ] + [_inv(total_tokens=10_000, tool_uses=10)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER]
-        assert len(outliers) >= 1
-        assert outliers[0].detail["ratio"] > 2.0
+        assert len(outliers) == 1
+        d = outliers[0].detail
+        assert d["actual_value"] == 1000.0
+        assert d["excess_iqrs"] > 1.5  # by definition of the threshold
+        assert {"q3_value", "iqr_value", "median_value", "p95_value", "threshold_value"} <= d.keys()
 
     def test_no_outlier_when_similar(self) -> None:
+        invocations = [_inv(total_tokens=1000 + 50 * i, tool_uses=10) for i in range(10)]
+        signals = extract_signals(invocations)
+        outliers = [s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER]
+        assert len(outliers) == 0
+
+    def test_below_min_sample_skipped(self) -> None:
+        # IQR detection needs OUTLIER_MIN_SAMPLE (= 4). At n=3 the rule
+        # mathematically applies but the architect review bounded
+        # detection at n>=4 for stability.
         invocations = [
-            _inv(total_tokens=1000, tool_uses=10),
-            _inv(total_tokens=1100, tool_uses=10),
-            _inv(total_tokens=900, tool_uses=10),
+            _inv(total_tokens=100, tool_uses=10),
+            _inv(total_tokens=100, tool_uses=10),
+            _inv(total_tokens=10_000, tool_uses=10),
         ]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER]
         assert len(outliers) == 0
 
-    def test_single_invocation_skipped(self) -> None:
-        invocations = [_inv(total_tokens=5000, tool_uses=10)]
+    def test_zero_iqr_skipped(self) -> None:
+        # All values identical → IQR=0 → can't establish outlier.
+        invocations = [_inv(total_tokens=1000, tool_uses=10) for _ in range(8)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER]
         assert len(outliers) == 0
 
     def test_no_metadata_skipped(self) -> None:
-        invocations = [
-            _inv(total_tokens=None, tool_uses=None),
-            _inv(total_tokens=None, tool_uses=None),
-        ]
+        invocations = [_inv(total_tokens=None, tool_uses=None) for _ in range(5)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER]
         assert len(outliers) == 0
@@ -115,14 +128,13 @@ class TestTokenOutlierDetection:
 
 class TestDurationOutlierDetection:
     def test_detects_outlier(self) -> None:
+        # Spread of 1000–1800 ms/use + one outlier at 50000.
         invocations = [
-            _inv(duration_ms=10000, tool_uses=10),  # 1000ms/use
-            _inv(duration_ms=10000, tool_uses=10),  # 1000ms/use
-            _inv(duration_ms=50000, tool_uses=10),  # 5000ms/use (5x mean ~2333)
-        ]
+            _inv(duration_ms=10_000 + 1000 * i, tool_uses=10) for i in range(9)
+        ] + [_inv(duration_ms=500_000, tool_uses=10)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
-        assert len(outliers) >= 1
+        assert len(outliers) == 1
 
     def test_single_invocation_skipped(self) -> None:
         invocations = [_inv(duration_ms=50000, tool_uses=10)]
@@ -131,26 +143,27 @@ class TestDurationOutlierDetection:
         assert len(outliers) == 0
 
     def test_uses_active_duration_when_trace_present(self) -> None:
-        # #230: outlier detection should compare active_duration_per_tool_use.
-        # Without #230's fix, the third invocation's wall-clock 50000ms would
-        # flag as an outlier; with the fix, its active duration of 1000ms (the
-        # other 49 seconds were idle wait) puts it in line with peers.
+        # #230: outlier detection compares active_duration_per_tool_use.
+        # Wall-clock 500_000ms would flag as an IQR-outlier; active
+        # duration of ~10_000ms (rest is idle wait) puts it in line.
         from agentfluent.traces.models import SubagentTrace
 
-        normal_a = _inv(duration_ms=10000, tool_uses=10, agent_id="ag-1")
-        normal_b = _inv(duration_ms=10000, tool_uses=10, agent_id="ag-2")
-        slow_wall = _inv(duration_ms=50000, tool_uses=10, agent_id="ag-3")
+        peers = [
+            _inv(duration_ms=10_000 + 1000 * i, tool_uses=10, agent_id=f"ag-{i}")
+            for i in range(9)
+        ]
+        slow_wall = _inv(duration_ms=500_000, tool_uses=10, agent_id="ag-slow")
         slow_wall.trace = SubagentTrace(
-            agent_id="t3",
+            agent_id="t-slow",
             agent_type="pm",
             delegation_prompt="x",
-            duration_ms=50000,
-            idle_gap_ms=40000,  # active = 10000ms, same per-tool rate as peers
+            duration_ms=500_000,
+            idle_gap_ms=490_000,  # active = 10_000ms, in line with peers
         )
 
-        signals = extract_signals([normal_a, normal_b, slow_wall])
+        signals = extract_signals([*peers, slow_wall])
         outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
-        assert outliers == []  # Wall-clock outlier is rescued by active duration
+        assert outliers == []
 
 
 class TestExtractSignals:
@@ -198,23 +211,22 @@ class TestInvocationIdPropagation:
         assert signals[0].invocation_id == "toolu_42"
 
     def test_token_outlier_signal_carries_invocation_id(self) -> None:
-        invocations = [
-            _inv(total_tokens=1000, tool_uses=10, agent_id="ag-1"),
-            _inv(total_tokens=1000, tool_uses=10, agent_id="ag-2"),
-            _inv(total_tokens=10000, tool_uses=10, agent_id="ag-3"),
+        peers = [
+            _inv(total_tokens=1000 + 100 * i, tool_uses=10, agent_id=f"ag-{i}")
+            for i in range(9)
         ]
-        signals = extract_signals(invocations)
+        outlier_inv = _inv(total_tokens=100_000, tool_uses=10, agent_id="ag-spike")
+        signals = extract_signals([*peers, outlier_inv])
         outlier = next(s for s in signals if s.signal_type == SignalType.TOKEN_OUTLIER)
-        # Outlier rule fires for ag-3 (10x the mean, well above 2x threshold).
-        assert outlier.invocation_id == "ag-3"
+        assert outlier.invocation_id == "ag-spike"
 
     def test_duration_outlier_signal_carries_invocation_id(self) -> None:
-        invocations = [
-            _inv(duration_ms=1000, tool_uses=10, agent_id="ag-1"),
-            _inv(duration_ms=1000, tool_uses=10, agent_id="ag-2"),
-            _inv(duration_ms=10000, tool_uses=10, agent_id="ag-slow"),
+        peers = [
+            _inv(duration_ms=1000 + 100 * i, tool_uses=10, agent_id=f"ag-{i}")
+            for i in range(9)
         ]
-        signals = extract_signals(invocations)
+        slow = _inv(duration_ms=100_000, tool_uses=10, agent_id="ag-slow")
+        signals = extract_signals([*peers, slow])
         outlier = next(s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER)
         assert outlier.invocation_id == "ag-slow"
 


### PR DESCRIPTION
Closes #186 and #235.

## Summary

Two related changes, two clean commits:

1. **#235** — extract \`_detect_outliers\` helper to remove pre-existing duplication between \`_extract_token_outliers\` and \`_extract_duration_outliers\` (no behavior change).
2. **#186 Phase 2** — migrate the helper from mean-ratio (\`val > mean × 2.0\`) to Tukey IQR (\`val > Q3 + 1.5 × IQR\`).

Per architect note in #235, doing the refactor first means the IQR migration only touches one helper.

## Why IQR

Per Section 10 of the calibration notebook (PR #233):
- **Mean is unstable under right-skew** — agent token/duration distributions are right-tailed; a few high values pull the mean up, making \"Nx above mean\" self-referential.
- **IQR is robust to skew** — Q1, Q3 don't move when extremes change.
- **Z-score** assumes normality (poor fit at small n with skew).
- **P95** is tautological at small n (top value IS P95).

## Detail-dict schema change

| Old | New |
|---|---|
| \`actual_value\` | \`actual_value\` |
| \`mean_value\` | \`median_value\` |
| \`ratio\` | \`excess_iqrs\` (= (val - Q3) / IQR) |
| — | \`q3_value\`, \`iqr_value\`, \`p95_value\`, \`threshold_value\` |

\`excess_iqrs\` is the analogue of \"how many std devs\" but robust to skew. Aggregation now builds \`\"3.2×–6.8×IQR above Q3\"\` instead of \`\"4.9x–8.0x above 5,064 mean\"\`.

**Breaking for JSON consumers** keying on \`detail.ratio\` or \`detail.mean_value\`. v0.5's \"Trustworthy Diagnostics\" theme is the right window for the schema change.

## Constants

- \`OUTLIER_THRESHOLD = 2.0\` → removed
- \`OUTLIER_IQR_MULTIPLIER = 1.5\` (Tukey standard)
- \`OUTLIER_MIN_SAMPLE = 4\` (required by \`statistics.quantiles(n=4)\`)
- IQR ≤ 0 (degenerate distributions) skips emission

## Dogfood spot-check

| Agent | Q3 tokens/use | IQR | Threshold | Sample flagged |
|---|---:|---:|---:|---|
| pm | 7,763 | 4,726 | ~14,852 | 14,974 (1.5×IQR), 21,903 (3.0×IQR) |
| architect | 4,210 | 1,048 | ~5,782 | 7,130 (2.8×IQR) |

| Agent | Q3 active s/use | IQR | Threshold | Sample flagged |
|---|---:|---:|---:|---|
| pm | 21.3s | 13.8s | 41.9s | 54.6s (2.4×IQR), 45.0s (1.7×IQR) |

All flagged invocations are genuine outliers above the IQR-based threshold.

## Test plan

- [x] \`uv run pytest -m \"not integration\"\` — 815 pass
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run mypy src/agentfluent/\` clean
- [x] Dogfood spot-check confirms reasonable threshold/excess values per agent type
- [x] Reviewer reviews glossary updates for token_outlier and duration_outlier entries

## Sequencing

This unblocks #187 (distribution context in verbose output) — the new \`detail\` fields are exactly what #187 needs to surface alongside outlier signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)