### PR TITLE
feat(diagnostics): file-rework density quality signal (#270)

### DIFF
--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -646,6 +646,61 @@ class UserCorrectionRule:
         )
 
 
+class FileReworkRule:
+    """FILE_REWORK -> recommend a review-style subagent.
+
+    Cross-cutting (``agent_type=None``), shape mirrors ``UserCorrectionRule``.
+    Recommendation copy branches on ``post_completion_edits``: edits that
+    happened after "completion" language (a stronger signal — the work was
+    declared done before further rework) get a different remediation than
+    edits that may reflect ordinary iterative development.
+
+    The ``[quality]`` prefix is transitional pending #273 (axis labels
+    rendered uniformly from ``primary_axis``).
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.FILE_REWORK
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        post_completion = signal.detail.get("post_completion_edits", 0)
+        if isinstance(post_completion, int) and post_completion > 0:
+            reason = (
+                "Repeated edits after the work was declared complete "
+                "indicate a pre-implementation review would have caught "
+                "issues earlier."
+            )
+            action = (
+                "Consider an architect subagent for design review before "
+                "starting implementation in this area, or a tester subagent "
+                "to verify completion claims."
+            )
+        else:
+            reason = (
+                "High edit density on a single file suggests the parent "
+                "would benefit from upfront design or incremental testing."
+            )
+            action = (
+                "Consider an architect subagent for design review, or split "
+                "the change into smaller verifiable steps."
+            )
+        return DiagnosticRecommendation(
+            target="subagent",
+            severity=signal.severity,
+            message=f"[quality] {observation}. {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file="",
+            signal_types=[signal.signal_type],
+        )
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -658,6 +713,7 @@ RULES: list[CorrelationRule] = [
     ModelRoutingRule(),
     McpAuditRule(),
     UserCorrectionRule(),
+    FileReworkRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -13,9 +13,11 @@ Tier 1 quality signals (per the v0.6 quality-axis epic, #268):
   mid-flight ("no, do X instead", "wait, that's wrong", "revert"). High
   correction frequency in sessions without review subagents is strong
   evidence the parent would benefit from independent review. Detected
-  here in #269.
-- ``FILE_REWORK`` — same file edited N+ times within a session. Detected
-  in #270.
+  in #269.
+- ``FILE_REWORK`` — same file edited N+ times within a session,
+  especially after a feature was declared "done". High rework density
+  indicates a pre-implementation review or incremental testing would
+  have caught issues earlier. Detected in #270.
 - ``REVIEWER_CAUGHT`` — review-style subagents that ran AND produced
   substantive findings the parent acted on. Detected in #271.
 
@@ -43,6 +45,7 @@ calibration notebook can sweep them without function-body edits.
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 from enum import StrEnum
 
 from agentfluent.agents.models import WRITE_TOOLS, AgentInvocation
@@ -134,6 +137,36 @@ _SOFT_PATTERN_CATEGORIES: tuple[
 _SNIPPET_MAX_CHARS = 140
 
 
+# Edit-tool subset of WRITE_TOOLS used for FILE_REWORK detection. Strict
+# subset by design: ``Bash`` is excluded because its ``input`` carries
+# ``command``, not ``file_path`` — extracting a filesystem target from a
+# shell command is out of scope and error-prone. ``NotebookEdit`` is
+# excluded because ``.ipynb`` rework is rare in our target use cases
+# (Agent SDK + Claude Code). Sync with ``WRITE_TOOLS`` if that set grows
+# with another file-path-bearing tool; the drift-prevention test in
+# ``test_quality_signals.py`` will fail if this subset escapes.
+_EDIT_TOOL_NAMES: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
+
+# A file edited at or above this threshold within a single session
+# fires ``FILE_REWORK``. Module-level constant for #274 calibration.
+_FILE_REWORK_THRESHOLD = 4
+
+# "Completion language" patterns. When any assistant message in the
+# session matches one of these, subsequent edits to any file are
+# counted as ``post_completion_edits``. Session-level granularity is
+# the intentional Tier 1 trade-off — per-file completion tracking
+# would require NLP to associate "done" with a specific file, which
+# is a #274 concern. ``completion_scope: "session"`` is stamped on
+# every emitted FILE_REWORK signal so calibration can measure how
+# often multi-task sessions cause false attribution.
+_COMPLETION_PATTERNS = _ci(
+    r"\b(done|complete|completed|finished)\b",
+    r"\bready\s+for\s+review\b",
+    r"\ball\s+set\b",
+    r"\bimplementation\s+complete\b",
+)
+
+
 def _classify_assistant(message: SessionMessage) -> tuple[bool, bool]:
     """Return ``(had_write_tool, is_question_only)`` for an assistant message.
 
@@ -187,36 +220,114 @@ def _build_snippet(text: str) -> str:
     return text[:_SNIPPET_MAX_CHARS].rstrip() + "…"
 
 
+def _matches_completion_phrase(text: str) -> bool:
+    return any(p.search(text) for p in _COMPLETION_PATTERNS)
+
+
+def _emit_user_correction_signals(
+    detections: list[tuple[CorrectionCategory, str, str, PrecedingAction]],
+    total_user_messages: int,
+) -> list[DiagnosticSignal]:
+    if not detections or total_user_messages == 0:
+        return []
+    session_correction_rate = len(detections) / total_user_messages
+    return [
+        DiagnosticSignal(
+            signal_type=SignalType.USER_CORRECTION,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message=f"User correction in parent thread: {snippet}",
+            detail={
+                "correction_text": snippet,
+                "matched_pattern": matched_phrase,
+                "matched_category": category.value,
+                "preceding_assistant_action": preceding.value,
+                "session_correction_rate": session_correction_rate,
+                "total_user_messages": total_user_messages,
+            },
+        )
+        for category, matched_phrase, snippet, preceding in detections
+    ]
+
+
+def _emit_file_rework_signals(
+    file_edit_counts: dict[str, int],
+    post_completion_edits: dict[str, int],
+    edit_tools_per_file: dict[str, set[str]],
+) -> list[DiagnosticSignal]:
+    return [
+        DiagnosticSignal(
+            signal_type=SignalType.FILE_REWORK,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message=(
+                f"File '{file_path}' edited {count} times in this session"
+            ),
+            detail={
+                "file_path": file_path,
+                "edit_count": count,
+                "post_completion_edits": post_completion_edits.get(
+                    file_path, 0,
+                ),
+                "edit_tools": sorted(edit_tools_per_file[file_path]),
+                "completion_scope": "session",
+            },
+        )
+        for file_path, count in file_edit_counts.items()
+        if count >= _FILE_REWORK_THRESHOLD
+    ]
+
+
 def extract_quality_signals(
     messages: list[SessionMessage],
     agent_invocations: list[AgentInvocation] | None = None,
 ) -> list[DiagnosticSignal]:
     """Extract quality-axis signals from parent-thread messages.
 
-    Currently emits ``USER_CORRECTION`` only; ``FILE_REWORK`` (#270) and
+    Emits ``USER_CORRECTION`` (#269) and ``FILE_REWORK`` (#270);
     ``REVIEWER_CAUGHT`` (#271) will land here. ``agent_invocations`` is
-    accepted but unused — locked in this signature so #271 can plug in
-    without breaking #270 mid-flight.
+    accepted but unused by the current detectors — locked in this
+    signature so #271 can plug in without breaking the existing
+    callers.
 
-    Returns an empty list when ``messages`` is empty or contains no
-    user prose. ``agent_type`` is ``None`` on every emitted signal:
-    these are cross-cutting parent-thread observations, not subagent-
-    scoped findings.
+    Returns an empty list when ``messages`` is empty. ``agent_type`` is
+    ``None`` on every emitted signal: these are cross-cutting
+    parent-thread observations, not subagent-scoped findings.
     """
     if not messages:
         return []
 
-    # Single forward pass: as we walk messages we update the most
-    # recently seen assistant's classification, and read it whenever
-    # we encounter user prose. Avoids the O(n²) backward scan that an
-    # earlier draft used.
+    # Single forward pass: track the most recently seen assistant's
+    # classification (for correction detection), file-edit counts (for
+    # rework detection), and a session-level ``completion_seen`` flag
+    # (gates ``post_completion_edits``).
     last_assistant: tuple[bool, bool] | None = None
-    detections: list[tuple[CorrectionCategory, str, str, PrecedingAction]] = []
+    correction_detections: list[
+        tuple[CorrectionCategory, str, str, PrecedingAction]
+    ] = []
     total_user_messages = 0
+    file_edit_counts: dict[str, int] = defaultdict(int)
+    post_completion_edits: dict[str, int] = defaultdict(int)
+    edit_tools_per_file: dict[str, set[str]] = defaultdict(set)
+    completion_seen = False
 
     for msg in messages:
         if msg.type == "assistant":
             last_assistant = _classify_assistant(msg)
+            if not completion_seen and _matches_completion_phrase(msg.text):
+                completion_seen = True
+            for block in msg.tool_use_blocks:
+                if block.name not in _EDIT_TOOL_NAMES:
+                    continue
+                fp = block.input.get("file_path")
+                if not isinstance(fp, str) or not fp:
+                    continue
+                file_edit_counts[fp] += 1
+                edit_tools_per_file[fp].add(block.name)
+                if completion_seen:
+                    post_completion_edits[fp] += 1
             continue
         if msg.type != "user":
             continue
@@ -242,30 +353,15 @@ def extract_quality_signals(
         else:
             preceding = PrecedingAction.TEXT_ONLY
 
-        detections.append(
+        correction_detections.append(
             (category, matched_phrase, _build_snippet(text), preceding),
         )
 
-    if not detections or total_user_messages == 0:
-        return []
-
-    session_correction_rate = len(detections) / total_user_messages
-
     return [
-        DiagnosticSignal(
-            signal_type=SignalType.USER_CORRECTION,
-            severity=Severity.WARNING,
-            agent_type=None,
-            invocation_id=None,
-            message=f"User correction in parent thread: {snippet}",
-            detail={
-                "correction_text": snippet,
-                "matched_pattern": matched_phrase,
-                "matched_category": category.value,
-                "preceding_assistant_action": preceding.value,
-                "session_correction_rate": session_correction_rate,
-                "total_user_messages": total_user_messages,
-            },
-        )
-        for category, matched_phrase, snippet, preceding in detections
+        *_emit_user_correction_signals(
+            correction_detections, total_user_messages,
+        ),
+        *_emit_file_rework_signals(
+            file_edit_counts, post_completion_edits, edit_tools_per_file,
+        ),
     ]

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -45,7 +45,7 @@ calibration notebook can sweep them without function-body edits.
 from __future__ import annotations
 
 import re
-from collections import defaultdict
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 from agentfluent.agents.models import WRITE_TOOLS, AgentInvocation
@@ -167,6 +167,21 @@ _COMPLETION_PATTERNS = _ci(
 )
 
 
+@dataclass(slots=True)
+class _FileEditStats:
+    """Accumulator for a single file's edit activity within a session.
+
+    Bundles the three lockstep state values (``count``, ``post_completion``,
+    ``tools``) so the forward-walk update site is one record mutation
+    rather than three parallel-dict updates, and the emit site reads
+    one struct rather than threading three dicts as parameters.
+    """
+
+    count: int = 0
+    post_completion: int = 0
+    tools: set[str] = field(default_factory=set)
+
+
 def _classify_assistant(message: SessionMessage) -> tuple[bool, bool]:
     """Return ``(had_write_tool, is_question_only)`` for an assistant message.
 
@@ -252,9 +267,7 @@ def _emit_user_correction_signals(
 
 
 def _emit_file_rework_signals(
-    file_edit_counts: dict[str, int],
-    post_completion_edits: dict[str, int],
-    edit_tools_per_file: dict[str, set[str]],
+    edit_stats: dict[str, _FileEditStats],
 ) -> list[DiagnosticSignal]:
     return [
         DiagnosticSignal(
@@ -263,20 +276,18 @@ def _emit_file_rework_signals(
             agent_type=None,
             invocation_id=None,
             message=(
-                f"File '{file_path}' edited {count} times in this session"
+                f"File '{file_path}' edited {stats.count} times in this session"
             ),
             detail={
                 "file_path": file_path,
-                "edit_count": count,
-                "post_completion_edits": post_completion_edits.get(
-                    file_path, 0,
-                ),
-                "edit_tools": sorted(edit_tools_per_file[file_path]),
+                "edit_count": stats.count,
+                "post_completion_edits": stats.post_completion,
+                "edit_tools": sorted(stats.tools),
                 "completion_scope": "session",
             },
         )
-        for file_path, count in file_edit_counts.items()
-        if count >= _FILE_REWORK_THRESHOLD
+        for file_path, stats in edit_stats.items()
+        if stats.count >= _FILE_REWORK_THRESHOLD
     ]
 
 
@@ -299,18 +310,12 @@ def extract_quality_signals(
     if not messages:
         return []
 
-    # Single forward pass: track the most recently seen assistant's
-    # classification (for correction detection), file-edit counts (for
-    # rework detection), and a session-level ``completion_seen`` flag
-    # (gates ``post_completion_edits``).
     last_assistant: tuple[bool, bool] | None = None
     correction_detections: list[
         tuple[CorrectionCategory, str, str, PrecedingAction]
     ] = []
     total_user_messages = 0
-    file_edit_counts: dict[str, int] = defaultdict(int)
-    post_completion_edits: dict[str, int] = defaultdict(int)
-    edit_tools_per_file: dict[str, set[str]] = defaultdict(set)
+    edit_stats: dict[str, _FileEditStats] = {}
     completion_seen = False
 
     for msg in messages:
@@ -324,10 +329,11 @@ def extract_quality_signals(
                 fp = block.input.get("file_path")
                 if not isinstance(fp, str) or not fp:
                     continue
-                file_edit_counts[fp] += 1
-                edit_tools_per_file[fp].add(block.name)
+                stats = edit_stats.setdefault(fp, _FileEditStats())
+                stats.count += 1
+                stats.tools.add(block.name)
                 if completion_seen:
-                    post_completion_edits[fp] += 1
+                    stats.post_completion += 1
             continue
         if msg.type != "user":
             continue
@@ -361,7 +367,5 @@ def extract_quality_signals(
         *_emit_user_correction_signals(
             correction_detections, total_user_messages,
         ),
-        *_emit_file_rework_signals(
-            file_edit_counts, post_completion_edits, edit_tools_per_file,
-        ),
+        *_emit_file_rework_signals(edit_stats),
     ]

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -675,3 +675,53 @@ class TestUserCorrectionRule:
         )
         recs = correlate([unrelated])
         assert all(rec.target != "subagent" for rec in recs)
+
+
+class TestFileReworkRule:
+    """FILE_REWORK -> ``target='subagent'`` recommendation, copy
+    branches on ``post_completion_edits``."""
+
+    @staticmethod
+    def _signal(post_completion: int = 0) -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.FILE_REWORK,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message="File '/src/foo.py' edited 5 times in this session",
+            detail={
+                "file_path": "/src/foo.py",
+                "edit_count": 5,
+                "post_completion_edits": post_completion,
+                "edit_tools": ["Edit"],
+                "completion_scope": "session",
+            },
+        )
+
+    def test_emits_subagent_target(self) -> None:
+        recs = correlate([self._signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "subagent"
+        assert rec.severity == Severity.WARNING
+        assert rec.agent_type is None
+        assert rec.signal_types == [SignalType.FILE_REWORK]
+
+    def test_message_carries_quality_prefix(self) -> None:
+        recs = correlate([self._signal()])
+        assert "[quality]" in recs[0].message
+
+    def test_recommends_review_subagent_iterative(self) -> None:
+        recs = correlate([self._signal(post_completion=0)])
+        action = recs[0].action.lower()
+        assert "architect" in action
+        assert "smaller" in action
+
+    def test_recommends_tester_for_post_completion_rework(self) -> None:
+        """When post_completion_edits > 0 the recommendation copy
+        mentions tester (verifying completion claims) in addition to
+        architect (design review)."""
+        recs = correlate([self._signal(post_completion=2)])
+        action = recs[0].action.lower()
+        assert "architect" in action
+        assert "tester" in action

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -736,3 +736,34 @@ class TestQualitySignalsWiring:
         assert not any(
             s.signal_type == SignalType.USER_CORRECTION for s in result.signals
         )
+
+    def test_user_correction_and_file_rework_coexist(self) -> None:
+        """Both quality signals fire on the same session when the
+        evidence is present — they are independent observations
+        (architect Q5 on #270)."""
+        edit_block = ContentBlock(
+            type="tool_use",
+            id="toolu_e",
+            name="Edit",
+            input={"file_path": "/src/foo.py"},
+        )
+        # Four assistant messages each with an Edit on /src/foo.py
+        # (threshold = 4) — the last one is also followed by a strong
+        # correction, so USER_CORRECTION fires too.
+        messages: list[SessionMessage] = []
+        for _ in range(4):
+            messages.append(
+                SessionMessage(type="assistant", content_blocks=[edit_block]),
+            )
+        messages.append(
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(type="text", text="that's wrong, undo it"),
+                ],
+            ),
+        )
+        result = run_diagnostics([_inv()], parent_messages=messages)
+        kinds = {s.signal_type for s in result.signals}
+        assert SignalType.USER_CORRECTION in kinds
+        assert SignalType.FILE_REWORK in kinds

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -8,11 +8,12 @@ even when #274 calibration tunes thresholds.
 
 from __future__ import annotations
 
-from agentfluent.agents.models import AgentInvocation
+from agentfluent.agents.models import WRITE_TOOLS, AgentInvocation
 from agentfluent.config.models import Severity
 from agentfluent.core.session import ContentBlock, SessionMessage
 from agentfluent.diagnostics.models import SignalType
 from agentfluent.diagnostics.quality_signals import (
+    _EDIT_TOOL_NAMES,
     REVIEW_AGENT_TYPES,
     extract_quality_signals,
 )
@@ -289,3 +290,171 @@ class TestExtractQualitySignalsSignature:
         assert REVIEW_AGENT_TYPES >= {
             "architect", "code-reviewer", "tester", "security-review",
         }
+
+
+def _assistant_with_edits(
+    *file_paths: str,
+    text: str = "",
+    tool_name: str = "Edit",
+) -> SessionMessage:
+    """Build an assistant message with one Edit tool_use per file_path."""
+    blocks: list[ContentBlock] = []
+    if text:
+        blocks.append(ContentBlock(type="text", text=text))
+    for i, fp in enumerate(file_paths):
+        blocks.append(
+            ContentBlock(
+                type="tool_use",
+                id=f"toolu_e{i}",
+                name=tool_name,
+                input={"file_path": fp},
+            ),
+        )
+    return SessionMessage(type="assistant", content_blocks=blocks)
+
+
+class TestFileReworkDetection:
+    """``FILE_REWORK`` fires when a single file is edited at or above
+    ``_FILE_REWORK_THRESHOLD`` (default 4) within one session. Detection
+    is cross-cutting — ``agent_type=None``."""
+
+    def test_fires_at_threshold(self) -> None:
+        messages = [
+            _assistant_with_edits("/src/foo.py") for _ in range(4)
+        ]
+        signals = extract_quality_signals(messages)
+        rework = [s for s in signals if s.signal_type == SignalType.FILE_REWORK]
+        assert len(rework) == 1
+        sig = rework[0]
+        assert sig.agent_type is None
+        assert sig.detail["file_path"] == "/src/foo.py"
+        assert sig.detail["edit_count"] == 4
+        assert sig.detail["post_completion_edits"] == 0
+        assert sig.detail["completion_scope"] == "session"
+
+    def test_below_threshold_does_not_fire(self) -> None:
+        messages = [
+            _assistant_with_edits("/src/foo.py") for _ in range(3)
+        ]
+        signals = extract_quality_signals(messages)
+        assert not any(
+            s.signal_type == SignalType.FILE_REWORK for s in signals
+        )
+
+    def test_post_completion_edits_counted(self) -> None:
+        """Edits after completion language fire ``post_completion_edits``."""
+        messages = [
+            *(_assistant_with_edits("/src/foo.py") for _ in range(2)),
+            _assistant_with_edits("/src/foo.py", text="all done with this"),
+            *(_assistant_with_edits("/src/foo.py") for _ in range(2)),
+        ]
+        signals = extract_quality_signals(messages)
+        rework = [s for s in signals if s.signal_type == SignalType.FILE_REWORK]
+        assert len(rework) == 1
+        # The completion-language message itself was an edit; the two
+        # afterward also count. Total post-completion edits >= 2.
+        assert rework[0].detail["post_completion_edits"] >= 2
+
+    def test_multiple_files_independent(self) -> None:
+        """Each file is evaluated against the threshold independently."""
+        messages = [
+            _assistant_with_edits("/a.py", "/b.py") for _ in range(2)
+        ] + [
+            _assistant_with_edits("/a.py", "/a.py") for _ in range(2)
+        ]
+        # /a.py: 6 edits (2 messages with 1 each + 2 messages with 2 each)
+        # /b.py: 2 edits
+        signals = extract_quality_signals(messages)
+        rework = {
+            s.detail["file_path"]: s for s in signals
+            if s.signal_type == SignalType.FILE_REWORK
+        }
+        assert "/a.py" in rework
+        assert "/b.py" not in rework
+
+    def test_multi_edit_counted(self) -> None:
+        """``MultiEdit`` is in ``_EDIT_TOOL_NAMES`` and contributes."""
+        messages = [
+            _assistant_with_edits("/x.py", tool_name="MultiEdit")
+            for _ in range(4)
+        ]
+        signals = extract_quality_signals(messages)
+        rework = [s for s in signals if s.signal_type == SignalType.FILE_REWORK]
+        assert len(rework) == 1
+        assert "MultiEdit" in rework[0].detail["edit_tools"]
+
+    def test_bash_ignored(self) -> None:
+        """``Bash`` is excluded from ``_EDIT_TOOL_NAMES`` (no
+        single ``file_path`` input — shell-command parsing is out of
+        scope for FILE_REWORK)."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id=f"toolu_b{i}",
+                        name="Bash",
+                        input={"command": "echo hello"},
+                    ),
+                ],
+            )
+            for i in range(5)
+        ]
+        signals = extract_quality_signals(messages)
+        assert not any(
+            s.signal_type == SignalType.FILE_REWORK for s in signals
+        )
+
+    def test_missing_file_path_skipped(self) -> None:
+        """An Edit block whose ``input`` lacks ``file_path`` (or has a
+        non-string value) is silently skipped — no ``None``-keyed entries
+        in the per-file count dict."""
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id=f"toolu_m{i}",
+                        name="Edit",
+                        input={},  # no file_path
+                    ),
+                ],
+            )
+            for i in range(5)
+        ]
+        signals = extract_quality_signals(messages)
+        assert not any(
+            s.signal_type == SignalType.FILE_REWORK for s in signals
+        )
+
+    def test_non_string_file_path_skipped(self) -> None:
+        messages = [
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id=f"toolu_n{i}",
+                        name="Edit",
+                        input={"file_path": 42},  # type: ignore[dict-item]
+                    ),
+                ],
+            )
+            for i in range(5)
+        ]
+        signals = extract_quality_signals(messages)
+        assert not any(
+            s.signal_type == SignalType.FILE_REWORK for s in signals
+        )
+
+
+class TestEditToolNamesContract:
+    """Drift-prevention: ``_EDIT_TOOL_NAMES`` is a strict subset of
+    ``WRITE_TOOLS``. If ``WRITE_TOOLS`` ever gains a new file-path-bearing
+    tool, this test fails as a reminder to consider extending the
+    rework detector to include it."""
+
+    def test_edit_tool_names_subset_of_write_tools(self) -> None:
+        assert _EDIT_TOOL_NAMES <= WRITE_TOOLS

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -33,21 +33,37 @@ def _assistant_text(text: str) -> SessionMessage:
     )
 
 
+def _assistant_with_edits(
+    *file_paths: str,
+    text: str = "",
+    tool_name: str = "Edit",
+) -> SessionMessage:
+    """Assistant message with one Edit tool_use per file_path.
+
+    Optional leading text block when ``text`` is non-empty. Tool block
+    ids are unique within the message (``toolu_e0``, ``toolu_e1``, ...)
+    so multiple-edit messages don't collide on tool_use_id.
+    """
+    blocks: list[ContentBlock] = []
+    if text:
+        blocks.append(ContentBlock(type="text", text=text))
+    for i, fp in enumerate(file_paths):
+        blocks.append(
+            ContentBlock(
+                type="tool_use",
+                id=f"toolu_e{i}",
+                name=tool_name,
+                input={"file_path": fp},
+            ),
+        )
+    return SessionMessage(type="assistant", content_blocks=blocks)
+
+
 def _assistant_with_write_tool(
     text: str = "Editing the file now.", tool_name: str = "Edit",
 ) -> SessionMessage:
-    return SessionMessage(
-        type="assistant",
-        content_blocks=[
-            ContentBlock(type="text", text=text),
-            ContentBlock(
-                type="tool_use",
-                id="toolu_w",
-                name=tool_name,
-                input={"file_path": "/tmp/x.py"},
-            ),
-        ],
-    )
+    """Single-file convenience wrapper around ``_assistant_with_edits``."""
+    return _assistant_with_edits("/tmp/x.py", text=text, tool_name=tool_name)
 
 
 class TestUserCorrectionDetection:
@@ -292,27 +308,6 @@ class TestExtractQualitySignalsSignature:
         }
 
 
-def _assistant_with_edits(
-    *file_paths: str,
-    text: str = "",
-    tool_name: str = "Edit",
-) -> SessionMessage:
-    """Build an assistant message with one Edit tool_use per file_path."""
-    blocks: list[ContentBlock] = []
-    if text:
-        blocks.append(ContentBlock(type="text", text=text))
-    for i, fp in enumerate(file_paths):
-        blocks.append(
-            ContentBlock(
-                type="tool_use",
-                id=f"toolu_e{i}",
-                name=tool_name,
-                input={"file_path": fp},
-            ),
-        )
-    return SessionMessage(type="assistant", content_blocks=blocks)
-
-
 class TestFileReworkDetection:
     """``FILE_REWORK`` fires when a single file is edited at or above
     ``_FILE_REWORK_THRESHOLD`` (default 4) within one session. Detection
@@ -342,7 +337,12 @@ class TestFileReworkDetection:
         )
 
     def test_post_completion_edits_counted(self) -> None:
-        """Edits after completion language fire ``post_completion_edits``."""
+        """Edits after completion language fire ``post_completion_edits``.
+
+        The completion-language message itself carries an edit and the
+        flag flips before the per-block loop, so its own edit counts
+        plus the two messages after it = 3.
+        """
         messages = [
             *(_assistant_with_edits("/src/foo.py") for _ in range(2)),
             _assistant_with_edits("/src/foo.py", text="all done with this"),
@@ -351,9 +351,7 @@ class TestFileReworkDetection:
         signals = extract_quality_signals(messages)
         rework = [s for s in signals if s.signal_type == SignalType.FILE_REWORK]
         assert len(rework) == 1
-        # The completion-language message itself was an edit; the two
-        # afterward also count. Total post-completion edits >= 2.
-        assert rework[0].detail["post_completion_edits"] >= 2
+        assert rework[0].detail["post_completion_edits"] == 3
 
     def test_multiple_files_independent(self) -> None:
         """Each file is evaluated against the threshold independently."""


### PR DESCRIPTION
## Summary
- Adds `FILE_REWORK` detection — the second Tier 1 quality signal in the v0.6 quality-axis epic (#268). Counts per-file edits across the parent thread (`Edit` / `Write` / `MultiEdit`); fires when any file is edited at or above the threshold (default 4) within a single session.
- Tracks session-level "completion language" (`done` / `completed` / `ready for review` / `all set` / `implementation complete`). Edits after a completion phrase increment a per-file `post_completion_edits` counter — a stronger diagnostic that the work was declared done before further rework.
- `_EDIT_TOOL_NAMES` is a strict subset of `WRITE_TOOLS` (excludes `Bash` — no single `file_path` input — and `NotebookEdit` — rare in our target use cases). A drift-prevention test asserts the subset contract so a future tool addition to `WRITE_TOOLS` triggers a CI reminder.
- `FileReworkRule` mirrors `UserCorrectionRule` (cross-cutting, `target=\"subagent\"`). Recommendation copy branches on `post_completion_edits`: 0 → architect for design review or split into smaller steps; >0 → architect OR tester to verify completion claims. Transitional `[quality]` prefix; #273 will clean both rules when the formatter renders axis labels uniformly.

Closes #270. Architect review (no blockers, three suggestions all incorporated): https://github.com/frederick-douglas-pearce/agentfluent/issues/270#issuecomment-4386018800

## Architect-review action items folded in

- *Important*: defensive `isinstance(fp, str) and fp` guard before keying the per-file count dict — avoids `None`/non-string keys from malformed JSONL.
- *Suggestion*: drift-prevention test `_EDIT_TOOL_NAMES <= WRITE_TOOLS`.
- *Suggestion*: `completion_scope: \"session\"` stamped on every FILE_REWORK signal so #274 calibration can measure multi-task false-attribution rates.

## Test plan
- [x] Unit tests pass: `uv run pytest -m \"not integration\"` — 1053 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 100% line coverage on `quality_signals.py`. New `TestFileReworkDetection` cases: fires at threshold, doesn't fire below, post-completion counted, multi-file independence, MultiEdit counted, Bash ignored, missing `file_path` skipped, non-string `file_path` skipped. Drift-prevention `TestEditToolNamesContract`. `TestFileReworkRule` in correlator tests. Pipeline coexistence test in `TestQualitySignalsWiring`.
- [ ] Manual smoke test via `uv run agentfluent ...` — not required (output rendering changes land in #273).

## Security review
- [x] **Skip review** — pure rule-based regex / dict counting on parent-thread message data already parsed by the existing JSONL parser. No shell, subprocess, network, path resolution, hooks, secret handling, or user-controlled string rendering.
- [ ] **Needs review**

## Breaking changes
None. Additive: new detection logic in an existing extractor, new correlator rule appended to `RULES`. Existing recommendations are unchanged. `SIGNAL_AXIS_MAP[FILE_REWORK] = Axis.QUALITY` was added in #269 so the new signal flows into the quality axis without further wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)