### PR TITLE
feat(diagnostics): user-correction quality signal + quality_signals module (#269)

### DIFF
--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -27,7 +27,7 @@ GENERAL_PURPOSE_AGENT_TYPE = "general-purpose"
 # complexity — presence of any of these signals a write workload that
 # typically needs a higher-tier model or different routing.
 WRITE_TOOLS: frozenset[str] = frozenset(
-    {"Write", "Edit", "Bash", "NotebookEdit"},
+    {"Write", "Edit", "MultiEdit", "Bash", "NotebookEdit"},
 )
 
 

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -46,10 +46,40 @@ from agentfluent.diagnostics.model_routing import SAVINGS_USD_KEY
 from agentfluent.diagnostics.models import (
     TRACE_SIGNAL_TYPES,
     AggregatedRecommendation,
+    Axis,
     DiagnosticRecommendation,
     DiagnosticSignal,
     SignalType,
 )
+
+# Single-axis classification per D022. Every ``SignalType`` maps to
+# exactly one ``Axis``; cross-cutting reduced-weight contributions were
+# rejected for Tier 1. ``ERROR_PATTERN``, ``PERMISSION_FAILURE``, and
+# ``MCP_MISSING_SERVER`` land on ``SPEED`` as the closest existing axis
+# for operational-health signals.
+#
+# Defined here (rather than alongside ``SignalType`` in ``models.py``)
+# because aggregation is the natural consumer — ``axis_scores`` and
+# ``primary_axis`` annotations on ``AggregatedRecommendation`` will be
+# computed by reading this map (#272). Defined-but-not-yet-consumed in
+# v0.6 #269; the drift-prevention test in
+# ``tests/unit/test_recommendation_aggregation.py`` ensures any new
+# ``SignalType`` lacking an entry fails CI.
+SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
+    SignalType.TOKEN_OUTLIER: Axis.COST,
+    SignalType.MODEL_MISMATCH: Axis.COST,
+    SignalType.MCP_UNUSED_SERVER: Axis.COST,
+    SignalType.DURATION_OUTLIER: Axis.SPEED,
+    SignalType.RETRY_LOOP: Axis.SPEED,
+    SignalType.STUCK_PATTERN: Axis.SPEED,
+    SignalType.TOOL_ERROR_SEQUENCE: Axis.SPEED,
+    SignalType.ERROR_PATTERN: Axis.SPEED,
+    SignalType.PERMISSION_FAILURE: Axis.SPEED,
+    SignalType.MCP_MISSING_SERVER: Axis.SPEED,
+    SignalType.USER_CORRECTION: Axis.QUALITY,
+    SignalType.FILE_REWORK: Axis.QUALITY,
+    SignalType.REVIEWER_CAUGHT: Axis.QUALITY,
+}
 
 # Signal types that carry comparable scalar metrics in ``detail``. Only
 # these produce a ``metric_range`` on the aggregated row.

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -602,6 +602,50 @@ class McpAuditRule:
         )
 
 
+class UserCorrectionRule:
+    """USER_CORRECTION -> recommend a review-style subagent.
+
+    Cross-cutting (``agent_type=None`` per ``quality_signals``), so this
+    rule does not branch on built-in vs custom agents — there is no
+    specific agent config to look up. Pattern follows ``McpAuditRule``,
+    which is also a cross-cutting rule with no ``_builtin_target`` /
+    ``_builtin_concern`` attributes.
+
+    The ``[quality]`` prefix on ``message`` is a transitional measure
+    until #273 renders axis labels from ``primary_axis`` via the
+    formatter; #273's AC includes removing this hardcoded prefix once
+    the formatter handles axis attribution uniformly.
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.USER_CORRECTION
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        reason = (
+            "Mid-flight corrections are evidence the parent would benefit "
+            "from independent review before acting."
+        )
+        action = (
+            "Consider delegating to a review-style subagent (architect, "
+            "code-reviewer) for design checks before implementation."
+        )
+        return DiagnosticRecommendation(
+            target="subagent",
+            severity=signal.severity,
+            message=f"[quality] {observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file="",
+            signal_types=[signal.signal_type],
+        )
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -613,6 +657,7 @@ RULES: list[CorrelationRule] = [
     ErrorSequenceRule(),
     ModelRoutingRule(),
     McpAuditRule(),
+    UserCorrectionRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -17,6 +17,23 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from agentfluent.config.models import Severity
 
 
+class Axis(StrEnum):
+    """Diagnostics axis classification for signals and recommendations.
+
+    Each ``SignalType`` maps to exactly one ``Axis`` via
+    ``aggregation.SIGNAL_AXIS_MAP`` (per D022). The axis labels what
+    dimension of agent improvement a recommendation addresses:
+
+    - ``COST`` — token spend, model selection, MCP server hygiene
+    - ``SPEED`` — duration, retry density, error sequences, operational health
+    - ``QUALITY`` — user corrections, file rework, reviewer-caught findings
+    """
+
+    COST = "cost"
+    SPEED = "speed"
+    QUALITY = "quality"
+
+
 class SignalType(StrEnum):
     """Types of behavior signals detected in agent invocations.
 
@@ -32,6 +49,9 @@ class SignalType(StrEnum):
 
     MCP audit signals (configured-vs-observed MCP server usage):
     - `MCP_UNUSED_SERVER`, `MCP_MISSING_SERVER`
+
+    Quality signals (extracted from parent-thread message patterns):
+    - `USER_CORRECTION`, `FILE_REWORK`, `REVIEWER_CAUGHT`
     """
 
     ERROR_PATTERN = "error_pattern"
@@ -44,6 +64,9 @@ class SignalType(StrEnum):
     MODEL_MISMATCH = "model_mismatch"
     MCP_UNUSED_SERVER = "mcp_unused_server"
     MCP_MISSING_SERVER = "mcp_missing_server"
+    USER_CORRECTION = "user_correction"
+    FILE_REWORK = "file_rework"
+    REVIEWER_CAUGHT = "reviewer_caught"
 
 
 # Signal types emitted by the trace-level extractor. Used by the dedup

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -51,6 +51,7 @@ from agentfluent.diagnostics.models import (
     SignalType,
 )
 from agentfluent.diagnostics.parent_workload import build_offload_candidates
+from agentfluent.diagnostics.quality_signals import extract_quality_signals
 from agentfluent.diagnostics.signals import extract_signals
 from agentfluent.diagnostics.trace_signals import extract_trace_signals
 
@@ -256,6 +257,16 @@ def run_diagnostics(
                     sessions_analyzed=len(invocations) or 1,
                 ),
             )
+
+    # Quality signals (#268). Parent-thread observations — corrections,
+    # rework, reviewer-caught findings — that drive the third diagnostics
+    # axis. Quiet-skip when the caller didn't pass parent_messages so
+    # programmatic consumers without message context don't get a noisy
+    # warning; the CLI always passes parent_messages.
+    if parent_messages is not None:
+        signals.extend(extract_quality_signals(parent_messages, invocations))
+    else:
+        logger.debug("quality signals skipped: parent_messages=None")
 
     correlated_pairs = correlate(signals, configs_by_name)
     recommendations = [rec for _, rec in correlated_pairs]

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -43,6 +43,7 @@ calibration notebook can sweep them without function-body edits.
 from __future__ import annotations
 
 import re
+from enum import StrEnum
 
 from agentfluent.agents.models import WRITE_TOOLS, AgentInvocation
 from agentfluent.config.models import Severity
@@ -51,102 +52,105 @@ from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 
 # Review-style subagents whose presence and findings drive the
 # REVIEWER_CAUGHT signal in #271. Defined here (not in ``agents.models``)
-# because it is quality-axis-specific and may diverge from ``BUILTIN_AGENT_TYPES``
-# as users add custom review agents (e.g. project-specific ``security-review``
-# variants). Custom review-agent names will be a calibration-time addition
-# in #274.
+# because it is quality-axis-specific and may diverge from
+# ``BUILTIN_AGENT_TYPES`` as users add custom review agents (e.g.
+# project-specific ``security-review`` variants). Custom review-agent
+# names will be a calibration-time addition in #274.
 REVIEW_AGENT_TYPES: frozenset[str] = frozenset(
     {"architect", "security-review", "tester", "code-reviewer"},
 )
 
 
+class PrecedingAction(StrEnum):
+    """How the assistant message preceding a user correction is classified.
+
+    Stamped on each ``USER_CORRECTION`` signal's ``detail`` so #274
+    calibration can analyze precision per-tier and so consumers can
+    distinguish corrections-of-action from corrections-of-reasoning.
+    """
+
+    WRITE_TOOL = "write_tool"
+    QUESTION = "question"
+    TEXT_ONLY = "text_only"
+
+
+class CorrectionCategory(StrEnum):
+    """Pattern-tier classification for a detected user correction.
+
+    ``STRONG`` corresponds to ``_STRONG_CORRECTION_PATTERNS``;
+    the soft tiers correspond to the categories in
+    ``_SOFT_PATTERN_CATEGORIES`` and are useful for #274 calibration.
+    """
+
+    STRONG = "strong"
+    NEGATION = "negation"
+    INTERRUPTION = "interruption"
+    REDIRECTION = "redirection"
+    UNDO = "undo"
+
+
+def _ci(*patterns: str) -> tuple[re.Pattern[str], ...]:
+    """Compile a tuple of case-insensitive regex patterns."""
+    return tuple(re.compile(p, re.IGNORECASE) for p in patterns)
+
+
 # Soft-correction pattern categories. These fire only when the primary
 # gate (preceding message has a write tool) is satisfied. Suppressed when
 # the preceding assistant message is question-only.
-_NEGATION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bno,?\s", re.IGNORECASE),
-    re.compile(r"\bno\s+don'?t\b", re.IGNORECASE),
-    re.compile(r"\bthat'?s\s+not\s+what\s+I\b", re.IGNORECASE),
+_NEGATION_PATTERNS = _ci(
+    r"\bno,?\s",
+    r"\bno\s+don'?t\b",
+    r"\bthat'?s\s+not\s+what\s+I\b",
 )
-_INTERRUPTION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bstop\b", re.IGNORECASE),
-    re.compile(r"\bwait\b", re.IGNORECASE),
-    re.compile(r"\bhold\s+on\b", re.IGNORECASE),
+_INTERRUPTION_PATTERNS = _ci(r"\bstop\b", r"\bwait\b", r"\bhold\s+on\b")
+_REDIRECTION_PATTERNS = _ci(
+    r"\bactually,?\s",
+    r"\binstead,?\s",
+    r"\bI\s+meant\b",
+    r"\bwhat\s+I\s+wanted\s+was\b",
 )
-_REDIRECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bactually,?\s", re.IGNORECASE),
-    re.compile(r"\binstead,?\s", re.IGNORECASE),
-    re.compile(r"\bI\s+meant\b", re.IGNORECASE),
-    re.compile(r"\bwhat\s+I\s+wanted\s+was\b", re.IGNORECASE),
-)
-_UNDO_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bgo\s+back\s+to\b", re.IGNORECASE),
-    re.compile(r"\brestore\b", re.IGNORECASE),
-)
+_UNDO_PATTERNS = _ci(r"\bgo\s+back\s+to\b", r"\brestore\b")
 
 # Strong-correction overlay: a strict subset of high-confidence phrases
 # that fire regardless of the preceding-message gate. ``revert`` and
 # ``undo`` are intentionally promoted out of ``_UNDO_PATTERNS`` to live
 # only here so a single regex match can never be claimed by both tiers.
-# ``that's wrong`` and ``that's not what I`` are corrections of the
-# parent's reasoning — they signal the user is overruling the system,
-# not answering a question.
-_STRONG_CORRECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bthat'?s\s+wrong\b", re.IGNORECASE),
-    re.compile(r"\brevert\b", re.IGNORECASE),
-    re.compile(r"\bundo\b", re.IGNORECASE),
-    re.compile(r"\bthat'?s\s+not\s+what\s+I\b", re.IGNORECASE),
+_STRONG_CORRECTION_PATTERNS = _ci(
+    r"\bthat'?s\s+wrong\b",
+    r"\brevert\b",
+    r"\bundo\b",
+    r"\bthat'?s\s+not\s+what\s+I\b",
 )
 
-# Soft-correction overlay: union of the category lists (all soft).
-# Iteration order preserved so the first-match category label is
-# deterministic and useful in ``detail.matched_pattern``.
-_SOFT_PATTERN_CATEGORIES: tuple[tuple[str, tuple[re.Pattern[str], ...]], ...] = (
-    ("negation", _NEGATION_PATTERNS),
-    ("interruption", _INTERRUPTION_PATTERNS),
-    ("redirection", _REDIRECTION_PATTERNS),
-    ("undo", _UNDO_PATTERNS),
+_SOFT_PATTERN_CATEGORIES: tuple[
+    tuple[CorrectionCategory, tuple[re.Pattern[str], ...]], ...
+] = (
+    (CorrectionCategory.NEGATION, _NEGATION_PATTERNS),
+    (CorrectionCategory.INTERRUPTION, _INTERRUPTION_PATTERNS),
+    (CorrectionCategory.REDIRECTION, _REDIRECTION_PATTERNS),
+    (CorrectionCategory.UNDO, _UNDO_PATTERNS),
 )
 
-# Cap on the user-message snippet stamped onto each signal's ``detail``.
-# 140 chars is enough to identify the correction in CLI output without
-# spilling whole prompts into the diagnostics envelope.
 _SNIPPET_MAX_CHARS = 140
 
 
-def _preceding_assistant_action(
-    messages: list[SessionMessage], user_idx: int,
-) -> tuple[bool, bool]:
-    """Classify the assistant message immediately preceding ``messages[user_idx]``.
+def _classify_assistant(message: SessionMessage) -> tuple[bool, bool]:
+    """Return ``(had_write_tool, is_question_only)`` for an assistant message.
 
-    Returns ``(had_write_tool, is_question_only)``:
-
-    - ``had_write_tool`` — True when the preceding assistant message
-      carries any ``tool_use`` block whose ``name`` is in ``WRITE_TOOLS``.
-      Indicates the assistant was actively implementing, so a follow-up
-      correction is structurally a correction-of-action.
-    - ``is_question_only`` — True when the preceding assistant message's
-      text ends with ``?`` AND no write tool was used. Indicates the
-      assistant was asking for clarification, so a "no" answer is not
-      a correction.
-
-    When no preceding assistant message exists (user is the first
-    analytical message), both flags are False — strong-correction
-    patterns can still fire, soft patterns cannot.
+    - ``had_write_tool`` — any ``tool_use`` block whose ``name`` is in
+      ``WRITE_TOOLS``. Indicates the assistant was actively implementing,
+      so a follow-up correction is structurally a correction-of-action.
+    - ``is_question_only`` — text ends with ``?`` AND no write tool.
+      Indicates the assistant was asking for clarification, so a "no"
+      answer is not a correction.
     """
-    for prev_idx in range(user_idx - 1, -1, -1):
-        prev = messages[prev_idx]
-        if prev.type != "assistant":
-            continue
-        had_write_tool = any(
-            block.name in WRITE_TOOLS for block in prev.tool_use_blocks
-        )
-        prev_text = prev.text.rstrip()
-        is_question_only = (
-            not had_write_tool and prev_text.endswith("?")
-        )
-        return had_write_tool, is_question_only
-    return False, False
+    had_write_tool = any(
+        block.name in WRITE_TOOLS for block in message.tool_use_blocks
+    )
+    is_question_only = (
+        not had_write_tool and message.text.rstrip().endswith("?")
+    )
+    return had_write_tool, is_question_only
 
 
 def _match_correction(
@@ -154,25 +158,19 @@ def _match_correction(
     *,
     had_write_tool: bool,
     is_question_only: bool,
-) -> tuple[str, str] | None:
-    """Apply the 3-tier heuristic and return ``(category, matched_phrase)``
-    when the user message is a correction; ``None`` otherwise.
+) -> tuple[CorrectionCategory, str] | None:
+    """Apply the 3-tier heuristic; return ``(category, matched_phrase)`` or ``None``.
 
-    Tier order:
-    1. Strong-correction override — fires unconditionally on hit.
-    2. Primary gate — soft patterns fire when ``had_write_tool``.
-    3. Question suppression — soft patterns suppressed when
-       ``is_question_only`` (already implied by ``not had_write_tool``
-       in this code path; the explicit check is kept for clarity).
-
-    Returns the first matching category and the matched substring so
-    callers can stamp it on the signal's ``detail.matched_pattern`` for
-    calibration analysis in #274.
+    Tier order: strong override → primary gate (write tool) → question
+    suppression. Returns the first matching category and matched
+    substring so callers can stamp it on ``detail`` for #274 calibration.
     """
     for pattern in _STRONG_CORRECTION_PATTERNS:
         if match := pattern.search(user_text):
-            return "strong", match.group(0)
+            return CorrectionCategory.STRONG, match.group(0)
 
+    # Soft patterns require the primary gate (write-tool present) and
+    # are suppressed by the question-only classification.
     if not had_write_tool or is_question_only:
         return None
 
@@ -183,15 +181,10 @@ def _match_correction(
     return None
 
 
-def _user_message_text(message: SessionMessage) -> str:
-    """Concatenated text content from a user message.
-
-    Mirrors ``SessionMessage.text`` but drops to the empty string for
-    messages whose content is purely tool_result blocks (no text). The
-    parent thread carries both kinds — agent tool_result envelopes are
-    not user prose and must not be scanned for correction patterns.
-    """
-    return message.text
+def _build_snippet(text: str) -> str:
+    if len(text) <= _SNIPPET_MAX_CHARS:
+        return text
+    return text[:_SNIPPET_MAX_CHARS].rstrip() + "…"
 
 
 def extract_quality_signals(
@@ -206,78 +199,73 @@ def extract_quality_signals(
     without breaking #270 mid-flight.
 
     Returns an empty list when ``messages`` is empty or contains no
-    user messages. ``agent_type`` is ``None`` on every emitted signal:
+    user prose. ``agent_type`` is ``None`` on every emitted signal:
     these are cross-cutting parent-thread observations, not subagent-
     scoped findings.
     """
-    del agent_invocations  # Reserved for #271 (REVIEWER_CAUGHT)
-
     if not messages:
         return []
 
-    # First pass: collect (user_idx, category, matched_phrase, snippet,
-    # preceding_action) for each detected correction. ``total_user_messages``
-    # is the denominator for ``session_correction_rate`` — counted on
-    # the same pass so we don't traverse twice.
-    detections: list[tuple[int, str, str, str, str]] = []
+    # Single forward pass: as we walk messages we update the most
+    # recently seen assistant's classification, and read it whenever
+    # we encounter user prose. Avoids the O(n²) backward scan that an
+    # earlier draft used.
+    last_assistant: tuple[bool, bool] | None = None
+    detections: list[tuple[CorrectionCategory, str, str, PrecedingAction]] = []
     total_user_messages = 0
 
-    for idx, msg in enumerate(messages):
+    for msg in messages:
+        if msg.type == "assistant":
+            last_assistant = _classify_assistant(msg)
+            continue
         if msg.type != "user":
             continue
-        text = _user_message_text(msg)
+        text = msg.text
         if not text:
             continue
         total_user_messages += 1
 
-        had_write_tool, is_question_only = _preceding_assistant_action(messages, idx)
-        match_result = _match_correction(
+        had_write_tool, is_question_only = last_assistant or (False, False)
+        result = _match_correction(
             text,
             had_write_tool=had_write_tool,
             is_question_only=is_question_only,
         )
-        if match_result is None:
+        if result is None:
             continue
-        category, matched_phrase = match_result
+        category, matched_phrase = result
 
         if had_write_tool:
-            preceding_action = "write_tool"
+            preceding = PrecedingAction.WRITE_TOOL
         elif is_question_only:
-            preceding_action = "question"
+            preceding = PrecedingAction.QUESTION
         else:
-            preceding_action = "text_only"
+            preceding = PrecedingAction.TEXT_ONLY
 
-        snippet = text[:_SNIPPET_MAX_CHARS]
-        if len(text) > _SNIPPET_MAX_CHARS:
-            snippet = snippet.rstrip() + "…"
-
-        detections.append((idx, category, matched_phrase, snippet, preceding_action))
+        detections.append(
+            (category, matched_phrase, _build_snippet(text), preceding),
+        )
 
     if not detections or total_user_messages == 0:
         return []
 
     session_correction_rate = len(detections) / total_user_messages
 
-    # Second pass: construct signals once with the rate already known.
-    # Avoids post-construction mutation of the detail dict.
-    signals: list[DiagnosticSignal] = []
-    for _, category, matched_phrase, snippet, preceding_action in detections:
-        signals.append(
-            DiagnosticSignal(
-                signal_type=SignalType.USER_CORRECTION,
-                severity=Severity.WARNING,
-                agent_type=None,
-                invocation_id=None,
-                message=f"User correction in parent thread: {snippet}",
-                detail={
-                    "correction_text": snippet,
-                    "matched_pattern": matched_phrase,
-                    "matched_category": category,
-                    "preceding_assistant_action": preceding_action,
-                    "session_correction_rate": session_correction_rate,
-                    "total_user_messages": total_user_messages,
-                    "total_corrections": len(detections),
-                },
-            ),
+    return [
+        DiagnosticSignal(
+            signal_type=SignalType.USER_CORRECTION,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message=f"User correction in parent thread: {snippet}",
+            detail={
+                "correction_text": snippet,
+                "matched_pattern": matched_phrase,
+                "matched_category": category.value,
+                "preceding_assistant_action": preceding.value,
+                "session_correction_rate": session_correction_rate,
+                "total_user_messages": total_user_messages,
+            },
         )
-    return signals
+        for category, matched_phrase, snippet, preceding in detections
+    ]

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -1,0 +1,283 @@
+"""Parent-thread quality signal extraction.
+
+Sibling to ``signals.py`` (metadata-level) and ``trace_signals.py``
+(subagent-trace-level). This module mines the parent session's user/
+assistant message stream for behavioral patterns that proxy quality
+misses — moments where a review-style subagent (architect, code-reviewer,
+tester, security-review) would likely have caught an issue before the
+parent committed to it.
+
+Tier 1 quality signals (per the v0.6 quality-axis epic, #268):
+
+- ``USER_CORRECTION`` — the user interrupts or redirects the parent
+  mid-flight ("no, do X instead", "wait, that's wrong", "revert"). High
+  correction frequency in sessions without review subagents is strong
+  evidence the parent would benefit from independent review. Detected
+  here in #269.
+- ``FILE_REWORK`` — same file edited N+ times within a session. Detected
+  in #270.
+- ``REVIEWER_CAUGHT`` — review-style subagents that ran AND produced
+  substantive findings the parent acted on. Detected in #271.
+
+The function signature accepts ``agent_invocations`` from day one so
+#271 can integrate without forcing a mid-flight refactor; #269's
+USER_CORRECTION detection ignores the param (messages-only).
+
+False-positive guardrail (3-tier heuristic) for USER_CORRECTION:
+
+1. **Strong-correction override** — high-confidence phrases (``that's
+   wrong``, ``revert``, ``undo``, ``that's not what I``) fire regardless
+   of the preceding-message classification. These are corrections of the
+   parent's reasoning, not answers to a question.
+2. **Primary gate** — when the preceding assistant message contains a
+   write-style ``tool_use`` (``WRITE_TOOLS``), any pattern hit fires.
+   The user is correcting an action, not answering a question.
+3. **Question suppression** — when the preceding assistant message ends
+   with ``?`` AND has no write tools, soft-correction patterns are
+   suppressed (only strong-correction can fire, already covered by #1).
+
+Pattern lists and tier-membership are module-level constants so #274's
+calibration notebook can sweep them without function-body edits.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agentfluent.agents.models import WRITE_TOOLS, AgentInvocation
+from agentfluent.config.models import Severity
+from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+
+# Review-style subagents whose presence and findings drive the
+# REVIEWER_CAUGHT signal in #271. Defined here (not in ``agents.models``)
+# because it is quality-axis-specific and may diverge from ``BUILTIN_AGENT_TYPES``
+# as users add custom review agents (e.g. project-specific ``security-review``
+# variants). Custom review-agent names will be a calibration-time addition
+# in #274.
+REVIEW_AGENT_TYPES: frozenset[str] = frozenset(
+    {"architect", "security-review", "tester", "code-reviewer"},
+)
+
+
+# Soft-correction pattern categories. These fire only when the primary
+# gate (preceding message has a write tool) is satisfied. Suppressed when
+# the preceding assistant message is question-only.
+_NEGATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bno,?\s", re.IGNORECASE),
+    re.compile(r"\bno\s+don'?t\b", re.IGNORECASE),
+    re.compile(r"\bthat'?s\s+not\s+what\s+I\b", re.IGNORECASE),
+)
+_INTERRUPTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bstop\b", re.IGNORECASE),
+    re.compile(r"\bwait\b", re.IGNORECASE),
+    re.compile(r"\bhold\s+on\b", re.IGNORECASE),
+)
+_REDIRECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bactually,?\s", re.IGNORECASE),
+    re.compile(r"\binstead,?\s", re.IGNORECASE),
+    re.compile(r"\bI\s+meant\b", re.IGNORECASE),
+    re.compile(r"\bwhat\s+I\s+wanted\s+was\b", re.IGNORECASE),
+)
+_UNDO_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bgo\s+back\s+to\b", re.IGNORECASE),
+    re.compile(r"\brestore\b", re.IGNORECASE),
+)
+
+# Strong-correction overlay: a strict subset of high-confidence phrases
+# that fire regardless of the preceding-message gate. ``revert`` and
+# ``undo`` are intentionally promoted out of ``_UNDO_PATTERNS`` to live
+# only here so a single regex match can never be claimed by both tiers.
+# ``that's wrong`` and ``that's not what I`` are corrections of the
+# parent's reasoning — they signal the user is overruling the system,
+# not answering a question.
+_STRONG_CORRECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bthat'?s\s+wrong\b", re.IGNORECASE),
+    re.compile(r"\brevert\b", re.IGNORECASE),
+    re.compile(r"\bundo\b", re.IGNORECASE),
+    re.compile(r"\bthat'?s\s+not\s+what\s+I\b", re.IGNORECASE),
+)
+
+# Soft-correction overlay: union of the category lists (all soft).
+# Iteration order preserved so the first-match category label is
+# deterministic and useful in ``detail.matched_pattern``.
+_SOFT_PATTERN_CATEGORIES: tuple[tuple[str, tuple[re.Pattern[str], ...]], ...] = (
+    ("negation", _NEGATION_PATTERNS),
+    ("interruption", _INTERRUPTION_PATTERNS),
+    ("redirection", _REDIRECTION_PATTERNS),
+    ("undo", _UNDO_PATTERNS),
+)
+
+# Cap on the user-message snippet stamped onto each signal's ``detail``.
+# 140 chars is enough to identify the correction in CLI output without
+# spilling whole prompts into the diagnostics envelope.
+_SNIPPET_MAX_CHARS = 140
+
+
+def _preceding_assistant_action(
+    messages: list[SessionMessage], user_idx: int,
+) -> tuple[bool, bool]:
+    """Classify the assistant message immediately preceding ``messages[user_idx]``.
+
+    Returns ``(had_write_tool, is_question_only)``:
+
+    - ``had_write_tool`` — True when the preceding assistant message
+      carries any ``tool_use`` block whose ``name`` is in ``WRITE_TOOLS``.
+      Indicates the assistant was actively implementing, so a follow-up
+      correction is structurally a correction-of-action.
+    - ``is_question_only`` — True when the preceding assistant message's
+      text ends with ``?`` AND no write tool was used. Indicates the
+      assistant was asking for clarification, so a "no" answer is not
+      a correction.
+
+    When no preceding assistant message exists (user is the first
+    analytical message), both flags are False — strong-correction
+    patterns can still fire, soft patterns cannot.
+    """
+    for prev_idx in range(user_idx - 1, -1, -1):
+        prev = messages[prev_idx]
+        if prev.type != "assistant":
+            continue
+        had_write_tool = any(
+            block.name in WRITE_TOOLS for block in prev.tool_use_blocks
+        )
+        prev_text = prev.text.rstrip()
+        is_question_only = (
+            not had_write_tool and prev_text.endswith("?")
+        )
+        return had_write_tool, is_question_only
+    return False, False
+
+
+def _match_correction(
+    user_text: str,
+    *,
+    had_write_tool: bool,
+    is_question_only: bool,
+) -> tuple[str, str] | None:
+    """Apply the 3-tier heuristic and return ``(category, matched_phrase)``
+    when the user message is a correction; ``None`` otherwise.
+
+    Tier order:
+    1. Strong-correction override — fires unconditionally on hit.
+    2. Primary gate — soft patterns fire when ``had_write_tool``.
+    3. Question suppression — soft patterns suppressed when
+       ``is_question_only`` (already implied by ``not had_write_tool``
+       in this code path; the explicit check is kept for clarity).
+
+    Returns the first matching category and the matched substring so
+    callers can stamp it on the signal's ``detail.matched_pattern`` for
+    calibration analysis in #274.
+    """
+    for pattern in _STRONG_CORRECTION_PATTERNS:
+        if match := pattern.search(user_text):
+            return "strong", match.group(0)
+
+    if not had_write_tool or is_question_only:
+        return None
+
+    for category, patterns in _SOFT_PATTERN_CATEGORIES:
+        for pattern in patterns:
+            if match := pattern.search(user_text):
+                return category, match.group(0)
+    return None
+
+
+def _user_message_text(message: SessionMessage) -> str:
+    """Concatenated text content from a user message.
+
+    Mirrors ``SessionMessage.text`` but drops to the empty string for
+    messages whose content is purely tool_result blocks (no text). The
+    parent thread carries both kinds — agent tool_result envelopes are
+    not user prose and must not be scanned for correction patterns.
+    """
+    return message.text
+
+
+def extract_quality_signals(
+    messages: list[SessionMessage],
+    agent_invocations: list[AgentInvocation] | None = None,
+) -> list[DiagnosticSignal]:
+    """Extract quality-axis signals from parent-thread messages.
+
+    Currently emits ``USER_CORRECTION`` only; ``FILE_REWORK`` (#270) and
+    ``REVIEWER_CAUGHT`` (#271) will land here. ``agent_invocations`` is
+    accepted but unused — locked in this signature so #271 can plug in
+    without breaking #270 mid-flight.
+
+    Returns an empty list when ``messages`` is empty or contains no
+    user messages. ``agent_type`` is ``None`` on every emitted signal:
+    these are cross-cutting parent-thread observations, not subagent-
+    scoped findings.
+    """
+    del agent_invocations  # Reserved for #271 (REVIEWER_CAUGHT)
+
+    if not messages:
+        return []
+
+    # First pass: collect (user_idx, category, matched_phrase, snippet,
+    # preceding_action) for each detected correction. ``total_user_messages``
+    # is the denominator for ``session_correction_rate`` — counted on
+    # the same pass so we don't traverse twice.
+    detections: list[tuple[int, str, str, str, str]] = []
+    total_user_messages = 0
+
+    for idx, msg in enumerate(messages):
+        if msg.type != "user":
+            continue
+        text = _user_message_text(msg)
+        if not text:
+            continue
+        total_user_messages += 1
+
+        had_write_tool, is_question_only = _preceding_assistant_action(messages, idx)
+        match_result = _match_correction(
+            text,
+            had_write_tool=had_write_tool,
+            is_question_only=is_question_only,
+        )
+        if match_result is None:
+            continue
+        category, matched_phrase = match_result
+
+        if had_write_tool:
+            preceding_action = "write_tool"
+        elif is_question_only:
+            preceding_action = "question"
+        else:
+            preceding_action = "text_only"
+
+        snippet = text[:_SNIPPET_MAX_CHARS]
+        if len(text) > _SNIPPET_MAX_CHARS:
+            snippet = snippet.rstrip() + "…"
+
+        detections.append((idx, category, matched_phrase, snippet, preceding_action))
+
+    if not detections or total_user_messages == 0:
+        return []
+
+    session_correction_rate = len(detections) / total_user_messages
+
+    # Second pass: construct signals once with the rate already known.
+    # Avoids post-construction mutation of the detail dict.
+    signals: list[DiagnosticSignal] = []
+    for _, category, matched_phrase, snippet, preceding_action in detections:
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.USER_CORRECTION,
+                severity=Severity.WARNING,
+                agent_type=None,
+                invocation_id=None,
+                message=f"User correction in parent thread: {snippet}",
+                detail={
+                    "correction_text": snippet,
+                    "matched_pattern": matched_phrase,
+                    "matched_category": category,
+                    "preceding_assistant_action": preceding_action,
+                    "session_correction_rate": session_correction_rate,
+                    "total_user_messages": total_user_messages,
+                    "total_corrections": len(detections),
+                },
+            ),
+        )
+    return signals

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -618,3 +618,60 @@ class TestInvocationIdPropagation:
         )
         recs = correlate([sig])
         assert recs and recs[0].invocation_id is None
+
+
+class TestUserCorrectionRule:
+    """USER_CORRECTION (cross-cutting quality signal) -> ``target='subagent'``
+    recommendation suggesting a review-style subagent."""
+
+    @staticmethod
+    def _user_correction_signal() -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.USER_CORRECTION,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message="User correction in parent thread: no, that's wrong",
+            detail={
+                "correction_text": "no, that's wrong",
+                "matched_pattern": "that's wrong",
+                "matched_category": "strong",
+                "preceding_assistant_action": "write_tool",
+                "session_correction_rate": 0.25,
+                "total_user_messages": 4,
+                "total_corrections": 1,
+            },
+        )
+
+    def test_emits_subagent_target(self) -> None:
+        recs = correlate([self._user_correction_signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "subagent"
+        assert rec.severity == Severity.WARNING
+        assert rec.agent_type is None
+        assert rec.invocation_id is None
+        assert rec.signal_types == [SignalType.USER_CORRECTION]
+
+    def test_message_carries_quality_prefix(self) -> None:
+        recs = correlate([self._user_correction_signal()])
+        # Transitional [quality] prefix until #273 renders axis labels
+        # via the formatter (architect review on #269, suggestion #5).
+        assert "[quality]" in recs[0].message
+
+    def test_recommends_review_style_subagent(self) -> None:
+        recs = correlate([self._user_correction_signal()])
+        action = recs[0].action.lower()
+        assert "architect" in action or "code-reviewer" in action
+
+    def test_does_not_match_other_signal_types(self) -> None:
+        # Ensure the rule's matches() doesn't catch unrelated signals.
+        unrelated = DiagnosticSignal(
+            signal_type=SignalType.TOKEN_OUTLIER,
+            severity=Severity.WARNING,
+            agent_type="pm",
+            message="High token usage.",
+            detail={"excess_iqrs": 3.0},
+        )
+        recs = correlate([unrelated])
+        assert all(rec.target != "subagent" for rec in recs)

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -6,6 +6,7 @@ and v0.2 output-shape regression for trace-less sessions.
 """
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ import pytest
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.mcp_discovery import _load_json
 from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.core.session import ContentBlock, SessionMessage
 from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
 from agentfluent.diagnostics.delegation import MODEL_OPUS
 from agentfluent.diagnostics.mcp_assessment import McpToolCall
@@ -666,3 +668,71 @@ class TestMcpAuditWiring:
         ]
         assert len(unused) == 1
         assert unused[0].detail["server_name"] == "unused-svc"
+
+
+class TestQualitySignalsWiring:
+    """``parent_messages`` opts the caller into quality-signal extraction.
+
+    Programmatic callers that don't pass ``parent_messages`` (libraries,
+    tests) silently skip. The CLI always passes it, so the user-visible
+    path always gets quality signals.
+    """
+
+    @staticmethod
+    def _correction_messages() -> list[SessionMessage]:
+        return [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(type="text", text="Editing the file."),
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_w",
+                        name="Edit",
+                        input={"file_path": "/tmp/x.py"},
+                    ),
+                ],
+            ),
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(
+                        type="text",
+                        text="no, that's wrong, undo it",
+                    ),
+                ],
+            ),
+        ]
+
+    def test_parent_messages_provided_emits_quality_signals(self) -> None:
+        result = run_diagnostics(
+            [_inv()], parent_messages=self._correction_messages(),
+        )
+        quality = [
+            s for s in result.signals
+            if s.signal_type == SignalType.USER_CORRECTION
+        ]
+        assert len(quality) == 1
+
+    def test_parent_messages_none_quiet_skips_with_debug_log(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(
+            logging.DEBUG, logger="agentfluent.diagnostics.pipeline",
+        ):
+            result = run_diagnostics([_inv()])
+        assert not any(
+            s.signal_type == SignalType.USER_CORRECTION for s in result.signals
+        )
+        assert any(
+            "quality signals skipped: parent_messages=None" in record.message
+            for record in caplog.records
+        )
+
+    def test_parent_messages_empty_list_skips_extraction(self) -> None:
+        """Empty parent_messages goes through the extractor (which returns
+        ``[]``) without firing the quiet-skip log."""
+        result = run_diagnostics([_inv()], parent_messages=[])
+        assert not any(
+            s.signal_type == SignalType.USER_CORRECTION for s in result.signals
+        )

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -1,0 +1,287 @@
+"""Tests for ``diagnostics.quality_signals``.
+
+Covers USER_CORRECTION detection. The 3-tier false-positive heuristic
+(strong-correction override / write-tool primary gate / question
+suppression) is exercised explicitly so the regressions stay anchored
+even when #274 calibration tunes thresholds.
+"""
+
+from __future__ import annotations
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import Severity
+from agentfluent.core.session import ContentBlock, SessionMessage
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.quality_signals import (
+    REVIEW_AGENT_TYPES,
+    extract_quality_signals,
+)
+
+
+def _user(text: str) -> SessionMessage:
+    return SessionMessage(
+        type="user",
+        content_blocks=[ContentBlock(type="text", text=text)],
+    )
+
+
+def _assistant_text(text: str) -> SessionMessage:
+    return SessionMessage(
+        type="assistant",
+        content_blocks=[ContentBlock(type="text", text=text)],
+    )
+
+
+def _assistant_with_write_tool(
+    text: str = "Editing the file now.", tool_name: str = "Edit",
+) -> SessionMessage:
+    return SessionMessage(
+        type="assistant",
+        content_blocks=[
+            ContentBlock(type="text", text=text),
+            ContentBlock(
+                type="tool_use",
+                id="toolu_w",
+                name=tool_name,
+                input={"file_path": "/tmp/x.py"},
+            ),
+        ],
+    )
+
+
+def _assistant_question(text: str) -> SessionMessage:
+    """Assistant message ending with '?' and no tool_use blocks."""
+    return _assistant_text(text)
+
+
+class TestUserCorrectionDetection:
+    def test_three_corrections_in_ten_user_messages_emits_three_signals(self) -> None:
+        """AC fixture: 3 corrections in 10 user messages -> 3 signals."""
+        messages: list[SessionMessage] = []
+        # 7 non-correction user messages (preceded by a non-write assistant
+        # text) interleaved with 3 corrections (preceded by write tools).
+        for i in range(7):
+            messages.append(_assistant_text(f"Step {i} complete."))
+            messages.append(_user(f"continue with step {i + 1}"))
+        for i in range(3):
+            messages.append(_assistant_with_write_tool(f"Edited file {i}"))
+            messages.append(_user(f"no, do something different ({i})"))
+
+        signals = extract_quality_signals(messages)
+
+        assert len(signals) == 3
+        assert all(s.signal_type == SignalType.USER_CORRECTION for s in signals)
+        # session_correction_rate stamped on every signal: 3 / 10 = 0.3
+        rate = signals[0].detail["session_correction_rate"]
+        assert isinstance(rate, float)
+        assert rate == 0.3
+        for s in signals:
+            assert s.detail["total_corrections"] == 3
+            assert s.detail["total_user_messages"] == 10
+
+    def test_zero_corrections_returns_empty(self) -> None:
+        """AC fixture: session with 0 corrections does not fire."""
+        messages = [
+            _assistant_text("Step one done."),
+            _user("looks good, please continue"),
+            _assistant_text("Step two done."),
+            _user("great, keep going"),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_no_answer_to_question_does_not_fire(self) -> None:
+        """AC fixture: 'no' as an answer to a question is not a correction."""
+        messages = [
+            _assistant_question("Should I keep going with approach A?"),
+            _user("no, let's stop here for now"),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_strong_correction_fires_after_question(self) -> None:
+        """Strong-correction patterns override question suppression.
+
+        Even when the preceding assistant message is question-only, a
+        strong phrase like 'that's wrong' is the user overruling the
+        system, not answering the question.
+        """
+        messages = [
+            _assistant_question("Did you want me to delete the file?"),
+            _user("that's wrong, we agreed not to delete anything"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "strong"
+        assert signals[0].detail["preceding_assistant_action"] == "question"
+
+    def test_revert_fires_regardless_of_preceding(self) -> None:
+        """``revert`` is a strong-correction phrase. Even after a plain
+        text assistant message (no write tool, not a question), it fires."""
+        messages = [
+            _assistant_text("Here is the plan we discussed."),
+            _user("revert that change please"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "strong"
+
+    def test_soft_pattern_after_write_tool_fires(self) -> None:
+        """Primary gate: soft patterns fire when preceding message used a write tool."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("actually, I wanted you to edit a different file"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "redirection"
+        assert signals[0].detail["preceding_assistant_action"] == "write_tool"
+
+    def test_soft_pattern_without_write_tool_or_question_does_not_fire(self) -> None:
+        """Without the primary gate (no write tool) and not a question
+        either, soft patterns are suppressed. Only strong-correction
+        survives this case."""
+        messages = [
+            _assistant_text("Let me think about this."),
+            _user("instead, please consider option B"),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_multi_edit_treated_as_write_tool(self) -> None:
+        """``MultiEdit`` is in WRITE_TOOLS (added in #269) so corrections
+        following a MultiEdit message fire under the primary gate."""
+        messages = [
+            _assistant_with_write_tool(tool_name="MultiEdit"),
+            _user("no, that's wrong"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+
+    def test_first_user_message_no_preceding(self) -> None:
+        """With no preceding assistant message, only strong-correction
+        patterns can fire (no write_tool, not a question)."""
+        soft_only = [_user("actually, do X instead")]
+        assert extract_quality_signals(soft_only) == []
+
+        strong_only = [_user("that's wrong")]
+        assert len(extract_quality_signals(strong_only)) == 1
+
+    def test_empty_messages_returns_empty(self) -> None:
+        assert extract_quality_signals([]) == []
+
+    def test_user_message_without_text_skipped(self) -> None:
+        """User messages whose content is purely tool_result blocks
+        (no text) are not user prose and must not be scanned."""
+        messages = [
+            _assistant_with_write_tool(),
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_result",
+                        tool_use_id="toolu_w",
+                        text="ok",
+                    ),
+                ],
+            ),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_no_match_after_write_tool_returns_no_signal(self) -> None:
+        """Primary gate is open (write tool present) but no correction
+        pattern hits — benign user message after a write tool produces
+        no signal. Counts toward total_user_messages denominator only
+        if a correction is detected later."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("looks great, please continue"),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_skips_intervening_non_assistant_messages(self) -> None:
+        """Look-back finds the most recent assistant, skipping any
+        intervening tool-result-only user messages."""
+        messages = [
+            _assistant_with_write_tool(),
+            # Tool-result-only user message (no text) — must be skipped
+            # by the look-back so the write-tool primary gate still
+            # applies to the next user prose.
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_result",
+                        tool_use_id="toolu_w",
+                        text="ok",
+                    ),
+                ],
+            ),
+            _user("actually, let's try something else"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["preceding_assistant_action"] == "write_tool"
+
+    def test_emitted_signal_shape(self) -> None:
+        """Verify cross-cutting attribution and required detail keys."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("no, that's wrong"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.severity == Severity.WARNING
+        assert sig.agent_type is None
+        assert sig.invocation_id is None
+        for key in (
+            "correction_text",
+            "matched_pattern",
+            "matched_category",
+            "preceding_assistant_action",
+            "session_correction_rate",
+            "total_user_messages",
+            "total_corrections",
+        ):
+            assert key in sig.detail
+
+    def test_long_correction_text_truncated(self) -> None:
+        """Snippet stamped on detail is capped to 140 chars."""
+        long_text = "no, " + ("very long context " * 20)
+        messages = [
+            _assistant_with_write_tool(),
+            _user(long_text),
+        ]
+        signals = extract_quality_signals(messages)
+        snippet = signals[0].detail["correction_text"]
+        assert isinstance(snippet, str)
+        assert len(snippet) <= 141  # 140 + ellipsis
+
+
+class TestExtractQualitySignalsSignature:
+    """Signature contract is locked per architect blocker on #269.
+
+    ``agent_invocations`` is unused by USER_CORRECTION detection but
+    must be accepted so #271 (REVIEWER_CAUGHT) can plug in without a
+    signature break."""
+
+    def test_agent_invocations_accepted_and_ignored(self) -> None:
+        messages = [
+            _assistant_with_write_tool(),
+            _user("no, that's wrong"),
+        ]
+        invocations = [
+            AgentInvocation(
+                agent_type="architect",
+                description="d",
+                prompt="p",
+                tool_use_id="toolu_a",
+            ),
+        ]
+        with_invocations = extract_quality_signals(messages, invocations)
+        without_invocations = extract_quality_signals(messages)
+        assert len(with_invocations) == len(without_invocations) == 1
+
+    def test_review_agent_types_constant_present(self) -> None:
+        assert "architect" in REVIEW_AGENT_TYPES
+        assert "code-reviewer" in REVIEW_AGENT_TYPES
+        assert "tester" in REVIEW_AGENT_TYPES
+        assert "security-review" in REVIEW_AGENT_TYPES

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -49,11 +49,6 @@ def _assistant_with_write_tool(
     )
 
 
-def _assistant_question(text: str) -> SessionMessage:
-    """Assistant message ending with '?' and no tool_use blocks."""
-    return _assistant_text(text)
-
-
 class TestUserCorrectionDetection:
     def test_three_corrections_in_ten_user_messages_emits_three_signals(self) -> None:
         """AC fixture: 3 corrections in 10 user messages -> 3 signals."""
@@ -76,7 +71,6 @@ class TestUserCorrectionDetection:
         assert isinstance(rate, float)
         assert rate == 0.3
         for s in signals:
-            assert s.detail["total_corrections"] == 3
             assert s.detail["total_user_messages"] == 10
 
     def test_zero_corrections_returns_empty(self) -> None:
@@ -92,7 +86,7 @@ class TestUserCorrectionDetection:
     def test_no_answer_to_question_does_not_fire(self) -> None:
         """AC fixture: 'no' as an answer to a question is not a correction."""
         messages = [
-            _assistant_question("Should I keep going with approach A?"),
+            _assistant_text("Should I keep going with approach A?"),
             _user("no, let's stop here for now"),
         ]
         assert extract_quality_signals(messages) == []
@@ -105,7 +99,7 @@ class TestUserCorrectionDetection:
         system, not answering the question.
         """
         messages = [
-            _assistant_question("Did you want me to delete the file?"),
+            _assistant_text("Did you want me to delete the file?"),
             _user("that's wrong, we agreed not to delete anything"),
         ]
         signals = extract_quality_signals(messages)
@@ -196,6 +190,18 @@ class TestUserCorrectionDetection:
         ]
         assert extract_quality_signals(messages) == []
 
+    def test_skips_unknown_message_types(self) -> None:
+        """Defensive guard: messages whose ``type`` is neither 'user'
+        nor 'assistant' are silently skipped without affecting state."""
+        messages = [
+            _assistant_with_write_tool(),
+            SessionMessage(type="system", content_blocks=[]),
+            _user("no, that's wrong"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["preceding_assistant_action"] == "write_tool"
+
     def test_skips_intervening_non_assistant_messages(self) -> None:
         """Look-back finds the most recent assistant, skipping any
         intervening tool-result-only user messages."""
@@ -239,7 +245,6 @@ class TestUserCorrectionDetection:
             "preceding_assistant_action",
             "session_correction_rate",
             "total_user_messages",
-            "total_corrections",
         ):
             assert key in sig.detail
 
@@ -281,7 +286,6 @@ class TestExtractQualitySignalsSignature:
         assert len(with_invocations) == len(without_invocations) == 1
 
     def test_review_agent_types_constant_present(self) -> None:
-        assert "architect" in REVIEW_AGENT_TYPES
-        assert "code-reviewer" in REVIEW_AGENT_TYPES
-        assert "tester" in REVIEW_AGENT_TYPES
-        assert "security-review" in REVIEW_AGENT_TYPES
+        assert REVIEW_AGENT_TYPES >= {
+            "architect", "code-reviewer", "tester", "security-review",
+        }

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -7,13 +7,33 @@ remain available for verbose drill-down.
 """
 
 from agentfluent.config.models import Severity
-from agentfluent.diagnostics.aggregation import aggregate_recommendations
+from agentfluent.diagnostics.aggregation import (
+    SIGNAL_AXIS_MAP,
+    aggregate_recommendations,
+)
 from agentfluent.diagnostics.models import (
     AggregatedRecommendation,
+    Axis,
     DiagnosticRecommendation,
     DiagnosticSignal,
     SignalType,
 )
+
+
+class TestSignalAxisMap:
+    """Drift-prevention contract on ``SIGNAL_AXIS_MAP``.
+
+    Per architect review on #269, every ``SignalType`` must map to
+    exactly one ``Axis``. A future contributor adding a ``SignalType``
+    without a corresponding map entry will fail this test in CI rather
+    than producing silently dropped axis attribution downstream.
+    """
+
+    def test_map_covers_every_signal_type(self) -> None:
+        assert set(SIGNAL_AXIS_MAP.keys()) == set(SignalType)
+
+    def test_every_value_is_an_axis(self) -> None:
+        assert all(isinstance(v, Axis) for v in SIGNAL_AXIS_MAP.values())
 
 
 def _token_outlier_pair(


### PR DESCRIPTION
## Summary
- Lands the v0.6 quality-axis foundation: `Axis` enum, three new `SignalType` values (`USER_CORRECTION`, `FILE_REWORK`, `REVIEWER_CAUGHT`), and `SIGNAL_AXIS_MAP` in `diagnostics/aggregation.py` (defined but not consumed — #272 wires it into priority scoring). A drift-prevention test asserts the map covers every `SignalType` so future additions fail CI rather than silently dropping axis attribution.
- Implements the first quality detector — `USER_CORRECTION` — in a new `diagnostics/quality_signals.py` module. Uses a 3-tier false-positive heuristic per architect review: strong-correction override (`that's wrong`, `revert`, `undo`, `that's not what I`) fires regardless of context; soft patterns require a write-tool primary gate; question-only preceding messages suppress soft matches. Pattern lists and tier-membership are module-level constants so #274 calibration can sweep them without function-body edits.
- `UserCorrectionRule` in the correlator emits `target="subagent"` recommendations suggesting a review-style subagent. Transitional `[quality]` message prefix; #273 will render axis labels uniformly from `primary_axis` and remove the hardcoded prefix (cleanup AC commented on #273).
- Adds `MultiEdit` to canonical `agents.models.WRITE_TOOLS` so the existing complexity classification (`_complexity.py`) and offload-candidate write detection (`parent_workload.py`) recognize it as a write tool, not just the new quality module — avoids a silent semantic divergence flagged in architect review.
- Function signature locked at `extract_quality_signals(messages, agent_invocations=None)` so #270 (FILE_REWORK) and #271 (REVIEWER_CAUGHT) can plug in without a signature break.

Closes #269. Architect review (Pass 2): https://github.com/frederick-douglas-pearce/agentfluent/issues/269#issuecomment-4385779566

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1038 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 100% line coverage on `diagnostics/quality_signals.py`; new tests in `test_quality_signals.py`, `test_correlator.py` (`UserCorrectionRule`), `test_diagnostics_pipeline.py` (wiring + caplog quiet-skip), `test_recommendation_aggregation.py` (`SIGNAL_AXIS_MAP` drift)
- [ ] Manual smoke test via `uv run agentfluent ...` — not required (no CLI output change in this PR; output rendering changes land in #273)

## Security review
- [x] **Skip review** — no security-sensitive surface. The new module performs rule-based regex matching on parent-thread user-message text already parsed by the existing JSONL parser. No shell, subprocess, network, path resolution, hooks, secret handling, or user-controlled string rendering. The `WRITE_TOOLS` change is a pure additive set membership update.
- [ ] **Needs review**

## Breaking changes
None. All changes are additive: new enum, new `SignalType` values, new module, new correlator rule appended to `RULES`. Existing recommendations, pricing, and `diff` semantics are unchanged because `SIGNAL_AXIS_MAP` is defined-but-not-consumed in this PR (per D021's annotations approach — #272 will consume it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)