### PR TITLE
feat(cli): agentfluent diff -- compare two analyze runs (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ Near-duplicate recommendations are aggregated per `(agent, target, signal)` shap
 
 Cost numbers reflect current per-token pricing; historical sessions are priced at today's rates until [#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80) (time-series pricing) lands.
 
+### `agentfluent diff` — compare two analyze runs
+
+```bash
+agentfluent analyze --project codefluent --json > baseline.json   # before a prompt change
+# ... edit agent prompts / tools / model ...
+agentfluent analyze --project codefluent --json > current.json    # after the change
+
+agentfluent diff baseline.json current.json                       # side-by-side report
+agentfluent diff baseline.json current.json --fail-on critical    # CI gate: exit 3 only on new critical findings
+agentfluent diff baseline.json current.json --json | jq '.data.regression_detected'
+```
+
+Compares two `analyze --json` envelopes and surfaces new, resolved, and persisting recommendations (keyed by `(agent_type, target, signal_types)`), token / cost deltas, and per-agent invocation deltas. The `--fail-on {info|warning|critical|off}` flag gates exit code 3 on new findings at or above the chosen severity, so `agentfluent diff` slots into a PR check the same way a test runner does. Baselines are user-managed files — no internal cache — so re-running against an older snapshot at any time is just `agentfluent diff old.json new.json`.
+
 ### `agentfluent config-check` — score agent definitions
 
 ```bash
@@ -388,12 +402,10 @@ Five GitHub Actions workflows run automatically:
 - Agent SDK main-session MCP + tool extraction ([#112](https://github.com/frederick-douglas-pearce/agentfluent/issues/112)).
 - Per-invocation token input/output split for more accurate cost estimates ([#143](https://github.com/frederick-douglas-pearce/agentfluent/issues/143)).
 - Hosted documentation site ([#97](https://github.com/frederick-douglas-pearce/agentfluent/issues/97)).
-- Prompt regression detection (`agentfluent diff`) across agent config versions.
 - Hook coverage in the config rubric.
 
 **Future:**
 - Webapp dashboard for trend visualization
-- `agentfluent diff` — side-by-side comparison of behavior before/after a prompt change
 - Closed-loop self-improvement — use AgentFluent's diagnostic output as a feedback signal the agent itself consumes to propose config edits against its own past sessions
 - Agent ROI reporting — roll up cost, usage, and task-completion signals over time so a business can evaluate whether an optimized agent is worth continuing to run
 

--- a/src/agentfluent/cli/commands/diff_cmd.py
+++ b/src/agentfluent/cli/commands/diff_cmd.py
@@ -1,0 +1,170 @@
+"""agentfluent diff -- compare two `analyze --json` envelopes.
+
+User manages baselines explicitly (no internal caching). Exits with
+:data:`agentfluent.cli.exit_codes.EXIT_REGRESSION` (3) when a new
+recommendation at or above ``--fail-on`` severity appears in the
+current run; useful as a CI gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from agentfluent.cli.exit_codes import (
+    EXIT_OK,
+    EXIT_REGRESSION,
+    EXIT_USER_ERROR,
+)
+from agentfluent.cli.formatters.diff_table import format_diff_table
+from agentfluent.cli.formatters.json_output import format_json_output
+from agentfluent.config.models import Severity
+from agentfluent.diff import (
+    EnvelopeLoadError,
+    compute_diff,
+    load_envelope,
+)
+from agentfluent.diff.models import DiffResult
+
+DIFF_EPILOG = """\
+Examples:
+
+  agentfluent diff baseline.json current.json
+      Compare two analyze runs (default: warn-level fail threshold).
+
+  agentfluent diff baseline.json current.json --fail-on critical
+      CI gate: exit 3 only when new critical findings appear.
+
+  agentfluent diff baseline.json current.json --json | jq '.data.regression_detected'
+      Programmatic consumption.
+
+Exit codes:
+  0  No regression (or --fail-on disabled).
+  1  User error (file missing, malformed JSON, schema mismatch).
+  3  Regression detected at or above --fail-on threshold.
+"""
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _resolve_fail_on(value: str | None) -> Severity | None:
+    """Map ``--fail-on`` string to a Severity (or None for "off")."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"off", "none", ""}:
+        return None
+    try:
+        return Severity(normalized)
+    except ValueError as e:
+        valid = ", ".join(s.value for s in Severity)
+        msg = f"Invalid --fail-on value: {value!r}. Choose one of: {valid}, off."
+        raise typer.BadParameter(msg) from e
+
+
+def _print_json(result: DiffResult, *, quiet: bool) -> None:
+    if quiet:
+        payload: dict[str, object] = {
+            "new_count": result.new_count,
+            "resolved_count": result.resolved_count,
+            "persisting_count": result.persisting_count,
+            "total_cost_delta": result.token_metrics.total_cost_delta,
+            "total_tokens_delta": result.token_metrics.total_tokens_delta,
+            "regression_detected": result.regression_detected,
+            "fail_on": result.fail_on.value if result.fail_on else None,
+        }
+    else:
+        payload = result.model_dump(mode="json")
+    print(format_json_output("diff", payload))
+
+
+def _print_quiet(result: DiffResult) -> None:
+    cost_delta = result.token_metrics.total_cost_delta
+    sign = "+" if cost_delta >= 0 else "-"
+    console.print(
+        f"Diff: {result.new_count} new, {result.resolved_count} resolved, "
+        f"{result.persisting_count} persisting | "
+        f"cost {sign}${abs(cost_delta):.4f}"
+        + (" | REGRESSION" if result.regression_detected else ""),
+    )
+
+
+def diff(
+    baseline: Path = typer.Argument(
+        ...,
+        help="Baseline `analyze --json` output file.",
+        exists=False,  # we surface a richer error than typer's default
+        dir_okay=False,
+    ),
+    current: Path = typer.Argument(
+        ...,
+        help="Current `analyze --json` output file.",
+        exists=False,
+        dir_okay=False,
+    ),
+    fail_on: str = typer.Option(
+        "warning",
+        "--fail-on",
+        help=(
+            "Exit with code 3 when a new recommendation at or above this "
+            "severity appears. Choices: info, warning, critical, off. "
+            "Default: warning."
+        ),
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format: table or json. Shortcut: --json.",
+    ),
+    json_flag: bool = typer.Option(
+        False,
+        "--json",
+        help="Shortcut for --format json.",
+    ),
+    top_n: int = typer.Option(
+        5,
+        "--top-n",
+        help=(
+            "Truncate each recommendations table (new / resolved / persisting) "
+            "to the top N by priority. Pass 0 to show all rows."
+        ),
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Include zero-delta agent rows.",
+    ),
+    quiet: bool = typer.Option(
+        False, "--quiet", "-q", help="One-line summary instead of full tables.",
+    ),
+) -> None:
+    """Compare two analyze runs and report new / resolved / persisting findings."""
+    if verbose and quiet:
+        raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+
+    if json_flag:
+        format = "json"
+
+    fail_on_severity = _resolve_fail_on(fail_on)
+
+    try:
+        baseline_data = load_envelope(baseline)
+        current_data = load_envelope(current)
+    except EnvelopeLoadError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=EXIT_USER_ERROR) from None
+
+    result = compute_diff(baseline_data, current_data, fail_on=fail_on_severity)
+
+    if format == "json":
+        _print_json(result, quiet=quiet)
+    elif quiet:
+        _print_quiet(result)
+    else:
+        format_diff_table(console, result, top_n=top_n, verbose=verbose)
+
+    exit_code = EXIT_REGRESSION if result.regression_detected else EXIT_OK
+    if exit_code != EXIT_OK:
+        raise typer.Exit(code=exit_code)

--- a/src/agentfluent/cli/exit_codes.py
+++ b/src/agentfluent/cli/exit_codes.py
@@ -1,10 +1,16 @@
 """Exit code invariant for AgentFluent commands.
 
+The contract below is the public CLI surface — CI consumers depend on
+these codes. Changing a code's meaning post-release is a breaking change.
+
 0 = success.
 1 = user named something specific and it's wrong (bad project slug, unknown
     session, unknown agent name, invalid scope value).
 2 = system searched and found nothing (no projects dir, project has no
     sessions, no agent definitions found).
+3 = `agentfluent diff` detected a regression at or above the
+    `--fail-on` severity threshold. Reserved for diff comparisons that
+    succeed mechanically but fail the configured CI check.
 
 `typer.BadParameter` exits 2 by Click convention for argument-level usage
 errors (e.g., `--verbose --quiet` together). That's a framework-handled
@@ -16,3 +22,4 @@ from __future__ import annotations
 EXIT_OK = 0
 EXIT_USER_ERROR = 1
 EXIT_NO_DATA = 2
+EXIT_REGRESSION = 3

--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -271,27 +271,26 @@ def _render_regression_footer(console: Console, result: DiffResult) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _signed_int(value: int) -> str:
+def _signed(value: float, formatted_abs: str) -> str:
+    """Wrap a pre-formatted magnitude in red (+) / green (-) markup.
+
+    Positive deltas are red because in the diff context they represent
+    growth in undesirable metrics (cost, regressions); zero is uncolored.
+    """
     if value > 0:
-        return f"[red]+{value:,}[/red]"
+        return f"[red]+{formatted_abs}[/red]"
     if value < 0:
-        return f"[green]{value:,}[/green]"
-    return "0"
+        return f"[green]-{formatted_abs}[/green]"
+    return formatted_abs
+
+
+def _signed_int(value: int) -> str:
+    return _signed(value, f"{abs(value):,}")
 
 
 def _signed_cost(value: float) -> str:
-    formatted = format_cost(abs(value))
-    if value > 0:
-        return f"[red]+{formatted}[/red]"
-    if value < 0:
-        return f"[green]-{formatted}[/green]"
-    return formatted
+    return _signed(value, format_cost(abs(value)))
 
 
 def _signed_float(value: float, *, precision: int, suffix: str = "") -> str:
-    fmt = f"{abs(value):.{precision}f}{suffix}"
-    if value > 0:
-        return f"[red]+{fmt}[/red]"
-    if value < 0:
-        return f"[green]-{fmt}[/green]"
-    return f"{abs(value):.{precision}f}{suffix}"
+    return _signed(value, f"{abs(value):.{precision}f}{suffix}")

--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -1,0 +1,297 @@
+"""Rich tables for ``agentfluent diff`` output.
+
+Three sections — Recommendations (new / resolved / persisting), Token
+Metrics, Per-Agent — laid out so a regression jumps off the page in
+table mode but everything serializes losslessly to JSON.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.markup import escape
+from rich.table import Table
+
+from agentfluent.cli.formatters.helpers import (
+    GLOBAL_AGENT_LABEL,
+    format_cost,
+    format_tokens,
+    severity_cell,
+    truncate,
+)
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from agentfluent.diff.models import (
+        DiffResult,
+        ModelTokenDelta,
+        RecommendationDelta,
+    )
+
+
+def format_diff_table(
+    console: Console,
+    result: DiffResult,
+    *,
+    top_n: int,
+    verbose: bool = False,
+) -> None:
+    """Render the full diff to ``console``.
+
+    ``top_n`` truncates the new/resolved/persisting recommendation
+    sections; pass ``0`` to show all. ``verbose`` shows zero-delta agent
+    rows (default hides them as noise).
+    """
+    _render_summary(console, result)
+    _render_recommendations(console, result, top_n=top_n)
+    _render_token_metrics(console, result)
+    _render_agent_metrics(console, result, verbose=verbose)
+    _render_regression_footer(console, result)
+
+
+def _render_summary(console: Console, result: DiffResult) -> None:
+    pieces = [
+        f"[bold]New:[/bold] {result.new_count}",
+        f"[bold]Resolved:[/bold] {result.resolved_count}",
+        f"[bold]Persisting:[/bold] {result.persisting_count}",
+    ]
+    if result.baseline_session_count or result.current_session_count:
+        pieces.append(
+            f"[dim]Sessions: {result.baseline_session_count} "
+            f"→ {result.current_session_count}[/dim]",
+        )
+    console.print("  ".join(pieces))
+    console.print()
+
+
+def _render_recommendations(
+    console: Console,
+    result: DiffResult,
+    *,
+    top_n: int,
+) -> None:
+    new = [r for r in result.recommendations if r.status == "new"]
+    resolved = [r for r in result.recommendations if r.status == "resolved"]
+    persisting = [r for r in result.recommendations if r.status == "persisting"]
+
+    if new:
+        _print_rec_table(
+            console,
+            "New Recommendations",
+            new,
+            top_n=top_n,
+            show_delta=False,
+        )
+    if resolved:
+        _print_rec_table(
+            console,
+            "Resolved Recommendations",
+            resolved,
+            top_n=top_n,
+            show_delta=False,
+        )
+    if persisting:
+        _print_rec_table(
+            console,
+            "Persisting Recommendations",
+            persisting,
+            top_n=top_n,
+            show_delta=True,
+        )
+
+    if not result.recommendations:
+        console.print("[dim]No recommendation changes.[/dim]")
+        console.print()
+
+
+def _print_rec_table(
+    console: Console,
+    title: str,
+    rows: list[RecommendationDelta],
+    *,
+    top_n: int,
+    show_delta: bool,
+) -> None:
+    table = Table(title=title, show_lines=False)
+    table.add_column("Severity", style="bold")
+    table.add_column("Agent", style="cyan")
+    table.add_column("Target")
+    if show_delta:
+        table.add_column("Count Δ", justify="right")
+        table.add_column("Priority Δ", justify="right")
+    else:
+        table.add_column("Count", justify="right")
+        table.add_column("Priority", justify="right")
+    table.add_column("Message")
+
+    truncated = rows if top_n <= 0 else rows[:top_n]
+
+    for row in truncated:
+        agent = row.agent_type or GLOBAL_AGENT_LABEL
+        if show_delta:
+            count_cell = _signed_int(row.count_delta)
+            priority_cell = _signed_float(row.priority_score_delta, precision=1)
+        else:
+            base_count = (
+                row.current_count if row.status == "new" else row.baseline_count
+            )
+            base_priority = (
+                row.current_priority_score
+                if row.status == "new"
+                else row.baseline_priority_score
+            )
+            count_cell = str(base_count)
+            priority_cell = f"{base_priority:.1f}"
+
+        table.add_row(
+            severity_cell(row.severity),
+            agent,
+            row.target,
+            count_cell,
+            priority_cell,
+            truncate(escape(row.representative_message), 80),
+        )
+
+    console.print(table)
+    if top_n > 0 and len(rows) > top_n:
+        console.print(
+            f"[dim]… {len(rows) - top_n} more rows; use --top-n 0 to see all.[/dim]",
+        )
+    console.print()
+
+
+def _render_token_metrics(console: Console, result: DiffResult) -> None:
+    tm = result.token_metrics
+    table = Table(title="Token Metrics")
+    table.add_column("Metric")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Current", justify="right")
+    table.add_column("Delta", justify="right")
+
+    table.add_row(
+        "Total cost",
+        format_cost(tm.baseline_total_cost),
+        format_cost(tm.current_total_cost),
+        _signed_cost(tm.total_cost_delta),
+    )
+    table.add_row(
+        "Total tokens",
+        format_tokens(tm.baseline_total_tokens),
+        format_tokens(tm.current_total_tokens),
+        _signed_int(tm.total_tokens_delta),
+    )
+    table.add_row(
+        "Cache efficiency",
+        f"{tm.baseline_cache_efficiency:.1f}%",
+        f"{tm.current_cache_efficiency:.1f}%",
+        _signed_float(tm.cache_efficiency_delta, precision=1, suffix="%"),
+    )
+    console.print(table)
+    console.print()
+
+    if tm.by_model:
+        _render_by_model(console, tm.by_model)
+
+
+def _render_by_model(console: Console, rows: list[ModelTokenDelta]) -> None:
+    table = Table(title="Token Metrics by Model")
+    table.add_column("Model", style="cyan")
+    table.add_column("Baseline cost", justify="right")
+    table.add_column("Current cost", justify="right")
+    table.add_column("Cost Δ", justify="right")
+    table.add_column("Tokens Δ", justify="right")
+
+    for row in rows:
+        table.add_row(
+            row.model,
+            format_cost(row.baseline_cost),
+            format_cost(row.current_cost),
+            _signed_cost(row.cost_delta),
+            _signed_int(row.total_tokens_delta),
+        )
+    console.print(table)
+    console.print()
+
+
+def _render_agent_metrics(
+    console: Console,
+    result: DiffResult,
+    *,
+    verbose: bool,
+) -> None:
+    rows = [
+        d for d in result.by_agent_type
+        if verbose
+        or d.invocation_count_delta != 0
+        or d.total_tokens_delta != 0
+        or d.estimated_cost_delta_usd != 0
+    ]
+    if not rows:
+        return
+
+    table = Table(title="Per-Agent Deltas")
+    table.add_column("Agent", style="cyan")
+    table.add_column("Invocations Δ", justify="right")
+    table.add_column("Tokens Δ", justify="right")
+    table.add_column("Cost Δ", justify="right")
+
+    rows.sort(
+        key=lambda d: (-abs(d.estimated_cost_delta_usd), d.agent_type),
+    )
+
+    for row in rows:
+        table.add_row(
+            row.agent_type,
+            _signed_int(row.invocation_count_delta),
+            _signed_int(row.total_tokens_delta),
+            _signed_cost(row.estimated_cost_delta_usd),
+        )
+    console.print(table)
+    console.print()
+
+
+def _render_regression_footer(console: Console, result: DiffResult) -> None:
+    if result.fail_on is None:
+        return
+    if result.regression_detected:
+        console.print(
+            f"[red]Regression detected:[/red] new findings at or above "
+            f"severity '{result.fail_on.value}' (--fail-on={result.fail_on.value}).",
+        )
+    else:
+        console.print(
+            f"[green]No regressions[/green] at or above severity "
+            f"'{result.fail_on.value}'.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cell formatters
+# ---------------------------------------------------------------------------
+
+
+def _signed_int(value: int) -> str:
+    if value > 0:
+        return f"[red]+{value:,}[/red]"
+    if value < 0:
+        return f"[green]{value:,}[/green]"
+    return "0"
+
+
+def _signed_cost(value: float) -> str:
+    formatted = format_cost(abs(value))
+    if value > 0:
+        return f"[red]+{formatted}[/red]"
+    if value < 0:
+        return f"[green]-{formatted}[/green]"
+    return formatted
+
+
+def _signed_float(value: float, *, precision: int, suffix: str = "") -> str:
+    fmt = f"{abs(value):.{precision}f}{suffix}"
+    if value > 0:
+        return f"[red]+{fmt}[/red]"
+    if value < 0:
+        return f"[green]-{fmt}[/green]"
+    return f"{abs(value):.{precision}f}{suffix}"

--- a/src/agentfluent/cli/formatters/json_output.py
+++ b/src/agentfluent/cli/formatters/json_output.py
@@ -19,7 +19,9 @@ from typing import Any, Literal
 
 SCHEMA_VERSION = "1"
 
-CommandName = Literal["list-projects", "list-sessions", "analyze", "config-check"]
+CommandName = Literal[
+    "list-projects", "list-sessions", "analyze", "config-check", "diff",
+]
 
 
 def format_json_output(command: CommandName, data: Any) -> str:

--- a/src/agentfluent/cli/main.py
+++ b/src/agentfluent/cli/main.py
@@ -9,6 +9,8 @@ from rich.console import Console
 
 from agentfluent import __version__
 from agentfluent.cli.commands import analyze, config_check, explain, list_cmd
+from agentfluent.cli.commands.diff_cmd import DIFF_EPILOG
+from agentfluent.cli.commands.diff_cmd import diff as diff_command
 from agentfluent.cli.exit_codes import EXIT_USER_ERROR
 from agentfluent.core.paths import validate_claude_config_dir
 
@@ -53,6 +55,9 @@ app = typer.Typer(
 
 app.add_typer(list_cmd.app, name="list")
 app.add_typer(analyze.app, name="analyze")
+app.command(
+    "diff", help="Compare two analyze runs.", epilog=DIFF_EPILOG,
+)(diff_command)
 app.add_typer(config_check.app, name="config-check")
 app.add_typer(explain.app, name="explain")
 

--- a/src/agentfluent/config/models.py
+++ b/src/agentfluent/config/models.py
@@ -43,6 +43,16 @@ class Severity(StrEnum):
     CRITICAL = "critical"
 
 
+SEVERITY_RANK: dict[Severity, int] = {
+    Severity.INFO: 1,
+    Severity.WARNING: 2,
+    Severity.CRITICAL: 3,
+}
+"""Numeric ordering for ``Severity`` comparisons. ``StrEnum`` provides no
+intrinsic ordering, so consumers that need >= / <= comparisons (priority
+scoring, ``--fail-on`` thresholds) look up integers here."""
+
+
 class AgentConfig(BaseModel):
     """Parsed agent definition from a `.md` file.
 

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 
+from agentfluent.config.models import SEVERITY_RANK as _SEVERITY_RANK
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.model_routing import SAVINGS_USD_KEY
 from agentfluent.diagnostics.models import (
@@ -49,12 +50,6 @@ from agentfluent.diagnostics.models import (
     DiagnosticSignal,
     SignalType,
 )
-
-_SEVERITY_RANK: dict[Severity, int] = {
-    Severity.CRITICAL: 3,
-    Severity.WARNING: 2,
-    Severity.INFO: 1,
-}
 
 # Signal types that carry comparable scalar metrics in ``detail``. Only
 # these produce a ``metric_range`` on the aggregated row.

--- a/src/agentfluent/diff/__init__.py
+++ b/src/agentfluent/diff/__init__.py
@@ -1,0 +1,35 @@
+"""Diff comparison between two `agentfluent analyze --json` envelopes.
+
+Public surface:
+
+- :func:`compute_diff` — pure function over two envelope dicts.
+- :func:`load_envelope` — file → validated envelope dict.
+- :class:`DiffResult` — typed output, JSON-serializable via ``model_dump``.
+
+The CLI wrapper (`agentfluent.cli.commands.diff_cmd`) layers I/O and
+formatting on top of these primitives.
+"""
+
+from __future__ import annotations
+
+from agentfluent.diff.compute import compute_diff, has_regression
+from agentfluent.diff.loader import EnvelopeLoadError, load_envelope
+from agentfluent.diff.models import (
+    AgentTypeDelta,
+    DiffResult,
+    ModelTokenDelta,
+    RecommendationDelta,
+    TokenMetricsDelta,
+)
+
+__all__ = [
+    "AgentTypeDelta",
+    "DiffResult",
+    "EnvelopeLoadError",
+    "ModelTokenDelta",
+    "RecommendationDelta",
+    "TokenMetricsDelta",
+    "compute_diff",
+    "has_regression",
+    "load_envelope",
+]

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -15,25 +15,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from agentfluent.config.models import Severity
+from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.diagnostics.models import SignalType
 from agentfluent.diff.models import (
     AgentTypeDelta,
+    DeltaStatus,
     DiffResult,
     ModelTokenDelta,
     RecommendationDelta,
     TokenMetricsDelta,
 )
-
-# Severity ranking for `--fail-on` threshold checks. Mirrors the
-# ordering implied by config.models.Severity but pinned numerically here
-# so the comparison is explicit.
-_SEVERITY_RANK: dict[Severity, int] = {
-    Severity.INFO: 1,
-    Severity.WARNING: 2,
-    Severity.CRITICAL: 3,
-}
-
 
 type RecKey = tuple[str | None, str, frozenset[SignalType]]
 """Mirrors ``diagnostics.aggregation.AggregationKey``. Re-declared
@@ -59,17 +50,18 @@ def compute_diff(
     token_delta = _diff_token_metrics(baseline, current)
     agent_deltas = _diff_agent_metrics(baseline, current)
 
-    new_count = sum(1 for r in rec_deltas if r.status == "new")
-    resolved_count = sum(1 for r in rec_deltas if r.status == "resolved")
-    persisting_count = sum(1 for r in rec_deltas if r.status == "persisting")
-
+    new_count = resolved_count = persisting_count = 0
+    threshold = SEVERITY_RANK[fail_on] if fail_on is not None else None
     regression = False
-    if fail_on is not None:
-        threshold = _SEVERITY_RANK[fail_on]
-        regression = any(
-            r.status == "new" and _SEVERITY_RANK[r.severity] >= threshold
-            for r in rec_deltas
-        )
+    for r in rec_deltas:
+        if r.status == "new":
+            new_count += 1
+            if threshold is not None and SEVERITY_RANK[r.severity] >= threshold:
+                regression = True
+        elif r.status == "resolved":
+            resolved_count += 1
+        else:
+            persisting_count += 1
 
     return DiffResult(
         new_count=new_count,
@@ -149,14 +141,16 @@ def _coerce_signal_type(value: Any) -> SignalType:
 
 def _make_delta(
     key: RecKey,
-    status: str,
+    status: DeltaStatus,
     *,
     baseline: dict[str, Any] | None,
     current: dict[str, Any] | None,
 ) -> RecommendationDelta:
     agent_type, target, signal_set = key
     sample = current if current is not None else baseline
-    assert sample is not None  # one side is always present  # noqa: S101
+    if sample is None:
+        msg = "_make_delta requires at least one of baseline or current"
+        raise ValueError(msg)
 
     baseline_count = int((baseline or {}).get("count", 0) or 0)
     current_count = int((current or {}).get("count", 0) or 0)
@@ -167,7 +161,7 @@ def _make_delta(
     representative = str(sample.get("representative_message", ""))
 
     return RecommendationDelta(
-        status=status,  # type: ignore[arg-type]
+        status=status,
         agent_type=agent_type,
         target=target,
         signal_types=sorted(signal_set, key=lambda s: s.value),
@@ -195,8 +189,6 @@ _STATUS_ORDER = {"new": 0, "persisting": 1, "resolved": 2}
 
 
 def _delta_sort_key(delta: RecommendationDelta) -> tuple[int, float, str, str]:
-    # Within each status group, highest current priority first; ties broken
-    # by agent_type then target for stable, human-friendly ordering.
     return (
         _STATUS_ORDER[delta.status],
         -delta.current_priority_score,
@@ -217,8 +209,8 @@ def _diff_token_metrics(
     baseline_tm = baseline.get("token_metrics") or {}
     current_tm = current.get("token_metrics") or {}
 
-    baseline_total_tokens = _total_tokens(baseline_tm)
-    current_total_tokens = _total_tokens(current_tm)
+    baseline_total_tokens = _sum_token_components(baseline_tm)
+    current_total_tokens = _sum_token_components(current_tm)
 
     baseline_cost = float(baseline_tm.get("total_cost", 0.0) or 0.0)
     current_cost = float(current_tm.get("total_cost", 0.0) or 0.0)
@@ -242,24 +234,15 @@ def _diff_token_metrics(
     )
 
 
-def _total_tokens(tm: dict[str, Any]) -> int:
-    # ``TokenMetrics.total_tokens`` is a ``@property``, not a serialized
-    # field — Pydantic's ``model_dump`` skips it. Reconstruct from the
-    # four token components which DO serialize.
+def _sum_token_components(d: dict[str, Any]) -> int:
+    # ``TokenMetrics.total_tokens`` and ``ModelTokenBreakdown.total_tokens``
+    # are ``@property`` accessors; Pydantic's ``model_dump`` skips them.
+    # Reconstruct from the four serialized fields shared by both shapes.
     return (
-        int(tm.get("input_tokens", 0) or 0)
-        + int(tm.get("output_tokens", 0) or 0)
-        + int(tm.get("cache_creation_input_tokens", 0) or 0)
-        + int(tm.get("cache_read_input_tokens", 0) or 0)
-    )
-
-
-def _model_total_tokens(breakdown: dict[str, Any]) -> int:
-    return (
-        int(breakdown.get("input_tokens", 0) or 0)
-        + int(breakdown.get("output_tokens", 0) or 0)
-        + int(breakdown.get("cache_creation_input_tokens", 0) or 0)
-        + int(breakdown.get("cache_read_input_tokens", 0) or 0)
+        int(d.get("input_tokens", 0) or 0)
+        + int(d.get("output_tokens", 0) or 0)
+        + int(d.get("cache_creation_input_tokens", 0) or 0)
+        + int(d.get("cache_read_input_tokens", 0) or 0)
     )
 
 
@@ -272,8 +255,8 @@ def _diff_by_model(
     for model in models:
         b = baseline.get(model) or {}
         c = current.get(model) or {}
-        b_tokens = _model_total_tokens(b)
-        c_tokens = _model_total_tokens(c)
+        b_tokens = _sum_token_components(b)
+        c_tokens = _sum_token_components(c)
         b_cost = float(b.get("cost", 0.0) or 0.0)
         c_cost = float(c.get("cost", 0.0) or 0.0)
         deltas.append(

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -1,0 +1,337 @@
+"""Pure compute layer for ``agentfluent diff``.
+
+No I/O, no formatting — takes two envelope dicts (as produced by
+:func:`agentfluent.diff.loader.load_envelope`) and returns a
+:class:`DiffResult`. Reusable by the CLI today and the v0.6 markdown
+report (#198) tomorrow.
+
+Recommendation grouping uses ``frozenset(signal_types)`` to match
+``diagnostics.aggregation._aggregation_key`` exactly — JSON
+deserialization gives ordered lists, so both sides are normalized to
+the same canonical form here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.diff.models import (
+    AgentTypeDelta,
+    DiffResult,
+    ModelTokenDelta,
+    RecommendationDelta,
+    TokenMetricsDelta,
+)
+
+# Severity ranking for `--fail-on` threshold checks. Mirrors the
+# ordering implied by config.models.Severity but pinned numerically here
+# so the comparison is explicit.
+_SEVERITY_RANK: dict[Severity, int] = {
+    Severity.INFO: 1,
+    Severity.WARNING: 2,
+    Severity.CRITICAL: 3,
+}
+
+
+type RecKey = tuple[str | None, str, frozenset[SignalType]]
+"""Mirrors ``diagnostics.aggregation.AggregationKey``. Re-declared
+locally so this module doesn't import from aggregation (which pulls in
+the whole diagnostics graph). The contract is enforced by tests."""
+
+
+def compute_diff(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    fail_on: Severity | None = None,
+) -> DiffResult:
+    """Compare two envelope ``data`` dicts and return a :class:`DiffResult`.
+
+    Args:
+        baseline: ``data`` payload from the older analyze run.
+        current: ``data`` payload from the newer analyze run.
+        fail_on: If set, mark ``regression_detected=True`` when any new
+            recommendation has severity at or above this threshold.
+    """
+    rec_deltas = _diff_recommendations(baseline, current)
+    token_delta = _diff_token_metrics(baseline, current)
+    agent_deltas = _diff_agent_metrics(baseline, current)
+
+    new_count = sum(1 for r in rec_deltas if r.status == "new")
+    resolved_count = sum(1 for r in rec_deltas if r.status == "resolved")
+    persisting_count = sum(1 for r in rec_deltas if r.status == "persisting")
+
+    regression = False
+    if fail_on is not None:
+        threshold = _SEVERITY_RANK[fail_on]
+        regression = any(
+            r.status == "new" and _SEVERITY_RANK[r.severity] >= threshold
+            for r in rec_deltas
+        )
+
+    return DiffResult(
+        new_count=new_count,
+        resolved_count=resolved_count,
+        persisting_count=persisting_count,
+        recommendations=rec_deltas,
+        token_metrics=token_delta,
+        by_agent_type=agent_deltas,
+        baseline_session_count=int(baseline.get("session_count", 0) or 0),
+        current_session_count=int(current.get("session_count", 0) or 0),
+        fail_on=fail_on,
+        regression_detected=regression,
+    )
+
+
+def has_regression(result: DiffResult) -> bool:
+    """Convenience accessor for the CLI's exit-code branch."""
+    return result.regression_detected
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+
+def _diff_recommendations(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+) -> list[RecommendationDelta]:
+    baseline_recs = _index_recommendations(baseline)
+    current_recs = _index_recommendations(current)
+
+    deltas: list[RecommendationDelta] = []
+
+    for key, current_rec in current_recs.items():
+        baseline_rec = baseline_recs.get(key)
+        if baseline_rec is None:
+            deltas.append(_make_delta(key, "new", baseline=None, current=current_rec))
+        else:
+            deltas.append(
+                _make_delta(key, "persisting", baseline=baseline_rec, current=current_rec),
+            )
+
+    for key, baseline_rec in baseline_recs.items():
+        if key not in current_recs:
+            deltas.append(_make_delta(key, "resolved", baseline=baseline_rec, current=None))
+
+    deltas.sort(key=_delta_sort_key)
+    return deltas
+
+
+def _index_recommendations(envelope: dict[str, Any]) -> dict[RecKey, dict[str, Any]]:
+    diagnostics = envelope.get("diagnostics") or {}
+    aggregated = diagnostics.get("aggregated_recommendations") or []
+    return {_rec_key(rec): rec for rec in aggregated if isinstance(rec, dict)}
+
+
+def _rec_key(rec: dict[str, Any]) -> RecKey:
+    agent_type = rec.get("agent_type")
+    target = str(rec.get("target", ""))
+    raw_signals = rec.get("signal_types") or []
+    signals = frozenset(_coerce_signal_type(s) for s in raw_signals)
+    return (agent_type, target, signals)
+
+
+def _coerce_signal_type(value: Any) -> SignalType:
+    """Recommendations come from JSON, so signal types arrive as strings.
+
+    Unknown values pass through as a synthetic enum member would be ugly;
+    instead we coerce by string equality and rely on the source contract
+    that aggregated recs only carry valid SignalType values.
+    """
+    if isinstance(value, SignalType):
+        return value
+    return SignalType(value)
+
+
+def _make_delta(
+    key: RecKey,
+    status: str,
+    *,
+    baseline: dict[str, Any] | None,
+    current: dict[str, Any] | None,
+) -> RecommendationDelta:
+    agent_type, target, signal_set = key
+    sample = current if current is not None else baseline
+    assert sample is not None  # one side is always present  # noqa: S101
+
+    baseline_count = int((baseline or {}).get("count", 0) or 0)
+    current_count = int((current or {}).get("count", 0) or 0)
+    baseline_priority = float((baseline or {}).get("priority_score", 0.0) or 0.0)
+    current_priority = float((current or {}).get("priority_score", 0.0) or 0.0)
+
+    severity = _coerce_severity(sample.get("severity"))
+    representative = str(sample.get("representative_message", ""))
+
+    return RecommendationDelta(
+        status=status,  # type: ignore[arg-type]
+        agent_type=agent_type,
+        target=target,
+        signal_types=sorted(signal_set, key=lambda s: s.value),
+        severity=severity,
+        representative_message=representative,
+        baseline_count=baseline_count,
+        current_count=current_count,
+        count_delta=current_count - baseline_count,
+        baseline_priority_score=baseline_priority,
+        current_priority_score=current_priority,
+        priority_score_delta=current_priority - baseline_priority,
+        is_builtin=bool(sample.get("is_builtin", False)),
+    )
+
+
+def _coerce_severity(value: Any) -> Severity:
+    if isinstance(value, Severity):
+        return value
+    if value is None:
+        return Severity.INFO
+    return Severity(value)
+
+
+_STATUS_ORDER = {"new": 0, "persisting": 1, "resolved": 2}
+
+
+def _delta_sort_key(delta: RecommendationDelta) -> tuple[int, float, str, str]:
+    # Within each status group, highest current priority first; ties broken
+    # by agent_type then target for stable, human-friendly ordering.
+    return (
+        _STATUS_ORDER[delta.status],
+        -delta.current_priority_score,
+        delta.agent_type or "",
+        delta.target,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token metrics
+# ---------------------------------------------------------------------------
+
+
+def _diff_token_metrics(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+) -> TokenMetricsDelta:
+    baseline_tm = baseline.get("token_metrics") or {}
+    current_tm = current.get("token_metrics") or {}
+
+    baseline_total_tokens = _total_tokens(baseline_tm)
+    current_total_tokens = _total_tokens(current_tm)
+
+    baseline_cost = float(baseline_tm.get("total_cost", 0.0) or 0.0)
+    current_cost = float(current_tm.get("total_cost", 0.0) or 0.0)
+
+    baseline_cache = float(baseline_tm.get("cache_efficiency", 0.0) or 0.0)
+    current_cache = float(current_tm.get("cache_efficiency", 0.0) or 0.0)
+
+    by_model = _diff_by_model(baseline_tm.get("by_model") or {}, current_tm.get("by_model") or {})
+
+    return TokenMetricsDelta(
+        baseline_total_tokens=baseline_total_tokens,
+        current_total_tokens=current_total_tokens,
+        total_tokens_delta=current_total_tokens - baseline_total_tokens,
+        baseline_total_cost=baseline_cost,
+        current_total_cost=current_cost,
+        total_cost_delta=current_cost - baseline_cost,
+        baseline_cache_efficiency=baseline_cache,
+        current_cache_efficiency=current_cache,
+        cache_efficiency_delta=current_cache - baseline_cache,
+        by_model=by_model,
+    )
+
+
+def _total_tokens(tm: dict[str, Any]) -> int:
+    # ``TokenMetrics.total_tokens`` is a ``@property``, not a serialized
+    # field — Pydantic's ``model_dump`` skips it. Reconstruct from the
+    # four token components which DO serialize.
+    return (
+        int(tm.get("input_tokens", 0) or 0)
+        + int(tm.get("output_tokens", 0) or 0)
+        + int(tm.get("cache_creation_input_tokens", 0) or 0)
+        + int(tm.get("cache_read_input_tokens", 0) or 0)
+    )
+
+
+def _model_total_tokens(breakdown: dict[str, Any]) -> int:
+    return (
+        int(breakdown.get("input_tokens", 0) or 0)
+        + int(breakdown.get("output_tokens", 0) or 0)
+        + int(breakdown.get("cache_creation_input_tokens", 0) or 0)
+        + int(breakdown.get("cache_read_input_tokens", 0) or 0)
+    )
+
+
+def _diff_by_model(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+) -> list[ModelTokenDelta]:
+    models = sorted(set(baseline.keys()) | set(current.keys()))
+    deltas: list[ModelTokenDelta] = []
+    for model in models:
+        b = baseline.get(model) or {}
+        c = current.get(model) or {}
+        b_tokens = _model_total_tokens(b)
+        c_tokens = _model_total_tokens(c)
+        b_cost = float(b.get("cost", 0.0) or 0.0)
+        c_cost = float(c.get("cost", 0.0) or 0.0)
+        deltas.append(
+            ModelTokenDelta(
+                model=model,
+                baseline_total_tokens=b_tokens,
+                current_total_tokens=c_tokens,
+                total_tokens_delta=c_tokens - b_tokens,
+                baseline_cost=b_cost,
+                current_cost=c_cost,
+                cost_delta=c_cost - b_cost,
+            ),
+        )
+    return deltas
+
+
+# ---------------------------------------------------------------------------
+# Agent metrics
+# ---------------------------------------------------------------------------
+
+
+def _diff_agent_metrics(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+) -> list[AgentTypeDelta]:
+    baseline_by = (baseline.get("agent_metrics") or {}).get("by_agent_type") or {}
+    current_by = (current.get("agent_metrics") or {}).get("by_agent_type") or {}
+
+    types = sorted(set(baseline_by.keys()) | set(current_by.keys()))
+    deltas: list[AgentTypeDelta] = []
+    for agent_type in types:
+        b = baseline_by.get(agent_type) or {}
+        c = current_by.get(agent_type) or {}
+
+        b_inv = int(b.get("invocation_count", 0) or 0)
+        c_inv = int(c.get("invocation_count", 0) or 0)
+        b_tok = int(b.get("total_tokens", 0) or 0)
+        c_tok = int(c.get("total_tokens", 0) or 0)
+        b_cost = float(b.get("estimated_total_cost_usd", 0.0) or 0.0)
+        c_cost = float(c.get("estimated_total_cost_usd", 0.0) or 0.0)
+
+        # is_builtin is identity-bound to the agent name; if either side
+        # has it set we can trust it.
+        is_builtin = bool(c.get("is_builtin", False) or b.get("is_builtin", False))
+
+        deltas.append(
+            AgentTypeDelta(
+                agent_type=agent_type,
+                is_builtin=is_builtin,
+                baseline_invocation_count=b_inv,
+                current_invocation_count=c_inv,
+                invocation_count_delta=c_inv - b_inv,
+                baseline_total_tokens=b_tok,
+                current_total_tokens=c_tok,
+                total_tokens_delta=c_tok - b_tok,
+                baseline_estimated_cost_usd=b_cost,
+                current_estimated_cost_usd=c_cost,
+                estimated_cost_delta_usd=c_cost - b_cost,
+            ),
+        )
+    return deltas

--- a/src/agentfluent/diff/loader.py
+++ b/src/agentfluent/diff/loader.py
@@ -1,0 +1,70 @@
+"""Load and validate `analyze --json` envelopes from disk.
+
+Wraps :func:`agentfluent.cli.formatters.json_output.parse_json_output`
+with a typed exception that the CLI maps to a user-friendly error.
+``--quiet`` envelopes are rejected because they omit the diagnostics +
+per-model breakdowns the diff needs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agentfluent.cli.formatters.json_output import parse_json_output
+
+
+class EnvelopeLoadError(ValueError):
+    """Raised when a baseline/current file isn't a valid analyze envelope.
+
+    The CLI catches this and surfaces ``str(error)`` to the user. Causes:
+    file missing, malformed JSON, schema-version mismatch, wrong
+    ``command``, or a ``--quiet`` envelope (lacks the diff inputs).
+    """
+
+
+_REQUIRED_KEYS = ("token_metrics", "agent_metrics")
+
+
+def load_envelope(path: Path) -> dict[str, Any]:
+    """Load ``path``, validate the envelope, return the ``data`` payload.
+
+    Returns the raw dict (not a Pydantic model) — :func:`compute_diff`
+    operates on dicts so it doesn't need to round-trip through the full
+    ``AnalysisResult`` model and stay coupled to optional fields.
+    """
+    if not path.exists():
+        msg = f"File not found: {path}"
+        raise EnvelopeLoadError(msg)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        msg = f"Could not read {path}: {e}"
+        raise EnvelopeLoadError(msg) from e
+
+    try:
+        data = parse_json_output(text, expected_command="analyze")
+    except json.JSONDecodeError as e:
+        msg = f"Invalid JSON in {path}: {e.msg}"
+        raise EnvelopeLoadError(msg) from e
+    except ValueError as e:
+        msg = f"{path}: {e}"
+        raise EnvelopeLoadError(msg) from e
+
+    if not isinstance(data, dict):
+        msg = f"{path}: envelope 'data' is not an object"
+        raise EnvelopeLoadError(msg)
+
+    missing = [k for k in _REQUIRED_KEYS if k not in data]
+    if missing:
+        keys = ", ".join(missing)
+        msg = (
+            f"{path}: envelope is missing required keys [{keys}]. "
+            "The diff command needs full `analyze --json` output — re-run "
+            "without --quiet."
+        )
+        raise EnvelopeLoadError(msg)
+
+    return data

--- a/src/agentfluent/diff/loader.py
+++ b/src/agentfluent/diff/loader.py
@@ -34,12 +34,11 @@ def load_envelope(path: Path) -> dict[str, Any]:
     operates on dicts so it doesn't need to round-trip through the full
     ``AnalysisResult`` model and stay coupled to optional fields.
     """
-    if not path.exists():
-        msg = f"File not found: {path}"
-        raise EnvelopeLoadError(msg)
-
     try:
         text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
+        msg = f"File not found: {path}"
+        raise EnvelopeLoadError(msg) from e
     except OSError as e:
         msg = f"Could not read {path}: {e}"
         raise EnvelopeLoadError(msg) from e

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -1,0 +1,140 @@
+"""Typed output of :func:`agentfluent.diff.compute.compute_diff`.
+
+Pydantic models so the CLI's JSON renderer, the v0.6 markdown report
+(#198), and a future webapp can all consume the same shape. Empty lists
+default for forward-compat — adding offload/delegation diff sections in
+v0.6 is additive.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import SignalType
+
+DeltaStatus = Literal["new", "resolved", "persisting"]
+
+
+class RecommendationDelta(BaseModel):
+    """One row in the recommendations diff.
+
+    Keyed by ``(agent_type, target, frozenset(signal_types))`` — the same
+    grouping ``diagnostics.aggregation`` uses for ``AggregatedRecommendation``.
+    For ``status='persisting'``, ``count_delta`` and ``priority_score_delta``
+    capture how the same finding shifted between runs.
+    """
+
+    status: DeltaStatus
+    agent_type: str | None
+    target: str
+    signal_types: list[SignalType] = Field(default_factory=list)
+    """Sorted alphabetically for stable JSON output (the underlying join
+    uses a frozenset, but lists serialize cleanly)."""
+
+    severity: Severity
+    """For ``new``/``persisting`` rows this is the current severity; for
+    ``resolved`` rows it's the baseline severity (the side that has the
+    rec)."""
+
+    representative_message: str = ""
+
+    baseline_count: int = 0
+    current_count: int = 0
+    count_delta: int = 0
+    """``current_count - baseline_count``. Negative for ``resolved`` rows;
+    positive for ``new``; can be either sign for ``persisting``."""
+
+    baseline_priority_score: float = 0.0
+    current_priority_score: float = 0.0
+    priority_score_delta: float = 0.0
+    """``current - baseline``. Surfaced in v0.5 output (architect review,
+    #199) so the v0.6 ``--fail-on priority-regression`` mode doesn't
+    require a schema change."""
+
+    is_builtin: bool = False
+
+
+class ModelTokenDelta(BaseModel):
+    """Per-model token / cost delta inside :class:`TokenMetricsDelta`."""
+
+    model: str
+    baseline_total_tokens: int = 0
+    current_total_tokens: int = 0
+    total_tokens_delta: int = 0
+
+    baseline_cost: float = 0.0
+    current_cost: float = 0.0
+    cost_delta: float = 0.0
+
+
+class TokenMetricsDelta(BaseModel):
+    """Session-level token / cost / cache deltas."""
+
+    baseline_total_tokens: int = 0
+    current_total_tokens: int = 0
+    total_tokens_delta: int = 0
+
+    baseline_total_cost: float = 0.0
+    current_total_cost: float = 0.0
+    total_cost_delta: float = 0.0
+
+    baseline_cache_efficiency: float = 0.0
+    current_cache_efficiency: float = 0.0
+    cache_efficiency_delta: float = 0.0
+
+    by_model: list[ModelTokenDelta] = Field(default_factory=list)
+    """One entry per model that appears in either baseline or current. A
+    model present on only one side has zero on the missing side."""
+
+
+class AgentTypeDelta(BaseModel):
+    """Per-agent-type invocation / token / cost delta."""
+
+    agent_type: str
+    is_builtin: bool = False
+
+    baseline_invocation_count: int = 0
+    current_invocation_count: int = 0
+    invocation_count_delta: int = 0
+
+    baseline_total_tokens: int = 0
+    current_total_tokens: int = 0
+    total_tokens_delta: int = 0
+
+    baseline_estimated_cost_usd: float = 0.0
+    current_estimated_cost_usd: float = 0.0
+    estimated_cost_delta_usd: float = 0.0
+
+
+class DiffResult(BaseModel):
+    """Complete diff output. JSON envelope wraps ``model_dump(mode='json')``.
+
+    Counts on the top level summarize the recommendations section so a CI
+    consumer can branch on totals without walking the per-row list.
+    """
+
+    new_count: int = 0
+    resolved_count: int = 0
+    persisting_count: int = 0
+
+    recommendations: list[RecommendationDelta] = Field(default_factory=list)
+    """All deltas in a stable order: new (priority desc), resolved
+    (priority desc), persisting (priority desc). Frontends can re-sort."""
+
+    token_metrics: TokenMetricsDelta = Field(default_factory=TokenMetricsDelta)
+    by_agent_type: list[AgentTypeDelta] = Field(default_factory=list)
+
+    baseline_session_count: int = 0
+    current_session_count: int = 0
+
+    fail_on: Severity | None = None
+    """The severity threshold the diff was evaluated against (``None``
+    means regression check disabled)."""
+
+    regression_detected: bool = False
+    """``True`` iff at least one ``new`` recommendation has severity
+    >= ``fail_on``. Persisting-rec ``priority_score`` increases do NOT
+    count in v0.5 (deferred to v0.6 per PRD)."""

--- a/tests/unit/cli/test_diff_cmd.py
+++ b/tests/unit/cli/test_diff_cmd.py
@@ -304,4 +304,3 @@ class TestOutputFormats:
         result = runner.invoke(cli_app, ["diff", "--help"])
         assert result.exit_code == 0
         assert "Examples" in result.output
-        assert "--fail-on" in result.output

--- a/tests/unit/cli/test_diff_cmd.py
+++ b/tests/unit/cli/test_diff_cmd.py
@@ -1,0 +1,307 @@
+"""End-to-end tests for ``agentfluent diff`` via Typer's CliRunner.
+
+Uses small synthetic envelope JSON files to exercise: arg validation,
+envelope load errors (missing file / malformed / quiet envelope /
+schema mismatch), table + JSON output, and the regression exit-code
+semantics that CI consumers depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.formatters.json_output import format_json_output
+
+
+def _write_envelope(path: Path, data: dict[str, Any]) -> Path:
+    path.write_text(format_json_output("analyze", data))
+    return path
+
+
+def _data(
+    *,
+    aggregated_recs: list[dict[str, Any]] | None = None,
+    total_cost: float = 0.0,
+) -> dict[str, Any]:
+    return {
+        "session_count": 1,
+        "token_metrics": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "total_cost": total_cost,
+            "cache_efficiency": 0.0,
+            "by_model": {},
+        },
+        "agent_metrics": {"by_agent_type": {}, "total_invocations": 0},
+        "diagnostics": {
+            "aggregated_recommendations": aggregated_recs or [],
+        },
+    }
+
+
+def _rec(*, severity: str = "warning", agent_type: str = "pm") -> dict[str, Any]:
+    return {
+        "agent_type": agent_type,
+        "target": "prompt",
+        "signal_types": ["retry_loop"],
+        "severity": severity,
+        "count": 1,
+        "priority_score": 10.0,
+        "representative_message": "Retry loop detected.",
+        "is_builtin": False,
+    }
+
+
+@pytest.fixture()
+def baseline_path(tmp_path: Path) -> Path:
+    return _write_envelope(tmp_path / "baseline.json", _data())
+
+
+@pytest.fixture()
+def current_with_new_warning(tmp_path: Path) -> Path:
+    return _write_envelope(
+        tmp_path / "current.json",
+        _data(aggregated_recs=[_rec(severity="warning")]),
+    )
+
+
+@pytest.fixture()
+def current_with_new_info(tmp_path: Path) -> Path:
+    return _write_envelope(
+        tmp_path / "current.json",
+        _data(aggregated_recs=[_rec(severity="info")]),
+    )
+
+
+class TestExitCodes:
+    def test_no_diff_no_regression_exits_zero(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        identical = _write_envelope(tmp_path / "current.json", _data())
+        result = runner.invoke(cli_app, ["diff", str(baseline_path), str(identical)])
+        assert result.exit_code == 0, result.output
+
+    def test_regression_at_threshold_exits_three(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--fail-on", "warning",
+            ],
+        )
+        assert result.exit_code == 3, result.output
+        assert "Regression detected" in result.output
+
+    def test_new_below_threshold_exits_zero(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_info: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_info),
+                "--fail-on", "warning",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_fail_on_off_disables_regression_check(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--fail-on", "off",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Regression detected" not in result.output
+
+    def test_invalid_fail_on_value_is_user_error(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--fail-on", "boom",
+            ],
+        )
+        assert result.exit_code != 0
+        # typer.BadParameter exits 2 by Click convention.
+        assert result.exit_code == 2
+
+
+class TestEnvelopeErrors:
+    def test_missing_file_surfaces_user_error(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        good = _write_envelope(tmp_path / "good.json", _data())
+        result = runner.invoke(
+            cli_app, ["diff", str(tmp_path / "missing.json"), str(good)],
+        )
+        assert result.exit_code == 1
+        assert "File not found" in result.output
+
+    def test_malformed_json_surfaces_user_error(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        good = _write_envelope(tmp_path / "good.json", _data())
+        result = runner.invoke(cli_app, ["diff", str(bad), str(good)])
+        assert result.exit_code == 1
+        assert "Invalid JSON" in result.output
+
+    def test_wrong_command_in_envelope_surfaces_user_error(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        wrong = tmp_path / "wrong.json"
+        wrong.write_text(json.dumps({"version": "1", "command": "list-projects", "data": {}}))
+        good = _write_envelope(tmp_path / "good.json", _data())
+        result = runner.invoke(cli_app, ["diff", str(wrong), str(good)])
+        assert result.exit_code == 1
+        assert "command" in result.output.lower()
+
+    def test_quiet_envelope_rejected_with_explanation(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        # `analyze --json --quiet` payload omits token_metrics + agent_metrics.
+        quiet_payload = {
+            "project": "x", "session_count": 1, "total_cost": 0.0,
+            "total_tokens": 0, "total_invocations": 0,
+            "diagnostic_signal_count": 0,
+        }
+        quiet_path = _write_envelope(tmp_path / "quiet.json", quiet_payload)
+        good = _write_envelope(tmp_path / "good.json", _data())
+        result = runner.invoke(cli_app, ["diff", str(quiet_path), str(good)])
+        assert result.exit_code == 1
+        assert "without --quiet" in result.output
+
+
+class TestOutputFormats:
+    def test_json_output_contains_diff_envelope(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--json", "--fail-on", "off",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["command"] == "diff"
+        assert payload["data"]["new_count"] == 1
+        assert payload["data"]["regression_detected"] is False
+
+    def test_json_output_carries_regression_flag(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--json",  # default --fail-on warning
+            ],
+        )
+        assert result.exit_code == 3
+        payload = json.loads(result.output)
+        assert payload["data"]["regression_detected"] is True
+        assert payload["data"]["fail_on"] == "warning"
+
+    def test_quiet_one_line_summary(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--quiet", "--fail-on", "off",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "1 new" in result.output
+
+    def test_table_output_includes_section_headers(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        baseline_path: Path,
+        current_with_new_warning: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "diff", str(baseline_path), str(current_with_new_warning),
+                "--fail-on", "off",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "New Recommendations" in result.output
+        assert "Token Metrics" in result.output
+
+    def test_help_includes_examples(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(cli_app, ["diff", "--help"])
+        assert result.exit_code == 0
+        assert "Examples" in result.output
+        assert "--fail-on" in result.output

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -1,0 +1,357 @@
+"""Unit tests for ``agentfluent.diff.compute``.
+
+Exercises the pure compute layer with synthetic envelope dicts. The
+fixtures intentionally include an empty diagnostics section, missing
+fields, and signal-type list ordering inversions to lock down the
+guarantees called out in architect review (#199): frozenset
+normalization of the grouping key, JSON-roundtripped severity strings,
+and additive forward-compat defaults.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentfluent.config.models import Severity
+from agentfluent.diff import compute_diff
+from agentfluent.diff.compute import _rec_key
+from agentfluent.diff.models import DiffResult
+
+
+def _envelope(
+    *,
+    aggregated_recs: list[dict[str, Any]] | None = None,
+    by_model: dict[str, dict[str, Any]] | None = None,
+    by_agent: dict[str, dict[str, Any]] | None = None,
+    total_cost: float = 0.0,
+    cache_efficiency: float = 0.0,
+    session_count: int = 1,
+) -> dict[str, Any]:
+    return {
+        "session_count": session_count,
+        "token_metrics": {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "total_cost": total_cost,
+            "cache_efficiency": cache_efficiency,
+            "by_model": by_model or {},
+        },
+        "agent_metrics": {
+            "by_agent_type": by_agent or {},
+            "total_invocations": 0,
+        },
+        "diagnostics": {
+            "aggregated_recommendations": aggregated_recs or [],
+        } if aggregated_recs is not None else None,
+    }
+
+
+def _agg_rec(
+    *,
+    agent_type: str | None,
+    target: str,
+    signal_types: list[str],
+    severity: str = "warning",
+    count: int = 1,
+    priority_score: float = 10.0,
+    representative_message: str = "Sample finding.",
+    is_builtin: bool = False,
+) -> dict[str, Any]:
+    return {
+        "agent_type": agent_type,
+        "target": target,
+        "signal_types": signal_types,
+        "severity": severity,
+        "count": count,
+        "priority_score": priority_score,
+        "representative_message": representative_message,
+        "is_builtin": is_builtin,
+    }
+
+
+class TestRecommendationDeltas:
+    def test_new_recommendation_appears_in_current_only(self) -> None:
+        baseline = _envelope(aggregated_recs=[])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
+        ])
+
+        result = compute_diff(baseline, current)
+
+        assert result.new_count == 1
+        assert result.resolved_count == 0
+        assert result.persisting_count == 0
+        new_rec = result.recommendations[0]
+        assert new_rec.status == "new"
+        assert new_rec.agent_type == "pm"
+        assert new_rec.target == "prompt"
+        assert new_rec.current_count == 1
+        assert new_rec.baseline_count == 0
+        assert new_rec.count_delta == 1
+
+    def test_resolved_recommendation_only_in_baseline(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
+        ])
+        current = _envelope(aggregated_recs=[])
+
+        result = compute_diff(baseline, current)
+
+        assert result.resolved_count == 1
+        assert result.recommendations[0].status == "resolved"
+        assert result.recommendations[0].count_delta == -1
+
+    def test_persisting_recommendation_in_both_with_count_delta(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                count=10, priority_score=15.0,
+            ),
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                count=4, priority_score=8.0,
+            ),
+        ])
+
+        result = compute_diff(baseline, current)
+
+        assert result.persisting_count == 1
+        rec = result.recommendations[0]
+        assert rec.status == "persisting"
+        assert rec.count_delta == -6
+        assert rec.priority_score_delta == -7.0
+
+    def test_signal_type_order_does_not_split_keys(self) -> None:
+        """Architect-flagged: frozenset normalization, not list order."""
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm",
+                target="prompt",
+                signal_types=["retry_loop", "tool_error_sequence"],
+            ),
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm",
+                target="prompt",
+                signal_types=["tool_error_sequence", "retry_loop"],
+            ),
+        ])
+
+        result = compute_diff(baseline, current)
+
+        # Same finding in different signal_types order MUST be persisting,
+        # not resolved+new.
+        assert result.new_count == 0
+        assert result.resolved_count == 0
+        assert result.persisting_count == 1
+
+    def test_none_agent_type_keeps_cross_cutting_findings_separate(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type=None, target="mcp", signal_types=["mcp_unused_server"],
+            ),
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type=None, target="mcp", signal_types=["mcp_unused_server"],
+            ),
+        ])
+
+        result = compute_diff(baseline, current)
+
+        assert result.persisting_count == 1
+        assert result.recommendations[0].agent_type is None
+
+    def test_rec_key_matches_aggregation_key_shape(self) -> None:
+        """Architect-flagged: the diff's join key must be byte-compatible
+        with ``diagnostics.aggregation._aggregation_key`` so a future
+        refactor that uses the latter directly stays sound.
+        """
+        rec = _agg_rec(
+            agent_type="pm", target="prompt",
+            signal_types=["retry_loop", "tool_error_sequence"],
+        )
+        key = _rec_key(rec)
+        assert isinstance(key[2], frozenset)
+        assert key[0] == "pm"
+        assert key[1] == "prompt"
+
+
+class TestRegressionDetection:
+    def test_no_regression_when_fail_on_disabled(self) -> None:
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                severity="critical",
+            ),
+        ])
+        result = compute_diff(_envelope(aggregated_recs=[]), current, fail_on=None)
+        assert result.regression_detected is False
+
+    def test_regression_when_new_meets_threshold(self) -> None:
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                severity="warning",
+            ),
+        ])
+        result = compute_diff(
+            _envelope(aggregated_recs=[]), current, fail_on=Severity.WARNING,
+        )
+        assert result.regression_detected is True
+
+    def test_no_regression_when_new_below_threshold(self) -> None:
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                severity="info",
+            ),
+        ])
+        result = compute_diff(
+            _envelope(aggregated_recs=[]), current, fail_on=Severity.WARNING,
+        )
+        assert result.regression_detected is False
+
+    def test_persisting_priority_increase_does_not_trigger_regression(self) -> None:
+        """v0.5: priority_score regressions on persisting recs are surfaced
+        but do NOT fail the diff (PRD-deferred to v0.6)."""
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                priority_score=5.0, severity="critical",
+            ),
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                priority_score=99.0, severity="critical",
+            ),
+        ])
+
+        result = compute_diff(baseline, current, fail_on=Severity.CRITICAL)
+
+        assert result.regression_detected is False
+        rec = result.recommendations[0]
+        assert rec.priority_score_delta == 94.0
+
+    def test_resolved_recommendation_does_not_trigger_regression(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                severity="critical",
+            ),
+        ])
+        current = _envelope(aggregated_recs=[])
+        result = compute_diff(baseline, current, fail_on=Severity.CRITICAL)
+        assert result.regression_detected is False
+
+
+class TestTokenMetricsDelta:
+    def test_total_cost_and_tokens_delta(self) -> None:
+        baseline = _envelope(total_cost=1.50, cache_efficiency=42.0)
+        current = _envelope(total_cost=2.10, cache_efficiency=55.0)
+        result = compute_diff(baseline, current)
+        assert result.token_metrics.total_cost_delta == pytest.approx(0.6)
+        assert result.token_metrics.cache_efficiency_delta == pytest.approx(13.0)
+
+    def test_per_model_delta_handles_added_and_removed_models(self) -> None:
+        baseline = _envelope(by_model={
+            "claude-opus-4-7": {
+                "input_tokens": 100, "output_tokens": 200,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 1.0,
+            },
+        })
+        current = _envelope(by_model={
+            "claude-sonnet-4-6": {
+                "input_tokens": 50, "output_tokens": 100,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 0.30,
+            },
+        })
+
+        result = compute_diff(baseline, current)
+        models = {row.model: row for row in result.token_metrics.by_model}
+        assert models["claude-opus-4-7"].current_cost == 0.0
+        assert models["claude-opus-4-7"].cost_delta == -1.0
+        assert models["claude-sonnet-4-6"].baseline_cost == 0.0
+        assert models["claude-sonnet-4-6"].cost_delta == 0.30
+
+
+class TestAgentTypeDelta:
+    def test_per_agent_invocation_count_delta(self) -> None:
+        baseline = _envelope(by_agent={
+            "general-purpose": {
+                "agent_type": "general-purpose", "is_builtin": True,
+                "invocation_count": 10, "total_tokens": 5000,
+                "estimated_total_cost_usd": 0.50,
+            },
+        })
+        current = _envelope(by_agent={
+            "general-purpose": {
+                "agent_type": "general-purpose", "is_builtin": True,
+                "invocation_count": 4, "total_tokens": 2000,
+                "estimated_total_cost_usd": 0.20,
+            },
+        })
+
+        result = compute_diff(baseline, current)
+        delta = next(d for d in result.by_agent_type if d.agent_type == "general-purpose")
+        assert delta.invocation_count_delta == -6
+        assert delta.total_tokens_delta == -3000
+        assert delta.estimated_cost_delta_usd == -0.30
+
+
+class TestForwardCompat:
+    def test_missing_diagnostics_section_yields_empty_recs(self) -> None:
+        baseline: dict[str, Any] = {
+            "session_count": 1,
+            "token_metrics": {
+                "input_tokens": 0, "output_tokens": 0,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "total_cost": 0.0, "cache_efficiency": 0.0, "by_model": {},
+            },
+            "agent_metrics": {"by_agent_type": {}, "total_invocations": 0},
+            "diagnostics": None,
+        }
+        current = baseline
+        result = compute_diff(baseline, current)
+        assert result.new_count == 0
+        assert result.resolved_count == 0
+        assert result.persisting_count == 0
+
+    def test_missing_priority_score_defaults_to_zero(self) -> None:
+        rec = {
+            "agent_type": "pm",
+            "target": "prompt",
+            "signal_types": ["retry_loop"],
+            "severity": "warning",
+            "count": 1,
+            "representative_message": "x",
+        }
+        baseline = _envelope(aggregated_recs=[rec])
+        current = _envelope(aggregated_recs=[rec])
+        result = compute_diff(baseline, current)
+        assert result.recommendations[0].priority_score_delta == 0.0
+
+
+class TestDiffResultSerialization:
+    def test_model_dump_round_trips(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
+        ])
+        current = _envelope(aggregated_recs=[])
+        result = compute_diff(baseline, current, fail_on=Severity.WARNING)
+
+        dumped = result.model_dump(mode="json")
+        # Re-validate ensures every field is JSON-serializable.
+        round_tripped = DiffResult.model_validate(dumped)
+        assert round_tripped.resolved_count == 1
+        assert round_tripped.fail_on == Severity.WARNING


### PR DESCRIPTION
## Summary
- New subcommand `agentfluent diff <baseline.json> <current.json>` that compares two `analyze --json` envelopes and surfaces new / resolved / persisting recommendations alongside token, cost, and per-agent deltas.
- CI-friendly via `--fail-on {info|warning|critical|off}` (default `warning`); triggers a new `EXIT_REGRESSION = 3` exit code on new findings at or above the chosen severity.
- Recommendations are joined on `(agent_type, target, frozenset(signal_types))` — matches `diagnostics.aggregation._aggregation_key` exactly so signal-list order from JSON round-trip doesn't split persisting findings into spurious resolved+new pairs.

Implements the design ratified by the architect review on issue #199 (no-cache, full diagnostics+token scope, exit-3 on regression, single PR, frozenset key normalization).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (994 tests)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (31 new tests across `tests/unit/diff/test_compute.py` and `tests/unit/cli/test_diff_cmd.py`)
- [x] Manual smoke test — dogfooded against two real `agentfluent analyze --project agentfluent` envelopes; regression detection, JSON envelope, and quiet mode all behave end-to-end

## Security review
- [x] **Skip review** — no security-sensitive surface. Reads two JSON files supplied by the user, parses with the existing envelope validator, and renders Rich tables. No subprocess, no network, no path manipulation beyond `Path.read_text()`. User-controlled strings rendered through Rich are escaped via the existing `escape()` helper.

## Breaking changes
None. Additive only:
- New `EXIT_REGRESSION = 3` exit code (previously unused).
- `CommandName` Literal in the JSON envelope gains `"diff"` — additive; existing consumers of `analyze`/`list-projects`/`list-sessions`/`config-check` envelopes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)