### PR TITLE
feat(core): extract first_message_timestamp during session discovery (#294)

### DIFF
--- a/src/agentfluent/core/discovery.py
+++ b/src/agentfluent/core/discovery.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from agentfluent.core.parser import iter_raw_messages, parse_timestamp
 from agentfluent.core.paths import (
     DEFAULT_CLAUDE_CONFIG_DIR,
     PROJECTS_SUBDIR,
     SUBAGENTS_SUBDIR,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_PROJECTS_DIR = DEFAULT_CLAUDE_CONFIG_DIR / PROJECTS_SUBDIR
 
@@ -25,6 +29,13 @@ class SessionInfo:
     modified: datetime
     subagent_count: int = 0
     """Number of subagent trace files in <session-uuid>/subagents/."""
+
+    first_message_timestamp: datetime | None = None
+    """Timestamp of the first analytical message in file order. Drives
+    the date-range filter introduced in v0.6 (#293) — content-derived
+    so it survives file copies and cloud-sync mtime churn that
+    ``modified`` cannot. ``None`` when the file is empty, has no
+    parseable timestamps, or could not be opened."""
 
 
 @dataclass
@@ -56,6 +67,34 @@ def slug_to_display_name(slug: str) -> str:
     # The last segment is typically the project name
     # For paths like -home-fdpearce-Documents-Projects-git-codefluent -> codefluent
     return parts[-1] if parts else slug
+
+
+def _extract_first_timestamp(path: Path) -> datetime | None:
+    """First analytical message timestamp in file order, or ``None``.
+
+    ``iter_raw_messages`` already filters ``SKIP_TYPES`` and silently
+    drops malformed lines, so the first yielded message is the first
+    analytical one. Stops on the first parseable timestamp (typically
+    within the first few lines of the file).
+
+    "First in file order" rather than "earliest" is intentional —
+    Claude Code writes JSONL sequentially as the session progresses,
+    so file order is the faithful proxy for "session start" per D024.
+
+    ``OSError`` (covers ``PermissionError`` / partially-written
+    cloud-synced files) is caught and logged so a single bad file
+    cannot abort discovery for an entire project.
+    """
+    try:
+        for _, data in iter_raw_messages(path):
+            ts = parse_timestamp(data.get("timestamp"))
+            if ts is not None:
+                return ts
+    except OSError:
+        logger.warning(
+            "Could not read timestamps from %s", path, exc_info=True,
+        )
+    return None
 
 
 def _count_subagent_files(session_path: Path) -> int:
@@ -92,6 +131,7 @@ def discover_sessions(project_path: Path) -> list[SessionInfo]:
                     size_bytes=stat.st_size,
                     modified=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
                     subagent_count=_count_subagent_files(entry),
+                    first_message_timestamp=_extract_first_timestamp(entry),
                 )
             )
 

--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -148,8 +148,13 @@ def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[C
     return []
 
 
-def _parse_timestamp(raw: str | None) -> datetime | None:
-    """Parse an ISO 8601 timestamp string."""
+def parse_timestamp(raw: str | None) -> datetime | None:
+    """Parse an ISO 8601 timestamp string.
+
+    Tolerates the trailing ``Z`` UTC marker that Claude Code emits and
+    returns ``None`` for missing or malformed input rather than raising,
+    so callers can iterate JSONL safely without per-line guards.
+    """
     if not raw:
         return None
     try:
@@ -174,7 +179,7 @@ def _parse_user_message(data: dict[str, Any]) -> SessionMessage:
 
     return SessionMessage(
         type="user",
-        timestamp=_parse_timestamp(data.get("timestamp")),
+        timestamp=parse_timestamp(data.get("timestamp")),
         content_blocks=_normalize_content(message.get("content")),
         metadata=metadata,
     )
@@ -196,7 +201,7 @@ def _parse_assistant_message(data: dict[str, Any]) -> SessionMessage:
 
     return SessionMessage(
         type="assistant",
-        timestamp=_parse_timestamp(data.get("timestamp")),
+        timestamp=parse_timestamp(data.get("timestamp")),
         message_id=message.get("id"),
         model=message.get("model"),
         content_blocks=_normalize_content(message.get("content")),

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,9 +1,11 @@
 """Tests for project and session discovery."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from agentfluent.core import discovery as discovery_mod
 from agentfluent.core.discovery import (
     discover_projects,
     discover_sessions,
@@ -82,6 +84,92 @@ class TestDiscoverSessions:
     def test_nonexistent_directory(self, tmp_path: Path) -> None:
         sessions = discover_sessions(tmp_path / "does-not-exist")
         assert sessions == []
+
+
+class TestFirstMessageTimestamp:
+    """``SessionInfo.first_message_timestamp`` -- foundation of the
+    v0.6 date-range filter (#293). Reads the first analytical message's
+    timestamp in file order so it survives mtime churn from cloud sync
+    or backup restores."""
+
+    def test_populated_from_first_message(self, tmp_path: Path) -> None:
+        (tmp_path / "session.jsonl").write_text(
+            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
+            '"message": {"role": "user", "content": "hello"}}\n'
+            '{"type": "assistant", "timestamp": "2026-04-10T10:00:05.000Z", '
+            '"message": {"role": "assistant", "content": []}}\n',
+        )
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].first_message_timestamp == datetime(
+            2026, 4, 10, 10, 0, 0, tzinfo=UTC,
+        )
+
+    def test_none_for_empty_file(self, tmp_path: Path) -> None:
+        (tmp_path / "empty.jsonl").write_text("")
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].first_message_timestamp is None
+
+    def test_none_when_no_parseable_timestamps(self, tmp_path: Path) -> None:
+        (tmp_path / "no-ts.jsonl").write_text(
+            '{"type": "user", "message": {"role": "user", "content": "x"}}\n',
+        )
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].first_message_timestamp is None
+
+    def test_skips_until_analytical_message(self, tmp_path: Path) -> None:
+        """Non-analytical types (file-history-snapshot, system, progress)
+        are filtered by ``iter_raw_messages``; the helper picks up the
+        first analytical message after them."""
+        (tmp_path / "skip-then-real.jsonl").write_text(
+            '{"type": "file-history-snapshot", "timestamp": "2026-04-09T00:00:00.000Z"}\n'
+            '{"type": "system", "timestamp": "2026-04-09T01:00:00.000Z"}\n'
+            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
+            '"message": {"role": "user", "content": "hello"}}\n',
+        )
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].first_message_timestamp == datetime(
+            2026, 4, 10, 10, 0, 0, tzinfo=UTC,
+        )
+
+    def test_none_when_only_malformed_lines(self, tmp_path: Path) -> None:
+        (tmp_path / "malformed.jsonl").write_text(
+            "this is not json\n{also not json\n",
+        )
+        sessions = discover_sessions(tmp_path)
+        assert sessions[0].first_message_timestamp is None
+
+    def test_oserror_on_one_file_does_not_abort_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A single corrupted/locked file must not prevent discovery
+        of the other sessions in the project. Cloud-synced directories
+        may have partially-written or permission-restricted files;
+        chmod-based tests of that condition are platform-fragile, so
+        we stub the I/O layer to raise."""
+        good = tmp_path / "good.jsonl"
+        good.write_text(
+            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
+            '"message": {"role": "user", "content": "hi"}}\n',
+        )
+        bad = tmp_path / "bad.jsonl"
+        bad.write_text("ok\n")
+
+        original = discovery_mod.iter_raw_messages
+
+        def _maybe_raise(path: Path):  # type: ignore[no-untyped-def]
+            if path == bad:
+                raise PermissionError("simulated lock")
+            yield from original(path)
+
+        monkeypatch.setattr(discovery_mod, "iter_raw_messages", _maybe_raise)
+
+        sessions = discover_sessions(tmp_path)
+
+        assert {s.filename for s in sessions} == {"good.jsonl", "bad.jsonl"}
+        bad_info = next(s for s in sessions if s.filename == "bad.jsonl")
+        good_info = next(s for s in sessions if s.filename == "good.jsonl")
+        assert bad_info.first_message_timestamp is None
+        assert good_info.first_message_timestamp is not None
 
 
 class TestDiscoverProjects:

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,7 +1,9 @@
 """Tests for project and session discovery."""
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -12,6 +14,15 @@ from agentfluent.core.discovery import (
     find_project,
     slug_to_display_name,
 )
+from tests._builders import user_message
+
+WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
+
+# Anchor timestamp + parsed equivalent shared across the
+# first-message-timestamp tests so the test intent ("first ts → field
+# value") is not buried in JSONL string noise.
+_FIRST_TS_ISO = "2026-04-10T10:00:00.000Z"
+_FIRST_TS = datetime(2026, 4, 10, 10, 0, 0, tzinfo=UTC)
 
 
 class TestSlugToDisplayName:
@@ -88,48 +99,60 @@ class TestDiscoverSessions:
 
 class TestFirstMessageTimestamp:
     """``SessionInfo.first_message_timestamp`` -- foundation of the
-    v0.6 date-range filter (#293). Reads the first analytical message's
+    v0.6 date-range filter. Reads the first analytical message's
     timestamp in file order so it survives mtime churn from cloud sync
     or backup restores."""
 
-    def test_populated_from_first_message(self, tmp_path: Path) -> None:
-        (tmp_path / "session.jsonl").write_text(
-            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
-            '"message": {"role": "user", "content": "hello"}}\n'
-            '{"type": "assistant", "timestamp": "2026-04-10T10:00:05.000Z", '
-            '"message": {"role": "assistant", "content": []}}\n',
+    def test_populated_from_first_message(
+        self, tmp_path: Path, write_jsonl: WriteJSONL,
+    ) -> None:
+        write_jsonl(
+            "session.jsonl",
+            [
+                user_message(content="hello", timestamp=_FIRST_TS_ISO),
+                user_message(
+                    content="follow up",
+                    timestamp="2026-04-10T10:00:05.000Z",
+                ),
+            ],
         )
         sessions = discover_sessions(tmp_path)
-        assert sessions[0].first_message_timestamp == datetime(
-            2026, 4, 10, 10, 0, 0, tzinfo=UTC,
-        )
+        assert sessions[0].first_message_timestamp == _FIRST_TS
 
     def test_none_for_empty_file(self, tmp_path: Path) -> None:
         (tmp_path / "empty.jsonl").write_text("")
         sessions = discover_sessions(tmp_path)
         assert sessions[0].first_message_timestamp is None
 
-    def test_none_when_no_parseable_timestamps(self, tmp_path: Path) -> None:
-        (tmp_path / "no-ts.jsonl").write_text(
-            '{"type": "user", "message": {"role": "user", "content": "x"}}\n',
-        )
+    def test_none_when_no_parseable_timestamps(
+        self, tmp_path: Path, write_jsonl: WriteJSONL,
+    ) -> None:
+        write_jsonl("no-ts.jsonl", [user_message(content="x", timestamp=None)])
         sessions = discover_sessions(tmp_path)
         assert sessions[0].first_message_timestamp is None
 
-    def test_skips_until_analytical_message(self, tmp_path: Path) -> None:
+    def test_skips_until_analytical_message(
+        self, tmp_path: Path, write_jsonl: WriteJSONL,
+    ) -> None:
         """Non-analytical types (file-history-snapshot, system, progress)
         are filtered by ``iter_raw_messages``; the helper picks up the
         first analytical message after them."""
-        (tmp_path / "skip-then-real.jsonl").write_text(
-            '{"type": "file-history-snapshot", "timestamp": "2026-04-09T00:00:00.000Z"}\n'
-            '{"type": "system", "timestamp": "2026-04-09T01:00:00.000Z"}\n'
-            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
-            '"message": {"role": "user", "content": "hello"}}\n',
+        write_jsonl(
+            "skip-then-real.jsonl",
+            [
+                {
+                    "type": "file-history-snapshot",
+                    "timestamp": "2026-04-09T00:00:00.000Z",
+                },
+                {
+                    "type": "system",
+                    "timestamp": "2026-04-09T01:00:00.000Z",
+                },
+                user_message(content="hello", timestamp=_FIRST_TS_ISO),
+            ],
         )
         sessions = discover_sessions(tmp_path)
-        assert sessions[0].first_message_timestamp == datetime(
-            2026, 4, 10, 10, 0, 0, tzinfo=UTC,
-        )
+        assert sessions[0].first_message_timestamp == _FIRST_TS
 
     def test_none_when_only_malformed_lines(self, tmp_path: Path) -> None:
         (tmp_path / "malformed.jsonl").write_text(
@@ -139,20 +162,30 @@ class TestFirstMessageTimestamp:
         assert sessions[0].first_message_timestamp is None
 
     def test_oserror_on_one_file_does_not_abort_discovery(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        write_jsonl: WriteJSONL,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A single corrupted/locked file must not prevent discovery
         of the other sessions in the project. Cloud-synced directories
         may have partially-written or permission-restricted files;
-        chmod-based tests of that condition are platform-fragile, so
-        we stub the I/O layer to raise."""
-        good = tmp_path / "good.jsonl"
-        good.write_text(
-            '{"type": "user", "timestamp": "2026-04-10T10:00:00.000Z", '
-            '"message": {"role": "user", "content": "hi"}}\n',
+        chmod-based tests are platform-fragile, so we stub the I/O
+        layer to raise.
+
+        ``bad.jsonl`` is written as VALID JSONL with a parseable
+        timestamp -- if the OSError catch were removed, the assertion
+        ``bad_info.first_message_timestamp is None`` would fail because
+        the file would parse successfully. That makes the monkeypatch
+        load-bearing."""
+        write_jsonl(
+            "good.jsonl",
+            [user_message(content="hi", timestamp=_FIRST_TS_ISO)],
         )
-        bad = tmp_path / "bad.jsonl"
-        bad.write_text("ok\n")
+        bad = write_jsonl(
+            "bad.jsonl",
+            [user_message(content="hi", timestamp="2026-04-11T10:00:00.000Z")],
+        )
 
         original = discovery_mod.iter_raw_messages
 
@@ -169,7 +202,7 @@ class TestFirstMessageTimestamp:
         bad_info = next(s for s in sessions if s.filename == "bad.jsonl")
         good_info = next(s for s in sessions if s.filename == "good.jsonl")
         assert bad_info.first_message_timestamp is None
-        assert good_info.first_message_timestamp is not None
+        assert good_info.first_message_timestamp == _FIRST_TS
 
 
 class TestDiscoverProjects:


### PR DESCRIPTION
## Summary
- Adds `SessionInfo.first_message_timestamp: datetime | None` populated during `discover_sessions()` from the first analytical message in JSONL file order. Foundation for the v0.6 date-range filter (#293) per D024 — content-derived so it survives mtime churn from cloud sync, file copies, and backup restores.
- Promotes `_parse_timestamp` → `parse_timestamp` in `core/parser.py` so discovery shares the parser's ISO 8601 + `Z`-marker handling instead of duplicating it. Two internal callers updated; rename is purely internal (no external imports).
- Catches `OSError` (covers `PermissionError` / partially-written cloud-synced files) inside `_extract_first_timestamp` so one bad file cannot abort discovery for an entire project. Defensive at the file-I/O system boundary per architect review.

Closes #294. Architect review (no blockers): https://github.com/frederick-douglas-pearce/agentfluent/issues/294#issuecomment-4386019464

## Test plan
- [x] Unit tests pass: `uv run pytest -m \"not integration\"` — 1045 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — six new cases in `test_discovery.py::TestFirstMessageTimestamp`: populated from first message, None for empty file, None when no parseable timestamps, skips SKIP_TYPES until analytical, None when only malformed lines, OSError on one file does not abort discovery (monkeypatch-based to avoid platform-fragile chmod tests).
- [ ] Manual smoke test via `uv run agentfluent ...` — not required (no CLI surface change in this PR; consumed by the upcoming #296/#297 filter work).

## Security review
- [x] **Skip review** — additive metadata field, defensive I/O guard, internal rename. No CLI argument parsing, hooks, secret handling, or user-controlled string rendering.
- [ ] **Needs review**

## Breaking changes
None. The new field defaults to `None`, preserving construction by any test or library callers that build `SessionInfo` directly. Sort order on `discover_sessions()` is unchanged (still `modified`, newest first). The `_parse_timestamp` → `parse_timestamp` rename is purely internal — there are no external imports of the private name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)