### PR TITLE
feat(diagnostics): cost estimation for parent-thread tool-bursts (#249)

### DIFF
--- a/src/agentfluent/diagnostics/parent_workload.py
+++ b/src/agentfluent/diagnostics/parent_workload.py
@@ -32,13 +32,9 @@ from dataclasses import dataclass, field
 
 from agentfluent.analytics.pricing import ModelPricing, compute_cost
 from agentfluent.core.session import SessionMessage, ToolUseBlock, Usage
+from agentfluent.diagnostics.delegation import MODEL_HAIKU, MODEL_SONNET
 
 logger = logging.getLogger(__name__)
-
-# Canonical alt-model targets per tier. Kept aligned with the keys in
-# analytics/pricing.py so get_pricing() resolves them.
-_ALT_FOR_OPUS = "claude-sonnet-4-6"
-_ALT_FOR_SONNET = "claude-haiku-4-5-20251001"
 
 MIN_BURST_TOOLS = 2
 
@@ -215,18 +211,16 @@ def filter_bursts(bursts: list[ToolBurst]) -> list[ToolBurst]:
 
 
 def pick_alternative_model(parent_model: str) -> str:
-    """Pick the next-cheaper tier for a given parent model.
-
-    Opus → Sonnet, Sonnet → Haiku, Haiku → Haiku (already cheapest).
-    Unknown models are returned unchanged so the caller surfaces a
-    no-savings result rather than projecting against a wrong tier.
-    """
+    """Pick the next-cheaper tier; Haiku and unknowns are returned unchanged."""
     lowered = parent_model.lower()
     if "opus" in lowered:
-        return _ALT_FOR_OPUS
+        return MODEL_SONNET
     if "sonnet" in lowered:
-        return _ALT_FOR_SONNET
+        return MODEL_HAIKU
     if "haiku" in lowered:
+        # Explicit fixed-point branch (rather than falling through to the
+        # bottom-of-function "unchanged" return) — Haiku is intentionally
+        # terminal, not "unknown."
         return parent_model
     return parent_model
 
@@ -239,21 +233,15 @@ def estimate_burst_cost(
 ) -> tuple[float, float]:
     """Return ``(parent_cost_usd, savings_usd_signed)`` for one burst.
 
-    Parent cost includes cache_read at the parent's rate (the full picture
-    of what was actually spent). The alt-model projection assumes NO cache
-    benefit — cache_read tokens get reclassified as fresh input at the
-    alt model's input rate. Conservative; a long-lived subagent might
-    warm its own cache, but we don't model warmup.
-
-    Savings is signed. Negative means offloading would cost MORE than
+    Savings is signed; negative means offloading would cost MORE than
     staying on the parent (cache is load-bearing for this pattern). Per
     architect review (#189), the sign is preserved — never clamped to
     zero — so callers can render negative-savings clusters with a
     distinct "do not offload" treatment.
 
-    When either pricing is unknown (the lookup returned ``None``), we
-    return ``(0.0, 0.0)`` and emit a debug log. Sub-issue D's caller
-    treats this as "no estimate available" rather than "free."
+    When either pricing is unknown (lookup returned ``None``), returns
+    ``(0.0, 0.0)`` and emits a debug log. Callers treat that as "no
+    estimate available" rather than "free."
     """
     if parent_pricing is None or alt_pricing is None:
         logger.debug(

--- a/src/agentfluent/diagnostics/parent_workload.py
+++ b/src/agentfluent/diagnostics/parent_workload.py
@@ -30,9 +30,15 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
+from agentfluent.analytics.pricing import ModelPricing, compute_cost
 from agentfluent.core.session import SessionMessage, ToolUseBlock, Usage
 
 logger = logging.getLogger(__name__)
+
+# Canonical alt-model targets per tier. Kept aligned with the keys in
+# analytics/pricing.py so get_pricing() resolves them.
+_ALT_FOR_OPUS = "claude-sonnet-4-6"
+_ALT_FOR_SONNET = "claude-haiku-4-5-20251001"
 
 MIN_BURST_TOOLS = 2
 
@@ -206,3 +212,68 @@ def filter_bursts(bursts: list[ToolBurst]) -> list[ToolBurst]:
             continue
         kept.append(b)
     return kept
+
+
+def pick_alternative_model(parent_model: str) -> str:
+    """Pick the next-cheaper tier for a given parent model.
+
+    Opus → Sonnet, Sonnet → Haiku, Haiku → Haiku (already cheapest).
+    Unknown models are returned unchanged so the caller surfaces a
+    no-savings result rather than projecting against a wrong tier.
+    """
+    lowered = parent_model.lower()
+    if "opus" in lowered:
+        return _ALT_FOR_OPUS
+    if "sonnet" in lowered:
+        return _ALT_FOR_SONNET
+    if "haiku" in lowered:
+        return parent_model
+    return parent_model
+
+
+def estimate_burst_cost(
+    burst: ToolBurst,
+    *,
+    parent_pricing: ModelPricing | None,
+    alt_pricing: ModelPricing | None,
+) -> tuple[float, float]:
+    """Return ``(parent_cost_usd, savings_usd_signed)`` for one burst.
+
+    Parent cost includes cache_read at the parent's rate (the full picture
+    of what was actually spent). The alt-model projection assumes NO cache
+    benefit — cache_read tokens get reclassified as fresh input at the
+    alt model's input rate. Conservative; a long-lived subagent might
+    warm its own cache, but we don't model warmup.
+
+    Savings is signed. Negative means offloading would cost MORE than
+    staying on the parent (cache is load-bearing for this pattern). Per
+    architect review (#189), the sign is preserved — never clamped to
+    zero — so callers can render negative-savings clusters with a
+    distinct "do not offload" treatment.
+
+    When either pricing is unknown (the lookup returned ``None``), we
+    return ``(0.0, 0.0)`` and emit a debug log. Sub-issue D's caller
+    treats this as "no estimate available" rather than "free."
+    """
+    if parent_pricing is None or alt_pricing is None:
+        logger.debug(
+            "Skipping cost estimate for burst: pricing unavailable "
+            "(parent=%s alt=%s).",
+            parent_pricing is not None, alt_pricing is not None,
+        )
+        return (0.0, 0.0)
+
+    u = burst.usage
+    parent_cost = compute_cost(
+        parent_pricing,
+        u.input_tokens, u.output_tokens,
+        u.cache_creation_input_tokens, u.cache_read_input_tokens,
+    )
+    # Alt-model has no cache benefit: cache_read becomes fresh input,
+    # cache_creation drops out (a delegated subagent would re-fetch its
+    # own context, not pay to write the parent's cache).
+    effective_input = u.input_tokens + u.cache_read_input_tokens
+    alt_cost = compute_cost(
+        alt_pricing, effective_input, u.output_tokens, 0, 0,
+    )
+    return (parent_cost, parent_cost - alt_cost)

--- a/tests/unit/test_parent_workload_cost.py
+++ b/tests/unit/test_parent_workload_cost.py
@@ -1,0 +1,223 @@
+"""Tests for cost estimation on parent-thread tool-bursts (sub-issue C of #189).
+
+Covers ``pick_alternative_model`` (tier mapping) and ``estimate_burst_cost``
+(parent cost + signed savings). The key invariant the architect review
+locked in: savings is signed; negative-savings clusters are surfaced,
+not clamped to zero.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentfluent.analytics.pricing import ModelPricing, get_pricing
+from agentfluent.core.session import Usage
+from agentfluent.diagnostics.parent_workload import (
+    ToolBurst,
+    estimate_burst_cost,
+    pick_alternative_model,
+)
+
+
+def _burst(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    model: str = "claude-opus-4-7",
+) -> ToolBurst:
+    return ToolBurst(
+        preceding_user_text="",
+        assistant_text="",
+        tool_use_blocks=[],
+        usage=Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+        ),
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# pick_alternative_model
+# ---------------------------------------------------------------------------
+
+
+class TestPickAlternativeModel:
+    def test_opus_routes_to_sonnet(self) -> None:
+        assert pick_alternative_model("claude-opus-4-7") == "claude-sonnet-4-6"
+
+    def test_opus_4_6_also_routes_to_sonnet(self) -> None:
+        # Substring match should cover all Opus variants.
+        assert pick_alternative_model("claude-opus-4-6") == "claude-sonnet-4-6"
+
+    def test_dated_opus_routes_to_sonnet(self) -> None:
+        assert pick_alternative_model("claude-opus-4-5-20251101") == "claude-sonnet-4-6"
+
+    def test_sonnet_routes_to_haiku(self) -> None:
+        assert (
+            pick_alternative_model("claude-sonnet-4-6")
+            == "claude-haiku-4-5-20251001"
+        )
+
+    def test_dated_sonnet_routes_to_haiku(self) -> None:
+        assert (
+            pick_alternative_model("claude-sonnet-4-5-20250929")
+            == "claude-haiku-4-5-20251001"
+        )
+
+    def test_haiku_returns_itself(self) -> None:
+        # Haiku is already the cheapest tier — no further offload target.
+        assert (
+            pick_alternative_model("claude-haiku-4-5-20251001")
+            == "claude-haiku-4-5-20251001"
+        )
+
+    def test_unknown_model_returns_unchanged(self) -> None:
+        # No tier match → caller surfaces "no estimate" rather than
+        # projecting against the wrong tier.
+        assert pick_alternative_model("gpt-5") == "gpt-5"
+
+    def test_empty_string_returns_unchanged(self) -> None:
+        assert pick_alternative_model("") == ""
+
+    def test_alt_targets_resolve_in_pricing_module(self) -> None:
+        # Lock the constants in pick_alternative_model against the pricing
+        # module: the alt target must resolve to a real ModelPricing entry.
+        # If a future pricing-data update renames the canonical Sonnet or
+        # Haiku id, this test fires before the cost path silently
+        # degrades to "no estimate."
+        for parent in ("claude-opus-4-7", "claude-sonnet-4-6"):
+            alt = pick_alternative_model(parent)
+            assert get_pricing(alt) is not None, f"alt model {alt!r} has no pricing"
+
+
+# ---------------------------------------------------------------------------
+# estimate_burst_cost
+# ---------------------------------------------------------------------------
+
+
+def _opus() -> ModelPricing:
+    pricing = get_pricing("claude-opus-4-7")
+    assert pricing is not None
+    return pricing
+
+
+def _sonnet() -> ModelPricing:
+    pricing = get_pricing("claude-sonnet-4-6")
+    assert pricing is not None
+    return pricing
+
+
+def _haiku() -> ModelPricing:
+    pricing = get_pricing("claude-haiku-4-5-20251001")
+    assert pricing is not None
+    return pricing
+
+
+class TestEstimateBurstCost:
+    def test_modest_cache_produces_positive_savings(self) -> None:
+        # Opus burst dominated by FRESH input (not cache reads). Sonnet
+        # without cache should still come out cheaper because Sonnet's
+        # input rate (3.0) is lower than Opus's (5.0).
+        burst = _burst(
+            input_tokens=1000, output_tokens=500,
+            cache_creation_input_tokens=200,
+            cache_read_input_tokens=500,
+        )
+        parent_cost, savings = estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+        )
+        assert parent_cost > 0
+        assert savings > 0
+
+    def test_cache_dominated_produces_negative_savings(self) -> None:
+        # Opus burst with TINY fresh-input/output and HUGE cache_read.
+        # Cache_read on Opus is $0.50/1M; Sonnet has no cache discount
+        # so the same tokens get charged at $3.00/1M as input. Sonnet
+        # ends up MORE expensive, savings goes negative — the actionable
+        # "do not offload" signal we're preserving per architect review.
+        burst = _burst(
+            input_tokens=10, output_tokens=10,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=100_000,
+        )
+        _parent_cost, savings = estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+        )
+        assert savings < 0, "negative savings must be preserved, not clamped"
+
+    def test_zero_usage_returns_zero_zero(self) -> None:
+        # An empty burst has no cost on either model.
+        burst = _burst()  # all token fields default to 0
+        assert estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+        ) == (0.0, 0.0)
+
+    def test_parent_cost_includes_cache_read(self) -> None:
+        # The "parent cost" half of the return should be the FULL picture
+        # including cache_read at the parent rate — that's what was
+        # actually spent. (The savings half is where cache_read gets
+        # reclassified for the alt projection.)
+        burst = _burst(cache_read_input_tokens=1_000_000)
+        parent_cost, _savings = estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+        )
+        # Opus cache_read is $0.50 per 1M tokens.
+        assert parent_cost == pytest.approx(0.50)
+
+    def test_alt_projection_excludes_cache_creation(self) -> None:
+        # cache_creation is a parent-side cost only — a delegated subagent
+        # would re-fetch its own context, not pay to write the parent's
+        # cache. The alt-model projection drops it.
+        # Set up a burst whose ONLY non-zero usage is cache_creation,
+        # then verify savings == parent_cost (alt_cost = 0).
+        burst = _burst(cache_creation_input_tokens=1_000_000)
+        parent_cost, savings = estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+        )
+        assert parent_cost == pytest.approx(6.25)  # Opus cache_creation rate
+        assert savings == pytest.approx(parent_cost)
+
+    def test_haiku_to_haiku_zero_savings(self) -> None:
+        # Same model on both sides: parent_cost > 0 but savings should
+        # be 0 because cache_read reclassifies to input at the SAME rate
+        # cache_read pays at... wait, Haiku cache_read is $0.10 vs input
+        # $1.00, so cache_read tokens get 10x more expensive on the alt
+        # side. With ANY cache_read present, savings goes negative.
+        # This test verifies the math is honest about that even when
+        # the caller "stayed put."
+        burst = _burst(input_tokens=100, output_tokens=100,
+                       cache_read_input_tokens=1000)
+        _parent_cost, savings = estimate_burst_cost(
+            burst, parent_pricing=_haiku(), alt_pricing=_haiku(),
+        )
+        # cache_read of 1000 tokens: Haiku input would charge 1000*1.0/1M = $0.001
+        # vs cache_read 1000*0.10/1M = $0.0001. Delta -$0.0009 swamps
+        # the no-savings input/output equality.
+        assert savings < 0
+
+    def test_unknown_parent_pricing_returns_zero_zero(self) -> None:
+        burst = _burst(input_tokens=1000, output_tokens=500)
+        assert estimate_burst_cost(
+            burst, parent_pricing=None, alt_pricing=_sonnet(),
+        ) == (0.0, 0.0)
+
+    def test_unknown_alt_pricing_returns_zero_zero(self) -> None:
+        burst = _burst(input_tokens=1000, output_tokens=500)
+        assert estimate_burst_cost(
+            burst, parent_pricing=_opus(), alt_pricing=None,
+        ) == (0.0, 0.0)
+
+    def test_missing_pricing_logs_at_debug(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        burst = _burst(input_tokens=100)
+        with caplog.at_level("DEBUG", logger="agentfluent.diagnostics.parent_workload"):
+            estimate_burst_cost(burst, parent_pricing=None, alt_pricing=_sonnet())
+        assert any(
+            "pricing unavailable" in rec.message for rec in caplog.records
+        )

--- a/tests/unit/test_parent_workload_cost.py
+++ b/tests/unit/test_parent_workload_cost.py
@@ -10,13 +10,25 @@ from __future__ import annotations
 
 import pytest
 
-from agentfluent.analytics.pricing import ModelPricing, get_pricing
+from agentfluent.analytics.pricing import get_pricing
 from agentfluent.core.session import Usage
 from agentfluent.diagnostics.parent_workload import (
     ToolBurst,
     estimate_burst_cost,
     pick_alternative_model,
 )
+
+# Resolve known-model pricing once at import time. The asserts here
+# also act as a sanity check that the pricing module still recognises
+# these canonical ids — if Anthropic renames one and the pricing module
+# isn't updated to match, the import-time assert fires before any test
+# silently runs against the wrong pricing.
+_OPUS = get_pricing("claude-opus-4-7")
+_SONNET = get_pricing("claude-sonnet-4-6")
+_HAIKU = get_pricing("claude-haiku-4-5-20251001")
+assert _OPUS is not None
+assert _SONNET is not None
+assert _HAIKU is not None
 
 
 def _burst(
@@ -58,15 +70,14 @@ class TestPickAlternativeModel:
         assert pick_alternative_model("claude-opus-4-5-20251101") == "claude-sonnet-4-6"
 
     def test_sonnet_routes_to_haiku(self) -> None:
-        assert (
-            pick_alternative_model("claude-sonnet-4-6")
-            == "claude-haiku-4-5-20251001"
-        )
+        # MODEL_HAIKU from delegation is the undated alias; both forms
+        # resolve to the same pricing entry via _ALIASES.
+        assert pick_alternative_model("claude-sonnet-4-6") == "claude-haiku-4-5"
 
     def test_dated_sonnet_routes_to_haiku(self) -> None:
         assert (
             pick_alternative_model("claude-sonnet-4-5-20250929")
-            == "claude-haiku-4-5-20251001"
+            == "claude-haiku-4-5"
         )
 
     def test_haiku_returns_itself(self) -> None:
@@ -100,116 +111,83 @@ class TestPickAlternativeModel:
 # ---------------------------------------------------------------------------
 
 
-def _opus() -> ModelPricing:
-    pricing = get_pricing("claude-opus-4-7")
-    assert pricing is not None
-    return pricing
-
-
-def _sonnet() -> ModelPricing:
-    pricing = get_pricing("claude-sonnet-4-6")
-    assert pricing is not None
-    return pricing
-
-
-def _haiku() -> ModelPricing:
-    pricing = get_pricing("claude-haiku-4-5-20251001")
-    assert pricing is not None
-    return pricing
-
-
 class TestEstimateBurstCost:
     def test_modest_cache_produces_positive_savings(self) -> None:
-        # Opus burst dominated by FRESH input (not cache reads). Sonnet
-        # without cache should still come out cheaper because Sonnet's
-        # input rate (3.0) is lower than Opus's (5.0).
         burst = _burst(
             input_tokens=1000, output_tokens=500,
             cache_creation_input_tokens=200,
             cache_read_input_tokens=500,
         )
         parent_cost, savings = estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+            burst, parent_pricing=_OPUS, alt_pricing=_SONNET,
         )
         assert parent_cost > 0
         assert savings > 0
 
     def test_cache_dominated_produces_negative_savings(self) -> None:
-        # Opus burst with TINY fresh-input/output and HUGE cache_read.
-        # Cache_read on Opus is $0.50/1M; Sonnet has no cache discount
-        # so the same tokens get charged at $3.00/1M as input. Sonnet
-        # ends up MORE expensive, savings goes negative — the actionable
-        # "do not offload" signal we're preserving per architect review.
+        # Opus cache_read is $0.50/1M; Sonnet has no cache discount so
+        # the same tokens get charged at $3.00/1M as input. Sonnet ends
+        # up more expensive — the actionable "do not offload" signal.
         burst = _burst(
             input_tokens=10, output_tokens=10,
-            cache_creation_input_tokens=0,
             cache_read_input_tokens=100_000,
         )
         _parent_cost, savings = estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+            burst, parent_pricing=_OPUS, alt_pricing=_SONNET,
         )
         assert savings < 0, "negative savings must be preserved, not clamped"
 
     def test_zero_usage_returns_zero_zero(self) -> None:
-        # An empty burst has no cost on either model.
-        burst = _burst()  # all token fields default to 0
+        burst = _burst()
         assert estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+            burst, parent_pricing=_OPUS, alt_pricing=_SONNET,
         ) == (0.0, 0.0)
 
     def test_parent_cost_includes_cache_read(self) -> None:
-        # The "parent cost" half of the return should be the FULL picture
-        # including cache_read at the parent rate — that's what was
-        # actually spent. (The savings half is where cache_read gets
-        # reclassified for the alt projection.)
         burst = _burst(cache_read_input_tokens=1_000_000)
         parent_cost, _savings = estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+            burst, parent_pricing=_OPUS, alt_pricing=_SONNET,
         )
         # Opus cache_read is $0.50 per 1M tokens.
         assert parent_cost == pytest.approx(0.50)
 
     def test_alt_projection_excludes_cache_creation(self) -> None:
-        # cache_creation is a parent-side cost only — a delegated subagent
-        # would re-fetch its own context, not pay to write the parent's
-        # cache. The alt-model projection drops it.
-        # Set up a burst whose ONLY non-zero usage is cache_creation,
-        # then verify savings == parent_cost (alt_cost = 0).
+        # cache_creation is a parent-side-only cost; the alt-model
+        # projection drops it (a delegated subagent would re-fetch its
+        # own context, not pay to write the parent's cache).
         burst = _burst(cache_creation_input_tokens=1_000_000)
         parent_cost, savings = estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=_sonnet(),
+            burst, parent_pricing=_OPUS, alt_pricing=_SONNET,
         )
         assert parent_cost == pytest.approx(6.25)  # Opus cache_creation rate
         assert savings == pytest.approx(parent_cost)
 
-    def test_haiku_to_haiku_zero_savings(self) -> None:
-        # Same model on both sides: parent_cost > 0 but savings should
-        # be 0 because cache_read reclassifies to input at the SAME rate
-        # cache_read pays at... wait, Haiku cache_read is $0.10 vs input
-        # $1.00, so cache_read tokens get 10x more expensive on the alt
-        # side. With ANY cache_read present, savings goes negative.
-        # This test verifies the math is honest about that even when
+    def test_haiku_to_haiku_negative_savings_from_cache_reclassification(
+        self,
+    ) -> None:
+        # Same model on both sides — but cache_read still reclassifies as
+        # fresh input under the no-cache-benefit projection. Haiku
+        # cache_read is $0.10/1M vs input $1.00/1M, so any cache_read
+        # produces a 10x cost penalty on the alt side and savings goes
+        # negative. The math is honest about reclassification even when
         # the caller "stayed put."
         burst = _burst(input_tokens=100, output_tokens=100,
                        cache_read_input_tokens=1000)
         _parent_cost, savings = estimate_burst_cost(
-            burst, parent_pricing=_haiku(), alt_pricing=_haiku(),
+            burst, parent_pricing=_HAIKU, alt_pricing=_HAIKU,
         )
-        # cache_read of 1000 tokens: Haiku input would charge 1000*1.0/1M = $0.001
-        # vs cache_read 1000*0.10/1M = $0.0001. Delta -$0.0009 swamps
-        # the no-savings input/output equality.
         assert savings < 0
 
     def test_unknown_parent_pricing_returns_zero_zero(self) -> None:
         burst = _burst(input_tokens=1000, output_tokens=500)
         assert estimate_burst_cost(
-            burst, parent_pricing=None, alt_pricing=_sonnet(),
+            burst, parent_pricing=None, alt_pricing=_SONNET,
         ) == (0.0, 0.0)
 
     def test_unknown_alt_pricing_returns_zero_zero(self) -> None:
         burst = _burst(input_tokens=1000, output_tokens=500)
         assert estimate_burst_cost(
-            burst, parent_pricing=_opus(), alt_pricing=None,
+            burst, parent_pricing=_OPUS, alt_pricing=None,
         ) == (0.0, 0.0)
 
     def test_missing_pricing_logs_at_debug(
@@ -217,7 +195,7 @@ class TestEstimateBurstCost:
     ) -> None:
         burst = _burst(input_tokens=100)
         with caplog.at_level("DEBUG", logger="agentfluent.diagnostics.parent_workload"):
-            estimate_burst_cost(burst, parent_pricing=None, alt_pricing=_sonnet())
+            estimate_burst_cost(burst, parent_pricing=None, alt_pricing=_SONNET)
         assert any(
             "pricing unavailable" in rec.message for rec in caplog.records
         )


### PR DESCRIPTION
Closes #249. Sub-issue C of #189 (parent-thread offload candidates).

## Summary
- New `pick_alternative_model(parent_model)` in `src/agentfluent/diagnostics/parent_workload.py`: substring-matches Opus → Sonnet, Sonnet → Haiku, Haiku → Haiku, unknown → unchanged.
- New `estimate_burst_cost(burst, parent_pricing, alt_pricing)`: returns `(parent_cost_usd, savings_usd_signed)`. Parent cost is the full picture (includes cache_read at the parent's rate). Alt-model projection assumes no cache benefit — cache_read reclassifies as fresh input, cache_creation drops out. **Savings is signed and never clamped** per architect review (#189): negative savings is the actionable "do not offload" signal that sub-issue F's CLI will surface distinctly.
- 18 new tests covering tier mapping, positive savings, negative-savings preservation, zero-usage edge case, cache_read inclusion in parent cost, cache_creation exclusion from alt projection, Haiku→Haiku with cache (math is honest about reclassification), and unknown-pricing fallback to `(0.0, 0.0)` + debug log.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — **936 passed** (was 918, +18 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/` — 55 source files
- [x] New behavior has test coverage — 18 tests across 2 test classes
- [x] `test_alt_targets_resolve_in_pricing_module` locks `pick_alternative_model`'s constants against pricing-module drift (if Anthropic renames a canonical id, this test fires before the cost path silently degrades)
- [x] Manual smoke test via `uv run agentfluent ...` — N/A (functions not yet wired into CLI; sub-issue F)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — pure internal cost arithmetic. Consumes the existing `analytics/pricing.py` module and the `ToolBurst` dataclass from sub-issue B; no CLI argument parsing, no path resolution, no JSONL parsing, no network/subprocess, no rendering. Internal logic only.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. New functions only; no public API touched. The dual return type `tuple[float, float]` is intentionally lightweight at this layer — sub-issue D wraps the result in the cross-boundary `OffloadCandidate` Pydantic model.

## Notes on design choices

**Cache_read excluded from savings projection.** Cache reads dominate parent-thread token counts (often 95%+) but cost ~10× less than fresh input. They don't transfer across cache namespaces to a delegated subagent. Counting them as "saved" would inflate the estimate by an order of magnitude. The PR's architect review framed this as the most fragile decision in the plan — the test `test_cache_dominated_produces_negative_savings` locks the methodology.

**Signed savings, no clamping.** When cache is load-bearing (heavy cache_read on parent), Sonnet-without-cache can cost more than Opus-with-cache. That negative number is the most actionable signal: "the parent-thread cache is doing real work; offloading would cost more, not less." Surfacing it as `0.0` would silently hide it. Sub-issue D will carry the signed value plus a `cost_note` field for sub-issue F's CLI to render with a distinct visual treatment.

**Unknown-pricing returns `(0.0, 0.0)` + debug log, not raise.** The pricing module already returns `None` for unknown models with its own debug log; this layer follows the same pattern so a future Anthropic model id appearing in a session doesn't crash analyze — it just produces "no estimate available" for those bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)