### PR TITLE
feat(diagnostics): frequency-filter delegation draft tools list (#184)

### DIFF
--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
 __all__ = [
     "DEFAULT_MIN_CLUSTER_SIZE",
     "DEFAULT_MIN_SIMILARITY",
+    "DEFAULT_TOOL_FREQUENCY_THRESHOLD",
     "MIN_TEXT_TOKENS",
     "MODEL_HAIKU",
     "MODEL_OPUS",
@@ -115,6 +116,16 @@ _CONFIDENCE_HIGH_SIZE = 10
 _CONFIDENCE_HIGH_COHESION = 0.50
 _CONFIDENCE_MEDIUM_COHESION = 0.35
 _PROMPT_BODY_SNIPPET_CHARS = 500
+
+# Frequency threshold for the per-tool inclusion filter. A tool is
+# kept on the draft's `tools` list only if it appears in at least this
+# fraction of the cluster's member traces (presence-based, NOT call-
+# count-based — one member running `Bash` 50 times still counts as a
+# single member). Default 0.5 per #184 architect review: presence
+# gives the least-privilege answer in every uneven-call-volume case
+# (the exact pathology #184 was filed to fix). Calibration sweep is
+# tracked in `scripts/calibration/threshold_validation.ipynb` (#140).
+DEFAULT_TOOL_FREQUENCY_THRESHOLD = 0.5
 
 # MODEL_HAIKU/SONNET/OPUS are re-exported from _complexity.py — see #185
 # for the consolidation. Pre-#185 they lived here directly.
@@ -294,11 +305,51 @@ def _synthesize_prompt(top_terms: list[str], members: list[AgentInvocation]) -> 
 
 
 def _collect_tools_from_traces(members: list[AgentInvocation]) -> list[str]:
+    """Sorted union of every tool observed across the cluster's traces.
+
+    The unfiltered list — surfaced on ``DelegationSuggestion.tools_observed``
+    so users can see what was filtered out. ``generate_draft`` runs
+    ``_filter_tools_by_frequency`` on top of this for the actual
+    frontmatter ``tools`` list.
+    """
     tools: set[str] = set()
     for m in members:
         if m.trace is not None:
             tools.update(m.trace.unique_tool_names)
     return sorted(tools)
+
+
+def _filter_tools_by_frequency(
+    members: list[AgentInvocation],
+    *,
+    threshold: float = DEFAULT_TOOL_FREQUENCY_THRESHOLD,
+) -> list[str]:
+    """Keep tools used in at least ``threshold`` fraction of cluster members.
+
+    Presence-based: a tool counts once per member that used it,
+    regardless of call volume within that member. This is the
+    least-privilege answer when call volume is uneven (one member
+    running ``Bash`` 50 times shouldn't keep ``Bash`` on the draft for
+    a 5-member cluster where 4 members never touched it). See #184 for
+    the architect-reviewed rationale.
+
+    Members without a linked trace are still counted in the denominator
+    — they contribute zero observed tools, which lowers every tool's
+    presence ratio. That's intentional: a half-traced cluster shouldn't
+    over-recommend tools based on the observed half.
+    """
+    if not members:
+        return []
+    tool_member_counts: dict[str, int] = {}
+    for m in members:
+        if m.trace is None:
+            continue
+        for tool_name in m.trace.unique_tool_names:
+            tool_member_counts[tool_name] = tool_member_counts.get(tool_name, 0) + 1
+    cutoff = threshold * len(members)
+    return sorted(
+        tool for tool, count in tool_member_counts.items() if count >= cutoff
+    )
 
 
 def _classify_model(tools: list[str], members: list[AgentInvocation]) -> str:
@@ -322,17 +373,32 @@ def _classify_confidence(cluster_size: int, cohesion: float) -> ConfidenceTier:
 
 
 def generate_draft(cluster: DelegationCluster) -> DelegationSuggestion:
-    """Synthesize a draft subagent definition from a cluster."""
-    tools = _collect_tools_from_traces(cluster.members)
-    tools_note = (
-        "" if tools
-        else "# run with newer session data for tool recommendations"
-    )
+    """Synthesize a draft subagent definition from a cluster.
+
+    ``tools`` is the frequency-filtered list (presence in
+    ``DEFAULT_TOOL_FREQUENCY_THRESHOLD`` of members) — the
+    least-privilege set used in the YAML frontmatter. ``tools_observed``
+    is the full union; users widening the draft can consult it. See
+    #184 for the rationale and architect review.
+    """
+    tools_observed = _collect_tools_from_traces(cluster.members)
+    tools = _filter_tools_by_frequency(cluster.members)
+    if not tools_observed:
+        tools_note = "# run with newer session data for tool recommendations"
+    elif not tools:
+        tools_note = (
+            f"# no tool used in >="
+            f"{int(DEFAULT_TOOL_FREQUENCY_THRESHOLD * 100)}% of cluster members "
+            f"— see tools_observed for the unfiltered list"
+        )
+    else:
+        tools_note = ""
     return DelegationSuggestion(
         name=_synthesize_name(cluster.top_terms),
         description=_synthesize_description(cluster.top_terms),
         model=_classify_model(tools, cluster.members),
         tools=tools,
+        tools_observed=tools_observed,
         tools_note=tools_note,
         prompt_template=_synthesize_prompt(cluster.top_terms, cluster.members),
         confidence=_classify_confidence(len(cluster.members), cluster.cohesion_score),

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import re
 import warnings
+from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -304,19 +305,24 @@ def _synthesize_prompt(top_terms: list[str], members: list[AgentInvocation]) -> 
     )
 
 
-def _collect_tools_from_traces(members: list[AgentInvocation]) -> list[str]:
-    """Sorted union of every tool observed across the cluster's traces.
+def _tool_presence_counts(members: list[AgentInvocation]) -> Counter[str]:
+    """Per-tool count of how many cluster members used that tool at least once.
 
-    The unfiltered list — surfaced on ``DelegationSuggestion.tools_observed``
-    so users can see what was filtered out. ``generate_draft`` runs
-    ``_filter_tools_by_frequency`` on top of this for the actual
-    frontmatter ``tools`` list.
+    Shared primitive for ``_collect_tools_from_traces`` (sort the keys)
+    and ``_filter_tools_by_frequency`` (apply the cutoff). Members
+    without a linked trace contribute nothing here, but still count in
+    the denominator at the filter site — see ``_filter_tools_by_frequency``.
     """
-    tools: set[str] = set()
+    counts: Counter[str] = Counter()
     for m in members:
         if m.trace is not None:
-            tools.update(m.trace.unique_tool_names)
-    return sorted(tools)
+            counts.update(m.trace.unique_tool_names)
+    return counts
+
+
+def _collect_tools_from_traces(members: list[AgentInvocation]) -> list[str]:
+    """Sorted union of every tool observed across the cluster's traces."""
+    return sorted(_tool_presence_counts(members))
 
 
 def _filter_tools_by_frequency(
@@ -340,16 +346,9 @@ def _filter_tools_by_frequency(
     """
     if not members:
         return []
-    tool_member_counts: dict[str, int] = {}
-    for m in members:
-        if m.trace is None:
-            continue
-        for tool_name in m.trace.unique_tool_names:
-            tool_member_counts[tool_name] = tool_member_counts.get(tool_name, 0) + 1
+    counts = _tool_presence_counts(members)
     cutoff = threshold * len(members)
-    return sorted(
-        tool for tool, count in tool_member_counts.items() if count >= cutoff
-    )
+    return sorted(t for t, c in counts.items() if c >= cutoff)
 
 
 def _classify_model(tools: list[str], members: list[AgentInvocation]) -> str:

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -180,12 +180,22 @@ class DelegationSuggestion(BaseModel):
     """Recommended Claude model ID (haiku / sonnet / opus)."""
 
     tools: list[str] = Field(default_factory=list)
-    """Union of tools observed in the cluster's subagent traces. Empty
-    when no traces were linked to the member invocations."""
+    """Filtered tool list for the draft's frontmatter — tools used in at
+    least ``DEFAULT_TOOL_FREQUENCY_THRESHOLD`` (50%) of cluster members.
+    The full observed union lives on ``tools_observed`` for reference.
+    Empty when no traces were linked to the member invocations OR when
+    no tool met the threshold (see ``tools_note``)."""
+
+    tools_observed: list[str] = Field(default_factory=list)
+    """Full union of tools observed across the cluster's subagent
+    traces, before frequency filtering. Surfaced so users can widen the
+    draft's ``tools`` list manually if the filter was too aggressive."""
 
     tools_note: str = ""
-    """Diagnostic note when ``tools`` cannot be derived (e.g., older
-    sessions lacking trace capture)."""
+    """Diagnostic note about the ``tools`` field. Populated when no
+    traces were linked (older sessions) OR when traces were linked but
+    no tool met the frequency threshold — in the latter case, the note
+    points the user at ``tools_observed`` to review what was filtered."""
 
     prompt_template: str
     """Draft prompt scaffold anchored on the cluster's top terms."""

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -18,6 +18,7 @@ from agentfluent.agents.models import AgentInvocation  # noqa: E402
 from agentfluent.config.models import AgentConfig, Scope  # noqa: E402
 from agentfluent.diagnostics import delegation  # noqa: E402
 from agentfluent.diagnostics.delegation import (  # noqa: E402
+    DEFAULT_TOOL_FREQUENCY_THRESHOLD,
     MODEL_HAIKU,
     MODEL_OPUS,
     MODEL_SONNET,
@@ -27,6 +28,7 @@ from agentfluent.diagnostics.delegation import (  # noqa: E402
     _classify_confidence,
     _classify_model,
     _collect_tools_from_traces,
+    _filter_tools_by_frequency,
     cluster_delegations,
     generate_draft,
     suggest_delegations,
@@ -359,6 +361,53 @@ class TestGenerateDraft:
         draft = generate_draft(self._cluster(members=members, cohesion=0.28))
         assert draft.confidence == "low"
 
+    def test_draft_tools_filtered_observed_populated_separately(self) -> None:
+        # End-to-end: incidental Bash from one member appears in
+        # tools_observed (so the user can see what was filtered) but
+        # is excluded from tools (the YAML frontmatter list).
+        members = [
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read", "Bash"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"])),
+        ]
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.tools == ["Read"]
+        assert draft.tools_observed == ["Bash", "Read"]
+        assert draft.tools_note == ""
+
+    def test_draft_no_filter_survivors_populates_tools_note(self) -> None:
+        # Every member uses a different tool — observed union is
+        # non-empty but no tool meets the 50% threshold. The note
+        # should point users at tools_observed for the unfiltered list.
+        members = [
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Bash"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Edit"])),
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Grep"])),
+        ]
+        draft = generate_draft(self._cluster(members=members))
+        assert draft.tools == []
+        assert draft.tools_observed == ["Bash", "Edit", "Grep", "Read"]
+        assert "tools_observed" in draft.tools_note
+        assert "50%" in draft.tools_note
+
+    def test_yaml_draft_renders_filtered_tools_only(self) -> None:
+        # The frontmatter `tools:` line in the YAML must reflect the
+        # filtered list, not the observed union — the entire point of
+        # #184 is least-privilege drafts.
+        members = [
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read", "Bash"])),
+        ] + [
+            _inv(description="d", prompt="p", trace=_trace_with_tools(["Read"]))
+            for _ in range(4)
+        ]
+        draft = generate_draft(self._cluster(members=members))
+        assert "- Read" in draft.yaml_draft
+        # Bash is in tools_observed but not in the rendered frontmatter.
+        assert "- Bash" not in draft.yaml_draft
+
 
 class TestClassifyHelpers:
     def test_classify_model_no_observed_data_recommends_sonnet(self) -> None:
@@ -378,6 +427,75 @@ class TestClassifyHelpers:
             _inv(trace=_trace_with_tools(["Grep", "Bash"])),
         ]
         assert _collect_tools_from_traces(members) == ["Bash", "Grep", "Read"]
+
+    def test_filter_drops_tool_below_threshold(self) -> None:
+        # Read appears in 4/5 members (0.8) → kept at threshold 0.5.
+        # Bash appears in 1/5 members (0.2) → dropped — the exact
+        # incidental-tool pathology #184 was filed to fix.
+        members = [
+            _inv(trace=_trace_with_tools(["Read", "Bash"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Edit"])),
+        ]
+        assert _filter_tools_by_frequency(members) == ["Read"]
+
+    def test_filter_keeps_tool_at_exact_threshold(self) -> None:
+        # Tool present in exactly threshold-fraction of members survives
+        # — `>=` not `>` is the documented contract.
+        members = [
+            _inv(trace=_trace_with_tools(["Grep"])),
+            _inv(trace=_trace_with_tools(["Grep"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+        ]
+        assert _filter_tools_by_frequency(members, threshold=0.5) == ["Grep", "Read"]
+
+    def test_filter_call_volume_does_not_inflate_presence(self) -> None:
+        # One member runs Bash 50 times; presence is still 1/5 → dropped.
+        # This is the case where a count-based threshold would have
+        # kept Bash; presence-based correctly rejects it.
+        bash_heavy_trace = SubagentTrace(
+            agent_id="agent-x",
+            agent_type="general-purpose",
+            delegation_prompt="",
+            tool_calls=[
+                SubagentToolCall(tool_name="Bash", input_summary="x", result_summary="ok")
+                for _ in range(50)
+            ],
+        )
+        members = [
+            _inv(trace=bash_heavy_trace),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+        ]
+        assert _filter_tools_by_frequency(members) == ["Read"]
+
+    def test_filter_untraced_members_lower_denominator(self) -> None:
+        # 2/4 members traced, both used Read → presence 2/4 = 0.5 → kept.
+        # If untraced members were excluded, ratio would be 2/2 = 1.0;
+        # this confirms the documented "untraced members count in
+        # denominator" behavior.
+        members = [
+            _inv(trace=_trace_with_tools(["Read", "Grep"])),
+            _inv(trace=_trace_with_tools(["Read"])),
+            _inv(trace=None),
+            _inv(trace=None),
+        ]
+        # Read: 2/4 = 0.5 → kept. Grep: 1/4 = 0.25 → dropped.
+        assert _filter_tools_by_frequency(members) == ["Read"]
+
+    def test_filter_no_traces_returns_empty(self) -> None:
+        members = [_inv(trace=None)] * 5
+        assert _filter_tools_by_frequency(members) == []
+
+    def test_default_threshold_is_half(self) -> None:
+        # Lock the architect-approved default; calibration may revisit
+        # but the constant is the contract for #189-D's draft synthesis.
+        assert DEFAULT_TOOL_FREQUENCY_THRESHOLD == 0.5
 
 
 class TestDedup:


### PR DESCRIPTION
## Summary
- Replaces the observed-tool union in `_collect_tools_from_traces` with a presence-based frequency filter (`_filter_tools_by_frequency`, default 50%) so draft `DelegationSuggestion.tools` reflect tools the *typical* cluster member uses, not every tool any single member touched.
- Adds `DelegationSuggestion.tools_observed` (full union) and `DEFAULT_TOOL_FREQUENCY_THRESHOLD` constant; updates `tools_note` to explain the empty-filtered case and point users at `tools_observed`.
- Closes #184. Architect-reviewed: https://github.com/frederick-douglas-pearce/agentfluent/issues/184#issuecomment-4368220219.

**Why this matters:** A 5-member code-review cluster where 1 member ran `Bash`/`Write` once would currently produce a YAML draft with read-write filesystem access. After this PR, only tools used by ≥50% of members survive — least-privilege drafts. Also unblocks #189 sub-issue D (parent-thread offload candidates), which reuses this code path.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 912 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 9 new tests covering presence-vs-call-volume, exact-threshold, untraced-member denominator, end-to-end `tools`/`tools_observed` separation, YAML rendering of filtered set only
- [x] Manual smoke test via `uv run agentfluent ...` — not required (no CLI output shape changes; `tools_observed` is JSON-additive and doesn't appear in the default table)

## Security review
- [x] **Skip review** — no security-sensitive surface (internal heuristic refactor + new Pydantic field; no hooks, secrets, parsing, subprocess, or user-string rendering changes).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None at the type level — `DelegationSuggestion.tools_observed` is JSON-additive (default `[]`). Behavior of `DelegationSuggestion.tools` changes for existing callers: it now returns the filtered subset instead of the full union. The full union is still available on `tools_observed`. JSON envelope `version` unchanged (additive field; same posture documented for #189-E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)