### PR TITLE
feat(diagnostics): cluster parent-thread bursts and synthesize OffloadCandidate drafts (#256)

### DIFF
--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -260,7 +260,7 @@ def cluster_delegations(
 _SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]")
 
 
-def _synthesize_name(top_terms: list[str]) -> str:
+def synthesize_name(top_terms: list[str]) -> str:
     """Build a kebab-case agent name from the top TF-IDF terms.
 
     Prefers the first two terms when available; otherwise falls back to
@@ -276,7 +276,7 @@ def _synthesize_name(top_terms: list[str]) -> str:
     return f"{cleaned[0]}-{cleaned[1]}"
 
 
-def _synthesize_description(top_terms: list[str]) -> str:
+def synthesize_description(top_terms: list[str]) -> str:
     if not top_terms:
         return "Handles a recurring delegation pattern."
     terms_list = ", ".join(top_terms[:3])
@@ -393,8 +393,8 @@ def generate_draft(cluster: DelegationCluster) -> DelegationSuggestion:
     else:
         tools_note = ""
     return DelegationSuggestion(
-        name=_synthesize_name(cluster.top_terms),
-        description=_synthesize_description(cluster.top_terms),
+        name=synthesize_name(cluster.top_terms),
+        description=synthesize_description(cluster.top_terms),
         model=_classify_model(tools, cluster.members),
         tools=tools,
         tools_observed=tools_observed,

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -271,6 +271,185 @@ class DelegationSuggestion(BaseModel):
         )
 
 
+class SkillScaffold(BaseModel):
+    """v0.6 placeholder for a skill-scaffold draft.
+
+    Intentionally empty in v0.5 — schema reservation only. ``OffloadCandidate``
+    serializes ``skill_draft: null`` for every candidate this release. Once
+    the skill scanner (#183) lands, fields will be added here additively;
+    consumers that rely on ``skill_draft is None`` to mean "v0.5 didn't ship
+    a skill" should switch to ``target_kind == 'skill'`` post-v0.6.
+    """
+
+
+class OffloadCandidate(BaseModel):
+    """A parent-thread workload pattern that could move to a cheaper subagent.
+
+    Produced by the parent-thread offload-candidate pipeline (#189) which
+    clusters ``ToolBurst`` records on the parent (typically Opus) thread,
+    estimates the cost delta against a cheaper alternative model, and
+    synthesizes a copy-paste-ready subagent draft. Peer concept to
+    ``DelegationSuggestion`` — that one comes from clustering existing
+    ``general-purpose`` delegations; this one comes from clustering the
+    parent thread's own tool-using turns.
+
+    ``estimated_savings_usd`` is **signed**: negative means offloading
+    would cost MORE than staying on the parent (cache is load-bearing for
+    this pattern). Per architect review for #189-C, the sign is preserved
+    rather than clamped — the negative case is the most actionable signal
+    this feature can produce. ``cost_note`` is populated when negative
+    with a CLI-render-ready warning.
+    """
+
+    name: str
+    """Kebab-case suggested subagent name synthesized from top terms."""
+
+    description: str
+    """One-line description synthesized from top terms."""
+
+    confidence: Literal["high", "medium", "low"]
+    """Confidence tier based on cluster size + cohesion (same boundaries
+    as ``DelegationSuggestion``)."""
+
+    cluster_size: int
+    """Number of bursts in the cluster."""
+
+    cohesion_score: float
+    """Mean pairwise cosine similarity within the cluster's TF-IDF vectors."""
+
+    top_terms: list[str] = Field(default_factory=list)
+    """Top TF-IDF terms characterizing the cluster."""
+
+    tool_sequence_summary: list[str] = Field(default_factory=list)
+    """Most common tool sequence across the cluster (in order, not deduped).
+    Modal sequence by ``Counter`` of tool-name tuples; empty when cluster
+    has no observed tool calls."""
+
+    estimated_parent_tokens: int = 0
+    """Sum of total tokens used across cluster bursts on the parent thread."""
+
+    estimated_parent_cost_usd: float = 0.0
+    """Aggregate parent-thread cost (USD) of the cluster's bursts at the
+    parent model's pricing. ``0.0`` when pricing was unavailable."""
+
+    estimated_savings_usd: float = 0.0
+    """Signed savings (USD) projected if the cluster's work moved to
+    ``alternative_model``. NEGATIVE means offloading would cost more —
+    see ``cost_note``. ``0.0`` when pricing unavailable."""
+
+    parent_model: str = ""
+    """Model id observed on the cluster's parent-thread bursts."""
+
+    alternative_model: str
+    """Recommended cheaper-tier model id (e.g., ``claude-sonnet-4-6``)."""
+
+    cost_note: str = ""
+    """Populated when ``estimated_savings_usd`` is negative — explains
+    that offloading would increase cost (parent-thread cache is
+    load-bearing) and recommends keeping the work on the parent."""
+
+    target_kind: Literal["subagent", "skill"] = "subagent"
+    """Always ``"subagent"`` in v0.5; ``"skill"`` reserved for v0.6 once
+    skill scanner #183 lands."""
+
+    subagent_draft: DelegationSuggestion | None = None
+    """Populated when ``target_kind == "subagent"`` (always in v0.5).
+    Reuses ``DelegationSuggestion`` so the YAML draft shape stays
+    consistent between this feature and the existing delegation
+    suggestions."""
+
+    skill_draft: SkillScaffold | None = None
+    """Always ``None`` in v0.5. Field shape reserved for v0.6."""
+
+    matched_agent: str = ""
+    """Name of an existing ``AgentConfig`` whose description overlaps this
+    candidate's draft above the dedup threshold. Populated by sub-issue E."""
+
+    dedup_note: str = ""
+    """Non-empty when the candidate overlaps an existing agent. Populated
+    by sub-issue E."""
+
+    # ``# type: ignore[prop-decorator]`` mirrors ``DelegationSuggestion`` —
+    # mypy + pydantic ``@computed_field`` interaction (pydantic/pydantic#6709).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def yaml_draft(self) -> str:
+        """Copy-paste-ready subagent block with offload-specific context.
+
+        Builds an offload-flavored preamble (savings, parent → alt model,
+        cost_note when negative) on top of the ``subagent_draft``'s
+        frontmatter + prompt body. Does NOT delegate to
+        ``DelegationSuggestion.yaml_draft`` — that one's preamble is
+        about delegation patterns; this one needs to communicate the
+        parent-thread offload framing and the dollar figure that
+        motivates the change.
+        """
+        if self.subagent_draft is None:
+            return ""
+
+        preamble: list[str] = [
+            f"# Suggested subagent (parent-thread offload candidate): {self.name}",
+        ]
+        if self.confidence == "low":
+            preamble.append("# REVIEW BEFORE USE — low confidence cluster")
+        preamble.append(
+            f"# Confidence: {self.confidence} "
+            f"({self.cluster_size} bursts, {self.cohesion_score:.2f} cohesion)",
+        )
+        if self.parent_model:
+            preamble.append(
+                f"# Parent model: {self.parent_model} "
+                f"→ recommended: {self.alternative_model}",
+            )
+        else:
+            preamble.append(f"# Recommended model: {self.alternative_model}")
+        if self.estimated_parent_tokens:
+            preamble.append(
+                f"# Parent-thread cost: ${self.estimated_parent_cost_usd:.4f} "
+                f"({self.estimated_parent_tokens:,} tokens)",
+            )
+        # Signed savings: positive renders as a savings figure, negative
+        # renders as the actionable "do not offload" signal.
+        if self.estimated_savings_usd >= 0:
+            preamble.append(
+                f"# Estimated savings: ${self.estimated_savings_usd:.4f}",
+            )
+        else:
+            preamble.append(
+                f"# Estimated cost change: +${-self.estimated_savings_usd:.4f} "
+                f"(offloading would cost MORE)",
+            )
+        if self.cost_note:
+            preamble.append(f"# Note: {self.cost_note}")
+        if self.top_terms:
+            preamble.append(f"# Top terms: {', '.join(self.top_terms)}")
+        if self.dedup_note:
+            preamble.append(f"# Dedup: {self.dedup_note}")
+
+        draft = self.subagent_draft
+        frontmatter_data: dict[str, object] = {
+            "description": draft.description,
+            "model": draft.model,
+            "tools": draft.tools,
+        }
+        frontmatter = yaml.safe_dump(
+            frontmatter_data, sort_keys=False, default_flow_style=False,
+        ).rstrip()
+
+        tools_comment = ""
+        if not draft.tools and draft.tools_note:
+            tools_comment = f"\n# tools: {draft.tools_note}"
+
+        return (
+            "\n".join(preamble)
+            + "\n---\n"
+            + frontmatter
+            + tools_comment
+            + "\n---\n\n"
+            + draft.prompt_template
+        )
+
+
 class DiagnosticsResult(BaseModel):
     """Complete diagnostics output for a session or set of sessions."""
 
@@ -292,3 +471,9 @@ class DiagnosticsResult(BaseModel):
 
     delegation_suggestions: list[DelegationSuggestion] = Field(default_factory=list)
     """Draft subagent definitions proposed by the clustering pipeline."""
+
+    # v0.5: added offload_candidates (#189). Wired up in sub-issue E.
+    offload_candidates: list[OffloadCandidate] = Field(default_factory=list)
+    """Parent-thread offload candidates surfaced by the burst-clustering
+    pipeline (#189). Empty list when sklearn isn't installed or no
+    cluster met ``min_cluster_size``."""

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -12,7 +12,7 @@ from enum import StrEnum
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from agentfluent.config.models import Severity
 
@@ -221,6 +221,29 @@ class DelegationSuggestion(BaseModel):
     not deduped). Exposed as a first-class field so cross-reference
     logic can look up the matched agent without parsing ``dedup_note``."""
 
+    def render_body(self) -> str:
+        """YAML frontmatter + tools_comment + ``---`` + prompt body.
+
+        Shared by ``yaml_draft`` here and ``OffloadCandidate.yaml_draft``,
+        which prepends a different preamble. Any frontmatter shape change
+        stays in lockstep across both consumers — the whole reason this
+        is one method instead of two.
+        """
+        frontmatter_data: dict[str, object] = {
+            "description": self.description,
+            "model": self.model,
+            "tools": self.tools,
+        }
+        frontmatter = yaml.safe_dump(
+            frontmatter_data, sort_keys=False, default_flow_style=False,
+        ).rstrip()
+        tools_comment = ""
+        if not self.tools and self.tools_note:
+            tools_comment = f"\n# tools: {self.tools_note}"
+        return (
+            "---\n" + frontmatter + tools_comment + "\n---\n\n" + self.prompt_template
+        )
+
     # ``# type: ignore[prop-decorator]`` is the documented workaround for
     # mypy not reconciling ``@computed_field`` stacked on ``@property``
     # (upstream: pydantic/pydantic#6709).
@@ -247,28 +270,7 @@ class DelegationSuggestion(BaseModel):
             preamble.append(f"# Top terms: {', '.join(self.top_terms)}")
         if self.dedup_note:
             preamble.append(f"# Note: {self.dedup_note}")
-
-        frontmatter_data: dict[str, object] = {
-            "description": self.description,
-            "model": self.model,
-            "tools": self.tools,
-        }
-        frontmatter = yaml.safe_dump(
-            frontmatter_data, sort_keys=False, default_flow_style=False,
-        ).rstrip()
-
-        tools_comment = ""
-        if not self.tools and self.tools_note:
-            tools_comment = f"\n# tools: {self.tools_note}"
-
-        return (
-            "\n".join(preamble)
-            + "\n---\n"
-            + frontmatter
-            + tools_comment
-            + "\n---\n\n"
-            + self.prompt_template
-        )
+        return "\n".join(preamble) + "\n" + self.render_body()
 
 
 class SkillScaffold(BaseModel):
@@ -279,7 +281,13 @@ class SkillScaffold(BaseModel):
     the skill scanner (#183) lands, fields will be added here additively;
     consumers that rely on ``skill_draft is None`` to mean "v0.5 didn't ship
     a skill" should switch to ``target_kind == 'skill'`` post-v0.6.
+
+    ``extra="forbid"`` is the forward-compat tripwire: a v0.6-emitted JSON
+    deserialized by a v0.5 consumer will raise instead of silently dropping
+    fields, so the migration plan can't get bypassed by accident.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class OffloadCandidate(BaseModel):
@@ -426,27 +434,8 @@ class OffloadCandidate(BaseModel):
         if self.dedup_note:
             preamble.append(f"# Dedup: {self.dedup_note}")
 
-        draft = self.subagent_draft
-        frontmatter_data: dict[str, object] = {
-            "description": draft.description,
-            "model": draft.model,
-            "tools": draft.tools,
-        }
-        frontmatter = yaml.safe_dump(
-            frontmatter_data, sort_keys=False, default_flow_style=False,
-        ).rstrip()
-
-        tools_comment = ""
-        if not draft.tools and draft.tools_note:
-            tools_comment = f"\n# tools: {draft.tools_note}"
-
         return (
-            "\n".join(preamble)
-            + "\n---\n"
-            + frontmatter
-            + tools_comment
-            + "\n---\n\n"
-            + draft.prompt_template
+            "\n".join(preamble) + "\n" + self.subagent_draft.render_body()
         )
 
 

--- a/src/agentfluent/diagnostics/parent_workload.py
+++ b/src/agentfluent/diagnostics/parent_workload.py
@@ -28,11 +28,48 @@ with no text — that's structural, not a human turn.
 from __future__ import annotations
 
 import logging
+import warnings
+from collections import Counter
 from dataclasses import dataclass, field
+from typing import Literal
 
+# sklearn is an optional extra; the cluster_bursts/generate_offload_candidate
+# code paths gate on SKLEARN_AVAILABLE. Pre-existing extract/cost helpers
+# don't need sklearn — they keep working without the extra installed.
+try:
+    import numpy as np
+    from sklearn.decomposition import TruncatedSVD
+    from sklearn.feature_extraction.text import TfidfVectorizer
+except ImportError:  # pragma: no cover — exercised via install-path test
+    pass
+
+from agentfluent.agents.models import WRITE_TOOLS
 from agentfluent.analytics.pricing import ModelPricing, compute_cost
 from agentfluent.core.session import SessionMessage, ToolUseBlock, Usage
-from agentfluent.diagnostics.delegation import MODEL_HAIKU, MODEL_SONNET
+from agentfluent.diagnostics._clustering import (
+    SKLEARN_AVAILABLE,
+    SklearnMissingError,
+    all_rows_identical,
+    cluster_embeddings,
+    group_indices_by_label,
+    mean_pairwise_cosine,
+    top_tfidf_terms,
+)
+from agentfluent.diagnostics._complexity import (
+    AgentStats,
+    classify_complexity,
+    recommend_model_for_complexity,
+)
+from agentfluent.diagnostics.delegation import (
+    MODEL_HAIKU,
+    MODEL_SONNET,
+    synthesize_description,
+    synthesize_name,
+)
+from agentfluent.diagnostics.models import (
+    DelegationSuggestion,
+    OffloadCandidate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -265,3 +302,351 @@ def estimate_burst_cost(
         alt_pricing, effective_input, u.output_tokens, 0, 0,
     )
     return (parent_cost, parent_cost - alt_cost)
+
+
+# --- Sub-issue D: clustering + offload candidate synthesis ----------------
+#
+# Mirrors delegation.cluster_delegations / generate_draft, but operates on
+# parent-thread bursts. The TF-IDF + LSA + KMeans pipeline is duplicated
+# (rather than extracted) per architect review for #189-D Q3: only two
+# consumers, ~30 lines each, premature abstraction. Structured as a
+# contiguous block so a future third consumer can extract cleanly.
+
+DEFAULT_BURST_CLUSTER_SIZE = 5
+"""Minimum bursts per cluster surfaced as an offload candidate."""
+
+LSA_COMPONENTS = 50
+"""Mirrors ``delegation.LSA_COMPONENTS``. Calibration sweep tracked in
+``scripts/calibration/threshold_validation.ipynb`` (#140)."""
+
+_TOOL_FREQUENCY_THRESHOLD = 0.5
+"""Same default as ``delegation.DEFAULT_TOOL_FREQUENCY_THRESHOLD`` (#184).
+Local copy rather than import because the burst path may calibrate
+independently — sub-issue F's notebook explicitly checks this. See #184
+architect-review note."""
+
+_CONFIDENCE_HIGH_SIZE = 10
+_CONFIDENCE_HIGH_COHESION = 0.50
+_CONFIDENCE_MEDIUM_COHESION = 0.35
+
+
+@dataclass
+class BurstCluster:
+    """A KMeans cluster of similar parent-thread bursts.
+
+    Internal type. ``OffloadCandidate`` (in ``diagnostics/models.py``) is
+    the cross-boundary Pydantic counterpart that downstream consumers see.
+    """
+
+    members: list[ToolBurst]
+    top_terms: list[str]
+    cohesion_score: float
+
+
+def _require_sklearn() -> None:
+    if not SKLEARN_AVAILABLE:
+        raise SklearnMissingError(
+            "Install agentfluent[clustering] to enable parent-thread "
+            "offload-candidate analysis.",
+        )
+
+
+def _build_single_burst_cluster(
+    bursts: list[ToolBurst],
+    tfidf_matrix: np.ndarray,
+    terms: np.ndarray,
+) -> BurstCluster:
+    """All-rows-identical fallback. Mirrors delegation's ``_build_single_cluster``.
+    Cohesion is 1.0 by definition since every member shares the same vector."""
+    all_indices = list(range(len(bursts)))
+    return BurstCluster(
+        members=list(bursts),
+        top_terms=top_tfidf_terms(tfidf_matrix, all_indices, terms),
+        cohesion_score=1.0,
+    )
+
+
+def cluster_bursts(
+    bursts: list[ToolBurst],
+    *,
+    min_cluster_size: int = DEFAULT_BURST_CLUSTER_SIZE,
+) -> list[BurstCluster]:
+    """Group similar parent-thread bursts via TF-IDF + LSA + KMeans.
+
+    Mirrors ``delegation.cluster_delegations`` operating on ``ToolBurst``
+    records and ``burst_text``. ``filter_bursts`` is applied internally to
+    drop too-small / too-large / sub-token-floor bursts.
+
+    Raises ``SklearnMissingError`` when scikit-learn is not installed.
+    Returns ``[]`` when fewer than ``min_cluster_size`` bursts survive
+    filtering, or when no KMeans cluster met ``min_cluster_size``.
+    """
+    _require_sklearn()
+
+    candidates = filter_bursts(bursts)
+    if len(candidates) < min_cluster_size:
+        return []
+
+    texts = [burst_text(b) for b in candidates]
+    tfidf = TfidfVectorizer(stop_words="english", max_features=500)
+    tfidf_matrix = tfidf.fit_transform(texts)
+    terms = tfidf.get_feature_names_out()
+
+    if all_rows_identical(tfidf_matrix):
+        logger.warning(
+            "Burst clustering: all %d TF-IDF rows are identical — "
+            "this is unusual for real parent-thread data. Check for "
+            "duplicate burst records or upstream extraction bugs.",
+            tfidf_matrix.shape[0],
+        )
+        return [_build_single_burst_cluster(candidates, tfidf_matrix, terms)]
+
+    n_components = min(
+        LSA_COMPONENTS, tfidf_matrix.shape[1] - 1, len(candidates) - 1,
+    )
+    if n_components >= 2:
+        with warnings.catch_warnings():
+            # TruncatedSVD can warn on near-zero variance; the
+            # degenerate-fallback in cluster_embeddings handles output.
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            lsa = TruncatedSVD(n_components=n_components, random_state=42)
+            embeddings = lsa.fit_transform(tfidf_matrix)
+    else:
+        embeddings = tfidf_matrix.toarray()
+
+    labels = cluster_embeddings(embeddings, len(candidates))
+    groups = group_indices_by_label(labels)
+
+    clusters: list[BurstCluster] = []
+    for _label, member_indices in sorted(groups.items()):
+        if len(member_indices) < min_cluster_size:
+            continue
+        members = [candidates[i] for i in member_indices]
+        member_embeddings = embeddings[member_indices]
+        cohesion = mean_pairwise_cosine(member_embeddings)
+        cluster_top_terms = top_tfidf_terms(tfidf_matrix, member_indices, terms)
+        clusters.append(
+            BurstCluster(
+                members=members,
+                top_terms=cluster_top_terms,
+                cohesion_score=cohesion,
+            ),
+        )
+    return clusters
+
+
+def _collect_tools_from_bursts(bursts: list[ToolBurst]) -> list[str]:
+    """Sorted union of every tool name observed across the cluster's bursts."""
+    return sorted({b.name for burst in bursts for b in burst.tool_use_blocks})
+
+
+def _filter_tools_from_bursts(
+    bursts: list[ToolBurst],
+    *,
+    threshold: float = _TOOL_FREQUENCY_THRESHOLD,
+) -> list[str]:
+    """Keep tools used in at least ``threshold`` fraction of cluster bursts.
+
+    Presence-based, mirroring ``delegation._filter_tools_by_frequency``: a
+    tool counts once per burst it appears in, regardless of call volume
+    within that burst. See #184 for the architect-reviewed rationale.
+    """
+    if not bursts:
+        return []
+    counts: Counter[str] = Counter()
+    for burst in bursts:
+        counts.update({b.name for b in burst.tool_use_blocks})
+    cutoff = threshold * len(bursts)
+    return sorted(t for t, c in counts.items() if c >= cutoff)
+
+
+def _aggregate_burst_stats(bursts: list[ToolBurst]) -> AgentStats:
+    """Build ``AgentStats`` for ``classify_complexity`` from a burst cluster.
+
+    ``error_rate`` defaults to 0.0 — bursts don't carry paired
+    ``tool_result.is_error`` data today (the extractor only captures
+    ``tool_use_blocks`` from assistant messages). If dogfood shows
+    error-prone clusters being misclassified as moderate, the extractor
+    can be extended in a follow-up to capture per-tool error counts.
+    """
+    if not bursts:
+        return AgentStats(
+            agent_type="<bursts>",
+            invocation_count=0,
+            mean_tool_calls=0.0,
+            mean_tokens=0.0,
+            error_rate=0.0,
+            has_write_tools=False,
+            current_model=None,
+        )
+    tool_counts = [len(b.tool_use_blocks) for b in bursts]
+    token_totals = [b.usage.total_tokens for b in bursts]
+    all_tools = {b.name for burst in bursts for b in burst.tool_use_blocks}
+    return AgentStats(
+        agent_type="<bursts>",
+        invocation_count=len(bursts),
+        mean_tool_calls=sum(tool_counts) / len(tool_counts),
+        mean_tokens=sum(token_totals) / len(token_totals),
+        error_rate=0.0,
+        has_write_tools=bool(all_tools & WRITE_TOOLS),
+        current_model=None,
+    )
+
+
+def _tool_sequence_summary(bursts: list[ToolBurst]) -> list[str]:
+    """The most common tool sequence across the cluster, in original order.
+
+    Picks the modal sequence by ``Counter`` of tool-name tuples. Ties are
+    broken by insertion order (Counter.most_common is stable on equal
+    counts). Returns an empty list when no burst has tool calls.
+    """
+    if not bursts:
+        return []
+    sequences = [
+        tuple(b.name for b in burst.tool_use_blocks)
+        for burst in bursts
+        if burst.tool_use_blocks
+    ]
+    if not sequences:
+        return []
+    most_common, _ = Counter(sequences).most_common(1)[0]
+    return list(most_common)
+
+
+def _classify_confidence(
+    cluster_size: int, cohesion: float,
+) -> Literal["high", "medium", "low"]:
+    """Same boundaries as ``delegation._classify_confidence``."""
+    if (
+        cluster_size >= _CONFIDENCE_HIGH_SIZE
+        and cohesion >= _CONFIDENCE_HIGH_COHESION
+    ):
+        return "high"
+    if cohesion >= _CONFIDENCE_MEDIUM_COHESION:
+        return "medium"
+    return "low"
+
+
+def _synthesize_burst_prompt(
+    top_terms: list[str], members: list[ToolBurst],
+) -> str:
+    """Burst-specific prompt scaffold.
+
+    Uses ``preceding_user_text[:120]`` from up to two members as
+    "Example user requests observed" — the ToolBurst analogue of
+    delegation's ``AgentInvocation.description``. Per architect review
+    for #189-D Q2: keep ``_synthesize_prompt`` private to delegation
+    (members type differs); write this sibling for bursts.
+    """
+    terms_list = ", ".join(top_terms[:3]) if top_terms else "this task"
+    examples = [
+        m.preceding_user_text[:120].strip()
+        for m in members[:2]
+        if m.preceding_user_text and m.preceding_user_text.strip()
+    ]
+    examples_block = ""
+    if examples:
+        examples_block = "\n\nExample user requests observed:\n" + "\n".join(
+            f"- {e}" for e in examples
+        )
+    return (
+        f"You handle recurring parent-thread workflows involving "
+        f"{terms_list}.\n\n"
+        "Scope your work to the specific request the parent agent "
+        "delegated. Return concise, structured output."
+        f"{examples_block}"
+    )
+
+
+def _build_subagent_draft(
+    cluster: BurstCluster, recommended_model: str,
+) -> DelegationSuggestion:
+    tools = _filter_tools_from_bursts(cluster.members)
+    tools_observed = _collect_tools_from_bursts(cluster.members)
+    if not tools_observed:
+        tools_note = "# no tool data captured from bursts"
+    elif not tools:
+        tools_note = (
+            f"# no tool used in >="
+            f"{int(_TOOL_FREQUENCY_THRESHOLD * 100)}% of cluster bursts "
+            f"— see tools_observed for the unfiltered list"
+        )
+    else:
+        tools_note = ""
+    return DelegationSuggestion(
+        name=synthesize_name(cluster.top_terms),
+        description=synthesize_description(cluster.top_terms),
+        model=recommended_model,
+        tools=tools,
+        tools_observed=tools_observed,
+        tools_note=tools_note,
+        prompt_template=_synthesize_burst_prompt(
+            cluster.top_terms, cluster.members,
+        ),
+        confidence=_classify_confidence(
+            len(cluster.members), cluster.cohesion_score,
+        ),
+        cluster_size=len(cluster.members),
+        cohesion_score=cluster.cohesion_score,
+        top_terms=list(cluster.top_terms),
+    )
+
+
+def generate_offload_candidate(
+    cluster: BurstCluster,
+    *,
+    parent_model: str,
+    parent_pricing: ModelPricing | None,
+    alt_pricing: ModelPricing | None,
+) -> OffloadCandidate:
+    """Synthesize an ``OffloadCandidate`` from a clustered group of bursts.
+
+    Aggregates parent-thread cost and signed savings across the cluster's
+    bursts (negative savings is preserved per #189-C — actionable signal).
+    Builds a ``DelegationSuggestion`` as the ``subagent_draft`` so the YAML
+    rendering surface stays consistent with the existing delegation flow.
+    Sub-issue E populates ``matched_agent`` / ``dedup_note`` afterward.
+    """
+    alt_model = pick_alternative_model(parent_model)
+
+    parent_tokens = 0
+    parent_cost_total = 0.0
+    savings_total = 0.0
+    for b in cluster.members:
+        parent_tokens += b.usage.total_tokens
+        parent_cost, savings_signed = estimate_burst_cost(
+            b, parent_pricing=parent_pricing, alt_pricing=alt_pricing,
+        )
+        parent_cost_total += parent_cost
+        savings_total += savings_signed
+
+    cost_note = ""
+    if savings_total < 0:
+        cost_note = (
+            "Offloading would increase cost — parent-thread cache appears "
+            "load-bearing for this pattern. Consider keeping on parent."
+        )
+
+    stats = _aggregate_burst_stats(cluster.members)
+    recommended_model = recommend_model_for_complexity(classify_complexity(stats))
+
+    subagent_draft = _build_subagent_draft(cluster, recommended_model)
+
+    return OffloadCandidate(
+        name=subagent_draft.name,
+        description=subagent_draft.description,
+        confidence=subagent_draft.confidence,
+        cluster_size=len(cluster.members),
+        cohesion_score=cluster.cohesion_score,
+        top_terms=list(cluster.top_terms),
+        tool_sequence_summary=_tool_sequence_summary(cluster.members),
+        estimated_parent_tokens=parent_tokens,
+        estimated_parent_cost_usd=parent_cost_total,
+        estimated_savings_usd=savings_total,
+        parent_model=parent_model,
+        alternative_model=alt_model,
+        cost_note=cost_note,
+        target_kind="subagent",
+        subagent_draft=subagent_draft,
+        skill_draft=None,
+    )

--- a/src/agentfluent/diagnostics/parent_workload.py
+++ b/src/agentfluent/diagnostics/parent_workload.py
@@ -304,13 +304,12 @@ def estimate_burst_cost(
     return (parent_cost, parent_cost - alt_cost)
 
 
-# --- Sub-issue D: clustering + offload candidate synthesis ----------------
-#
-# Mirrors delegation.cluster_delegations / generate_draft, but operates on
-# parent-thread bursts. The TF-IDF + LSA + KMeans pipeline is duplicated
-# (rather than extracted) per architect review for #189-D Q3: only two
-# consumers, ~30 lines each, premature abstraction. Structured as a
-# contiguous block so a future third consumer can extract cleanly.
+# Burst-cluster classification + offload-candidate synthesis. Mirrors
+# delegation.cluster_delegations / generate_draft on parent-thread bursts.
+# The TF-IDF + LSA + KMeans pipeline is duplicated rather than extracted
+# (#189-D Q3 architect review): two consumers, ~30 lines each, premature
+# abstraction. Structured as a contiguous block for future extraction if
+# a third consumer appears.
 
 DEFAULT_BURST_CLUSTER_SIZE = 5
 """Minimum bursts per cluster surfaced as an offload candidate."""
@@ -328,6 +327,11 @@ architect-review note."""
 _CONFIDENCE_HIGH_SIZE = 10
 _CONFIDENCE_HIGH_COHESION = 0.50
 _CONFIDENCE_MEDIUM_COHESION = 0.35
+
+_BURST_AGENT_TYPE = "<bursts>"
+"""Sentinel ``AgentStats.agent_type`` for burst clusters. Not user-facing;
+exists so downstream consumers (e.g., ``classify_complexity``) can detect
+burst-cluster stats vs real-agent stats if they ever need to."""
 
 
 @dataclass
@@ -471,7 +475,7 @@ def _aggregate_burst_stats(bursts: list[ToolBurst]) -> AgentStats:
     """
     if not bursts:
         return AgentStats(
-            agent_type="<bursts>",
+            agent_type=_BURST_AGENT_TYPE,
             invocation_count=0,
             mean_tool_calls=0.0,
             mean_tokens=0.0,
@@ -483,7 +487,7 @@ def _aggregate_burst_stats(bursts: list[ToolBurst]) -> AgentStats:
     token_totals = [b.usage.total_tokens for b in bursts]
     all_tools = {b.name for burst in bursts for b in burst.tool_use_blocks}
     return AgentStats(
-        agent_type="<bursts>",
+        agent_type=_BURST_AGENT_TYPE,
         invocation_count=len(bursts),
         mean_tool_calls=sum(tool_counts) / len(tool_counts),
         mean_tokens=sum(token_totals) / len(token_totals),

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -237,7 +237,7 @@ class TestGenerateDraft:
     ) -> DelegationCluster:
         # Use `is None` rather than `or` so an explicitly-empty
         # `top_terms=[]` reaches the cluster (needed to exercise the
-        # fallback-name path in _synthesize_name).
+        # fallback-name path in synthesize_name).
         return DelegationCluster(
             members=members if members is not None else [_inv(description="d", prompt="p")] * 10,
             top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],

--- a/tests/unit/test_parent_workload_cluster.py
+++ b/tests/unit/test_parent_workload_cluster.py
@@ -1,0 +1,439 @@
+"""Tests for burst clustering + offload-candidate synthesis (sub-issue D of #189).
+
+Covers ``cluster_bursts``, ``generate_offload_candidate``, and the helpers
+that build ``OffloadCandidate`` records (frequency-filtered tool list,
+burst-stats aggregation, modal tool-sequence summary, signed-savings
+preservation, offload-flavored YAML preamble).
+
+scikit-learn is an optional extra; the cluster-path tests are skipped
+wholesale when it's not installed (``pytest.importorskip``). The
+"sklearn missing" path is exercised by stubbing ``SKLEARN_AVAILABLE``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("sklearn")
+
+from agentfluent.analytics.pricing import get_pricing  # noqa: E402
+from agentfluent.core.session import ToolUseBlock, Usage  # noqa: E402
+from agentfluent.diagnostics import parent_workload  # noqa: E402
+from agentfluent.diagnostics.models import (  # noqa: E402
+    DelegationSuggestion,
+    OffloadCandidate,
+    SkillScaffold,
+)
+from agentfluent.diagnostics.parent_workload import (  # noqa: E402
+    DEFAULT_BURST_CLUSTER_SIZE,
+    BurstCluster,
+    SklearnMissingError,
+    ToolBurst,
+    _aggregate_burst_stats,
+    _classify_confidence,
+    _collect_tools_from_bursts,
+    _filter_tools_from_bursts,
+    _tool_sequence_summary,
+    cluster_bursts,
+    generate_offload_candidate,
+)
+
+_OPUS = get_pricing("claude-opus-4-7")
+_SONNET = get_pricing("claude-sonnet-4-6")
+assert _OPUS is not None
+assert _SONNET is not None
+
+
+def _tool(name: str, idx: int = 0) -> ToolUseBlock:
+    return ToolUseBlock(id=f"toolu_{name}_{idx}", name=name, input={})
+
+
+def _burst(
+    *,
+    user_text: str = "run the test suite",
+    assistant_text: str = "I'll run pytest now.",
+    tools: list[str] | None = None,
+    input_tokens: int = 100,
+    output_tokens: int = 200,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    model: str = "claude-opus-4-7",
+) -> ToolBurst:
+    blocks = [_tool(t, i) for i, t in enumerate(tools or [])]
+    return ToolBurst(
+        preceding_user_text=user_text,
+        assistant_text=assistant_text,
+        tool_use_blocks=blocks,
+        usage=Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+        ),
+        model=model,
+    )
+
+
+# Two semantically-distinct burst patterns — pytest-flavored vs PR-review-
+# flavored. Each cluster has 6 bursts (above DEFAULT_BURST_CLUSTER_SIZE=5)
+# and enough lexical variation to clear MIN_BURST_TEXT_TOKENS without
+# blunting inter-cluster TF-IDF separation.
+_PYTEST_TAIL = (
+    " collect coverage with pytest-cov and emit xunit results per pytest "
+    "module; use pytest fixtures and parametrize markers to exercise the "
+    "edge cases reported by pytest collectors."
+)
+_PR_TAIL = (
+    " summarize the pull request diff, list changed files, identify any "
+    "regressions in the PR description, and highlight review comments "
+    "from prior reviewers in the pull-request thread."
+)
+
+
+def _pytest_burst(idx: int) -> ToolBurst:
+    return _burst(
+        user_text=f"run pytest cycle {idx} for the test suite" + _PYTEST_TAIL,
+        assistant_text=f"Running pytest now for round {idx}." + _PYTEST_TAIL,
+        tools=["Bash", "Read", "Read"],
+    )
+
+
+def _pr_burst(idx: int) -> ToolBurst:
+    return _burst(
+        user_text=f"summarize pull request #{idx + 100}" + _PR_TAIL,
+        assistant_text=f"Reviewing PR diff for #{idx + 100}." + _PR_TAIL,
+        tools=["Bash", "Read", "Grep"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAndFilterTools:
+    def test_collect_dedups_across_bursts(self) -> None:
+        bursts = [
+            _burst(tools=["Read", "Bash"]),
+            _burst(tools=["Read", "Grep"]),
+        ]
+        assert _collect_tools_from_bursts(bursts) == ["Bash", "Grep", "Read"]
+
+    def test_filter_drops_tool_below_threshold(self) -> None:
+        # Read appears in 4/5 bursts (0.8) → kept. Bash appears in
+        # 1/5 (0.2) → dropped — least-privilege filter mirrors #184.
+        bursts = [
+            _burst(tools=["Read", "Bash"]),
+            _burst(tools=["Read"]),
+            _burst(tools=["Read"]),
+            _burst(tools=["Read"]),
+            _burst(tools=["Edit"]),
+        ]
+        assert _filter_tools_from_bursts(bursts) == ["Read"]
+
+    def test_filter_call_volume_does_not_inflate_presence(self) -> None:
+        # 50 Bash calls in one burst still count as 1 burst-presence.
+        bash_heavy = ToolBurst(
+            preceding_user_text="x",
+            assistant_text="x",
+            tool_use_blocks=[_tool("Bash", i) for i in range(50)],
+            usage=Usage(),
+            model="claude-opus-4-7",
+        )
+        bursts = [
+            bash_heavy,
+            _burst(tools=["Read"]),
+            _burst(tools=["Read"]),
+            _burst(tools=["Read"]),
+            _burst(tools=["Read"]),
+        ]
+        assert _filter_tools_from_bursts(bursts) == ["Read"]
+
+
+class TestAggregateBurstStats:
+    def test_means_computed_across_bursts(self) -> None:
+        bursts = [
+            _burst(tools=["Read", "Read"], input_tokens=100, output_tokens=100),
+            _burst(tools=["Read"] * 6, input_tokens=300, output_tokens=300),
+        ]
+        stats = _aggregate_burst_stats(bursts)
+        assert stats.mean_tool_calls == 4.0
+        assert stats.mean_tokens == 400.0
+        assert stats.error_rate == 0.0
+        assert stats.has_write_tools is False
+
+    def test_has_write_tools_set_when_any_member_writes(self) -> None:
+        bursts = [
+            _burst(tools=["Read"]),
+            _burst(tools=["Edit"]),
+        ]
+        stats = _aggregate_burst_stats(bursts)
+        assert stats.has_write_tools is True
+
+    def test_empty_bursts_returns_zero_stats(self) -> None:
+        stats = _aggregate_burst_stats([])
+        assert stats.invocation_count == 0
+        assert stats.mean_tokens == 0.0
+
+
+class TestToolSequenceSummary:
+    def test_picks_modal_sequence(self) -> None:
+        bursts = [
+            _burst(tools=["Read", "Bash"]),
+            _burst(tools=["Read", "Bash"]),
+            _burst(tools=["Read", "Bash"]),
+            _burst(tools=["Edit", "Write"]),
+        ]
+        assert _tool_sequence_summary(bursts) == ["Read", "Bash"]
+
+    def test_empty_bursts_returns_empty_list(self) -> None:
+        assert _tool_sequence_summary([]) == []
+
+    def test_bursts_without_tool_calls_returns_empty_list(self) -> None:
+        bursts = [_burst(tools=[]), _burst(tools=[])]
+        assert _tool_sequence_summary(bursts) == []
+
+
+class TestClassifyConfidence:
+    def test_high_requires_size_and_cohesion(self) -> None:
+        assert _classify_confidence(10, 0.50) == "high"
+        assert _classify_confidence(9, 0.95) == "medium"  # size guard
+
+    def test_medium_at_realistic_cohesion(self) -> None:
+        assert _classify_confidence(5, 0.40) == "medium"
+
+    def test_low_below_medium_floor(self) -> None:
+        assert _classify_confidence(5, 0.30) == "low"
+
+
+# ---------------------------------------------------------------------------
+# cluster_bursts
+# ---------------------------------------------------------------------------
+
+
+class TestClusterBursts:
+    def test_two_distinct_patterns_produce_two_clusters(self) -> None:
+        bursts = [_pytest_burst(i) for i in range(6)] + [
+            _pr_burst(i) for i in range(6)
+        ]
+        clusters = cluster_bursts(bursts, min_cluster_size=5)
+        assert len(clusters) == 2
+        # Each cluster covers all 6 of its kind (clean separation).
+        sizes = sorted(len(c.members) for c in clusters)
+        assert sizes == [6, 6]
+        # Top terms reflect the dominant vocabulary.
+        all_top_terms = {term for c in clusters for term in c.top_terms}
+        assert "pytest" in all_top_terms
+        # PR-cluster surfaces some PR-flavored term ("pull", "request",
+        # "summarize", "reviewers", or "diff" — TF-IDF picks one).
+        pr_terms = {"pull", "request", "summarize", "reviewers", "diff"}
+        assert all_top_terms & pr_terms
+
+    def test_below_min_cluster_size_returns_empty(self) -> None:
+        bursts = [_pytest_burst(i) for i in range(3)]
+        assert cluster_bursts(bursts, min_cluster_size=5) == []
+
+    def test_sklearn_missing_raises(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(parent_workload, "SKLEARN_AVAILABLE", False)
+        with pytest.raises(SklearnMissingError):
+            cluster_bursts([_pytest_burst(i) for i in range(6)])
+
+
+# ---------------------------------------------------------------------------
+# generate_offload_candidate
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOffloadCandidate:
+    def _cluster(
+        self,
+        members: list[ToolBurst] | None = None,
+        top_terms: list[str] | None = None,
+        cohesion: float = 0.55,
+    ) -> BurstCluster:
+        return BurstCluster(
+            members=members if members is not None else [_pytest_burst(i) for i in range(6)],
+            top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
+            cohesion_score=cohesion,
+        )
+
+    def test_basic_candidate_population(self) -> None:
+        candidate = generate_offload_candidate(
+            self._cluster(),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        assert candidate.parent_model == "claude-opus-4-7"
+        assert candidate.alternative_model == "claude-sonnet-4-6"
+        assert candidate.cluster_size == 6
+        assert candidate.target_kind == "subagent"
+        assert candidate.subagent_draft is not None
+        assert candidate.subagent_draft.cluster_size == 6
+        assert candidate.skill_draft is None
+        assert candidate.tool_sequence_summary == ["Bash", "Read", "Read"]
+
+    def test_positive_savings_with_modest_cache_read(self) -> None:
+        members = [
+            _burst(
+                tools=["Bash", "Read"],
+                input_tokens=2000, output_tokens=2000,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=500,
+            ),
+        ] * 6
+        candidate = generate_offload_candidate(
+            BurstCluster(members=members, top_terms=["pytest"], cohesion_score=0.55),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        assert candidate.estimated_savings_usd > 0
+        assert candidate.cost_note == ""
+
+    def test_negative_savings_preserved_with_cost_note(self) -> None:
+        # Cache-read-dominated burst: alt-model loses cache benefit so
+        # savings goes negative. #189-C invariant: the sign is preserved
+        # rather than clamped, and cost_note carries the warning.
+        members = [
+            _burst(
+                tools=["Read"],
+                input_tokens=100, output_tokens=100,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=100_000,
+            ),
+        ] * 6
+        candidate = generate_offload_candidate(
+            BurstCluster(
+                members=members, top_terms=["analyze"], cohesion_score=0.45,
+            ),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        assert candidate.estimated_savings_usd < 0
+        assert "cache" in candidate.cost_note.lower()
+
+    def test_unknown_pricing_returns_zero_costs(self) -> None:
+        candidate = generate_offload_candidate(
+            self._cluster(),
+            parent_model="claude-opus-4-7",
+            parent_pricing=None,
+            alt_pricing=None,
+        )
+        assert candidate.estimated_parent_cost_usd == 0.0
+        assert candidate.estimated_savings_usd == 0.0
+
+    def test_subagent_draft_tools_frequency_filtered(self) -> None:
+        # 5/6 bursts use Read; 1/6 uses Bash. Threshold filters Bash out.
+        members = [_burst(tools=["Read"]) for _ in range(5)] + [
+            _burst(tools=["Read", "Bash"]),
+        ]
+        candidate = generate_offload_candidate(
+            BurstCluster(members=members, top_terms=["t"], cohesion_score=0.45),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        assert candidate.subagent_draft is not None
+        assert candidate.subagent_draft.tools == ["Read"]
+        assert candidate.subagent_draft.tools_observed == ["Bash", "Read"]
+
+    def test_yaml_draft_renders_offload_preamble(self) -> None:
+        candidate = generate_offload_candidate(
+            self._cluster(),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        yaml_text = candidate.yaml_draft
+        # Offload-specific framing the architect required (Q-followup):
+        assert "parent-thread offload candidate" in yaml_text
+        assert "claude-opus-4-7" in yaml_text
+        assert "claude-sonnet-4-6" in yaml_text
+        # Frontmatter from subagent_draft still rendered:
+        assert "description:" in yaml_text
+        assert "model:" in yaml_text
+
+    def test_yaml_draft_negative_savings_renders_cost_warning(self) -> None:
+        members = [
+            _burst(
+                input_tokens=10, output_tokens=10,
+                cache_read_input_tokens=100_000,
+                tools=["Read"],
+            ),
+        ] * 6
+        candidate = generate_offload_candidate(
+            BurstCluster(members=members, top_terms=["x"], cohesion_score=0.45),
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        yaml_text = candidate.yaml_draft
+        assert "cost MORE" in yaml_text
+        # The cost_note (from generate_offload_candidate) reaches the YAML.
+        assert "cache" in yaml_text.lower()
+
+    def test_yaml_draft_empty_when_no_subagent_draft(self) -> None:
+        # Defensive: a hand-constructed candidate without subagent_draft
+        # renders empty rather than blowing up. Production code always
+        # populates subagent_draft, but JSON deserialization could yield
+        # this shape.
+        candidate = OffloadCandidate(
+            name="x", description="x", confidence="low",
+            cluster_size=0, cohesion_score=0.0,
+            alternative_model="claude-sonnet-4-6",
+            subagent_draft=None,
+        )
+        assert candidate.yaml_draft == ""
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip — sub-issue E will rely on this when wiring
+# DiagnosticsResult.offload_candidates into the JSON envelope.
+# ---------------------------------------------------------------------------
+
+
+class TestJsonRoundTrip:
+    def test_offload_candidate_round_trips(self) -> None:
+        bursts = [_pytest_burst(i) for i in range(6)]
+        clusters = cluster_bursts(bursts, min_cluster_size=5)
+        assert clusters
+        candidate = generate_offload_candidate(
+            clusters[0],
+            parent_model="claude-opus-4-7",
+            parent_pricing=_OPUS,
+            alt_pricing=_SONNET,
+        )
+        payload = candidate.model_dump(mode="json")
+        # skill_draft is null in v0.5 — the contract for the v0.6 migration.
+        assert payload["skill_draft"] is None
+        # Round-trip through json.dumps + json.loads to catch any
+        # non-JSON-native types slipping through computed_field.
+        rehydrated = OffloadCandidate.model_validate(
+            json.loads(json.dumps(payload)),
+        )
+        assert rehydrated.name == candidate.name
+        assert rehydrated.estimated_savings_usd == candidate.estimated_savings_usd
+        assert rehydrated.subagent_draft is not None
+        assert isinstance(rehydrated.subagent_draft, DelegationSuggestion)
+
+    def test_skill_scaffold_is_intentionally_empty(self) -> None:
+        # Sentinel test: SkillScaffold has no fields in v0.5. If a v0.6
+        # PR adds fields to it, this test breaks loudly so the migration
+        # plan is reconsidered explicitly.
+        scaffold = SkillScaffold()
+        assert scaffold.model_dump() == {}
+
+
+# ---------------------------------------------------------------------------
+# Default constant lock — calibration sweep in sub-issue F may revisit.
+# ---------------------------------------------------------------------------
+
+
+def test_default_burst_cluster_size_is_five() -> None:
+    assert DEFAULT_BURST_CLUSTER_SIZE == 5


### PR DESCRIPTION
## Summary
- Sub-issue D of #189 — clusters recurring parent-thread tool-bursts via TF-IDF + LSA + KMeans, aggregates signed cost-delta against a cheaper-tier alternative model, and emits a copy-paste-ready subagent YAML draft per cluster as an `OffloadCandidate`.
- Adds `OffloadCandidate` + `SkillScaffold` (v0.6 stub) Pydantic models with an offload-flavored `yaml_draft` preamble (savings, parent → alt model, cost_note when negative).
- Closes #256. Architect review locked in 5 design calls; full review on the parent issue: https://github.com/frederick-douglas-pearce/agentfluent/issues/189#issuecomment-4368669629

**Why this matters**: this is the first AgentFluent diagnostic that surfaces *parent-thread* offload opportunities — the ~99.4% of session tokens previously invisible to delegation analysis. Negative `estimated_savings_usd` is preserved (not clamped) so "do not offload, parent cache is load-bearing" surfaces as actionable signal.

## Test plan
- [x] Unit tests pass: `uv run pytest -m \"not integration\"` — 938 passed (912 prior + 26 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 26 new tests in `test_parent_workload_cluster.py` covering: helper correctness (collect/filter/stats/sequence/confidence), two-distinct-pattern clustering, sklearn-missing path, candidate population, positive savings, **negative savings preservation + cost_note**, unknown-pricing fallback, frequency-filtered subagent draft tools, **offload-preamble in `yaml_draft`**, JSON round-trip with `skill_draft is None`
- [x] Manual smoke test via `uv run agentfluent ...` — N/A this PR (pipeline wiring lands in sub-issue E; no CLI surface yet)

## Security review
- [x] **Skip review** — internal heuristic + new Pydantic models. No hooks, secrets, parsing, subprocess, network, or user-string rendering changes. Trace-data text already passes through `escape()` at the existing CLI boundary; new YAML output reuses `yaml.safe_dump`.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Additive at the JSON level: `OffloadCandidate` + `SkillScaffold` are new types; `DiagnosticsResult.offload_candidates` defaults to `[]` (populated by sub-issue E). `DelegationSuggestion` is unchanged. The two `synthesize_name`/`synthesize_description` helpers in `delegation.py` were dropped from underscore-private to module-public for cross-module reuse — no consumers outside the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)