### PR TITLE
fix(diagnostics): bound is_error regex fallback to leading 200 chars (#238)

### DIFF
--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -49,14 +49,9 @@ from agentfluent.traces.retry import detect_retry_sequences
 IDLE_GAP_K = 10
 IDLE_GAP_FLOOR_MS = 300_000
 
-# Window (in chars) the regex fallback in ``_detect_is_error`` searches.
 # Real error messages lead with the indicator ("Error: ...", "Permission
-# denied", "Failed to ..."); successful Reads of files that mention error
-# keywords mid-text should not synthesize ``is_error=True``. The v0.5
-# dogfood (2026-05-01) showed 2,202/3,081 (71%) of tool_results lack
-# explicit ``is_error`` and routed through this fallback, producing
-# spurious ``permission_failure`` and ``tool_error_sequence`` signals on
-# successful reads of files like signals.py and the calibration notebook.
+# denied", "Failed to ..."). Bounding the regex prevents successful Reads
+# of files that mention error keywords mid-text from synthesizing is_error.
 ERROR_DETECTION_WINDOW_CHARS = 200
 
 

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -49,6 +49,16 @@ from agentfluent.traces.retry import detect_retry_sequences
 IDLE_GAP_K = 10
 IDLE_GAP_FLOOR_MS = 300_000
 
+# Window (in chars) the regex fallback in ``_detect_is_error`` searches.
+# Real error messages lead with the indicator ("Error: ...", "Permission
+# denied", "Failed to ..."); successful Reads of files that mention error
+# keywords mid-text should not synthesize ``is_error=True``. The v0.5
+# dogfood (2026-05-01) showed 2,202/3,081 (71%) of tool_results lack
+# explicit ``is_error`` and routed through this fallback, producing
+# spurious ``permission_failure`` and ``tool_error_sequence`` signals on
+# successful reads of files like signals.py and the calibration notebook.
+ERROR_DETECTION_WINDOW_CHARS = 200
+
 
 def _truncate_input(input_dict: dict[str, Any] | None) -> str:
     """Serialize a tool_use input dict and truncate to the model's max.
@@ -75,14 +85,17 @@ def _detect_is_error(block: ContentBlock) -> bool:
     """Detect whether a tool_result block represents an error.
 
     Explicit ``is_error`` field is authoritative when present (True or
-    False). When missing, fall back to regex-matching the result text
-    against ``ERROR_PATTERNS`` keywords (case-insensitive).
+    False). When missing, fall back to regex-matching the *leading*
+    ``ERROR_DETECTION_WINDOW_CHARS`` of the result text against
+    ``ERROR_PATTERNS`` keywords (case-insensitive). The leading-window
+    bound prevents successful Reads of files that mention error
+    keywords mid-text from synthesizing ``is_error=True``.
     """
     if block.is_error is not None:
         return block.is_error
     if not block.text:
         return False
-    return bool(ERROR_REGEX.search(block.text))
+    return bool(ERROR_REGEX.search(block.text[:ERROR_DETECTION_WINDOW_CHARS]))
 
 
 def _sum_usage(messages: list[SessionMessage]) -> Usage:

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -15,7 +15,10 @@ from agentfluent.traces.models import (
     UNKNOWN_AGENT_TYPE,
     SubagentTrace,
 )
-from agentfluent.traces.parser import parse_subagent_trace
+from agentfluent.traces.parser import (
+    ERROR_DETECTION_WINDOW_CHARS,
+    parse_subagent_trace,
+)
 from tests._builders import (
     assistant_message as _assistant,
 )
@@ -272,10 +275,10 @@ class TestIsErrorDetection:
     def test_keyword_outside_leading_window_stays_false(
         self, write_jsonl: WriteJSONL,
     ) -> None:
-        # Successful Read of a file that mentions "error" / "failed" mid-text
-        # (e.g., reading signals.py itself) must not synthesize is_error.
-        # The keyword sits past the leading detection window.
-        leading_padding = "ok " * 80  # ~240 chars of benign prefix
+        # Successful Read of a file that mentions error keywords mid-text
+        # must not synthesize is_error. Padding sized off the constant so
+        # the test self-updates if the window is tuned.
+        leading_padding = "ok " * (ERROR_DETECTION_WINDOW_CHARS // 3 + 20)
         result_text = leading_padding + "definitions of error and failed live here"
         path = write_jsonl(
             "agent-x.jsonl",

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -269,6 +269,38 @@ class TestIsErrorDetection:
         )
         assert parse_subagent_trace(path).tool_calls[0].is_error is False
 
+    def test_keyword_outside_leading_window_stays_false(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # Successful Read of a file that mentions "error" / "failed" mid-text
+        # (e.g., reading signals.py itself) must not synthesize is_error.
+        # The keyword sits past the leading detection window.
+        leading_padding = "ok " * 80  # ~240 chars of benign prefix
+        result_text = leading_padding + "definitions of error and failed live here"
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Read")]),
+                _user([_tool_result("t1", result_text)]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is False
+
+    def test_short_error_with_leading_keyword_fires(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # Real error messages lead with the indicator — must still fire.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1", "Error: command not found: foo")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
 
 class TestUsageAggregation:
     def test_sums_across_assistants(self, write_jsonl: WriteJSONL) -> None:


### PR DESCRIPTION
## Summary

- Bounds `traces.parser._detect_is_error` regex fallback to the leading 200 chars of result text. Successful Reads of files that mention error keywords mid-text (e.g., `signals.py`, `correlator.py`, the v0.5 calibration notebook) no longer synthesize `is_error=True`.
- Adds two tests: leading-keyword case still fires; mid-text keyword stays `False`.
- Constant `ERROR_DETECTION_WINDOW_CHARS = 200` with rationale comment near other parser thresholds.

Implements Option A from #238.

## Why 200 chars

Real error messages lead with the indicator: `"Error: ..."`, `"Permission denied"`, `"Failed to ..."`. 200 chars is wide enough to cover wrapped error prefaces but narrow enough to skip mid-file content from the dominant false-positive case (Read results). Option B (drop the fallback entirely) was the alternative, but the dogfood showed 71% of tool_results lack explicit `is_error` — losing detection on that majority is too steep a price for the marginal cleanliness gain.

## Dogfood validation

`agentfluent analyze --project agentfluent --diagnostics --json` before/after on `main`:

| Signal type | Before | After |
|-------------|--------|-------|
| `tool_error_sequence` | 101 | **26** |
| `retry_loop` | 78 | 78 |
| `token_outlier` | 19 | 19 |
| `duration_outlier` | 14 | 14 |
| `permission_failure` | 1 | 1 |
| `model_mismatch` | 1 | **0** |
| **TOTAL** | **214** | **138** |

74% reduction in `tool_error_sequence` and the spurious `model_mismatch` clears, consistent with the architect's review on #231 and the empirical scope captured in #238 (2,202/3,081 = 71% of tool_results route through the fallback). `retry_loop` is unchanged because it doesn't consume `is_error`.

## Out of scope (follow-up)

`diagnostics/mcp_assessment.py:157` has the same regex-fallback pattern (`bool(ERROR_REGEX.search(result_text))` on full text) for parent-thread MCP tool results. Same bug class, same fix would apply, but #238 explicitly scopes to `_detect_is_error`. Worth a follow-up issue if MCP signal noise shows up in dogfood.

Closes #238.

## Test plan

- [x] `uv run pytest -m "not integration"` — 827 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean
- [x] New unit tests: `test_keyword_outside_leading_window_stays_false`, `test_short_error_with_leading_keyword_fires`
- [x] Existing `is_error` tests still pass (4 cases in `TestIsErrorDetection`)
- [x] Dogfood signal counts captured above