### PR TITLE
fix(diagnostics): filter PERMISSION_FAILURE false positives (#231)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -327,6 +327,14 @@ single config change ("grant tool X"). Cross-cuts with
 the remediation surfaces are different (tool config vs. prompt
 fallback).
 
+**False-positive filter.** Two structural patterns suppress emission
+even when the keyword matches: a leading line-number prefix
+(`<n>\t...` from Read or `<n>:...` from Grep — successful tool
+output where the keyword appears in source code, not as an error),
+and a result truncated at the 500-char summary cap (file content,
+not a denial message). Both fail open — preferring suppression to
+spurious denials.
+
 **Example:**
 
 ```

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -36,6 +36,7 @@ import re
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 from agentfluent.traces.models import (
+    RESULT_SUMMARY_MAX_CHARS,
     RetrySequence,
     SubagentToolCall,
     SubagentTrace,
@@ -56,6 +57,37 @@ PERMISSION_REGEX = re.compile(
     "|".join(re.escape(k) for k in _PERMISSION_KEYWORDS),
     re.IGNORECASE,
 )
+
+# Line-number prefix on the first line of tool output (#231):
+#  - Read uses ``<n>\t<content>``
+#  - Grep uses ``<n>:<content>`` (or ``<file>:<n>:<content>``)
+# A successful read of source code that incidentally contains a
+# permission keyword (e.g., ``signals.py``'s ``ERROR_PATTERNS`` listing
+# "blocked", "permission denied") would otherwise emit a false
+# PERMISSION_FAILURE. Real read/grep errors don't carry line numbers.
+_LINE_NUMBERED_RESULT = re.compile(r"^\s*\d+[\t:]")
+
+
+def _is_false_positive_denial(result_summary: str) -> bool:
+    """Skip PERMISSION_FAILURE emission when the keyword match is
+    structurally indistinguishable from successful file content (#231).
+
+    Two empirically-grounded indicators:
+
+    1. Line-number prefix on the first line — Claude Code's Read tool's
+       output format. Real error messages don't have line numbers.
+    2. Result truncated at ``RESULT_SUMMARY_MAX_CHARS`` — the original
+       was at least 500 chars, far longer than typical denial messages
+       and consistent with file content.
+
+    Both fail open (suppression rather than spurious emission), matching
+    the trustworthiness goal: rather noise than false denials.
+    """
+    if _LINE_NUMBERED_RESULT.search(result_summary):
+        return True
+    if len(result_summary) >= RESULT_SUMMARY_MAX_CHARS:
+        return True
+    return False
 
 # Cap on the `detail.tool_calls` evidence list. The true count lives in
 # the sibling `error_count` / `retry_count` / `stuck_count` detail key.
@@ -108,6 +140,8 @@ def _extract_permission_failures(
     for i, call in enumerate(trace.tool_calls):
         match = PERMISSION_REGEX.search(call.result_summary)
         if match is None:
+            continue
+        if _is_false_positive_denial(call.result_summary):
             continue
         matches.append((i, call, match.group(0).lower()))
 

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -58,36 +58,18 @@ PERMISSION_REGEX = re.compile(
     re.IGNORECASE,
 )
 
-# Line-number prefix on the first line of tool output (#231):
-#  - Read uses ``<n>\t<content>``
-#  - Grep uses ``<n>:<content>`` (or ``<file>:<n>:<content>``)
-# A successful read of source code that incidentally contains a
-# permission keyword (e.g., ``signals.py``'s ``ERROR_PATTERNS`` listing
-# "blocked", "permission denied") would otherwise emit a false
-# PERMISSION_FAILURE. Real read/grep errors don't carry line numbers.
+# Match a leading line-number prefix from successful Read (``<n>\t``) or
+# Grep (``<n>:``) output. Permission-keyword hits inside such results
+# are file content, not error messages.
 _LINE_NUMBERED_RESULT = re.compile(r"^\s*\d+[\t:]")
 
 
 def _is_false_positive_denial(result_summary: str) -> bool:
-    """Skip PERMISSION_FAILURE emission when the keyword match is
-    structurally indistinguishable from successful file content (#231).
-
-    Two empirically-grounded indicators:
-
-    1. Line-number prefix on the first line — Claude Code's Read tool's
-       output format. Real error messages don't have line numbers.
-    2. Result truncated at ``RESULT_SUMMARY_MAX_CHARS`` — the original
-       was at least 500 chars, far longer than typical denial messages
-       and consistent with file content.
-
-    Both fail open (suppression rather than spurious emission), matching
-    the trustworthiness goal: rather noise than false denials.
-    """
-    if _LINE_NUMBERED_RESULT.search(result_summary):
+    """True when a permission keyword in ``result_summary`` is structurally
+    file content (line-numbered Read/Grep output, or truncated to the cap)."""
+    if _LINE_NUMBERED_RESULT.match(result_summary):
         return True
-    if len(result_summary) >= RESULT_SUMMARY_MAX_CHARS:
-        return True
-    return False
+    return len(result_summary) >= RESULT_SUMMARY_MAX_CHARS
 
 # Cap on the `detail.tool_calls` evidence list. The true count lives in
 # the sibling `error_count` / `retry_count` / `stuck_count` detail key.

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -240,6 +240,14 @@
     `tool_error_sequence` -- both fire from the same evidence -- because
     the remediation surfaces are different (tool config vs. prompt
     fallback).
+
+    **False-positive filter.** Two structural patterns suppress emission
+    even when the keyword matches: a leading line-number prefix
+    (`<n>\t...` from Read or `<n>:...` from Grep — successful tool
+    output where the keyword appears in source code, not as an error),
+    and a result truncated at the 500-char summary cap (file content,
+    not a denial message). Both fail open — preferring suppression to
+    spurious denials.
   example: "Subagent 'pm' was denied access to tool 'Write' ('permission denied')."
   severity_range: critical
   threshold: "keyword match: permission denied / access denied / not allowed / blocked"

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -1,9 +1,12 @@
 """Tests for trace-level signal extraction."""
 
+import pytest
+
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import SignalType
 from agentfluent.diagnostics.trace_signals import extract_trace_signals
 from agentfluent.traces.models import (
+    RESULT_SUMMARY_MAX_CHARS,
     RetrySequence,
     SubagentToolCall,
     SubagentTrace,
@@ -132,54 +135,39 @@ class TestPermissionFailure:
 
 
 class TestPermissionFailureFalsePositiveFilter:
-    """#231: skip emission when the keyword match is structurally
-    indistinguishable from successful file content. Two indicators:
-    line-number prefix (Claude Code's Read format) and result
-    truncated at RESULT_SUMMARY_MAX_CHARS."""
+    """Suppress emission on Read/Grep output that incidentally matches a keyword."""
 
     def test_line_numbered_read_does_not_fire(self) -> None:
-        # Successful Read of signals.py — first line is "1\t<content>".
-        # The full file mentions "blocked" in ERROR_PATTERNS and would
-        # otherwise emit a false PERMISSION_FAILURE.
         result = (
             '1\t"""Behavior signal extraction from agent invocations."""\n'
             '2\t\n'
             '3\tfrom agentfluent.diagnostics.signals import "blocked" keyword'
         )
-        trace = _trace(calls=[_tc(tool="Read", res=result, err=True)])
+        trace = _trace(calls=[_tc(tool="Read", res=result, err=False)])
         signals = extract_trace_signals(trace)
         perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
         assert perms == []
 
     def test_truncated_long_result_does_not_fire(self) -> None:
-        # Result reaching RESULT_SUMMARY_MAX_CHARS implies file content,
-        # not a denial message (real denials are short).
-        from agentfluent.traces.models import RESULT_SUMMARY_MAX_CHARS
-
         long_result = "x" * (RESULT_SUMMARY_MAX_CHARS - len("blocked")) + "blocked"
         trace = _trace(calls=[_tc(tool="Bash", res=long_result, err=True)])
         signals = extract_trace_signals(trace)
         perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
         assert perms == []
 
-    def test_short_denial_still_fires(self) -> None:
-        # Sanity: real denial messages — short, no line numbers — are
-        # still flagged.
-        trace = _trace(
-            calls=[_tc(tool="Read", res="Permission denied: /etc/shadow", err=True)],
-        )
+    @pytest.mark.parametrize(
+        ("result", "keyword"),
+        [
+            ("Permission denied: /etc/shadow", "permission denied"),
+            ("Operation blocked by policy.", "blocked"),
+        ],
+    )
+    def test_short_denial_still_fires(self, result: str, keyword: str) -> None:
+        trace = _trace(calls=[_tc(res=result, err=True)])
         signals = extract_trace_signals(trace)
         perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
         assert len(perms) == 1
-        assert perms[0].detail["matched_keyword"] == "permission denied"
-
-    def test_short_blocked_message_still_fires(self) -> None:
-        trace = _trace(
-            calls=[_tc(tool="Bash", res="Operation blocked by policy.", err=True)],
-        )
-        signals = extract_trace_signals(trace)
-        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
-        assert len(perms) == 1
+        assert perms[0].detail["matched_keyword"] == keyword
 
 
 class TestErrorSequences:

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -131,6 +131,57 @@ class TestPermissionFailure:
         assert tools == {"Write", "Bash"}
 
 
+class TestPermissionFailureFalsePositiveFilter:
+    """#231: skip emission when the keyword match is structurally
+    indistinguishable from successful file content. Two indicators:
+    line-number prefix (Claude Code's Read format) and result
+    truncated at RESULT_SUMMARY_MAX_CHARS."""
+
+    def test_line_numbered_read_does_not_fire(self) -> None:
+        # Successful Read of signals.py — first line is "1\t<content>".
+        # The full file mentions "blocked" in ERROR_PATTERNS and would
+        # otherwise emit a false PERMISSION_FAILURE.
+        result = (
+            '1\t"""Behavior signal extraction from agent invocations."""\n'
+            '2\t\n'
+            '3\tfrom agentfluent.diagnostics.signals import "blocked" keyword'
+        )
+        trace = _trace(calls=[_tc(tool="Read", res=result, err=True)])
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert perms == []
+
+    def test_truncated_long_result_does_not_fire(self) -> None:
+        # Result reaching RESULT_SUMMARY_MAX_CHARS implies file content,
+        # not a denial message (real denials are short).
+        from agentfluent.traces.models import RESULT_SUMMARY_MAX_CHARS
+
+        long_result = "x" * (RESULT_SUMMARY_MAX_CHARS - len("blocked")) + "blocked"
+        trace = _trace(calls=[_tc(tool="Bash", res=long_result, err=True)])
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert perms == []
+
+    def test_short_denial_still_fires(self) -> None:
+        # Sanity: real denial messages — short, no line numbers — are
+        # still flagged.
+        trace = _trace(
+            calls=[_tc(tool="Read", res="Permission denied: /etc/shadow", err=True)],
+        )
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 1
+        assert perms[0].detail["matched_keyword"] == "permission denied"
+
+    def test_short_blocked_message_still_fires(self) -> None:
+        trace = _trace(
+            calls=[_tc(tool="Bash", res="Operation blocked by policy.", err=True)],
+        )
+        signals = extract_trace_signals(trace)
+        perms = [s for s in signals if s.signal_type == SignalType.PERMISSION_FAILURE]
+        assert len(perms) == 1
+
+
 class TestErrorSequences:
     def test_single_error_no_signal(self) -> None:
         trace = _trace(calls=[_tc(err=True)])


### PR DESCRIPTION
Closes #231.

## Summary

Reduces \`permission_failure\` noise from 17 → 1 on the v0.5 dogfood (94% reduction). Diagnosis turned out to be different from the issue's original framing — most useful piece is the architect review on the issue.

## What was actually wrong

Issue body said \"most permission_failure signals come from the secret-blocking PreToolUse hook.\" Empirical investigation showed something else:

- All 17 flagged signals were on **successful Reads of source files** that incidentally contain the keywords (\`signals.py\` defining \`ERROR_PATTERNS\`, \`correlator.py\` referencing them in \`AccessErrorRule._KEYWORDS\`, the calibration notebook, etc.)
- Zero hook-denial outputs found in the JSONL data — the original framing's premise doesn't hold for this dataset
- Root cause: \`_detect_is_error\` in \`traces/parser.py\` regex-matches the same keywords inside file content and synthesizes \`is_error=True\`. Then \`_extract_permission_failures\` matches them again and emits a signal.

## Architect review

Posted on issue #231 ([comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/231)). Verdict: proceed with consumer-layer filter for #231 scope, file separate issue for the deeper parser-layer fix.

Done — that's #238, filed alongside this PR.

## Implementation

Add \`_is_false_positive_denial\` to \`trace_signals.py\`. Skip \`PERMISSION_FAILURE\` emission when result_summary matches:

1. **Line-number prefix** (\`^\\s*\\d+[\\t:]\`) — Claude Code's Read uses \`<n>\\t...\`, Grep uses \`<n>:...\`. Real Read/Grep errors don't carry line numbers.
2. **Truncated at \`RESULT_SUMMARY_MAX_CHARS\`** — implies file content (real denial messages are short).

Both fail open (suppression vs spurious emission), matching v0.5's Trustworthy Diagnostics theme.

## What was dropped from the original plan

- **Hook-pattern filters** (\`Blocked by .* hook\`, \`PreToolUse hook\`, \`.claude/hooks/\`) — zero empirical matches; YAGNI per architect.
- **\`is_error=True\` precondition** — would mask nothing because the inflated \`is_error=True\` is itself the false-positive signal, not the gate.

## Dogfood

| | Before | After |
|---|---|---|
| permission_failure | 17 | 1 |

The remaining 1 is a \`gh issue view\` Bash output containing markdown text \"Blocked on #114\". Accepted as residual; refining the keyword regex to dodge it would risk false negatives on real denials like \"Operation blocked.\".

## Test plan

- [x] 4 new tests in \`tests/unit/test_trace_signals.py\` (line-number false positive, length false positive, short denial still fires, short blocked still fires)
- [x] All 825 tests pass; ruff + mypy clean
- [x] Dogfood reduction confirmed 17 → 1
- [x] Reviewer confirms glossary entry for \`permission_failure\` reads sensibly with the false-positive note

## Follow-up

[#238](https://github.com/frederick-douglas-pearce/agentfluent/issues/238) — parser-layer fix to \`_detect_is_error\` regex fallback. Broader scope; affects \`tool_error_sequence\` (99 signals in dogfood, likely many similarly inflated). Should land before #172 (priority ranking) to avoid phantom errors being ranked as actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)