### PR TITLE
refactor(diagnostics): extract shared clustering helpers into _clustering.py (#242)

### DIFF
--- a/src/agentfluent/diagnostics/_clustering.py
+++ b/src/agentfluent/diagnostics/_clustering.py
@@ -45,7 +45,7 @@ class SklearnMissingError(RuntimeError):
     """Raised when clustering is invoked but scikit-learn is not installed."""
 
 
-def _fit_kmeans(
+def fit_kmeans(
     embeddings: np.ndarray,
     n_clusters: int,
     *,
@@ -62,7 +62,7 @@ def _fit_kmeans(
     return np.asarray(km.fit_predict(embeddings))
 
 
-def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
+def cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
     """Return KMeans labels from the k that scores highest on silhouette.
 
     For n < 10, silhouette's useful k-range collapses (e.g. k_upper=1) —
@@ -71,16 +71,16 @@ def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
     refit.
     """
     if n_samples < _SMALL_N_THRESHOLD:
-        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+        return fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     k_upper = min(_SILHOUETTE_K_MAX, n_samples // 5)
     if k_upper < 2:
-        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+        return fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     best_labels: np.ndarray | None = None
     best_score = -1.0
     for k in range(2, k_upper + 1):
-        labels = _fit_kmeans(embeddings, k)
+        labels = fit_kmeans(embeddings, k)
         if len(set(labels)) < 2:
             continue
         score = silhouette_score(embeddings, labels)
@@ -102,12 +102,12 @@ def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
         )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+            return fit_kmeans(embeddings, _FORCED_SMALL_K)
 
     return best_labels
 
 
-def _mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
+def mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
     """Average pairwise cosine similarity within a cluster — our cohesion proxy."""
     if len(cluster_embeddings) < 2:
         return 1.0
@@ -118,7 +118,7 @@ def _mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
     return float(total)
 
 
-def _top_tfidf_terms(
+def top_tfidf_terms(
     tfidf_matrix: np.ndarray,
     member_indices: list[int],
     terms: np.ndarray,
@@ -131,7 +131,7 @@ def _top_tfidf_terms(
     return [str(terms[i]) for i in top_idx if mean_array[i] > 0]
 
 
-def _group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
+def group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
     """Single-pass grouping of sample indices by their cluster label."""
     groups: dict[int, list[int]] = defaultdict(list)
     for i, lab in enumerate(labels):
@@ -139,7 +139,7 @@ def _group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
     return groups
 
 
-def _all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
+def all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
     """Detect an anomaly: byte-identical TF-IDF rows across all members.
 
     Agent-generated prompts are probabilistic; identical rows across

--- a/src/agentfluent/diagnostics/_clustering.py
+++ b/src/agentfluent/diagnostics/_clustering.py
@@ -1,0 +1,164 @@
+"""Generic TF-IDF + KMeans clustering primitives shared across diagnostics.
+
+Houses the input-agnostic building blocks used by ``delegation.py`` and
+(starting with #189) ``parent_workload.py``: KMeans fit + silhouette
+sweep, cosine-cohesion scoring, top-term extraction, label grouping,
+and the degenerate-input ("all rows identical") detector. Anything
+shaped to a specific diagnostic input (delegation prompts, parent-thread
+bursts, etc.) lives in the consumer module, not here.
+
+scikit-learn remains an **optional extra** (``agentfluent[clustering]``).
+The canonical ``SKLEARN_AVAILABLE`` flag and ``SklearnMissingError``
+type live here; consumer modules re-export them so existing callers and
+test monkeypatches keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from collections import defaultdict
+
+try:
+    import numpy as np
+    from sklearn.cluster import KMeans
+    from sklearn.metrics import silhouette_score
+    from sklearn.metrics.pairwise import cosine_similarity
+
+    SKLEARN_AVAILABLE = True
+except ImportError:  # pragma: no cover — exercised via the install-path test
+    SKLEARN_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+# Tunables shared across all clustering consumers. Override via kwargs at
+# the call site rather than mutating these.
+_SILHOUETTE_K_MAX = 10        # upper bound on silhouette-selected k
+_SMALL_N_THRESHOLD = 10       # below this, force k=2 without silhouette
+_FORCED_SMALL_K = 2
+_KMEANS_RANDOM_STATE = 42     # default seed for reproducible clustering
+_KMEANS_N_INIT = 10           # KMeans restarts; higher resists bad local minima
+_TOP_TERMS_COUNT = 5
+
+
+class SklearnMissingError(RuntimeError):
+    """Raised when clustering is invoked but scikit-learn is not installed."""
+
+
+def _fit_kmeans(
+    embeddings: np.ndarray,
+    n_clusters: int,
+    *,
+    random_state: int = _KMEANS_RANDOM_STATE,
+    n_init: int = _KMEANS_N_INIT,
+) -> np.ndarray:
+    """Fit KMeans and return labels as a concrete ndarray.
+
+    Thin wrapper that fixes the ``random_state`` / ``n_init`` defaults
+    (both tunable via kwargs) and converts sklearn's ``Any``-typed
+    ``fit_predict`` return value to an ndarray so mypy stays strict.
+    """
+    km = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=n_init)
+    return np.asarray(km.fit_predict(embeddings))
+
+
+def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
+    """Return KMeans labels from the k that scores highest on silhouette.
+
+    For n < 10, silhouette's useful k-range collapses (e.g. k_upper=1) —
+    force k=2 and do a single fit. Otherwise, sweep k and keep the
+    labels from the best-scoring fit so we avoid a redundant final-k
+    refit.
+    """
+    if n_samples < _SMALL_N_THRESHOLD:
+        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+
+    k_upper = min(_SILHOUETTE_K_MAX, n_samples // 5)
+    if k_upper < 2:
+        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+
+    best_labels: np.ndarray | None = None
+    best_score = -1.0
+    for k in range(2, k_upper + 1):
+        labels = _fit_kmeans(embeddings, k)
+        if len(set(labels)) < 2:
+            continue
+        score = silhouette_score(embeddings, labels)
+        if score > best_score:
+            best_score = score
+            best_labels = labels
+
+    # Degenerate fallback: every k collapsed to a single cluster. Rare,
+    # but possible with near-identical embeddings that survived row
+    # de-dup but lose variance after LSA. Log it so the anomaly is
+    # observable, then force k=2 and suppress the resulting
+    # convergence warning.
+    if best_labels is None:
+        logger.info(
+            "KMeans produced no multi-cluster solution for %d samples; "
+            "falling back to k=2. Input may have near-zero variance "
+            "after TF-IDF + LSA reduction.",
+            n_samples,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _fit_kmeans(embeddings, _FORCED_SMALL_K)
+
+    return best_labels
+
+
+def _mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
+    """Average pairwise cosine similarity within a cluster — our cohesion proxy."""
+    if len(cluster_embeddings) < 2:
+        return 1.0
+    sim = cosine_similarity(cluster_embeddings)
+    # Exclude the diagonal (self-sim=1) to avoid biasing toward 1.0.
+    n = sim.shape[0]
+    total = (sim.sum() - n) / (n * n - n)
+    return float(total)
+
+
+def _top_tfidf_terms(
+    tfidf_matrix: np.ndarray,
+    member_indices: list[int],
+    terms: np.ndarray,
+    top_n: int = _TOP_TERMS_COUNT,
+) -> list[str]:
+    member_vecs = tfidf_matrix[member_indices]
+    mean_scores = member_vecs.mean(axis=0)
+    mean_array = np.asarray(mean_scores).ravel()
+    top_idx = mean_array.argsort()[::-1][:top_n]
+    return [str(terms[i]) for i in top_idx if mean_array[i] > 0]
+
+
+def _group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
+    """Single-pass grouping of sample indices by their cluster label."""
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i, lab in enumerate(labels):
+        groups[int(lab)].append(i)
+    return groups
+
+
+def _all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
+    """Detect an anomaly: byte-identical TF-IDF rows across all members.
+
+    Agent-generated prompts are probabilistic; identical rows across
+    multiple invocations is very unlikely in real data. When it does
+    happen, it usually points upstream — duplicate session records,
+    an invocation-extraction bug, or a parent agent producing
+    non-probabilistic output. Detecting this case lets callers emit a
+    clear warning instead of silently producing zero clusters or sklearn
+    convergence noise.
+
+    Densifies once and compares rows to row 0 with a vectorized numpy
+    equality check. A single ``toarray()`` + broadcast is ~O(n × features);
+    faster and more predictable than a row-by-row densify loop, and
+    avoids sparse-sparse ``!=`` short-circuit quirks across scipy
+    versions.
+    """
+    if tfidf_matrix.shape[0] <= 1:
+        return True
+    # sklearn TfidfVectorizer returns a scipy sparse matrix, not a
+    # numpy ndarray — no type stubs for scipy.sparse in this project.
+    dense = tfidf_matrix.toarray()  # type: ignore[attr-defined]
+    return bool((dense == dense[0]).all())

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -24,28 +24,50 @@ from __future__ import annotations
 import logging
 import re
 import warnings
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 try:
     import numpy as np
-    from sklearn.cluster import KMeans
     from sklearn.decomposition import TruncatedSVD
     from sklearn.feature_extraction.text import TfidfVectorizer
-    from sklearn.metrics import silhouette_score
     from sklearn.metrics.pairwise import cosine_similarity
-
-    SKLEARN_AVAILABLE = True
 except ImportError:  # pragma: no cover — exercised via the install-path test
-    SKLEARN_AVAILABLE = False
+    pass
 
 from agentfluent.agents.models import WRITE_TOOLS, is_general_purpose
+from agentfluent.diagnostics._clustering import (
+    SKLEARN_AVAILABLE,
+    SklearnMissingError,
+    _all_rows_identical,
+    _cluster_embeddings,
+    _group_indices_by_label,
+    _mean_pairwise_cosine,
+    _top_tfidf_terms,
+)
 from agentfluent.diagnostics.models import DelegationSuggestion
 
 if TYPE_CHECKING:
     from agentfluent.agents.models import AgentInvocation
     from agentfluent.config.models import AgentConfig
+
+# Re-exported from _clustering so existing import paths keep working
+# (e.g., ``from agentfluent.diagnostics.delegation import SKLEARN_AVAILABLE``,
+# ``SklearnMissingError``, and ``monkeypatch.setattr(delegation, "SKLEARN_AVAILABLE", ...)``).
+__all__ = [
+    "DEFAULT_MIN_CLUSTER_SIZE",
+    "DEFAULT_MIN_SIMILARITY",
+    "MIN_TEXT_TOKENS",
+    "MODEL_HAIKU",
+    "MODEL_OPUS",
+    "MODEL_SONNET",
+    "SKLEARN_AVAILABLE",
+    "DelegationCluster",
+    "SklearnMissingError",
+    "cluster_delegations",
+    "generate_draft",
+    "suggest_delegations",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -67,11 +89,6 @@ MIN_TEXT_TOKENS = 50
 LSA_COMPONENTS = 50
 DEFAULT_MIN_CLUSTER_SIZE = 5
 DEFAULT_MIN_SIMILARITY = 0.7
-_SILHOUETTE_K_MAX = 10        # upper bound on silhouette-selected k
-_SMALL_N_THRESHOLD = 10       # below this, force k=2 without silhouette
-_FORCED_SMALL_K = 2
-_KMEANS_RANDOM_STATE = 42     # default seed for reproducible clustering
-_KMEANS_N_INIT = 10           # KMeans restarts; higher resists bad local minima
 # Confidence tier boundaries: calibrated against two real-world
 # datasets (agentfluent: 5 clusters, cohesion 0.26–0.46; codefluent:
 # 2 clusters, cohesion 0.16–0.31) in the #167 investigation. Clusters
@@ -88,7 +105,6 @@ _TOOL_READ_ONLY = frozenset(
     {"Read", "Grep", "Glob", "WebFetch", "WebSearch", "LS"},
 )
 _HEAVY_TOKEN_THRESHOLD = 20_000
-_TOP_TERMS_COUNT = 5
 _PROMPT_BODY_SNIPPET_CHARS = 500
 
 # Model tiers for draft generation. Kept as module constants so later
@@ -96,10 +112,6 @@ _PROMPT_BODY_SNIPPET_CHARS = 500
 MODEL_HAIKU = "claude-haiku-4-5"
 MODEL_SONNET = "claude-sonnet-4-6"
 MODEL_OPUS = "claude-opus-4-7"
-
-
-class SklearnMissingError(RuntimeError):
-    """Raised when clustering is invoked but scikit-learn is not installed."""
 
 
 @dataclass
@@ -138,125 +150,6 @@ def _filter_candidates(
         if is_general_purpose(inv.agent_type)
         and _combined_text_tokens(inv) >= MIN_TEXT_TOKENS
     ]
-
-
-def _fit_kmeans(
-    embeddings: np.ndarray,
-    n_clusters: int,
-    *,
-    random_state: int = _KMEANS_RANDOM_STATE,
-    n_init: int = _KMEANS_N_INIT,
-) -> np.ndarray:
-    """Fit KMeans and return labels as a concrete ndarray.
-
-    Thin wrapper that fixes the ``random_state`` / ``n_init`` defaults
-    (both tunable via kwargs) and converts sklearn's ``Any``-typed
-    ``fit_predict`` return value to an ndarray so mypy stays strict.
-    """
-    km = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=n_init)
-    return np.asarray(km.fit_predict(embeddings))
-
-
-def _cluster_embeddings(embeddings: np.ndarray, n_samples: int) -> np.ndarray:
-    """Return KMeans labels from the k that scores highest on silhouette.
-
-    For n < 10, silhouette's useful k-range collapses (e.g. k_upper=1) —
-    force k=2 and do a single fit. Otherwise, sweep k and keep the
-    labels from the best-scoring fit so we avoid a redundant final-k
-    refit.
-    """
-    if n_samples < _SMALL_N_THRESHOLD:
-        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
-
-    k_upper = min(_SILHOUETTE_K_MAX, n_samples // 5)
-    if k_upper < 2:
-        return _fit_kmeans(embeddings, _FORCED_SMALL_K)
-
-    best_labels: np.ndarray | None = None
-    best_score = -1.0
-    for k in range(2, k_upper + 1):
-        labels = _fit_kmeans(embeddings, k)
-        if len(set(labels)) < 2:
-            continue
-        score = silhouette_score(embeddings, labels)
-        if score > best_score:
-            best_score = score
-            best_labels = labels
-
-    # Degenerate fallback: every k collapsed to a single cluster. Rare,
-    # but possible with near-identical embeddings that survived row
-    # de-dup but lose variance after LSA. Log it so the anomaly is
-    # observable, then force k=2 and suppress the resulting
-    # convergence warning.
-    if best_labels is None:
-        logger.info(
-            "KMeans produced no multi-cluster solution for %d samples; "
-            "falling back to k=2. Input may have near-zero variance "
-            "after TF-IDF + LSA reduction.",
-            n_samples,
-        )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            return _fit_kmeans(embeddings, _FORCED_SMALL_K)
-
-    return best_labels
-
-
-def _mean_pairwise_cosine(cluster_embeddings: np.ndarray) -> float:
-    """Average pairwise cosine similarity within a cluster — our cohesion proxy."""
-    if len(cluster_embeddings) < 2:
-        return 1.0
-    sim = cosine_similarity(cluster_embeddings)
-    # Exclude the diagonal (self-sim=1) to avoid biasing toward 1.0.
-    n = sim.shape[0]
-    total = (sim.sum() - n) / (n * n - n)
-    return float(total)
-
-
-def _top_tfidf_terms(
-    tfidf_matrix: np.ndarray,
-    member_indices: list[int],
-    terms: np.ndarray,
-    top_n: int = _TOP_TERMS_COUNT,
-) -> list[str]:
-    member_vecs = tfidf_matrix[member_indices]
-    mean_scores = member_vecs.mean(axis=0)
-    mean_array = np.asarray(mean_scores).ravel()
-    top_idx = mean_array.argsort()[::-1][:top_n]
-    return [str(terms[i]) for i in top_idx if mean_array[i] > 0]
-
-
-def _group_indices_by_label(labels: np.ndarray) -> dict[int, list[int]]:
-    """Single-pass grouping of sample indices by their cluster label."""
-    groups: dict[int, list[int]] = defaultdict(list)
-    for i, lab in enumerate(labels):
-        groups[int(lab)].append(i)
-    return groups
-
-
-def _all_rows_identical(tfidf_matrix: np.ndarray) -> bool:
-    """Detect an anomaly: byte-identical TF-IDF rows across all members.
-
-    Agent-generated prompts are probabilistic; identical rows across
-    multiple invocations is very unlikely in real data. When it does
-    happen, it usually points upstream — duplicate session records,
-    an invocation-extraction bug, or a parent agent producing
-    non-probabilistic output. Detecting this case lets us emit a clear
-    warning instead of silently producing zero clusters or sklearn
-    convergence noise.
-
-    Densifies once and compares rows to row 0 with a vectorized numpy
-    equality check. A single ``toarray()`` + broadcast is ~O(n × features);
-    faster and more predictable than a row-by-row densify loop, and
-    avoids sparse-sparse ``!=`` short-circuit quirks across scipy
-    versions.
-    """
-    if tfidf_matrix.shape[0] <= 1:
-        return True
-    # sklearn TfidfVectorizer returns a scipy sparse matrix, not a
-    # numpy ndarray — no type stubs for scipy.sparse in this project.
-    dense = tfidf_matrix.toarray()  # type: ignore[attr-defined]
-    return bool((dense == dense[0]).all())
 
 
 def _build_single_cluster(

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -27,6 +27,11 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+# sklearn is an optional extra; module bodies that reference these
+# names are only ever called via the SKLEARN_AVAILABLE gate. Leaving
+# the names undefined when sklearn is missing matches the established
+# pattern (see _clustering.py) — function-local attribute resolution
+# means delegation.py still imports cleanly without sklearn installed.
 try:
     import numpy as np
     from sklearn.decomposition import TruncatedSVD
@@ -39,11 +44,11 @@ from agentfluent.agents.models import WRITE_TOOLS, is_general_purpose
 from agentfluent.diagnostics._clustering import (
     SKLEARN_AVAILABLE,
     SklearnMissingError,
-    _all_rows_identical,
-    _cluster_embeddings,
-    _group_indices_by_label,
-    _mean_pairwise_cosine,
-    _top_tfidf_terms,
+    all_rows_identical,
+    cluster_embeddings,
+    group_indices_by_label,
+    mean_pairwise_cosine,
+    top_tfidf_terms,
 )
 from agentfluent.diagnostics.models import DelegationSuggestion
 
@@ -163,7 +168,7 @@ def _build_single_cluster(
     all_indices = list(range(len(candidates)))
     return DelegationCluster(
         members=list(candidates),
-        top_terms=_top_tfidf_terms(tfidf_matrix, all_indices, terms),
+        top_terms=top_tfidf_terms(tfidf_matrix, all_indices, terms),
         cohesion_score=1.0,
     )
 
@@ -193,7 +198,7 @@ def cluster_delegations(
     # Anomaly: if every row is identical, surface the upstream issue and
     # return a single cluster. Clustering algorithms below would either
     # emit confusing convergence warnings or silently produce no output.
-    if _all_rows_identical(tfidf_matrix):
+    if all_rows_identical(tfidf_matrix):
         logger.warning(
             "Delegation clustering: all %d TF-IDF rows are identical — "
             "this is unusual for real agent data. Check for duplicate "
@@ -211,24 +216,24 @@ def cluster_delegations(
         with warnings.catch_warnings():
             # TruncatedSVD can raise a RuntimeWarning on near-zero
             # variance input; the degenerate-fallback in
-            # _cluster_embeddings already handles the output path.
+            # cluster_embeddings already handles the output path.
             warnings.simplefilter("ignore", category=RuntimeWarning)
             lsa = TruncatedSVD(n_components=n_components, random_state=42)
             embeddings = lsa.fit_transform(tfidf_matrix)
     else:
         embeddings = tfidf_matrix.toarray()
 
-    labels = _cluster_embeddings(embeddings, len(candidates))
-    groups = _group_indices_by_label(labels)
+    labels = cluster_embeddings(embeddings, len(candidates))
+    groups = group_indices_by_label(labels)
 
     clusters: list[DelegationCluster] = []
     for _label, member_indices in sorted(groups.items()):
         if len(member_indices) < min_cluster_size:
             continue
         members = [candidates[i] for i in member_indices]
-        cluster_embeddings = embeddings[member_indices]
-        cohesion = _mean_pairwise_cosine(cluster_embeddings)
-        top_terms = _top_tfidf_terms(tfidf_matrix, member_indices, terms)
+        member_embeddings = embeddings[member_indices]
+        cohesion = mean_pairwise_cosine(member_embeddings)
+        top_terms = top_tfidf_terms(tfidf_matrix, member_indices, terms)
         clusters.append(
             DelegationCluster(
                 members=members,

--- a/tests/unit/test_clustering.py
+++ b/tests/unit/test_clustering.py
@@ -20,12 +20,12 @@ from agentfluent.diagnostics import _clustering  # noqa: E402
 from agentfluent.diagnostics._clustering import (  # noqa: E402
     SKLEARN_AVAILABLE,
     SklearnMissingError,
-    _all_rows_identical,
-    _cluster_embeddings,
-    _fit_kmeans,
-    _group_indices_by_label,
-    _mean_pairwise_cosine,
-    _top_tfidf_terms,
+    all_rows_identical,
+    cluster_embeddings,
+    fit_kmeans,
+    group_indices_by_label,
+    mean_pairwise_cosine,
+    top_tfidf_terms,
 )
 
 
@@ -40,7 +40,7 @@ def _two_blob_embeddings(n_per: int = 6, seed: int = 0) -> np.ndarray:
 class TestFitKmeans:
     def test_recovers_two_blobs(self) -> None:
         embeddings = _two_blob_embeddings(n_per=6)
-        labels = _fit_kmeans(embeddings, n_clusters=2)
+        labels = fit_kmeans(embeddings, n_clusters=2)
         # Either label assignment is valid; what matters is that the two
         # halves end up in different clusters.
         assert labels[:6].tolist().count(labels[0]) == 6
@@ -49,13 +49,13 @@ class TestFitKmeans:
 
     def test_returns_ndarray(self) -> None:
         embeddings = _two_blob_embeddings(n_per=4)
-        labels = _fit_kmeans(embeddings, n_clusters=2)
+        labels = fit_kmeans(embeddings, n_clusters=2)
         assert isinstance(labels, np.ndarray)
 
     def test_random_state_is_reproducible(self) -> None:
         embeddings = _two_blob_embeddings(n_per=5)
-        a = _fit_kmeans(embeddings, n_clusters=2, random_state=7)
-        b = _fit_kmeans(embeddings, n_clusters=2, random_state=7)
+        a = fit_kmeans(embeddings, n_clusters=2, random_state=7)
+        b = fit_kmeans(embeddings, n_clusters=2, random_state=7)
         assert np.array_equal(a, b)
 
 
@@ -63,14 +63,14 @@ class TestClusterEmbeddings:
     def test_small_n_forces_k2(self) -> None:
         # n=8 < _SMALL_N_THRESHOLD (10) → forced k=2 path.
         embeddings = _two_blob_embeddings(n_per=4)
-        labels = _cluster_embeddings(embeddings, n_samples=8)
+        labels = cluster_embeddings(embeddings, n_samples=8)
         assert set(labels.tolist()) == {0, 1}
 
     def test_large_n_uses_silhouette_sweep(self) -> None:
         # n=12 >= threshold → sweep path. With clearly separated blobs,
         # the sweep should still resolve to two clusters.
         embeddings = _two_blob_embeddings(n_per=6)
-        labels = _cluster_embeddings(embeddings, n_samples=12)
+        labels = cluster_embeddings(embeddings, n_samples=12)
         assert len(set(labels.tolist())) >= 2
 
     def test_degenerate_input_logs_and_falls_back(
@@ -80,7 +80,7 @@ class TestClusterEmbeddings:
         # collapses, fallback path fires + logs.
         embeddings = np.zeros((12, 4))
         with caplog.at_level("INFO", logger="agentfluent.diagnostics._clustering"):
-            labels = _cluster_embeddings(embeddings, n_samples=12)
+            labels = cluster_embeddings(embeddings, n_samples=12)
         assert isinstance(labels, np.ndarray)
         assert len(labels) == 12
         assert any(
@@ -90,15 +90,15 @@ class TestClusterEmbeddings:
 
 class TestMeanPairwiseCosine:
     def test_single_member_is_one(self) -> None:
-        assert _mean_pairwise_cosine(np.array([[1.0, 0.0, 0.0]])) == 1.0
+        assert mean_pairwise_cosine(np.array([[1.0, 0.0, 0.0]])) == 1.0
 
     def test_identical_vectors_max_cohesion(self) -> None:
         embeddings = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
-        assert _mean_pairwise_cosine(embeddings) == pytest.approx(1.0)
+        assert mean_pairwise_cosine(embeddings) == pytest.approx(1.0)
 
     def test_orthogonal_vectors_zero_cohesion(self) -> None:
         embeddings = np.array([[1.0, 0.0], [0.0, 1.0]])
-        assert _mean_pairwise_cosine(embeddings) == pytest.approx(0.0, abs=1e-9)
+        assert mean_pairwise_cosine(embeddings) == pytest.approx(0.0, abs=1e-9)
 
     def test_excludes_self_similarity_from_average(self) -> None:
         # Two identical rows: pairwise sim matrix is [[1,1],[1,1]].
@@ -108,7 +108,7 @@ class TestMeanPairwiseCosine:
         # Off-diagonal cosines: (a,b)=0, (a,c)=√2/2, (b,c)=√2/2.
         # Mean of off-diagonal half-matrix = (0 + 0.7071 + 0.7071)/3.
         expected = (0.0 + (2 ** 0.5) / 2 + (2 ** 0.5) / 2) / 3
-        assert _mean_pairwise_cosine(embeddings) == pytest.approx(expected, abs=1e-6)
+        assert mean_pairwise_cosine(embeddings) == pytest.approx(expected, abs=1e-6)
 
 
 class TestTopTfidfTerms:
@@ -121,7 +121,7 @@ class TestTopTfidfTerms:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(texts)
         terms = vec.get_feature_names_out()
-        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=1)
+        top = top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=1)
         assert top == ["pytest"]
 
     def test_skips_zero_score_terms(self) -> None:
@@ -131,7 +131,7 @@ class TestTopTfidfTerms:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(texts)
         terms = vec.get_feature_names_out()
-        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=5)
+        top = top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=5)
         assert top == ["alpha"]
 
     def test_returns_at_most_top_n(self) -> None:
@@ -145,24 +145,24 @@ class TestTopTfidfTerms:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(texts)
         terms = vec.get_feature_names_out()
-        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=3)
+        top = top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=3)
         assert len(top) == 3
 
 
 class TestGroupIndicesByLabel:
     def test_groups_in_input_order(self) -> None:
         labels = np.array([0, 1, 0, 1, 0])
-        groups = _group_indices_by_label(labels)
+        groups = group_indices_by_label(labels)
         assert groups[0] == [0, 2, 4]
         assert groups[1] == [1, 3]
 
     def test_handles_single_cluster(self) -> None:
         labels = np.array([7, 7, 7])
-        groups = _group_indices_by_label(labels)
+        groups = group_indices_by_label(labels)
         assert dict(groups) == {7: [0, 1, 2]}
 
     def test_handles_empty_labels(self) -> None:
-        groups = _group_indices_by_label(np.array([], dtype=int))
+        groups = group_indices_by_label(np.array([], dtype=int))
         assert dict(groups) == {}
 
 
@@ -170,17 +170,17 @@ class TestAllRowsIdentical:
     def test_single_row_is_identical(self) -> None:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(["only one"])
-        assert _all_rows_identical(matrix) is True
+        assert all_rows_identical(matrix) is True
 
     def test_truly_identical_rows(self) -> None:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(["same text", "same text", "same text"])
-        assert _all_rows_identical(matrix) is True
+        assert all_rows_identical(matrix) is True
 
     def test_distinct_rows_return_false(self) -> None:
         vec = TfidfVectorizer()
         matrix = vec.fit_transform(["pytest run", "review pull request", "build deploy"])
-        assert _all_rows_identical(matrix) is False
+        assert all_rows_identical(matrix) is False
 
 
 class TestSklearnAvailability:

--- a/tests/unit/test_clustering.py
+++ b/tests/unit/test_clustering.py
@@ -1,0 +1,198 @@
+"""Tests for the shared TF-IDF + KMeans clustering primitives.
+
+Covers each helper at the ``_clustering.py`` boundary, in isolation.
+End-to-end behavior (these helpers wired into ``cluster_delegations``)
+is exercised by ``test_delegation.py`` and is unaffected by sub-issue
+A's pure refactor — these tests just lock the public-ish surface so
+``parent_workload.py`` (sub-issue B onward) can rely on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sklearn")
+
+import numpy as np  # noqa: E402
+from sklearn.feature_extraction.text import TfidfVectorizer  # noqa: E402
+
+from agentfluent.diagnostics import _clustering  # noqa: E402
+from agentfluent.diagnostics._clustering import (  # noqa: E402
+    SKLEARN_AVAILABLE,
+    SklearnMissingError,
+    _all_rows_identical,
+    _cluster_embeddings,
+    _fit_kmeans,
+    _group_indices_by_label,
+    _mean_pairwise_cosine,
+    _top_tfidf_terms,
+)
+
+
+def _two_blob_embeddings(n_per: int = 6, seed: int = 0) -> np.ndarray:
+    """Two well-separated Gaussian blobs in 4-D — easy KMeans target."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(loc=0.0, scale=0.05, size=(n_per, 4))
+    b = rng.normal(loc=5.0, scale=0.05, size=(n_per, 4))
+    return np.vstack([a, b])
+
+
+class TestFitKmeans:
+    def test_recovers_two_blobs(self) -> None:
+        embeddings = _two_blob_embeddings(n_per=6)
+        labels = _fit_kmeans(embeddings, n_clusters=2)
+        # Either label assignment is valid; what matters is that the two
+        # halves end up in different clusters.
+        assert labels[:6].tolist().count(labels[0]) == 6
+        assert labels[6:].tolist().count(labels[6]) == 6
+        assert labels[0] != labels[6]
+
+    def test_returns_ndarray(self) -> None:
+        embeddings = _two_blob_embeddings(n_per=4)
+        labels = _fit_kmeans(embeddings, n_clusters=2)
+        assert isinstance(labels, np.ndarray)
+
+    def test_random_state_is_reproducible(self) -> None:
+        embeddings = _two_blob_embeddings(n_per=5)
+        a = _fit_kmeans(embeddings, n_clusters=2, random_state=7)
+        b = _fit_kmeans(embeddings, n_clusters=2, random_state=7)
+        assert np.array_equal(a, b)
+
+
+class TestClusterEmbeddings:
+    def test_small_n_forces_k2(self) -> None:
+        # n=8 < _SMALL_N_THRESHOLD (10) → forced k=2 path.
+        embeddings = _two_blob_embeddings(n_per=4)
+        labels = _cluster_embeddings(embeddings, n_samples=8)
+        assert set(labels.tolist()) == {0, 1}
+
+    def test_large_n_uses_silhouette_sweep(self) -> None:
+        # n=12 >= threshold → sweep path. With clearly separated blobs,
+        # the sweep should still resolve to two clusters.
+        embeddings = _two_blob_embeddings(n_per=6)
+        labels = _cluster_embeddings(embeddings, n_samples=12)
+        assert len(set(labels.tolist())) >= 2
+
+    def test_degenerate_input_logs_and_falls_back(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # All-identical rows: silhouette can't separate them, sweep
+        # collapses, fallback path fires + logs.
+        embeddings = np.zeros((12, 4))
+        with caplog.at_level("INFO", logger="agentfluent.diagnostics._clustering"):
+            labels = _cluster_embeddings(embeddings, n_samples=12)
+        assert isinstance(labels, np.ndarray)
+        assert len(labels) == 12
+        assert any(
+            "no multi-cluster solution" in rec.message for rec in caplog.records
+        )
+
+
+class TestMeanPairwiseCosine:
+    def test_single_member_is_one(self) -> None:
+        assert _mean_pairwise_cosine(np.array([[1.0, 0.0, 0.0]])) == 1.0
+
+    def test_identical_vectors_max_cohesion(self) -> None:
+        embeddings = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+        assert _mean_pairwise_cosine(embeddings) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_zero_cohesion(self) -> None:
+        embeddings = np.array([[1.0, 0.0], [0.0, 1.0]])
+        assert _mean_pairwise_cosine(embeddings) == pytest.approx(0.0, abs=1e-9)
+
+    def test_excludes_self_similarity_from_average(self) -> None:
+        # Two identical rows: pairwise sim matrix is [[1,1],[1,1]].
+        # If we forgot to subtract the diagonal, the average would still
+        # be 1.0 only by coincidence — use mixed similarity to expose it.
+        embeddings = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+        # Off-diagonal cosines: (a,b)=0, (a,c)=√2/2, (b,c)=√2/2.
+        # Mean of off-diagonal half-matrix = (0 + 0.7071 + 0.7071)/3.
+        expected = (0.0 + (2 ** 0.5) / 2 + (2 ** 0.5) / 2) / 3
+        assert _mean_pairwise_cosine(embeddings) == pytest.approx(expected, abs=1e-6)
+
+
+class TestTopTfidfTerms:
+    def test_picks_term_with_highest_mean_score(self) -> None:
+        texts = [
+            "pytest pytest pytest",
+            "pytest run failure",
+            "pytest assertion error",
+        ]
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(texts)
+        terms = vec.get_feature_names_out()
+        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=1)
+        assert top == ["pytest"]
+
+    def test_skips_zero_score_terms(self) -> None:
+        # All members are the same single word; only that word should
+        # appear in the top-N — never zero-score noise.
+        texts = ["alpha", "alpha", "alpha"]
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(texts)
+        terms = vec.get_feature_names_out()
+        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=5)
+        assert top == ["alpha"]
+
+    def test_returns_at_most_top_n(self) -> None:
+        # Default TfidfVectorizer regex requires 2+ char tokens, so use
+        # words rather than single letters.
+        texts = [
+            "alpha beta gamma delta epsilon zeta",
+            "alpha beta gamma delta epsilon zeta",
+            "alpha beta gamma delta epsilon zeta",
+        ]
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(texts)
+        terms = vec.get_feature_names_out()
+        top = _top_tfidf_terms(matrix, member_indices=[0, 1, 2], terms=terms, top_n=3)
+        assert len(top) == 3
+
+
+class TestGroupIndicesByLabel:
+    def test_groups_in_input_order(self) -> None:
+        labels = np.array([0, 1, 0, 1, 0])
+        groups = _group_indices_by_label(labels)
+        assert groups[0] == [0, 2, 4]
+        assert groups[1] == [1, 3]
+
+    def test_handles_single_cluster(self) -> None:
+        labels = np.array([7, 7, 7])
+        groups = _group_indices_by_label(labels)
+        assert dict(groups) == {7: [0, 1, 2]}
+
+    def test_handles_empty_labels(self) -> None:
+        groups = _group_indices_by_label(np.array([], dtype=int))
+        assert dict(groups) == {}
+
+
+class TestAllRowsIdentical:
+    def test_single_row_is_identical(self) -> None:
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(["only one"])
+        assert _all_rows_identical(matrix) is True
+
+    def test_truly_identical_rows(self) -> None:
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(["same text", "same text", "same text"])
+        assert _all_rows_identical(matrix) is True
+
+    def test_distinct_rows_return_false(self) -> None:
+        vec = TfidfVectorizer()
+        matrix = vec.fit_transform(["pytest run", "review pull request", "build deploy"])
+        assert _all_rows_identical(matrix) is False
+
+
+class TestSklearnAvailability:
+    def test_module_exposes_sklearn_flag(self) -> None:
+        # The flag is the canonical source of truth for whether the
+        # optional extra is installed; consumer modules re-export it.
+        assert SKLEARN_AVAILABLE is True
+
+    def test_sklearn_missing_error_is_runtime_error(self) -> None:
+        assert issubclass(SklearnMissingError, RuntimeError)
+
+    def test_module_has_canonical_definitions(self) -> None:
+        # Sub-issue B and onward will import these from _clustering.
+        assert hasattr(_clustering, "SKLEARN_AVAILABLE")
+        assert hasattr(_clustering, "SklearnMissingError")


### PR DESCRIPTION
Closes #242. Sub-issue A of #189 (parent-thread offload candidates).

## Summary

- Pure refactor — zero behavior change. Lands first to unblock #189's parent-thread workload pipeline without conflicting with #185 / #184 (different lines of `delegation.py`).
- Extracts the input-agnostic TF-IDF + KMeans machinery — KMeans fit + silhouette sweep, cosine-cohesion scoring, top-term extraction, label grouping, and the all-rows-identical detector — into a new module-private `agentfluent.diagnostics._clustering`.
- `SKLEARN_AVAILABLE` and `SklearnMissingError` now live in `_clustering` as their canonical source. `delegation.py` re-exports both, so `cli/commands/analyze.py`, `diagnostics/pipeline.py`, and existing test monkeypatches keep working unchanged.

## Backward-compat detail

`tests/unit/test_delegation.py:483` does `monkeypatch.setattr(delegation, "SKLEARN_AVAILABLE", False)` and expects the patched value to govern `cluster_delegations`'s gate. The local `_require_sklearn` in `delegation.py` reads the module-level binding (the re-export), so the patch still takes effect. Same pattern applies to `pipeline.py:255`, which already has its own local `SKLEARN_AVAILABLE` binding.

## What stays in `delegation.py`

- `MIN_TEXT_TOKENS = 50` (delegation prompts use a denser floor than parent-thread bursts will)
- Confidence tier constants `_CONFIDENCE_HIGH_SIZE / HIGH_COHESION / MEDIUM_COHESION` (delegation-specific calibration)
- `DelegationCluster`, `cluster_delegations`, `generate_draft`, `_apply_dedup`, `suggest_delegations`
- Model tier constants `MODEL_HAIKU / SONNET / OPUS`
- `_classify_model`, `_collect_tools_from_traces` (where #185 / #184 will land)

## Convention deviation from the plan

The plan called for `tests/unit/diagnostics/test_clustering.py`. The repo's existing convention is flat (`tests/unit/test_*.py`) — `test_delegation.py`, `test_correlator.py`, `test_signals.py`, etc. all sit at the unit/ root. This PR follows that convention with `tests/unit/test_clustering.py`. If a future sub-issue introduces a `tests/unit/diagnostics/` subdirectory as a structural change, this file can move without difficulty.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/agentfluent/` — clean (54 source files)
- [x] `uv run pytest` — 885 passed (was 863, +22 new in `test_clustering.py`)
- [x] `uv run pytest tests/unit/test_delegation.py tests/unit/test_diagnostics_pipeline.py tests/unit/test_model_routing.py` — 95 passed (downstream consumers unaffected)
- [x] Smoke-tested re-export identity: `delegation.SklearnMissingError is _clustering.SklearnMissingError` is `True`

## Sequencing

This PR must merge **before** #185 (`_classify_model` extract) and #184 (frequency-filtered tools) to avoid rebase pain on `delegation.py`. Line ranges are disjoint, so the cost is small if the order slips, but earlier is cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)