### PR TITLE
feat(diagnostics): explain empty delegation_suggestions in JSON (#215)

### DIFF
--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -80,6 +80,7 @@ __all__ = [
     "DelegationCluster",
     "SklearnMissingError",
     "cluster_delegations",
+    "count_clusterable_invocations",
     "generate_draft",
     "suggest_delegations",
 ]
@@ -168,6 +169,16 @@ def _filter_candidates(
         if is_general_purpose(inv.agent_type)
         and _combined_text_tokens(inv) >= MIN_TEXT_TOKENS
     ]
+
+
+def count_clusterable_invocations(invocations: list[AgentInvocation]) -> int:
+    """Count general-purpose invocations eligible for clustering.
+
+    Public surface used by the diagnostics pipeline to distinguish
+    "insufficient invocations" from "clustering produced nothing" when
+    populating ``delegation_suggestions_skipped_reason``.
+    """
+    return len(_filter_candidates(invocations))
 
 
 def _build_single_cluster(

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -80,7 +80,6 @@ __all__ = [
     "DelegationCluster",
     "SklearnMissingError",
     "cluster_delegations",
-    "count_clusterable_invocations",
     "generate_draft",
     "suggest_delegations",
 ]
@@ -171,12 +170,12 @@ def _filter_candidates(
     ]
 
 
-def count_clusterable_invocations(invocations: list[AgentInvocation]) -> int:
+def _count_clusterable_invocations(invocations: list[AgentInvocation]) -> int:
     """Count general-purpose invocations eligible for clustering.
 
-    Public surface used by the diagnostics pipeline to distinguish
-    "insufficient invocations" from "clustering produced nothing" when
-    populating ``delegation_suggestions_skipped_reason``.
+    Used by the diagnostics pipeline to distinguish "insufficient
+    invocations" from "clustering produced nothing" when populating
+    ``delegation_suggestions_skipped_reason``.
     """
     return len(_filter_candidates(invocations))
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -477,6 +477,13 @@ class OffloadCandidate(BaseModel):
         )
 
 
+DelegationSkippedReason = Literal[
+    "sklearn_not_installed",
+    "insufficient_invocations",
+    "no_clusters_above_min_size",
+]
+
+
 class DiagnosticsResult(BaseModel):
     """Complete diagnostics output for a session or set of sessions."""
 
@@ -499,14 +506,7 @@ class DiagnosticsResult(BaseModel):
     delegation_suggestions: list[DelegationSuggestion] = Field(default_factory=list)
     """Draft subagent definitions proposed by the clustering pipeline."""
 
-    delegation_suggestions_skipped_reason: (
-        Literal[
-            "sklearn_not_installed",
-            "insufficient_invocations",
-            "no_clusters_above_min_size",
-        ]
-        | None
-    ) = None
+    delegation_suggestions_skipped_reason: DelegationSkippedReason | None = None
     """When ``delegation_suggestions`` is empty, names the reason so JSON
     consumers can distinguish "feature unavailable" from "ran but found
     nothing." ``None`` when suggestions are present. Reasons:

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -499,6 +499,28 @@ class DiagnosticsResult(BaseModel):
     delegation_suggestions: list[DelegationSuggestion] = Field(default_factory=list)
     """Draft subagent definitions proposed by the clustering pipeline."""
 
+    delegation_suggestions_skipped_reason: (
+        Literal[
+            "sklearn_not_installed",
+            "insufficient_invocations",
+            "no_clusters_above_min_size",
+        ]
+        | None
+    ) = None
+    """When ``delegation_suggestions`` is empty, names the reason so JSON
+    consumers can distinguish "feature unavailable" from "ran but found
+    nothing." ``None`` when suggestions are present. Reasons:
+
+    - ``sklearn_not_installed`` — the ``agentfluent[clustering]`` extra is
+      not installed; the clustering path was skipped entirely.
+    - ``insufficient_invocations`` — sklearn is available but the count
+      of clusterable general-purpose invocations is below
+      ``--min-cluster-size``.
+    - ``no_clusters_above_min_size`` — clustering ran but produced no
+      drafts (no clusters met the threshold, or all drafts were deduped
+      against existing agent configs).
+    """
+
     # v0.5: added offload_candidates (#189). Wired up in sub-issue E.
     offload_candidates: list[OffloadCandidate] = Field(default_factory=list)
     """Parent-thread offload candidates surfaced by the burst-clustering

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Literal
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.mcp_discovery import discover_mcp_servers
@@ -29,6 +30,7 @@ from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_CLUSTER_SIZE,
     DEFAULT_MIN_SIMILARITY,
     SKLEARN_AVAILABLE,
+    count_clusterable_invocations,
     suggest_delegations,
 )
 from agentfluent.diagnostics.mcp_assessment import (
@@ -262,15 +264,28 @@ def run_diagnostics(
     subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
 
     delegation_suggestions: list[DelegationSuggestion] = []
+    delegation_skipped_reason: (
+        Literal[
+            "sklearn_not_installed",
+            "insufficient_invocations",
+            "no_clusters_above_min_size",
+        ]
+        | None
+    ) = None
     offload_candidates: list[OffloadCandidate] = []
     if SKLEARN_AVAILABLE:
-        delegation_suggestions = suggest_delegations(
-            invocations,
-            existing_configs=agent_configs or None,
-            min_cluster_size=min_cluster_size,
-            min_similarity=min_similarity,
-        )
-        _enrich_dedup_with_mismatches(delegation_suggestions, signals)
+        if count_clusterable_invocations(invocations) < min_cluster_size:
+            delegation_skipped_reason = "insufficient_invocations"
+        else:
+            delegation_suggestions = suggest_delegations(
+                invocations,
+                existing_configs=agent_configs or None,
+                min_cluster_size=min_cluster_size,
+                min_similarity=min_similarity,
+            )
+            _enrich_dedup_with_mismatches(delegation_suggestions, signals)
+            if not delegation_suggestions:
+                delegation_skipped_reason = "no_clusters_above_min_size"
         if parent_messages:
             offload_candidates = build_offload_candidates(
                 parent_messages,
@@ -278,6 +293,7 @@ def run_diagnostics(
                 min_similarity=min_similarity,
             )
     else:
+        delegation_skipped_reason = "sklearn_not_installed"
         logger.debug(
             "Delegation clustering and offload-candidate analysis skipped: "
             "scikit-learn not installed. Install agentfluent[clustering] "
@@ -290,5 +306,6 @@ def run_diagnostics(
         aggregated_recommendations=aggregated,
         subagent_trace_count=subagent_trace_count,
         delegation_suggestions=delegation_suggestions,
+        delegation_suggestions_skipped_reason=delegation_skipped_reason,
         offload_candidates=offload_candidates,
     )

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Literal
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.mcp_discovery import discover_mcp_servers
@@ -30,7 +29,7 @@ from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_CLUSTER_SIZE,
     DEFAULT_MIN_SIMILARITY,
     SKLEARN_AVAILABLE,
-    count_clusterable_invocations,
+    _count_clusterable_invocations,
     suggest_delegations,
 )
 from agentfluent.diagnostics.mcp_assessment import (
@@ -44,6 +43,7 @@ from agentfluent.diagnostics.model_routing import (
 )
 from agentfluent.diagnostics.models import (
     TRACE_SIGNAL_TYPES,
+    DelegationSkippedReason,
     DelegationSuggestion,
     DiagnosticSignal,
     DiagnosticsResult,
@@ -264,17 +264,10 @@ def run_diagnostics(
     subagent_trace_count = sum(1 for inv in invocations if inv.trace is not None)
 
     delegation_suggestions: list[DelegationSuggestion] = []
-    delegation_skipped_reason: (
-        Literal[
-            "sklearn_not_installed",
-            "insufficient_invocations",
-            "no_clusters_above_min_size",
-        ]
-        | None
-    ) = None
+    delegation_skipped_reason: DelegationSkippedReason | None = None
     offload_candidates: list[OffloadCandidate] = []
     if SKLEARN_AVAILABLE:
-        if count_clusterable_invocations(invocations) < min_cluster_size:
+        if _count_clusterable_invocations(invocations) < min_cluster_size:
             delegation_skipped_reason = "insufficient_invocations"
         else:
             delegation_suggestions = suggest_delegations(

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -286,6 +286,11 @@ class TestDelegationSuggestions:
         result = run_diagnostics(self._GP_INVS)
         assert len(result.delegation_suggestions) >= 1
 
+    def test_skipped_reason_is_none_when_suggestions_present(self) -> None:
+        pytest.importorskip("sklearn")
+        result = run_diagnostics(self._GP_INVS)
+        assert result.delegation_suggestions_skipped_reason is None
+
     def test_pipeline_empty_suggestions_when_sklearn_missing(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -295,6 +300,40 @@ class TestDelegationSuggestions:
         # Silent skip — no raise, no suggestions, other output intact.
         result = run_diagnostics(self._GP_INVS)
         assert result.delegation_suggestions == []
+        assert (
+            result.delegation_suggestions_skipped_reason
+            == "sklearn_not_installed"
+        )
+
+    def test_skipped_reason_insufficient_invocations(self) -> None:
+        pytest.importorskip("sklearn")
+        # Two GP invocations is well under DEFAULT_MIN_CLUSTER_SIZE.
+        result = run_diagnostics(self._GP_INVS[:2])
+        assert result.delegation_suggestions == []
+        assert (
+            result.delegation_suggestions_skipped_reason
+            == "insufficient_invocations"
+        )
+
+    def test_skipped_reason_no_clusters_above_min_size(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # GP invocation count is above min_cluster_size, so the pipeline
+        # commits to running suggest_delegations. Monkeypatch it to return
+        # [] — this is the union of "no clusters formed" and "all drafts
+        # were deduped against existing configs," both of which the
+        # public reason field collapses to ``no_clusters_above_min_size``.
+        pytest.importorskip("sklearn")
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline.suggest_delegations",
+            lambda *args, **kwargs: [],
+        )
+        result = run_diagnostics(self._GP_INVS)
+        assert result.delegation_suggestions == []
+        assert (
+            result.delegation_suggestions_skipped_reason
+            == "no_clusters_above_min_size"
+        )
 
 
 class TestOffloadCandidates:


### PR DESCRIPTION
## Summary
- Add `delegation_suggestions_skipped_reason` to the diagnostics envelope (closes #215)
- Three skip reasons surface: `sklearn_not_installed`, `insufficient_invocations`, `no_clusters_above_min_size`
- Field is null when suggestions are present (no leaking of internal state when the user got what they wanted)

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 997 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 4 new tests in `TestDelegationSuggestions`
- [ ] Manual smoke test — N/A (JSON-only change, no CLI surface affected)

## Security review
- [x] **Skip review** — no security-sensitive surface (additive Pydantic field + internal pipeline branching).
- [ ] Needs review

## Breaking changes
None. The new field is additive and defaults to `None`. Existing JSON consumers see one new field; no existing field is renamed, removed, or repurposed.