### PR TITLE
feat(analytics): Cost by Model includes subagent tokens (#227)

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -21,7 +21,9 @@ from agentfluent.analytics.agent_metrics import (
 from agentfluent.analytics.tokens import (
     ModelTokenBreakdown,
     TokenMetrics,
+    compute_subagent_token_metrics,
     compute_token_metrics,
+    fold_subagent_metrics_in,
 )
 from agentfluent.analytics.tools import (
     ConcentrationEntry,
@@ -116,6 +118,13 @@ def analyze_session(
     invocations = _link_subagent_traces(invocations, path)
     mcp_tool_calls = extract_mcp_calls_from_messages(messages)
 
+    # Fold subagent token usage into the per-model breakdown so the
+    # session-level TokenMetrics reflects the true cost (parent thread
+    # + linked subagent runs). #227.
+    subagent_traces = [inv.trace for inv in invocations if inv.trace is not None]
+    subagent_rows = compute_subagent_token_metrics(subagent_traces)
+    token_metrics = fold_subagent_metrics_in(token_metrics, subagent_rows)
+
     agent_metrics = compute_agent_metrics(
         invocations,
         session_total_tokens=token_metrics.total_tokens,
@@ -175,22 +184,24 @@ def analyze_sessions(
 
 
 def _merge_token_metrics(metrics_list: list[TokenMetrics]) -> TokenMetrics:
-    """Merge multiple TokenMetrics by summing per-model breakdowns."""
-    merged_models: dict[str, ModelTokenBreakdown] = {}
+    """Merge multiple TokenMetrics by summing per-(model, origin) breakdowns."""
+    merged_models: dict[tuple[str, str], ModelTokenBreakdown] = {}
     api_call_count = 0
 
     for tm in metrics_list:
         api_call_count += tm.api_call_count
-        for model_name, breakdown in tm.by_model.items():
-            existing = merged_models.get(model_name)
+        for breakdown in tm.by_model:
+            key = (breakdown.model, breakdown.origin)
+            existing = merged_models.get(key)
             if existing is None:
-                merged_models[model_name] = ModelTokenBreakdown(
-                    model=model_name,
+                merged_models[key] = ModelTokenBreakdown(
+                    model=breakdown.model,
                     input_tokens=breakdown.input_tokens,
                     output_tokens=breakdown.output_tokens,
                     cache_creation_input_tokens=breakdown.cache_creation_input_tokens,
                     cache_read_input_tokens=breakdown.cache_read_input_tokens,
                     cost=breakdown.cost,
+                    origin=breakdown.origin,
                 )
             else:
                 existing.input_tokens += breakdown.input_tokens
@@ -218,7 +229,7 @@ def _merge_token_metrics(metrics_list: list[TokenMetrics]) -> TokenMetrics:
         total_cost=total_cost,
         cache_efficiency=cache_efficiency,
         api_call_count=api_call_count,
-        by_model=merged_models,
+        by_model=list(merged_models.values()),
     )
 
 

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -21,6 +21,7 @@ from agentfluent.analytics.agent_metrics import (
 from agentfluent.analytics.tokens import (
     ModelTokenBreakdown,
     TokenMetrics,
+    _aggregate_totals,
     compute_subagent_token_metrics,
     compute_token_metrics,
     fold_subagent_metrics_in,
@@ -118,9 +119,6 @@ def analyze_session(
     invocations = _link_subagent_traces(invocations, path)
     mcp_tool_calls = extract_mcp_calls_from_messages(messages)
 
-    # Fold subagent token usage into the per-model breakdown so the
-    # session-level TokenMetrics reflects the true cost (parent thread
-    # + linked subagent runs). #227.
     subagent_traces = [inv.trace for inv in invocations if inv.trace is not None]
     subagent_rows = compute_subagent_token_metrics(subagent_traces)
     token_metrics = fold_subagent_metrics_in(token_metrics, subagent_rows)
@@ -210,16 +208,11 @@ def _merge_token_metrics(metrics_list: list[TokenMetrics]) -> TokenMetrics:
                 existing.cache_read_input_tokens += breakdown.cache_read_input_tokens
                 existing.cost += breakdown.cost
 
-    total_input = sum(b.input_tokens for b in merged_models.values())
-    total_output = sum(b.output_tokens for b in merged_models.values())
-    total_cache_creation = sum(b.cache_creation_input_tokens for b in merged_models.values())
-    total_cache_read = sum(b.cache_read_input_tokens for b in merged_models.values())
-    total_cost = sum(b.cost for b in merged_models.values())
-
-    cache_denom = total_cache_read + total_input + total_cache_creation
-    cache_efficiency = (
-        round(total_cache_read / cache_denom * 100, 1) if cache_denom > 0 else 0.0
-    )
+    rows = list(merged_models.values())
+    (
+        total_input, total_output, total_cache_creation, total_cache_read,
+        total_cost, cache_efficiency,
+    ) = _aggregate_totals(rows)
 
     return TokenMetrics(
         input_tokens=total_input,
@@ -229,7 +222,7 @@ def _merge_token_metrics(metrics_list: list[TokenMetrics]) -> TokenMetrics:
         total_cost=total_cost,
         cache_efficiency=cache_efficiency,
         api_call_count=api_call_count,
-        by_model=list(merged_models.values()),
+        by_model=rows,
     )
 
 

--- a/src/agentfluent/analytics/tokens.py
+++ b/src/agentfluent/analytics/tokens.py
@@ -2,20 +2,32 @@
 
 Computes token usage totals, dollar costs, and cache efficiency from
 parsed session messages. Handles mixed-model sessions with per-model
-cost breakdown.
+cost breakdown and parent-vs-subagent origin attribution.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
 
 from agentfluent.analytics.pricing import SYNTHETIC_MODELS, compute_cost, get_pricing
 from agentfluent.core.session import SessionMessage
 
+if TYPE_CHECKING:
+    from agentfluent.traces.models import SubagentTrace
+
+Origin = Literal["parent", "subagent"]
+
 
 @dataclass
 class ModelTokenBreakdown:
-    """Token counts and cost for a single model within a session."""
+    """Token counts and cost for a single (model, origin) row.
+
+    ``origin`` distinguishes whether the usage came from the parent
+    session's assistant messages or from a subagent trace. Two rows can
+    share a model but differ in origin (e.g., Opus used in both the
+    parent thread and a delegated subagent run).
+    """
 
     model: str
     input_tokens: int = 0
@@ -23,6 +35,7 @@ class ModelTokenBreakdown:
     cache_creation_input_tokens: int = 0
     cache_read_input_tokens: int = 0
     cost: float = 0.0
+    origin: Origin = "parent"
 
     @property
     def total_tokens(self) -> int:
@@ -36,7 +49,13 @@ class ModelTokenBreakdown:
 
 @dataclass
 class TokenMetrics:
-    """Aggregated token usage and cost metrics for a session."""
+    """Aggregated token usage and cost metrics for a session.
+
+    Top-level totals are *comprehensive*: parent-thread + subagent
+    contributions summed. The ``by_model`` list decomposes them by
+    ``(model, origin)``. Per #227, this matches users' intuition that
+    "total cost" reflects what the session actually spent.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
@@ -48,10 +67,15 @@ class TokenMetrics:
     Formula: cache_read / (cache_read + input + cache_creation) * 100."""
 
     api_call_count: int = 0
-    """Number of deduplicated assistant messages (API calls)."""
+    """Number of deduplicated assistant messages (API calls). Counts
+    parent-session messages only — subagent traces' per-call usage is
+    not reliably attributable per call, so we sum at the trace level
+    instead (see ``SubagentTrace.usage``)."""
 
-    by_model: dict[str, ModelTokenBreakdown] = field(default_factory=dict)
-    """Per-model token breakdown, keyed by model name."""
+    by_model: list[ModelTokenBreakdown] = field(default_factory=list)
+    """Per-(model, origin) token breakdown. Schema v2: list, not dict.
+    The ``origin`` field on each row distinguishes parent vs subagent.
+    See #227."""
 
     @property
     def total_tokens(self) -> int:
@@ -63,22 +87,39 @@ class TokenMetrics:
         )
 
 
+def _populate_costs(by_model: dict[tuple[str, str], ModelTokenBreakdown]) -> float:
+    """Compute per-row costs in place, return the summed total."""
+    total = 0.0
+    for breakdown in by_model.values():
+        pricing = get_pricing(breakdown.model)
+        if pricing:
+            breakdown.cost = compute_cost(
+                pricing,
+                breakdown.input_tokens,
+                breakdown.output_tokens,
+                breakdown.cache_creation_input_tokens,
+                breakdown.cache_read_input_tokens,
+            )
+            total += breakdown.cost
+    return total
+
+
 def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
-    """Compute token usage totals and dollar costs from session messages.
+    """Compute parent-session token usage totals and dollar costs.
 
     Processes only assistant messages that have usage data. Messages should
-    already be deduplicated (streaming snapshots collapsed).
-
-    Handles mixed-model sessions by computing per-model breakdowns and
-    summing costs across models.
-
-    Args:
-        messages: Parsed and deduplicated session messages.
+    already be deduplicated (streaming snapshots collapsed). Subagent
+    contributions are not included here — call
+    ``compute_subagent_token_metrics`` separately and merge into the
+    parent ``TokenMetrics`` (see ``analytics.pipeline.analyze_session``).
 
     Returns:
-        TokenMetrics with totals, per-model breakdown, cost, and cache efficiency.
+        TokenMetrics with parent-only totals, per-model breakdown
+        (origin="parent"), cost, and cache efficiency.
     """
-    by_model: dict[str, ModelTokenBreakdown] = {}
+    # Internal indexing by (model, origin) so subsequent merges and
+    # subagent additions can dedupe deterministically.
+    by_model: dict[tuple[str, str], ModelTokenBreakdown] = {}
     api_call_count = 0
 
     for msg in messages:
@@ -93,32 +134,20 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
         api_call_count += 1
         model_name = msg.model or "unknown"
         usage = msg.usage
+        key = (model_name, "parent")
 
-        breakdown = by_model.get(model_name)
+        breakdown = by_model.get(key)
         if breakdown is None:
-            breakdown = ModelTokenBreakdown(model=model_name)
-            by_model[model_name] = breakdown
+            breakdown = ModelTokenBreakdown(model=model_name, origin="parent")
+            by_model[key] = breakdown
 
         breakdown.input_tokens += usage.input_tokens
         breakdown.output_tokens += usage.output_tokens
         breakdown.cache_creation_input_tokens += usage.cache_creation_input_tokens
         breakdown.cache_read_input_tokens += usage.cache_read_input_tokens
 
-    # Compute per-model costs
-    total_cost = 0.0
-    for breakdown in by_model.values():
-        pricing = get_pricing(breakdown.model)
-        if pricing:
-            breakdown.cost = compute_cost(
-                pricing,
-                breakdown.input_tokens,
-                breakdown.output_tokens,
-                breakdown.cache_creation_input_tokens,
-                breakdown.cache_read_input_tokens,
-            )
-            total_cost += breakdown.cost
+    total_cost = _populate_costs(by_model)
 
-    # Aggregate totals
     total_input = sum(b.input_tokens for b in by_model.values())
     total_output = sum(b.output_tokens for b in by_model.values())
     total_cache_creation = sum(b.cache_creation_input_tokens for b in by_model.values())
@@ -138,5 +167,81 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
         total_cost=total_cost,
         cache_efficiency=cache_efficiency,
         api_call_count=api_call_count,
-        by_model=by_model,
+        by_model=list(by_model.values()),
+    )
+
+
+def compute_subagent_token_metrics(
+    traces: list[SubagentTrace],
+) -> list[ModelTokenBreakdown]:
+    """Aggregate subagent-trace token usage into per-model breakdowns.
+
+    Uses ``SubagentTrace.usage`` (the trace-level aggregate) as the
+    authoritative source — per-call ``SubagentToolCall.usage`` is left
+    at zero by the parser (see traces/parser.py docstring). Skips
+    traces with no model and traces whose usage is wholly zero (no
+    assistant messages).
+
+    Returns one ``ModelTokenBreakdown`` per distinct subagent model,
+    each carrying ``origin="subagent"``. Costs are populated. The
+    caller is responsible for merging these rows into a parent
+    ``TokenMetrics``.
+    """
+    by_model: dict[tuple[str, str], ModelTokenBreakdown] = {}
+    for trace in traces:
+        if trace.model is None or trace.model in SYNTHETIC_MODELS:
+            continue
+        usage = trace.usage
+        if usage is None:
+            continue
+        key = (trace.model, "subagent")
+        breakdown = by_model.get(key)
+        if breakdown is None:
+            breakdown = ModelTokenBreakdown(model=trace.model, origin="subagent")
+            by_model[key] = breakdown
+        breakdown.input_tokens += usage.input_tokens
+        breakdown.output_tokens += usage.output_tokens
+        breakdown.cache_creation_input_tokens += usage.cache_creation_input_tokens
+        breakdown.cache_read_input_tokens += usage.cache_read_input_tokens
+
+    _populate_costs(by_model)
+    return list(by_model.values())
+
+
+def fold_subagent_metrics_in(
+    parent: TokenMetrics, subagent_rows: list[ModelTokenBreakdown],
+) -> TokenMetrics:
+    """Return a new ``TokenMetrics`` with subagent rows folded into parent.
+
+    Top-level totals (input/output/cache + cost) become comprehensive.
+    The ``by_model`` list is the union of parent and subagent rows
+    (rows with the same ``model`` but different ``origin`` stay
+    distinct). Cache efficiency is recomputed from the comprehensive
+    totals.
+    """
+    if not subagent_rows:
+        return parent
+
+    combined_rows = list(parent.by_model) + list(subagent_rows)
+    total_input = sum(r.input_tokens for r in combined_rows)
+    total_output = sum(r.output_tokens for r in combined_rows)
+    total_cache_creation = sum(r.cache_creation_input_tokens for r in combined_rows)
+    total_cache_read = sum(r.cache_read_input_tokens for r in combined_rows)
+    total_cost = sum(r.cost for r in combined_rows)
+
+    cache_denominator = total_cache_read + total_input + total_cache_creation
+    cache_efficiency = (
+        round(total_cache_read / cache_denominator * 100, 1)
+        if cache_denominator > 0 else 0.0
+    )
+
+    return TokenMetrics(
+        input_tokens=total_input,
+        output_tokens=total_output,
+        cache_creation_input_tokens=total_cache_creation,
+        cache_read_input_tokens=total_cache_read,
+        total_cost=total_cost,
+        cache_efficiency=cache_efficiency,
+        api_call_count=parent.api_call_count,
+        by_model=combined_rows,
     )

--- a/src/agentfluent/analytics/tokens.py
+++ b/src/agentfluent/analytics/tokens.py
@@ -7,6 +7,7 @@ cost breakdown and parent-vs-subagent origin attribution.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -104,6 +105,35 @@ def _populate_costs(by_model: dict[tuple[str, str], ModelTokenBreakdown]) -> flo
     return total
 
 
+def _aggregate_totals(
+    rows: Iterable[ModelTokenBreakdown],
+) -> tuple[int, int, int, int, float, float]:
+    """Sum totals across breakdown rows. Returns (input, output, cache_creation,
+    cache_read, total_cost, cache_efficiency).
+
+    Cache efficiency formula: cache_read / (cache_read + input + cache_creation) * 100.
+    """
+    total_input = 0
+    total_output = 0
+    total_cache_creation = 0
+    total_cache_read = 0
+    total_cost = 0.0
+    for r in rows:
+        total_input += r.input_tokens
+        total_output += r.output_tokens
+        total_cache_creation += r.cache_creation_input_tokens
+        total_cache_read += r.cache_read_input_tokens
+        total_cost += r.cost
+    cache_denom = total_cache_read + total_input + total_cache_creation
+    cache_efficiency = (
+        round(total_cache_read / cache_denom * 100, 1) if cache_denom > 0 else 0.0
+    )
+    return (
+        total_input, total_output, total_cache_creation, total_cache_read,
+        total_cost, cache_efficiency,
+    )
+
+
 def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
     """Compute parent-session token usage totals and dollar costs.
 
@@ -117,17 +147,13 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
         TokenMetrics with parent-only totals, per-model breakdown
         (origin="parent"), cost, and cache efficiency.
     """
-    # Internal indexing by (model, origin) so subsequent merges and
-    # subagent additions can dedupe deterministically.
     by_model: dict[tuple[str, str], ModelTokenBreakdown] = {}
     api_call_count = 0
 
     for msg in messages:
         if msg.type != "assistant" or msg.usage is None:
             continue
-
-        # Skip synthetic/internal sentinel models emitted by Claude Code.
-        # These are not real API calls -- no tokens billed, no pricing needed.
+        # <synthetic> is a Claude Code sentinel — no real API call, no pricing.
         if msg.model in SYNTHETIC_MODELS:
             continue
 
@@ -146,18 +172,12 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
         breakdown.cache_creation_input_tokens += usage.cache_creation_input_tokens
         breakdown.cache_read_input_tokens += usage.cache_read_input_tokens
 
-    total_cost = _populate_costs(by_model)
-
-    total_input = sum(b.input_tokens for b in by_model.values())
-    total_output = sum(b.output_tokens for b in by_model.values())
-    total_cache_creation = sum(b.cache_creation_input_tokens for b in by_model.values())
-    total_cache_read = sum(b.cache_read_input_tokens for b in by_model.values())
-
-    # Cache efficiency: cache_read / (cache_read + input + cache_creation)
-    cache_denominator = total_cache_read + total_input + total_cache_creation
-    cache_efficiency = (
-        round(total_cache_read / cache_denominator * 100, 1) if cache_denominator > 0 else 0.0
-    )
+    _populate_costs(by_model)
+    rows = list(by_model.values())
+    (
+        total_input, total_output, total_cache_creation, total_cache_read,
+        total_cost, cache_efficiency,
+    ) = _aggregate_totals(rows)
 
     return TokenMetrics(
         input_tokens=total_input,
@@ -167,7 +187,7 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
         total_cost=total_cost,
         cache_efficiency=cache_efficiency,
         api_call_count=api_call_count,
-        by_model=list(by_model.values()),
+        by_model=rows,
     )
 
 
@@ -217,23 +237,17 @@ def fold_subagent_metrics_in(
     The ``by_model`` list is the union of parent and subagent rows
     (rows with the same ``model`` but different ``origin`` stay
     distinct). Cache efficiency is recomputed from the comprehensive
-    totals.
+    totals. When ``subagent_rows`` is empty, returns ``parent`` itself
+    (identity preserved) so the merge is free in the common no-trace case.
     """
     if not subagent_rows:
         return parent
 
     combined_rows = list(parent.by_model) + list(subagent_rows)
-    total_input = sum(r.input_tokens for r in combined_rows)
-    total_output = sum(r.output_tokens for r in combined_rows)
-    total_cache_creation = sum(r.cache_creation_input_tokens for r in combined_rows)
-    total_cache_read = sum(r.cache_read_input_tokens for r in combined_rows)
-    total_cost = sum(r.cost for r in combined_rows)
-
-    cache_denominator = total_cache_read + total_input + total_cache_creation
-    cache_efficiency = (
-        round(total_cache_read / cache_denominator * 100, 1)
-        if cache_denominator > 0 else 0.0
-    )
+    (
+        total_input, total_output, total_cache_creation, total_cache_read,
+        total_cost, cache_efficiency,
+    ) = _aggregate_totals(combined_rows)
 
     return TokenMetrics(
         input_tokens=total_input,

--- a/src/agentfluent/cli/formatters/json_output.py
+++ b/src/agentfluent/cli/formatters/json_output.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 import json
 from typing import Any, Literal
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
+"""v2 (#227): ``token_metrics.by_model`` is a list of objects (each with
+``origin``: parent or subagent), not a dict keyed by model. The diff
+module reads both shapes via a compatibility shim, but new envelopes
+always emit v2."""
 
 CommandName = Literal[
     "list-projects", "list-sessions", "analyze", "config-check", "diff",

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -154,24 +154,26 @@ def format_analysis_table(
 
     if tm.by_model and (verbose or len(tm.by_model) > 1):
         model_table = Table(
-            title="Cost by Model — Parent Session (API rate)",
-            show_header=True,
+            title="Cost by Model (API rate)", show_header=True,
         )
         model_table.add_column("Model", style="cyan")
+        model_table.add_column("Origin")
         model_table.add_column("Tokens", justify="right")
         model_table.add_column("Cost", justify="right")
-        for model_name, breakdown in sorted(tm.by_model.items()):
+        # Group rows by (model, origin); parent first, then subagent
+        # within each model so the table reads top-down by source.
+        sorted_rows = sorted(
+            tm.by_model,
+            key=lambda b: (b.model, 0 if b.origin == "parent" else 1),
+        )
+        for breakdown in sorted_rows:
             model_table.add_row(
-                model_name,
+                breakdown.model,
+                breakdown.origin,
                 format_tokens(breakdown.total_tokens),
                 format_cost(breakdown.cost),
             )
         console.print(model_table)
-        console.print(
-            "Subagent tokens are not broken out by model here — "
-            "see Agent Invocations for per-agent totals.",
-            style="dim",
-        )
 
     if tlm.total_tool_calls > 0:
         tool_table = Table(title="Tool Usage", show_header=True)

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -160,8 +160,6 @@ def format_analysis_table(
         model_table.add_column("Origin")
         model_table.add_column("Tokens", justify="right")
         model_table.add_column("Cost", justify="right")
-        # Group rows by (model, origin); parent first, then subagent
-        # within each model so the table reads top-down by source.
         sorted_rows = sorted(
             tm.by_model,
             key=lambda b: (b.model, 0 if b.origin == "parent" else 1),

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.diagnostics.models import SignalType
 from agentfluent.diff.models import (
@@ -251,32 +252,31 @@ def _sum_token_components(d: dict[str, Any]) -> int:
 
 def _normalize_by_model(
     raw: dict[str, Any] | list[Any],
-) -> dict[tuple[str, str], dict[str, Any]]:
+) -> dict[tuple[str, Origin], dict[str, Any]]:
     """Coerce a ``by_model`` payload to ``{(model, origin): row}``.
 
     Schema v2 (#227) emits a list of rows with an ``origin`` field. The
     pre-#227 schema (v1) emitted a dict keyed by model name with no
     ``origin`` field; for cross-version diffs we treat those rows as
     parent-origin so legacy saved envelopes remain comparable. Rows
-    without a ``model`` field are dropped — defensive guard against
-    user-edited JSON.
+    without a ``model`` field, or with an unknown ``origin`` value, are
+    treated defensively (skip / default to parent) — a user-edited JSON
+    file should not crash the diff.
     """
     if isinstance(raw, dict):
-        # Legacy v1: dict keyed by model name; everything is parent.
         return {
             (model, "parent"): (row if isinstance(row, dict) else {})
             for model, row in raw.items()
         }
-    out: dict[tuple[str, str], dict[str, Any]] = {}
+    out: dict[tuple[str, Origin], dict[str, Any]] = {}
     for row in raw:
         if not isinstance(row, dict):
             continue
         model = row.get("model")
         if not isinstance(model, str):
             continue
-        origin = row.get("origin", "parent")
-        if not isinstance(origin, str):
-            origin = "parent"
+        raw_origin = row.get("origin", "parent")
+        origin: Origin = raw_origin if raw_origin in ("parent", "subagent") else "parent"
         out[(model, origin)] = row
     return out
 

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -218,7 +218,10 @@ def _diff_token_metrics(
     baseline_cache = float(baseline_tm.get("cache_efficiency", 0.0) or 0.0)
     current_cache = float(current_tm.get("cache_efficiency", 0.0) or 0.0)
 
-    by_model = _diff_by_model(baseline_tm.get("by_model") or {}, current_tm.get("by_model") or {})
+    by_model = _diff_by_model(
+        baseline_tm.get("by_model") or [],
+        current_tm.get("by_model") or [],
+    )
 
     return TokenMetricsDelta(
         baseline_total_tokens=baseline_total_tokens,
@@ -246,15 +249,49 @@ def _sum_token_components(d: dict[str, Any]) -> int:
     )
 
 
+def _normalize_by_model(
+    raw: dict[str, Any] | list[Any],
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """Coerce a ``by_model`` payload to ``{(model, origin): row}``.
+
+    Schema v2 (#227) emits a list of rows with an ``origin`` field. The
+    pre-#227 schema (v1) emitted a dict keyed by model name with no
+    ``origin`` field; for cross-version diffs we treat those rows as
+    parent-origin so legacy saved envelopes remain comparable. Rows
+    without a ``model`` field are dropped — defensive guard against
+    user-edited JSON.
+    """
+    if isinstance(raw, dict):
+        # Legacy v1: dict keyed by model name; everything is parent.
+        return {
+            (model, "parent"): (row if isinstance(row, dict) else {})
+            for model, row in raw.items()
+        }
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        model = row.get("model")
+        if not isinstance(model, str):
+            continue
+        origin = row.get("origin", "parent")
+        if not isinstance(origin, str):
+            origin = "parent"
+        out[(model, origin)] = row
+    return out
+
+
 def _diff_by_model(
-    baseline: dict[str, Any],
-    current: dict[str, Any],
+    baseline: dict[str, Any] | list[Any],
+    current: dict[str, Any] | list[Any],
 ) -> list[ModelTokenDelta]:
-    models = sorted(set(baseline.keys()) | set(current.keys()))
+    baseline_map = _normalize_by_model(baseline)
+    current_map = _normalize_by_model(current)
+    keys = sorted(set(baseline_map.keys()) | set(current_map.keys()))
     deltas: list[ModelTokenDelta] = []
-    for model in models:
-        b = baseline.get(model) or {}
-        c = current.get(model) or {}
+    for model, origin in keys:
+        b = baseline_map.get((model, origin)) or {}
+        c = current_map.get((model, origin)) or {}
         b_tokens = _sum_token_components(b)
         c_tokens = _sum_token_components(c)
         b_cost = float(b.get("cost", 0.0) or 0.0)
@@ -262,6 +299,7 @@ def _diff_by_model(
         deltas.append(
             ModelTokenDelta(
                 model=model,
+                origin=origin,
                 baseline_total_tokens=b_tokens,
                 current_total_tokens=c_tokens,
                 total_tokens_delta=c_tokens - b_tokens,

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -58,9 +58,16 @@ class RecommendationDelta(BaseModel):
 
 
 class ModelTokenDelta(BaseModel):
-    """Per-model token / cost delta inside :class:`TokenMetricsDelta`."""
+    """Per-(model, origin) token / cost delta inside :class:`TokenMetricsDelta`.
+
+    ``origin`` distinguishes parent vs subagent rows (#227). Defaults
+    to ``"parent"`` so legacy v1 envelopes (which had no origin field)
+    diff cleanly under the compatibility shim in
+    :func:`agentfluent.diff.compute._diff_by_model`.
+    """
 
     model: str
+    origin: str = "parent"
     baseline_total_tokens: int = 0
     current_total_tokens: int = 0
     total_tokens_delta: int = 0

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import SignalType
 
@@ -67,7 +68,7 @@ class ModelTokenDelta(BaseModel):
     """
 
     model: str
-    origin: str = "parent"
+    origin: Origin = "parent"
     baseline_total_tokens: int = 0
     current_total_tokens: int = 0
     total_tokens_delta: int = 0

--- a/tests/unit/cli/test_glossary_footer.py
+++ b/tests/unit/cli/test_glossary_footer.py
@@ -78,13 +78,15 @@ class TestGlossaryFooterOnConfigCheck:
         assert "GLOSSARY" not in json.dumps(payload)
 
 
-class TestCostByModelLabelClarification:
-    """#188 stretch: Cost by Model table title is scoped to parent session."""
+class TestCostByModelTableShape:
+    """#227 (Phase 2): Cost by Model table covers parent + subagent rows.
 
-    def test_table_title_names_parent_session(self) -> None:
-        # Direct formatter test: the fixture sessions used by the CLI smoke
-        # tests don't populate by_model, so the table only renders when
-        # constructed explicitly.
+    Phase 1 (#188) renamed the table to "— Parent Session" and added a
+    "subagent tokens are not broken out" footer note. Phase 2 closes
+    the gap, so the title drops the qualifier and the footer goes away.
+    """
+
+    def test_table_title_drops_parent_session_qualifier(self) -> None:
         from io import StringIO
 
         from rich.console import Console
@@ -100,17 +102,19 @@ class TestCostByModelLabelClarification:
 
         result = AnalysisResult(
             token_metrics=TokenMetrics(
-                input_tokens=100,
-                output_tokens=200,
-                total_cost=0.50,
-                by_model={
-                    "claude-opus-4-7": ModelTokenBreakdown(
-                        model="claude-opus-4-7",
-                        input_tokens=100,
-                        output_tokens=200,
-                        cost=0.50,
+                input_tokens=300,
+                output_tokens=350,
+                total_cost=0.75,
+                by_model=[
+                    ModelTokenBreakdown(
+                        model="claude-opus-4-7", origin="parent",
+                        input_tokens=100, output_tokens=200, cost=0.50,
                     ),
-                },
+                    ModelTokenBreakdown(
+                        model="claude-haiku-4-5-20251001", origin="subagent",
+                        input_tokens=200, output_tokens=150, cost=0.25,
+                    ),
+                ],
             ),
             tool_metrics=ToolMetrics(),
             agent_metrics=AgentMetrics(),
@@ -123,5 +127,11 @@ class TestCostByModelLabelClarification:
             verbose=True,
         )
         out = buf.getvalue()
-        assert "Cost by Model — Parent Session" in out
-        assert "Subagent tokens are not broken out" in out
+        assert "Cost by Model" in out
+        # Phase 1 qualifier and footer are gone now that subagents land
+        # in the table directly.
+        assert "Parent Session" not in out
+        assert "Subagent tokens are not broken out" not in out
+        # Origin column surfaces both rows.
+        assert "parent" in out
+        assert "subagent" in out

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -23,12 +23,19 @@ from agentfluent.diff.models import DiffResult
 def _envelope(
     *,
     aggregated_recs: list[dict[str, Any]] | None = None,
-    by_model: dict[str, dict[str, Any]] | None = None,
+    by_model: dict[str, dict[str, Any]] | list[dict[str, Any]] | None = None,
     by_agent: dict[str, dict[str, Any]] | None = None,
     total_cost: float = 0.0,
     cache_efficiency: float = 0.0,
     session_count: int = 1,
 ) -> dict[str, Any]:
+    by_model_payload: dict[str, Any] | list[Any]
+    if by_model is None:
+        # Default to v2 list shape for new tests; legacy dict tests pass
+        # explicitly.
+        by_model_payload = []
+    else:
+        by_model_payload = by_model
     return {
         "session_count": session_count,
         "token_metrics": {
@@ -38,7 +45,7 @@ def _envelope(
             "cache_read_input_tokens": 0,
             "total_cost": total_cost,
             "cache_efficiency": cache_efficiency,
-            "by_model": by_model or {},
+            "by_model": by_model_payload,
         },
         "agent_metrics": {
             "by_agent_type": by_agent or {},
@@ -283,6 +290,58 @@ class TestTokenMetricsDelta:
         assert models["claude-opus-4-7"].cost_delta == -1.0
         assert models["claude-sonnet-4-6"].baseline_cost == 0.0
         assert models["claude-sonnet-4-6"].cost_delta == 0.30
+
+    def test_legacy_dict_envelope_diffs_against_v2_list_envelope(self) -> None:
+        # Cross-version: pre-#227 saved JSON used a dict keyed by model
+        # (no origin). The compat shim treats those rows as parent. A
+        # v2 envelope with the same parent row should diff to zero.
+        baseline_legacy = _envelope(by_model={
+            "claude-opus-4-7": {
+                "input_tokens": 100, "output_tokens": 200,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 1.0,
+            },
+        })
+        current_v2 = _envelope(by_model=[
+            {
+                "model": "claude-opus-4-7", "origin": "parent",
+                "input_tokens": 100, "output_tokens": 200,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 1.0,
+            },
+        ])
+
+        result = compute_diff(baseline_legacy, current_v2)
+        rows = result.token_metrics.by_model
+        assert len(rows) == 1
+        assert rows[0].model == "claude-opus-4-7"
+        assert rows[0].origin == "parent"
+        assert rows[0].cost_delta == 0.0
+        assert rows[0].total_tokens_delta == 0
+
+    def test_v2_list_envelope_distinguishes_parent_and_subagent(self) -> None:
+        # Same model used by parent and subagent → two distinct rows in
+        # the diff output, keyed by (model, origin).
+        baseline = _envelope(by_model=[])
+        current = _envelope(by_model=[
+            {
+                "model": "claude-opus-4-7", "origin": "parent",
+                "input_tokens": 100, "output_tokens": 0,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 0.5,
+            },
+            {
+                "model": "claude-opus-4-7", "origin": "subagent",
+                "input_tokens": 50, "output_tokens": 0,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+                "cost": 0.25,
+            },
+        ])
+
+        result = compute_diff(baseline, current)
+        keyed = {(r.model, r.origin): r for r in result.token_metrics.by_model}
+        assert keyed[("claude-opus-4-7", "parent")].cost_delta == pytest.approx(0.5)
+        assert keyed[("claude-opus-4-7", "subagent")].cost_delta == pytest.approx(0.25)
 
 
 class TestAgentTypeDelta:

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -4,8 +4,30 @@ import logging
 
 import pytest
 
-from agentfluent.analytics.tokens import compute_token_metrics
+from agentfluent.analytics.tokens import (
+    ModelTokenBreakdown,
+    TokenMetrics,
+    compute_subagent_token_metrics,
+    compute_token_metrics,
+    fold_subagent_metrics_in,
+)
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
+from agentfluent.traces.models import SubagentTrace
+
+
+def _by_model(metrics: TokenMetrics, model: str, origin: str = "parent") -> ModelTokenBreakdown:
+    """Find the breakdown row matching ``(model, origin)`` or fail."""
+    for row in metrics.by_model:
+        if row.model == model and row.origin == origin:
+            return row
+    raise AssertionError(
+        f"by_model has no ({model!r}, {origin!r}); rows: "
+        f"{[(r.model, r.origin) for r in metrics.by_model]}",
+    )
+
+
+def _model_names(metrics: TokenMetrics) -> set[str]:
+    return {row.model for row in metrics.by_model}
 
 
 def _assistant(
@@ -64,7 +86,7 @@ class TestComputeTokenMetrics:
         assert metrics.total_tokens == 0
         assert metrics.total_cost == 0.0
         assert metrics.api_call_count == 0
-        assert metrics.by_model == {}
+        assert metrics.by_model == []
 
     def test_skips_non_assistant(self) -> None:
         messages = [
@@ -119,7 +141,7 @@ class TestCostComputation:
         metrics = compute_token_metrics(messages)
         # 1M * 5/1M + 100K * 25/1M = 5.0 + 2.5 = 7.5
         assert abs(metrics.total_cost - 7.5) < 0.001
-        assert "claude-opus-4-7" in metrics.by_model
+        assert "claude-opus-4-7" in _model_names(metrics)
 
     def test_unknown_model_zero_cost(self) -> None:
         messages = [_assistant(model="unknown-model", input_tokens=1000, output_tokens=500)]
@@ -154,7 +176,7 @@ class TestSyntheticFiltering:
         assert metrics.output_tokens == 0
         assert metrics.total_cost == 0.0
         assert metrics.api_call_count == 0
-        assert "<synthetic>" not in metrics.by_model
+        assert "<synthetic>" not in _model_names(metrics)
         # No "Unknown model" log entry at any level.
         assert not any(
             "<synthetic>" in r.getMessage() for r in caplog.records
@@ -171,7 +193,7 @@ class TestSyntheticFiltering:
         assert metrics.input_tokens == 100
         assert metrics.output_tokens == 50
         assert metrics.api_call_count == 1
-        assert list(metrics.by_model.keys()) == ["claude-sonnet-4-6"]
+        assert _model_names(metrics) == {"claude-sonnet-4-6"}
 
 
 class TestPerModelBreakdown:
@@ -182,7 +204,7 @@ class TestPerModelBreakdown:
         ]
         metrics = compute_token_metrics(messages)
         assert len(metrics.by_model) == 1
-        breakdown = metrics.by_model["claude-sonnet-4-20250514"]
+        breakdown = _by_model(metrics, "claude-sonnet-4-20250514")
         assert breakdown.input_tokens == 300
         assert breakdown.output_tokens == 150
 
@@ -193,15 +215,15 @@ class TestPerModelBreakdown:
         ]
         metrics = compute_token_metrics(messages)
         assert len(metrics.by_model) == 2
-        assert metrics.by_model["claude-sonnet-4-20250514"].input_tokens == 100
-        assert metrics.by_model["claude-opus-4-6"].input_tokens == 200
+        assert _by_model(metrics, "claude-sonnet-4-20250514").input_tokens == 100
+        assert _by_model(metrics, "claude-opus-4-6").input_tokens == 200
 
     def test_model_breakdown_total_tokens(self) -> None:
         messages = [
             _assistant(input_tokens=100, output_tokens=50, cache_creation=200, cache_read=300),
         ]
         metrics = compute_token_metrics(messages)
-        breakdown = metrics.by_model["claude-sonnet-4-20250514"]
+        breakdown = _by_model(metrics, "claude-sonnet-4-20250514")
         assert breakdown.total_tokens == 650
 
     def test_missing_model_uses_unknown(self) -> None:
@@ -211,7 +233,15 @@ class TestPerModelBreakdown:
             usage=Usage(input_tokens=100, output_tokens=50),
         )
         metrics = compute_token_metrics([msg])
-        assert "unknown" in metrics.by_model
+        assert "unknown" in _model_names(metrics)
+
+    def test_parent_origin_set_on_breakdowns(self) -> None:
+        # #227: every parent breakdown row carries origin="parent" so the
+        # downstream JSON envelope is unambiguous even before subagent
+        # contributions land.
+        messages = [_assistant(input_tokens=100, output_tokens=50)]
+        metrics = compute_token_metrics(messages)
+        assert all(r.origin == "parent" for r in metrics.by_model)
 
 
 class TestCacheEfficiency:
@@ -240,3 +270,102 @@ class TestCacheEfficiency:
     def test_empty_session_zero_efficiency(self) -> None:
         metrics = compute_token_metrics([])
         assert metrics.cache_efficiency == 0.0
+
+
+def _trace(
+    model: str | None,
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+) -> SubagentTrace:
+    return SubagentTrace(
+        agent_id="ag",
+        agent_type="general-purpose",
+        delegation_prompt="p",
+        model=model,
+        usage=Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=cache_creation,
+            cache_read_input_tokens=cache_read,
+        ),
+    )
+
+
+class TestComputeSubagentTokenMetrics:
+    """Coverage for the subagent-side aggregator that #227 wires in."""
+
+    def test_returns_subagent_origin(self) -> None:
+        rows = compute_subagent_token_metrics([
+            _trace("claude-haiku-4-5-20251001", input_tokens=100, output_tokens=50),
+        ])
+        assert len(rows) == 1
+        assert rows[0].model == "claude-haiku-4-5-20251001"
+        assert rows[0].origin == "subagent"
+
+    def test_skips_traces_with_no_model(self) -> None:
+        rows = compute_subagent_token_metrics([
+            _trace(None, input_tokens=999, output_tokens=999),
+        ])
+        # No model means no usable cost or breakdown row — skip.
+        assert rows == []
+
+    def test_aggregates_same_model_across_traces(self) -> None:
+        rows = compute_subagent_token_metrics([
+            _trace("claude-haiku-4-5-20251001", input_tokens=100, output_tokens=50),
+            _trace("claude-haiku-4-5-20251001", input_tokens=200, output_tokens=100),
+        ])
+        assert len(rows) == 1
+        assert rows[0].input_tokens == 300
+        assert rows[0].output_tokens == 150
+
+
+class TestFoldSubagentMetricsIn:
+    """Combined comprehensiveness — top-level totals reflect parent + subagent."""
+
+    def test_no_subagent_rows_returns_parent_unchanged(self) -> None:
+        parent = compute_token_metrics([
+            _assistant(input_tokens=100, output_tokens=50),
+        ])
+        result = fold_subagent_metrics_in(parent, [])
+        # Parent was returned as-is (object identity preserved is fine).
+        assert result is parent
+
+    def test_top_level_tokens_become_comprehensive(self) -> None:
+        parent = compute_token_metrics([
+            _assistant(
+                model="claude-opus-4-7", input_tokens=100, output_tokens=50,
+            ),
+        ])
+        subagent_rows = compute_subagent_token_metrics([
+            _trace(
+                "claude-haiku-4-5-20251001", input_tokens=200, output_tokens=100,
+            ),
+        ])
+        result = fold_subagent_metrics_in(parent, subagent_rows)
+        assert result.input_tokens == 300
+        assert result.output_tokens == 150
+        # Parent and subagent rows kept distinct.
+        assert {(r.model, r.origin) for r in result.by_model} == {
+            ("claude-opus-4-7", "parent"),
+            ("claude-haiku-4-5-20251001", "subagent"),
+        }
+
+    def test_total_cost_includes_subagent(self) -> None:
+        # Sonnet parent + Haiku subagent — both real models with pricing.
+        parent = compute_token_metrics([
+            _assistant(
+                model="claude-sonnet-4-6", input_tokens=1_000_000, output_tokens=0,
+            ),
+        ])
+        subagent_rows = compute_subagent_token_metrics([
+            _trace(
+                "claude-haiku-4-5-20251001",
+                input_tokens=1_000_000, output_tokens=0,
+            ),
+        ])
+        result = fold_subagent_metrics_in(parent, subagent_rows)
+        # Comprehensive = parent_cost + subagent_cost (both > 0).
+        assert result.total_cost > parent.total_cost


### PR DESCRIPTION
## Summary
- Phase 2 of #188: wires `SubagentTrace` token usage into the per-model cost breakdown so the table reflects the true session cost (parent + subagent), not just the parent thread (closes #227)
- Adds `origin` field to `ModelTokenBreakdown` and `ModelTokenDelta`; `TokenMetrics.by_model` becomes a `list` (was `dict`); `SCHEMA_VERSION` bumps to 2
- `_diff_by_model` carries a compat shim so legacy v1 envelopes (dict) diff cleanly against v2 envelopes (list) — legacy rows normalize as `origin="parent"`
- Top-level `total_cost` / `total_tokens` are now comprehensive (parent + subagent)

## Architect-review-driven decisions
Per the architect review on #227:
- **Schema:** Option (a) — flat list with `origin` field, not nested grouping or composite keys
- **Subagent traces with `model=None`:** skipped (no usable cost row)
- **Authoritative usage source:** `SubagentTrace.usage` (trace-level aggregate), not per-call `SubagentToolCall.usage` (zero per parser docstring)
- **`total_tokens` semantics:** comprehensive (the architect's lean recommendation)

## Smoke test (real data)
\`\`\`
              Cost by Model (API rate)
┃ Model           ┃ Origin   ┃     Tokens ┃   Cost ┃
│ claude-opus-4-6 │ subagent │  7,825,483 │  $8.93 │
│ claude-opus-4-7 │ parent   │ 44,981,437 │ $30.68 │
│ claude-opus-4-7 │ subagent │  1,213,063 │  $1.50 │
\`\`\`
JSON envelope confirmed at \`version: 2\` with \`by_model\` as a list.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` — 1003 passed (was 996; +7 new tests)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New tests cover: subagent aggregation, model=None skip, origin propagation, comprehensive totals, legacy-dict-vs-v2-list cross-version diff, parent-and-subagent same-model distinction
- [x] Manual smoke test — verified table render and JSON envelope shape against real session data

## Security review
- [x] **Skip review** — internal data-model refactor + presentation change. No new attack surface.
- [ ] Needs review

## Breaking changes
**JSON envelope schema bumps from v1 to v2.**
- \`token_metrics.by_model\` was a dict keyed by model name, now a list of objects with an \`origin\` field
- Top-level totals (\`total_tokens\`, \`total_cost\`) now include subagent contributions; previously parent-only

The diff module reads both shapes (legacy dict normalized as parent-origin), so saved v1 envelopes remain diffable against new runs. JSON consumers that walk \`by_model\` as a dict will need to update; the v2 schema version makes the change detectable.