### PR TITLE
docs: catch up README + GLOSSARY for v0.5 features and v0.6 quality-axis (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ agentfluent analyze --project codefluent --no-diagnostics      # Token + cost on
 agentfluent analyze --project codefluent --agent pm            # Filter to one subagent
 agentfluent analyze --project codefluent --latest 5            # Last 5 sessions only
 agentfluent analyze --project codefluent -v                    # + YAML subagent drafts
+agentfluent analyze --project codefluent --min-severity warning  # Hide info-level recs
+agentfluent analyze --project codefluent --top-n 10            # Top-10 priority fixes summary block
 agentfluent analyze --project codefluent --format json | jq '.data.token_metrics.total_cost'
 
 # Save the top-confidence cluster as a real subagent definition:
@@ -138,11 +140,13 @@ agentfluent analyze --project codefluent --format json \
   > ~/.claude/agents/new-agent.md
 ```
 
-Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. Behavior diagnostics run by default and surface the full v0.3 signal surface (pass `--no-diagnostics` to skip):
+Produces a token-usage table, per-model cost breakdown (labeled as API rate — subscription plans differ), tool usage concentration, and an Agent Invocations table summarizing each subagent's token, duration, and tool-use count. The Cost by Model table breaks out parent vs subagent rows (a model used in both shows two rows with `Origin` distinguishing them), and the top-line `Total cost` / `Total tokens` are comprehensive — parent thread + linked subagent runs combined. Behavior diagnostics run by default and surface signals across three layers (pass `--no-diagnostics` to skip):
 
 - **Metadata-level** (from invocation summaries): tool-error keywords, token-per-tool-use outliers, duration outliers.
 - **Trace-level** (from `~/.claude/projects/<session>/subagents/`): retry loops, stuck patterns, permission failures, consecutive tool-error sequences — each with per-tool-call evidence.
 - **Aggregate**: model mismatch (complexity class wrong for declared/observed model), delegation clustering (recurring `general-purpose` patterns → proposed specialized subagents), MCP server audit (configured-but-unused, observed-but-missing).
+
+Above the Recommendations table, a **Top-N priority fixes summary** ranks findings by a composite `priority_score` that combines severity, occurrence count, cost impact (for `target='model'` mismatches), and trace-evidence boost — so the highest-leverage changes surface first instead of asking the reader to scan a flat severity-sorted list. The sort key is part of the JSON envelope (`aggregated_recommendations[].priority_score`), so a CI gate can fail the run on priority regression. An **Offload Candidates** section calls out clusters of repeating tool-use patterns in the parent thread and proposes subagent / skill drafts that move that work onto cheaper-tier models — the dominant cost lever for users running agents at scale.
 
 Near-duplicate recommendations are aggregated per `(agent, target, signal)` shape into one row with an occurrence `Count` and metric range (e.g. *"4 invocations (4.9x–8.0x above 5,064 mean). Consider adding more specific instructions..."*). Each recommendation carries a specific config surface to change (prompt, tools, model, mcp) and a pointer to the file to edit. Recommendations for built-in agents (Explore, general-purpose, Plan, etc.) use concern-specific action text — wrapper subagent for scope issues, retry bounds on the delegating agent for recovery issues, reroute for tools/model — since built-in agents have no user-editable prompt or tool config.
 
@@ -191,6 +195,9 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 | `--diagnostics / --no-diagnostics` | on | `analyze`: behavior-correlation signals (default on; `--no-diagnostics` skips the pipeline) |
 | `--min-cluster-size` | 5 | Delegation clustering: minimum invocations per cluster (requires `agentfluent[clustering]`) |
 | `--min-similarity` | 0.7 | Delegation dedup: cosine-similarity threshold against existing agents |
+| `--top-n N` | 5 | `analyze`: number of priority-ranked recommendations to summarize above the Recommendations table. Pass 0 to disable the summary block. |
+| `--min-severity` | (none) | `analyze`: drop recommendations below `info` / `warning` / `critical`. Filters both the default table and the `--verbose` per-invocation surface; signals are not affected. |
+| `--fail-on` | (none) | `diff`: gate exit code 3 on new recommendations at or above `info` / `warning` / `critical`, or `off` to disable. |
 | `--claude-config-dir` | `~/.claude/` | Override the Claude config root (also honors `$CLAUDE_CONFIG_DIR`) |
 | `--format` | `table` | Output format: `table` (Rich) or `json` (envelope). Shortcut: `--json` (equivalent to `--format json`) |
 | `--verbose` | off | Extra detail: per-session breakdown, per-invocation detail, raw (un-aggregated) recommendations, and YAML subagent drafts for suggested clusters |
@@ -204,16 +211,31 @@ AgentFluent's "configuration" is CLI flags — no config file, no environment va
 
 ```json
 {
-  "version": 1,
+  "version": "2",
   "command": "analyze",
   "data": {
-    "token_metrics": { "total_cost": 15.42, "total_tokens": 82940115, ... },
-    "by_model": { "claude-opus-4-7": {...}, "claude-sonnet-4-6": {...} },
+    "token_metrics": {
+      "total_cost": 41.11,
+      "total_tokens": 54019983,
+      "by_model": [
+        {"model": "claude-opus-4-7", "origin": "parent",   "cost": 30.68, "input_tokens": 6829, ...},
+        {"model": "claude-opus-4-7", "origin": "subagent", "cost":  1.50, "input_tokens": 1213, ...},
+        {"model": "claude-opus-4-6", "origin": "subagent", "cost":  8.93, "input_tokens": 7825, ...}
+      ]
+    },
     "tool_usage": [...],
-    "agent_invocations": [...]
+    "agent_invocations": [...],
+    "diagnostics": {
+      "aggregated_recommendations": [...],
+      "offload_candidates": [...],
+      "delegation_suggestions": [...],
+      "delegation_suggestions_skipped_reason": null
+    }
   }
 }
 ```
+
+**Schema v2 (v0.5):** `token_metrics.by_model` changed from a dict keyed by model name to a list of rows where each row carries an `origin` field (`"parent"` or `"subagent"`). Two rows can share a model with different origins (Opus used in both parent and subagent runs). Top-level `total_cost` and `total_tokens` are now comprehensive — they include subagent contributions. `agentfluent diff` reads both v1 and v2 envelopes (legacy v1 rows normalize as `origin="parent"`), so saved baselines remain diffable across the upgrade.
 
 No ANSI escapes in JSON output, guaranteed. The key `total_cost` is the pay-per-token equivalent; subscribers on Pro/Max/Team/Enterprise plans see a flat monthly charge regardless.
 
@@ -272,9 +294,13 @@ Everything runs locally. No outbound network calls, ever. No API key needed.
 
 - **Project and Session Discovery** — Enumerates `~/.claude/projects/`, groups sessions by project, shows per-project session count, total size, and last-modified timestamp. Handles Claude Code subagent sidechain files and Agent SDK sessions uniformly.
 - **Execution Analytics** — Token usage, API-rate cost, cache efficiency, per-model breakdown, tool-call concentration, and per-agent invocation metrics (tokens, duration, tool-use count). Cache creation and cache read tokens are tracked separately so you can see where your prompt caching is working.
+- **Comprehensive Cost Attribution** — Top-line `total_cost` and `total_tokens` reflect parent + subagent runs combined. The per-model breakdown decomposes by `(model, origin)` so a user who sees "100% Opus" can tell whether their Haiku-routed Explore subagent contributed cost, and whether Opus spend lives in the parent thread or a delegated agent. JSON envelope is at schema v2.
 - **Agent Config Assessment** — 4-dimension rubric (description, tools, model, prompt) applied to every `.md` file in `~/.claude/agents/` and `./.claude/agents/`. Produces a 0–100 score plus ranked, specific recommendations ("Prompt body doesn't mention error handling"). Catches agents that are technically valid but miss well-known best practices.
 - **Subagent Trace Parsing** — Parses the internal tool-call sequences Claude Code emits under `~/.claude/projects/<session>/subagents/agent-<agentId>.jsonl`, links them back to the delegating invocation, and detects retry sequences. Gives diagnostics per-call evidence (which tool, which attempt, which error) instead of just an invocation-level summary.
-- **Behavior Diagnostics** — `--diagnostics` emits signals across three layers. *Metadata*: tool-error keywords, token-per-tool-use outliers, duration outliers. *Trace-level*: retry loops, stuck patterns (same call repeated with no progress), permission failures, consecutive tool-error sequences. *Aggregate*: model mismatch (declared/observed model wrong for the workload's complexity), MCP server audit (configured-but-unused, observed-but-missing). Near-duplicate recommendations collapse into one row per `(agent, target, signal)` shape with an occurrence `Count` and metric range, sorted severity-desc then count-desc so the highest-impact findings surface first. Recommendations for built-in agents (Explore, general-purpose, Plan, code-reviewer, etc.) use concern-specific action text since built-ins have no user-editable config. Each signal routes to a `target` config surface — prompt, tools, model, or mcp — and the recommendation names the file to edit and the specific change to make.
+- **Behavior Diagnostics** — `--diagnostics` emits signals across three layers. *Metadata*: tool-error keywords, token-per-tool-use outliers, duration outliers. *Trace-level*: retry loops, stuck patterns (same call repeated with no progress), permission failures, consecutive tool-error sequences. *Aggregate*: model mismatch (declared/observed model wrong for the workload's complexity), MCP server audit (configured-but-unused, observed-but-missing). Near-duplicate recommendations collapse into one row per `(agent, target, signal)` shape with an occurrence `Count` and metric range. Recommendations for built-in agents (Explore, general-purpose, Plan, code-reviewer, etc.) use concern-specific action text since built-ins have no user-editable config. Each signal routes to a `target` config surface — prompt, tools, model, or mcp — and the recommendation names the file to edit and the specific change to make.
+- **Priority Ranking** — A composite `priority_score` ranks recommendations by severity, occurrence count, cost impact (model-mismatch findings carry the dollar savings), and trace-evidence boost. The default Recommendations table is sorted by priority desc, and a Top-N priority-fixes summary surfaces above the table so the highest-leverage changes are the first thing the reader sees. `--top-n N` controls the summary depth; `--min-severity {info|warning|critical}` filters the recommendation surface without touching the underlying signals.
+- **Offload Candidates** — Detects clusters of repeating tool-use patterns in the parent Claude Code thread, estimates the cost saved by routing them through a cheaper subagent or skill, and proposes a draft definition for each cluster. The dominant cost lever for users running agents at scale: a Sonnet thread that does 80 GitHub PR reviews per week is cheaper as a Haiku-routed `pr-review` subagent. Calibrated against real-world burst distributions (`scripts/calibration/`).
+- **Comparison Workflow** — `agentfluent diff baseline.json current.json` compares two `analyze --json` envelopes, classifying each recommendation as `new` / `resolved` / `persisting`, computing token / cost / cache deltas, and emitting per-agent invocation deltas. `--fail-on {info|warning|critical}` gates exit code 3 on new findings at or above the chosen severity, so `agentfluent diff` slots into a PR check the same way a test runner does. Baselines are user-managed files — no internal cache — so re-running against an older snapshot at any time is just one command. Reads both v1 (legacy) and v2 (current) JSON envelopes via a compatibility shim.
 - **Delegation Clustering** — TF-IDF + KMeans on recurring `general-purpose` invocations surfaces patterns that would benefit from their own specialized subagent. Proposes a complete draft: name, description, recommended model (with cost reasoning), tool list derived from the cluster's trace data, and a prompt-body scaffold. Under `--verbose`, each cluster emits a copy-paste-ready **YAML subagent definition block** (frontmatter + prompt body) that can be saved directly as `~/.claude/agents/<name>.md`. Low-confidence clusters are kept but prefixed with a `REVIEW BEFORE USE` comment so loose groupings don't land in production blindly. Confidence tiers (high/medium/low) are calibrated against real-world cohesion distributions from multi-contributor datasets. Suppresses drafts that overlap existing agents and annotates the overlap. Requires the optional `agentfluent[clustering]` extra.
 - **Model-Routing Diagnostics** — Per-agent-type classification of observed complexity (tool-call counts, token footprint, error rate, write-tool presence) compared against the agent's declared model tier. Flags overspec (complex model on simple workload — cost savings estimate included) and underspec (simple model struggling). Consumes trace-based model inference when frontmatter is absent.
 - **MCP Server Assessment** — Reads configured MCP servers from `~/.claude.json` (user + project-local) and `.mcp.json` (project-shared), honoring per-user enable/disable gating. Compares against observed `mcp__<server>__*` tool usage from both parent sessions and subagent traces. Emits `MCP_UNUSED_SERVER` (INFO, configured but zero calls) and `MCP_MISSING_SERVER` (WARNING, failing calls to an unconfigured server) signals with actionable recommendations.
@@ -394,20 +420,54 @@ Five GitHub Actions workflows run automatically:
 - `--claude-config-dir` flag and `$CLAUDE_CONFIG_DIR` env var for non-default session paths ([#90](https://github.com/frederick-douglas-pearce/agentfluent/issues/90)).
 - Empirical threshold calibration via a committed Jupyter notebook ([#140](https://github.com/frederick-douglas-pearce/agentfluent/issues/140)).
 
-**v0.4+:**
-- Parent-thread offload analysis ([#189](https://github.com/frederick-douglas-pearce/agentfluent/issues/189)) — detect repeating tool-use patterns in the parent Claude Code thread and recommend subagent / skill candidates that move that work onto cheaper-tier models. The dominant cost lever for users who deploy agents at scale.
-- In-product glossary ([#190](https://github.com/frederick-douglas-pearce/agentfluent/issues/190), [#191](https://github.com/frederick-douglas-pearce/agentfluent/issues/191)) — definitions for token types, tool names, agent types, signal types, severity / confidence levels surfaced via static markdown (Phase 1) and `agentfluent explain <term>` CLI subcommand (Phase 2).
-- Outlier-detection distribution recalibration ([#186](https://github.com/frederick-douglas-pearce/agentfluent/issues/186)) — replace ratio-to-mean outlier signals with distribution-aware detection (z-score / IQR) backed by per-agent distribution analysis.
+**v0.4 (shipped):**
+- In-product glossary — Phase 1 markdown reference + Phase 2 `agentfluent explain <term>` CLI subcommand ([#190](https://github.com/frederick-douglas-pearce/agentfluent/issues/190), [#191](https://github.com/frederick-douglas-pearce/agentfluent/issues/191)). Defines every term that appears in CLI output.
+- Wait-time exclusion from duration metrics ([#230](https://github.com/frederick-douglas-pearce/agentfluent/issues/230)) — subtract idle gaps so duration-based outlier detection doesn't false-positive on user-input wait time.
+- IQR-based outlier detection ([#186](https://github.com/frederick-douglas-pearce/agentfluent/issues/186), [#187](https://github.com/frederick-douglas-pearce/agentfluent/issues/187)) — replace naive mean-ratio with distribution-aware Q3+1.5·IQR, with `--verbose` distribution context.
+- Bounded `is_error` regex fallback ([#238](https://github.com/frederick-douglas-pearce/agentfluent/issues/238)) — leading-window match on subagent trace results to suppress mid-text false positives.
+- `PERMISSION_FAILURE` false-positive filter ([#231](https://github.com/frederick-douglas-pearce/agentfluent/issues/231)) — drops signals from hook-induced denials that don't reflect agent misbehavior.
+- `--diagnostics` defaults on, `--json` shortcut, parse warnings to stderr ([#202](https://github.com/frederick-douglas-pearce/agentfluent/issues/202), [#196](https://github.com/frederick-douglas-pearce/agentfluent/issues/196), [#206](https://github.com/frederick-douglas-pearce/agentfluent/issues/206)).
+- Cost surfacing on `by_agent_type` ([#200](https://github.com/frederick-douglas-pearce/agentfluent/issues/200)) — `total_cost_usd` + `avg_cost_per_invocation_usd` per agent.
+
+**v0.5 (shipped — "Trustworthy Diagnostics"):**
+
+The release theme: make diagnostic signals reliable enough that a user who doesn't know the internals can act on them without second-guessing.
+
+- `agentfluent diff` ([#199](https://github.com/frederick-douglas-pearce/agentfluent/issues/199)) — comparison workflow with `--fail-on` for CI gates. The feature that makes AgentFluent habit-forming: re-run, diff, and a regression-check exit code lands the same way a test runner does.
+- Priority ranking + Top-N priority fixes summary ([#172](https://github.com/frederick-douglas-pearce/agentfluent/issues/172)) — composite `priority_score` across severity, count, cost impact, and trace evidence; sorts the Recommendations table and powers the priority-fixes summary block.
+- Parent-thread offload candidates ([#189](https://github.com/frederick-douglas-pearce/agentfluent/issues/189), [#256](https://github.com/frederick-douglas-pearce/agentfluent/issues/256)–[#260](https://github.com/frederick-douglas-pearce/agentfluent/issues/260)) — detect repeating parent-thread tool-bursts and propose subagent / skill drafts that move work onto cheaper-tier models. Dominant cost lever for users running agents at scale, calibrated against real burst distributions.
+- `--min-severity` filter ([#205](https://github.com/frederick-douglas-pearce/agentfluent/issues/205)) — drop recommendations below `info` / `warning` / `critical` without affecting signals.
+- `delegation_suggestions_skipped_reason` JSON field ([#215](https://github.com/frederick-douglas-pearce/agentfluent/issues/215)) — names *why* `delegation_suggestions` is empty (`sklearn_not_installed` / `insufficient_invocations` / `no_clusters_above_min_size`) so JSON consumers can distinguish "feature unavailable" from "ran but found nothing".
+- Cost by Model includes subagent tokens, JSON schema v2 ([#227](https://github.com/frederick-douglas-pearce/agentfluent/issues/227)) — `by_model` becomes a list with an `origin` field per row, top-line `total_cost` is now comprehensive (parent + subagent), `agentfluent diff` reads both v1 and v2 envelopes via a compat shim.
+- MCP `is_error` leading-window FP fix ([#241](https://github.com/frederick-douglas-pearce/agentfluent/issues/241)) — ports the #238 bound to MCP tool results, eliminating ~86% / ~63% false-positive rates measured against real GitHub-MCP-heavy projects.
+- Outlier-detection recalibration + extractor consolidation ([#186](https://github.com/frederick-douglas-pearce/agentfluent/issues/186), [#235](https://github.com/frederick-douglas-pearce/agentfluent/issues/235)).
+- Delegation-draft tools list frequency filter ([#184](https://github.com/frederick-douglas-pearce/agentfluent/issues/184)) — least-privilege tool inclusion so generated drafts don't request the union of every member's tools.
+- Unified complexity classifier across model_routing and delegation ([#185](https://github.com/frederick-douglas-pearce/agentfluent/issues/185)).
+
+**v0.6 (planned — "Quality Axis: Tier 1"):**
+
+The next theme adds a third diagnostics axis alongside cost and speed: **quality**. Review-style subagents (architect, tester, security-review, code-reviewer) are systematically under-recommended today because their primary value is *independent context and quality improvement*, not token offload or wallclock savings — the existing recommendation engine can't see that benefit. v0.6 closes the gap. See PRD: [`.claude/specs/prd-quality-axis.md`](.claude/specs/prd-quality-axis.md). Tier-1 epic + stories at [#268](https://github.com/frederick-douglas-pearce/agentfluent/issues/268), with decisions D015–D022 in [`.claude/specs/decisions.md`](.claude/specs/decisions.md).
+
+- Tier-1 quality signals (no new data sources):
+  - User mid-flight corrections ([#269](https://github.com/frederick-douglas-pearce/agentfluent/issues/269)) — frequency of "no, do X instead" / "wait" / "actually" patterns as a parent-quality miss-rate proxy.
+  - File rework density ([#270](https://github.com/frederick-douglas-pearce/agentfluent/issues/270)) — same file edited N+ times within a session as a missing-pre-implementation-review signal.
+  - "Reviewer caught" rate ([#271](https://github.com/frederick-douglas-pearce/agentfluent/issues/271)) — when architect / security-review / tester subagents *do* run, measure substantive findings and whether the parent acted on them.
+- Multi-axis priority scoring ([#272](https://github.com/frederick-douglas-pearce/agentfluent/issues/272)) — annotations approach per D017 + D021: extend the existing `priority_score` formula with a `quality_evidence_factor * W_QUALITY` term, expose per-axis `axis_scores: {cost, speed, quality}` and `primary_axis` as post-hoc annotations. Schema-additive, preserves `diff` comparison semantics.
+- Single-axis signal classification ([D022](.claude/specs/decisions.md)) — every `SignalType` maps to exactly one axis (no cross-cutting), with the mapping pinned as a module-level `SIGNAL_AXIS_MAP` constant.
+- CLI/JSON axis attribution ([#273](https://github.com/frederick-douglas-pearce/agentfluent/issues/273)) — recommendations name *which axis* triggered them (`[quality] 7 user corrections in 3 sessions — consider an architect agent for design review`).
+- Calibration sweep ([#274](https://github.com/frederick-douglas-pearce/agentfluent/issues/274)) — modeled on #260's pattern; tunes thresholds against real data before shipping. The calibration story gates between "implemented" and "shipped" for the v0.6 release.
+- Tier-2 stretch ([#275](https://github.com/frederick-douglas-pearce/agentfluent/issues/275)) — local-git correlation (feat→fix proximity, revert rate, file re-touch decay). Pulled in if Tier 1 lands cleanly; otherwise deferred to v0.7.
+
+**Future:**
+- Quality-axis Tier 3 — opt-in GitHub enrichment: PR review comment density and topic clustering on Claude-authored PRs, CI-failure-on-first-push rate, post-merge issue references.
 - Time-series pricing data structure ([#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80)) + session-timestamp-aware cost calculation ([#81](https://github.com/frederick-douglas-pearce/agentfluent/issues/81)) + automated pricing updates ([#82](https://github.com/frederick-douglas-pearce/agentfluent/issues/82)).
 - Agent SDK main-session MCP + tool extraction ([#112](https://github.com/frederick-douglas-pearce/agentfluent/issues/112)).
 - Per-invocation token input/output split for more accurate cost estimates ([#143](https://github.com/frederick-douglas-pearce/agentfluent/issues/143)).
 - Hosted documentation site ([#97](https://github.com/frederick-douglas-pearce/agentfluent/issues/97)).
 - Hook coverage in the config rubric.
-
-**Future:**
-- Webapp dashboard for trend visualization
-- Closed-loop self-improvement — use AgentFluent's diagnostic output as a feedback signal the agent itself consumes to propose config edits against its own past sessions
-- Agent ROI reporting — roll up cost, usage, and task-completion signals over time so a business can evaluate whether an optimized agent is worth continuing to run
+- Webapp dashboard for trend visualization.
+- Closed-loop self-improvement — use AgentFluent's diagnostic output as a feedback signal the agent itself consumes to propose config edits against its own past sessions.
+- Agent ROI reporting — roll up cost, usage, and task-completion signals over time so a business can evaluate whether an optimized agent is worth continuing to run.
 
 Browse [open issues](https://github.com/frederick-douglas-pearce/agentfluent/issues) for the full backlog.
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -730,6 +730,191 @@ costs *more*); the recommendation is purely about output quality.
 
 ---
 
+## Diagnostics output fields
+
+### `priority_score`
+
+**Short:** Composite ranking score on each `aggregated_recommendation`.
+Higher = act on this first.
+
+**Detail:** Combines four signals: severity rank, log-scaled occurrence count,
+estimated cost impact (for `target='model'` mismatches that carry
+a dollar savings figure), and a trace-evidence boost when the
+recommendation is grounded in subagent trace data instead of
+just metadata. The formula and weights are tunable, calibrated
+in `scripts/calibration/threshold_validation.ipynb`.
+
+The Recommendations table is sorted by `priority_score` descending,
+and a Top-N priority-fixes summary surfaces above the table so the
+highest-leverage changes are the first thing the reader sees. Use
+`--top-n N` to control summary depth, or `--top-n 0` to disable.
+
+Exposed on every row in `aggregated_recommendations[].priority_score`.
+`agentfluent diff` reports `priority_score_delta` on persisting rows
+so you can detect *quiet regression* — a finding that didn't change
+severity or occurrence count but climbed in priority because its
+cost contribution rose.
+
+**Example:**
+
+```
+Top-N priority fixes:
+  1. [critical] pm: tool_error_sequence (priority 23.4) — ...
+  2. [warning]  general-purpose: model_mismatch (priority 18.7) — ...
+```
+
+**Threshold:** tunable; severity * 4 + log1p(count) * 2 + savings_usd / 5 + trace_boost
+
+### `offload_candidate`
+
+**Short:** A cluster of repeating tool-use patterns in the parent thread that
+could be moved to a cheaper subagent or skill.
+
+**Detail:** Surfaced by the parent-thread offload pipeline (#189). Detects
+bursts of similar tool-call sequences in the main Claude Code
+thread, clusters them by tool-use shape and prompt similarity,
+estimates the cost saved by routing the cluster through a
+Haiku- or Sonnet-tier subagent instead of Opus, and proposes a
+draft definition. Two draft kinds emit: a `subagent_draft` for
+delegation patterns and a `skill_draft` for repeated invocation
+patterns that map cleanly to a slash command.
+
+The Offload Candidates CLI section ranks clusters by estimated
+monthly savings. JSON consumers read
+`data.diagnostics.offload_candidates`. Calibrated against
+real-world burst distributions; see
+`scripts/calibration/threshold_validation.ipynb`.
+
+Empty when scikit-learn isn't installed (the `agentfluent[clustering]`
+extra is required) or when no cluster cleared the minimum size.
+
+**Example:**
+
+```
+Offload Candidates (potential savings: $42/mo):
+  1. PR review (8 occurrences) → propose pr-review subagent (Haiku)
+```
+
+### `delegation_suggestions_skipped_reason`
+
+**Short:** Names *why* `delegation_suggestions` is empty in JSON output.
+
+**Detail:** `null` when suggestions are present. Otherwise one of:
+
+- `sklearn_not_installed` — the `agentfluent[clustering]` extra
+  is not installed; the clustering pipeline was skipped entirely.
+- `insufficient_invocations` — sklearn is available but the count
+  of clusterable general-purpose invocations is below
+  `--min-cluster-size` (default 5).
+- `no_clusters_above_min_size` — clustering ran but produced no
+  drafts. Either no cluster met the size threshold, or every
+  draft was deduped against an existing agent config (cosine
+  similarity above `--min-similarity`).
+
+Lets JSON consumers distinguish "feature unavailable" from "ran
+but found nothing" without inspecting the install or counting
+invocations themselves.
+
+**Example:**
+
+```
+{"delegation_suggestions": [], "delegation_suggestions_skipped_reason": "insufficient_invocations"}
+```
+
+### `origin`
+
+**Short:** On a `by_model` cost row, distinguishes parent-thread vs subagent
+contributions: `"parent"` or `"subagent"`.
+
+**Detail:** Added in JSON schema v2 (#227). The Cost by Model breakdown is now
+a list of rows where each row carries an `origin` field. A model
+used by both the parent thread and a delegated subagent shows two
+rows — one per origin — instead of being aggregated into one.
+`total_cost` and `total_tokens` at the top level are comprehensive
+(parent + subagent), reflecting the true API spend for the
+session.
+
+`agentfluent diff` reads both v1 (legacy dict) and v2 (current
+list) envelopes via a compatibility shim. Legacy v1 rows
+normalize as `origin="parent"` so saved baselines remain diffable.
+
+**Example:**
+
+```
+[
+  {"model": "claude-opus-4-7", "origin": "parent",   "cost": 30.68},
+  {"model": "claude-opus-4-7", "origin": "subagent", "cost":  1.50},
+  {"model": "claude-opus-4-6", "origin": "subagent", "cost":  8.93}
+]
+```
+
+
+---
+
+## Comparison row status
+
+### `new`
+
+**Short:** A recommendation present in the current run but not the baseline.
+
+**Detail:** `agentfluent diff` keys recommendations by
+`(agent_type, target, frozenset(signal_types))`. A row is
+classified `new` when that key appears in the current envelope
+but not the baseline. `--fail-on {info|warning|critical}` gates
+exit code 3 on any `new` row at or above the chosen severity, so
+a CI check can fail on regression without needing per-row
+bookkeeping.
+
+Only `new` rows count against `--fail-on` in v0.5; persisting-row
+`priority_score` increases are deferred to v0.6's
+`--fail-on priority-regression` mode.
+
+**Example:**
+
+```
+Recommendations diff: 2 new, 1 resolved, 5 persisting
+[new] critical pm: stuck_pattern — ...
+```
+
+### `resolved`
+
+**Short:** A recommendation present in the baseline but not the current run —
+a fix landed.
+
+**Detail:** Same keying as `new` (the `(agent_type, target, signal_types)`
+tuple). A row is `resolved` when the baseline emitted it but the
+current run no longer does. Surfaces wins from prompt edits,
+tool-allowlist tightenings, and model swaps. Does not count
+against `--fail-on`.
+
+**Example:**
+
+```
+[resolved] warning architect: model_mismatch — already fixed
+```
+
+### `persisting`
+
+**Short:** A recommendation present in both runs. Carries `count_delta` and
+`priority_score_delta` so a CI consumer can detect quiet movement.
+
+**Detail:** Persisting rows surface count drift (the same finding firing more
+or fewer times than baseline) and priority drift (the
+`priority_score` climbed because cost impact rose, even though
+severity and count stayed the same). The deltas are exposed on
+each persisting row as `count_delta` and `priority_score_delta`
+so a downstream gate can flag *quiet regression* — a finding
+that's getting worse without crossing a discrete threshold.
+
+**Example:**
+
+```
+[persisting] warning pm: tool_error_sequence (count_delta=+2, priority_score_delta=+4.1)
+```
+
+
+---
+
 ## Built-in agent types
 
 ### `general-purpose`

--- a/src/agentfluent/glossary/models.py
+++ b/src/agentfluent/glossary/models.py
@@ -20,6 +20,8 @@ GlossaryCategory = Literal[
     "agent_concern",
     "cluster_metric",
     "model_routing",
+    "diagnostics_field",
+    "diff_status",
     "builtin_agent_type",
     "builtin_tool",
 ]
@@ -35,6 +37,8 @@ GLOSSARY_CATEGORIES: tuple[tuple[GlossaryCategory, str], ...] = (
     ("agent_concern", "Built-in agent concern"),
     ("cluster_metric", "Cluster metrics"),
     ("model_routing", "Model routing"),
+    ("diagnostics_field", "Diagnostics output fields"),
+    ("diff_status", "Comparison row status"),
     ("builtin_agent_type", "Built-in agent types"),
     ("builtin_tool", "Built-in tools"),
 )

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -686,3 +686,164 @@
     with underscore. The first `__` after the `mcp__` prefix is the
     server/tool boundary. Not a closed enum -- MCP servers contribute
     additional namespaced tools at runtime.
+
+# =============================================================================
+# Diagnostics output fields
+# =============================================================================
+
+- name: priority_score
+  category: diagnostics_field
+  short: |
+    Composite ranking score on each `aggregated_recommendation`.
+    Higher = act on this first.
+  long: |
+    Combines four signals: severity rank, log-scaled occurrence count,
+    estimated cost impact (for `target='model'` mismatches that carry
+    a dollar savings figure), and a trace-evidence boost when the
+    recommendation is grounded in subagent trace data instead of
+    just metadata. The formula and weights are tunable, calibrated
+    in `scripts/calibration/threshold_validation.ipynb`.
+
+    The Recommendations table is sorted by `priority_score` descending,
+    and a Top-N priority-fixes summary surfaces above the table so the
+    highest-leverage changes are the first thing the reader sees. Use
+    `--top-n N` to control summary depth, or `--top-n 0` to disable.
+
+    Exposed on every row in `aggregated_recommendations[].priority_score`.
+    `agentfluent diff` reports `priority_score_delta` on persisting rows
+    so you can detect *quiet regression* — a finding that didn't change
+    severity or occurrence count but climbed in priority because its
+    cost contribution rose.
+  example: |
+    Top-N priority fixes:
+      1. [critical] pm: tool_error_sequence (priority 23.4) — ...
+      2. [warning]  general-purpose: model_mismatch (priority 18.7) — ...
+  threshold: tunable; severity * 4 + log1p(count) * 2 + savings_usd / 5 + trace_boost
+
+- name: offload_candidate
+  category: diagnostics_field
+  short: |
+    A cluster of repeating tool-use patterns in the parent thread that
+    could be moved to a cheaper subagent or skill.
+  long: |
+    Surfaced by the parent-thread offload pipeline (#189). Detects
+    bursts of similar tool-call sequences in the main Claude Code
+    thread, clusters them by tool-use shape and prompt similarity,
+    estimates the cost saved by routing the cluster through a
+    Haiku- or Sonnet-tier subagent instead of Opus, and proposes a
+    draft definition. Two draft kinds emit: a `subagent_draft` for
+    delegation patterns and a `skill_draft` for repeated invocation
+    patterns that map cleanly to a slash command.
+
+    The Offload Candidates CLI section ranks clusters by estimated
+    monthly savings. JSON consumers read
+    `data.diagnostics.offload_candidates`. Calibrated against
+    real-world burst distributions; see
+    `scripts/calibration/threshold_validation.ipynb`.
+
+    Empty when scikit-learn isn't installed (the `agentfluent[clustering]`
+    extra is required) or when no cluster cleared the minimum size.
+  example: |
+    Offload Candidates (potential savings: $42/mo):
+      1. PR review (8 occurrences) → propose pr-review subagent (Haiku)
+
+- name: delegation_suggestions_skipped_reason
+  category: diagnostics_field
+  short: |
+    Names *why* `delegation_suggestions` is empty in JSON output.
+  long: |
+    `null` when suggestions are present. Otherwise one of:
+
+    - `sklearn_not_installed` — the `agentfluent[clustering]` extra
+      is not installed; the clustering pipeline was skipped entirely.
+    - `insufficient_invocations` — sklearn is available but the count
+      of clusterable general-purpose invocations is below
+      `--min-cluster-size` (default 5).
+    - `no_clusters_above_min_size` — clustering ran but produced no
+      drafts. Either no cluster met the size threshold, or every
+      draft was deduped against an existing agent config (cosine
+      similarity above `--min-similarity`).
+
+    Lets JSON consumers distinguish "feature unavailable" from "ran
+    but found nothing" without inspecting the install or counting
+    invocations themselves.
+  example: |
+    {"delegation_suggestions": [], "delegation_suggestions_skipped_reason": "insufficient_invocations"}
+
+- name: origin
+  category: diagnostics_field
+  short: |
+    On a `by_model` cost row, distinguishes parent-thread vs subagent
+    contributions: `"parent"` or `"subagent"`.
+  long: |
+    Added in JSON schema v2 (#227). The Cost by Model breakdown is now
+    a list of rows where each row carries an `origin` field. A model
+    used by both the parent thread and a delegated subagent shows two
+    rows — one per origin — instead of being aggregated into one.
+    `total_cost` and `total_tokens` at the top level are comprehensive
+    (parent + subagent), reflecting the true API spend for the
+    session.
+
+    `agentfluent diff` reads both v1 (legacy dict) and v2 (current
+    list) envelopes via a compatibility shim. Legacy v1 rows
+    normalize as `origin="parent"` so saved baselines remain diffable.
+  example: |
+    [
+      {"model": "claude-opus-4-7", "origin": "parent",   "cost": 30.68},
+      {"model": "claude-opus-4-7", "origin": "subagent", "cost":  1.50},
+      {"model": "claude-opus-4-6", "origin": "subagent", "cost":  8.93}
+    ]
+
+# =============================================================================
+# Comparison row status (agentfluent diff)
+# =============================================================================
+
+- name: new
+  category: diff_status
+  short: |
+    A recommendation present in the current run but not the baseline.
+  long: |
+    `agentfluent diff` keys recommendations by
+    `(agent_type, target, frozenset(signal_types))`. A row is
+    classified `new` when that key appears in the current envelope
+    but not the baseline. `--fail-on {info|warning|critical}` gates
+    exit code 3 on any `new` row at or above the chosen severity, so
+    a CI check can fail on regression without needing per-row
+    bookkeeping.
+
+    Only `new` rows count against `--fail-on` in v0.5; persisting-row
+    `priority_score` increases are deferred to v0.6's
+    `--fail-on priority-regression` mode.
+  example: |
+    Recommendations diff: 2 new, 1 resolved, 5 persisting
+    [new] critical pm: stuck_pattern — ...
+
+- name: resolved
+  category: diff_status
+  short: |
+    A recommendation present in the baseline but not the current run —
+    a fix landed.
+  long: |
+    Same keying as `new` (the `(agent_type, target, signal_types)`
+    tuple). A row is `resolved` when the baseline emitted it but the
+    current run no longer does. Surfaces wins from prompt edits,
+    tool-allowlist tightenings, and model swaps. Does not count
+    against `--fail-on`.
+  example: |
+    [resolved] warning architect: model_mismatch — already fixed
+
+- name: persisting
+  category: diff_status
+  short: |
+    A recommendation present in both runs. Carries `count_delta` and
+    `priority_score_delta` so a CI consumer can detect quiet movement.
+  long: |
+    Persisting rows surface count drift (the same finding firing more
+    or fewer times than baseline) and priority drift (the
+    `priority_score` climbed because cost impact rose, even though
+    severity and count stayed the same). The deltas are exposed on
+    each persisting row as `count_delta` and `priority_score_delta`
+    so a downstream gate can flag *quiet regression* — a finding
+    that's getting worse without crossing a discrete threshold.
+  example: |
+    [persisting] warning pm: tool_error_sequence (count_delta=+2, priority_score_delta=+4.1)

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Closes #280. Catches the documentation up to v0.5 shipped features and prepares v0.6's quality-axis roadmap entry. Screenshots regenerate in a follow-up PR (#282).

### README.md
- **Roadmap restructured.** v0.4 (shipped), v0.5 (shipped — "Trustworthy Diagnostics"), v0.6 (planned — "Quality Axis: Tier 1"), Future. The v0.6 section spells out the new third diagnostics axis, the 5 Tier-1 stories under #268, multi-axis scoring per D017+D021 (annotations approach), and single-axis classification per D022. Future picks up Tier 3 GitHub enrichment alongside the existing webapp / closed-loop / ROI items.
- **JSON envelope example** bumped to schema v2. `by_model` is now a list of `{model, origin, ...}` rows; top-line `total_cost` / `total_tokens` are comprehensive. Added a paragraph on the v1→v2 transition and the `agentfluent diff` compat shim.
- **Configuration table** adds `--top-n`, `--min-severity`, `--fail-on`.
- **`agentfluent analyze` section** calls out the Top-N priority fixes summary, Offload Candidates section, and Cost by Model parent/subagent origin breakout.
- **Features list** adds: Comprehensive Cost Attribution, Priority Ranking, Offload Candidates, Comparison Workflow.

### docs/GLOSSARY.md (regenerated from `terms.yaml`)
- **Two new categories:** `diagnostics_field`, `diff_status`.
- **7 new entries:**
  - Diagnostics output fields: `priority_score`, `offload_candidate`, `delegation_suggestions_skipped_reason`, `origin`
  - Comparison row status: `new`, `resolved`, `persisting`
- Smoke-tested via `agentfluent explain priority_score` / `origin` / `new` — all three render correctly.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1012 passed (was 1003 before this branch)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] GLOSSARY drift test passes (`tests/unit/test_glossary_drift.py`) — confirms `docs/GLOSSARY.md` matches `terms.yaml`
- [x] `agentfluent explain` smoke test on three new terms

## Security review
- [x] **Skip review** — documentation only; no code path changes that affect security surfaces.
- [ ] Needs review

## Breaking changes
None. Documentation only.

## Sequencing
v0.5.1 is gated on this PR + #282 (screenshot regeneration follow-up). Both must merge before the v0.5.1 release-please PR is approved for the deferred PyPI publish.