### PR TITLE
fix(diagnostics): bound MCP is_error regex fallback to leading window (#241)

### DIFF
--- a/src/agentfluent/diagnostics/mcp_assessment.py
+++ b/src/agentfluent/diagnostics/mcp_assessment.py
@@ -38,7 +38,7 @@ from pydantic import BaseModel, ConfigDict
 from agentfluent.config.models import Severity
 from agentfluent.core.session import index_tool_results_by_id
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
-from agentfluent.diagnostics.signals import ERROR_REGEX
+from agentfluent.diagnostics.signals import detect_is_error_from_text
 
 if TYPE_CHECKING:
     from agentfluent.agents.models import AgentInvocation
@@ -154,7 +154,12 @@ def extract_mcp_calls_from_messages(
             elif explicit_error is False:
                 is_error = False
             else:
-                is_error = bool(ERROR_REGEX.search(result_text))
+                # Bounded leading-window match (#241): full-text matches
+                # produced ~86% FPs against agentfluent and ~63% against
+                # codefluent because GitHub MCP responses, Playwright
+                # snapshots, etc. embed error keywords in successful
+                # bodies. Shared helper with traces.parser (#238).
+                is_error = detect_is_error_from_text(result_text)
             calls.append(
                 McpToolCall(
                     server_name=server, tool_name=tool, is_error=is_error,

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -37,6 +37,29 @@ ERROR_REGEX = re.compile(
     re.IGNORECASE,
 )
 
+# Real error messages lead with the indicator ("Error: ...", "Permission
+# denied", "Failed to ..."). Bounding the regex prevents successful
+# results that mention error keywords mid-text — GitHub issue bodies,
+# Playwright snapshots, file Reads — from synthesizing is_error=True.
+# Shared between traces.parser._detect_is_error and
+# mcp_assessment.extract_mcp_calls_from_messages (#241).
+ERROR_DETECTION_WINDOW_CHARS = 200
+
+
+def detect_is_error_from_text(text: str | None) -> bool:
+    """Synthesize ``is_error`` from result text by matching the leading window.
+
+    Used as a fallback when the upstream tool result has no explicit
+    ``is_error`` boolean. The leading-window bound is the FP defense:
+    it keeps long, successful results (issue bodies, web fetches, file
+    contents) from being flagged just because an error keyword appears
+    deep in the body. ``None`` and empty strings always return False.
+    """
+    if not text:
+        return False
+    return bool(ERROR_REGEX.search(text[:ERROR_DETECTION_WINDOW_CHARS]))
+
+
 # Map matched text back to severity
 _KEYWORD_SEVERITY: dict[str, Severity] = {kw.lower(): sev for kw, sev in ERROR_PATTERNS}
 

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -29,7 +29,7 @@ from typing import Any
 
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
-from agentfluent.diagnostics.signals import ERROR_REGEX
+from agentfluent.diagnostics.signals import detect_is_error_from_text
 from agentfluent.traces.discovery import AGENT_FILENAME_PATTERN
 from agentfluent.traces.models import (
     INPUT_SUMMARY_MAX_CHARS,
@@ -48,11 +48,6 @@ from agentfluent.traces.retry import detect_retry_sequences
 # against future workloads with higher baseline tool latency.
 IDLE_GAP_K = 10
 IDLE_GAP_FLOOR_MS = 300_000
-
-# Real error messages lead with the indicator ("Error: ...", "Permission
-# denied", "Failed to ..."). Bounding the regex prevents successful Reads
-# of files that mention error keywords mid-text from synthesizing is_error.
-ERROR_DETECTION_WINDOW_CHARS = 200
 
 
 def _truncate_input(input_dict: dict[str, Any] | None) -> str:
@@ -80,17 +75,13 @@ def _detect_is_error(block: ContentBlock) -> bool:
     """Detect whether a tool_result block represents an error.
 
     Explicit ``is_error`` field is authoritative when present (True or
-    False). When missing, fall back to regex-matching the *leading*
-    ``ERROR_DETECTION_WINDOW_CHARS`` of the result text against
-    ``ERROR_PATTERNS`` keywords (case-insensitive). The leading-window
-    bound prevents successful Reads of files that mention error
-    keywords mid-text from synthesizing ``is_error=True``.
+    False). When missing, fall back to ``detect_is_error_from_text``
+    (shared helper bounded by ``ERROR_DETECTION_WINDOW_CHARS``; see
+    #238 / #241 for the FP-defense rationale).
     """
     if block.is_error is not None:
         return block.is_error
-    if not block.text:
-        return False
-    return bool(ERROR_REGEX.search(block.text[:ERROR_DETECTION_WINDOW_CHARS]))
+    return detect_is_error_from_text(block.text)
 
 
 def _sum_usage(messages: list[SessionMessage]) -> Usage:

--- a/tests/unit/test_mcp_assessment.py
+++ b/tests/unit/test_mcp_assessment.py
@@ -23,6 +23,7 @@ from agentfluent.diagnostics.mcp_assessment import (
     parse_mcp_tool_name,
 )
 from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
 from agentfluent.traces.models import SubagentToolCall, SubagentTrace
 from tests._builders import (
     assistant_message,
@@ -176,6 +177,36 @@ class TestExtractMcpCallsFromMessages:
         ]
         calls = extract_mcp_calls_from_messages(messages)
         assert calls[0].is_error is True  # "unable to" matches ERROR_REGEX
+
+    def test_keyword_outside_leading_window_stays_false(self) -> None:
+        # #241 fix: GitHub MCP responses, Playwright snapshots, etc.
+        # embed error keywords in successful bodies. Bound regex search
+        # to the leading window so mid-text keywords no longer flip
+        # is_error=True.
+        leading_padding = "ok " * (ERROR_DETECTION_WINDOW_CHARS // 3 + 20)
+        result_text = (
+            leading_padding + "definitions of error and failed live here"
+        )
+        messages = [
+            _assistant_with_mcp("tu-window", "mcp__github__get_issue"),
+            _user_with_result("tu-window", text=result_text, is_error=None),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls[0].is_error is False
+
+    def test_short_error_with_leading_keyword_fires(self) -> None:
+        # Real error messages lead with the indicator — must still fire
+        # under the bounded fallback.
+        messages = [
+            _assistant_with_mcp("tu-lead", "mcp__github__create_issue"),
+            _user_with_result(
+                "tu-lead",
+                text="Error: 422 Unprocessable Entity from GitHub",
+                is_error=None,
+            ),
+        ]
+        calls = extract_mcp_calls_from_messages(messages)
+        assert calls[0].is_error is True
 
     def test_explicit_is_error_false_wins_over_error_keyword(self) -> None:
         # Documents the ERROR_REGEX fallback's limited scope: explicit

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -9,16 +9,14 @@ from typing import Any
 
 import pytest
 
+from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
 from agentfluent.traces.models import (
     INPUT_SUMMARY_MAX_CHARS,
     RESULT_SUMMARY_MAX_CHARS,
     UNKNOWN_AGENT_TYPE,
     SubagentTrace,
 )
-from agentfluent.traces.parser import (
-    ERROR_DETECTION_WINDOW_CHARS,
-    parse_subagent_trace,
-)
+from agentfluent.traces.parser import parse_subagent_trace
 from tests._builders import (
     assistant_message as _assistant,
 )


### PR DESCRIPTION
## Summary
- Ports the #238 leading-window defense from `traces.parser._detect_is_error` to `mcp_assessment.extract_mcp_calls_from_messages` (closes #241)
- Refactors the duplicated `ERROR_DETECTION_WINDOW_CHARS` + bound logic into a shared `detect_is_error_from_text` helper in `diagnostics/signals.py`

## Research finding (per #241 AC)

Quantified the FP rate against two real projects with substantial MCP traffic:

| Project | MCP results | Fallbacks | Full-text fires True | Leading-200 fires True | FPs (divergence) |
|---|---|---|---|---|---|
| agentfluent | 85 | 84 | 73 | 1 | **72 (86%)** |
| codefluent | 307 | 279 | 49 | 18 | **31 (63% of fires)** |

FP examples: GitHub MCP issue/PR JSON bodies, Playwright snapshots, multi-issue list arrays — all successful responses with error keywords (\`error\`, \`failed\`, \`not found\`, etc.) embedded mid-text. Decision: fix needed.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` — 996 passed
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New tests in \`test_mcp_assessment.py\` mirror the #238 pair: keyword outside window stays False, leading keyword fires True

## Security review
- [x] **Skip review** — internal-data parsing logic refactor. No new attack surface; tightens an existing FP.
- [ ] Needs review

## Breaking changes
None for users. Internal: \`ERROR_DETECTION_WINDOW_CHARS\` moved from \`agentfluent.traces.parser\` to \`agentfluent.diagnostics.signals\`. The old import path is gone. No public consumer outside this repo.