### PR TITLE
feat(diagnostics): reviewer-caught quality signal + _QualityRule base (#271)

### DIFF
--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -732,7 +732,8 @@ class ReviewerCaughtRule(_QualityRule):
         self, signal: DiagnosticSignal,
     ) -> tuple[str, str, str]:
         agent_type = signal.agent_type or "review-style subagent"
-        finding_count = signal.detail.get("finding_count", 0)
+        keywords = signal.detail.get("finding_keywords", [])
+        finding_count = len(keywords) if isinstance(keywords, list) else 0
         parent_acted = signal.detail.get("parent_acted", False)
         observation = (
             f"`{agent_type}` produced {finding_count} substantive "

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -7,7 +7,8 @@ for extensibility.
 
 from __future__ import annotations
 
-from typing import Protocol
+from abc import ABC, abstractmethod
+from typing import ClassVar, Protocol
 
 from agentfluent.agents.models import is_builtin_agent
 from agentfluent.config.models import AgentConfig, Severity
@@ -602,40 +603,48 @@ class McpAuditRule:
         )
 
 
-class UserCorrectionRule:
-    """USER_CORRECTION -> recommend a review-style subagent.
+class _QualityRule(ABC):
+    """Shared base for cross-cutting and per-agent quality-axis rules.
 
-    Cross-cutting (``agent_type=None`` per ``quality_signals``), so this
-    rule does not branch on built-in vs custom agents — there is no
-    specific agent config to look up. Pattern follows ``McpAuditRule``,
-    which is also a cross-cutting rule with no ``_builtin_target`` /
-    ``_builtin_concern`` attributes.
+    Three concrete rules now follow this shape (``UserCorrectionRule``,
+    ``FileReworkRule``, ``ReviewerCaughtRule``); the base eliminates
+    ~30 lines × 3 of identical ``DiagnosticRecommendation`` boilerplate
+    and normalizes the message format (``f"[quality] {obs}. {reason}
+    {action}"``) across all three.
 
     The ``[quality]`` prefix on ``message`` is a transitional measure
     until #273 renders axis labels from ``primary_axis`` via the
-    formatter; #273's AC includes removing this hardcoded prefix once
-    the formatter handles axis attribution uniformly.
+    formatter; #273's AC includes removing the hardcoded prefix from
+    every concrete subclass once the formatter handles axis attribution
+    uniformly.
+
+    Subclasses must set ``SIGNAL_TYPE`` and override
+    ``_observation_reason_action``. ``TARGET`` defaults to ``"subagent"``
+    (the right answer for all three current rules); future quality
+    rules that need a different config surface (e.g., ``"prompt"``) can
+    override the class variable.
     """
 
+    SIGNAL_TYPE: ClassVar[SignalType]
+    TARGET: ClassVar[str] = "subagent"
+
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
-        return signal.signal_type == SignalType.USER_CORRECTION
+        return signal.signal_type == self.SIGNAL_TYPE
+
+    @abstractmethod
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        """Return ``(observation, reason, action)`` for the recommendation."""
 
     def recommend(
         self, signal: DiagnosticSignal, config: AgentConfig | None,
     ) -> DiagnosticRecommendation:
-        observation = signal.message
-        reason = (
-            "Mid-flight corrections are evidence the parent would benefit "
-            "from independent review before acting."
-        )
-        action = (
-            "Consider delegating to a review-style subagent (architect, "
-            "code-reviewer) for design checks before implementation."
-        )
+        observation, reason, action = self._observation_reason_action(signal)
         return DiagnosticRecommendation(
-            target="subagent",
+            target=self.TARGET,
             severity=signal.severity,
-            message=f"[quality] {observation} {reason} {action}",
+            message=f"[quality] {observation}. {reason} {action}",
             observation=observation,
             reason=reason,
             action=action,
@@ -646,26 +655,42 @@ class UserCorrectionRule:
         )
 
 
-class FileReworkRule:
-    """FILE_REWORK -> recommend a review-style subagent.
+class UserCorrectionRule(_QualityRule):
+    """USER_CORRECTION -> recommend a review-style subagent.
 
-    Cross-cutting (``agent_type=None``), shape mirrors ``UserCorrectionRule``.
-    Recommendation copy branches on ``post_completion_edits``: edits that
-    happened after "completion" language (a stronger signal — the work was
-    declared done before further rework) get a different remediation than
-    edits that may reflect ordinary iterative development.
-
-    The ``[quality]`` prefix is transitional pending #273 (axis labels
-    rendered uniformly from ``primary_axis``).
+    Cross-cutting (``agent_type=None`` on the source signal). The
+    recommendation copy is constant — it does not branch on detail
+    keys.
     """
 
-    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
-        return signal.signal_type == SignalType.FILE_REWORK
+    SIGNAL_TYPE = SignalType.USER_CORRECTION
 
-    def recommend(
-        self, signal: DiagnosticSignal, config: AgentConfig | None,
-    ) -> DiagnosticRecommendation:
-        observation = signal.message
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        return (
+            signal.message,
+            "Mid-flight corrections are evidence the parent would benefit "
+            "from independent review before acting.",
+            "Consider delegating to a review-style subagent (architect, "
+            "code-reviewer) for design checks before implementation.",
+        )
+
+
+class FileReworkRule(_QualityRule):
+    """FILE_REWORK -> recommend a review-style subagent.
+
+    Cross-cutting (``agent_type=None``). Recommendation copy branches
+    on ``post_completion_edits``: edits after the work was declared
+    complete (stronger signal) get distinct remediation from ordinary
+    iterative-development rework.
+    """
+
+    SIGNAL_TYPE = SignalType.FILE_REWORK
+
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
         post_completion = signal.detail.get("post_completion_edits", 0)
         if isinstance(post_completion, int) and post_completion > 0:
             reason = (
@@ -687,18 +712,52 @@ class FileReworkRule:
                 "Consider an architect subagent for design review, or split "
                 "the change into smaller verifiable steps."
             )
-        return DiagnosticRecommendation(
-            target="subagent",
-            severity=signal.severity,
-            message=f"[quality] {observation}. {reason} {action}",
-            observation=observation,
-            reason=reason,
-            action=action,
-            agent_type=signal.agent_type,
-            invocation_id=signal.invocation_id,
-            config_file="",
-            signal_types=[signal.signal_type],
+        return signal.message, reason, action
+
+
+class ReviewerCaughtRule(_QualityRule):
+    """REVIEWER_CAUGHT -> route more sessions through this review agent.
+
+    Per-agent (``agent_type=invocation.agent_type`` on the source signal),
+    so aggregation groups findings under each named review agent rather
+    than lumping them into the global bucket. Recommendation copy
+    branches on ``parent_acted``: when the parent followed up with
+    edits to the reviewed files, the review demonstrably had impact;
+    when not, the review may not be actionable or is being ignored.
+    """
+
+    SIGNAL_TYPE = SignalType.REVIEWER_CAUGHT
+
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        agent_type = signal.agent_type or "review-style subagent"
+        finding_count = signal.detail.get("finding_count", 0)
+        parent_acted = signal.detail.get("parent_acted", False)
+        observation = (
+            f"`{agent_type}` produced {finding_count} substantive "
+            "review finding(s) in this session"
         )
+        if parent_acted:
+            reason = (
+                "and the parent acted on them — direct evidence the "
+                "review caught real issues."
+            )
+            action = (
+                f"Consider routing more sessions through `{agent_type}` "
+                "for consistent design / quality review."
+            )
+        else:
+            reason = (
+                "but the parent's subsequent edits did not appear to "
+                "address them."
+            )
+            action = (
+                f"Investigate whether `{agent_type}`'s findings are "
+                "actionable, or whether the parent prompt should require "
+                "follow-through on review feedback."
+            )
+        return observation, reason, action
 
 
 RULES: list[CorrelationRule] = [
@@ -714,6 +773,7 @@ RULES: list[CorrelationRule] = [
     McpAuditRule(),
     UserCorrectionRule(),
     FileReworkRule(),
+    ReviewerCaughtRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -167,6 +167,59 @@ _COMPLETION_PATTERNS = _ci(
 )
 
 
+# Keywords that indicate a review subagent's response contains a
+# substantive finding rather than a "looks good" pass. Combined with
+# ``_SUBSTANTIVE_RESPONSE_MIN_CHARS`` as an AND-gate before emitting a
+# REVIEWER_CAUGHT signal: short responses or those without these
+# keywords are treated as clean passes and produce no signal.
+_FINDING_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "blocker", "issue", "concern", "must", "should",
+        "warning", "risk", "vulnerability", "fix", "change needed",
+    },
+)
+_FINDING_KEYWORDS_PATTERN = re.compile(
+    "|".join(rf"\b{re.escape(k)}\b" for k in _FINDING_KEYWORDS),
+    re.IGNORECASE,
+)
+
+# Minimum response length (chars) for a review subagent's output to
+# count as substantive. Short responses are ``LGTM``-style passes.
+_SUBSTANTIVE_RESPONSE_MIN_CHARS = 500
+
+# Source-file extensions a review subagent is plausibly referencing.
+# The list is conservative — including version strings (``v1.0``) and
+# domain names (``github.com``) as "files" would inflate ``parent_acted``
+# counts. Architect review on #271 promoted this list to a module
+# constant for #274 calibration.
+_SOURCE_FILE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        "py", "ts", "js", "jsx", "tsx", "md", "yaml", "yml", "json",
+        "toml", "rs", "go", "java", "rb", "sh", "css", "html", "c",
+        "cpp", "h", "hpp",
+    },
+)
+_SOURCE_FILE_EXTENSIONS_RE = "|".join(_SOURCE_FILE_EXTENSIONS)
+# Match either (a) paths with a directory component (anything before a
+# ``/``) and a file-like name, or (b) bare filenames whose extension is
+# in our known-source-extension set. Both styles are common in review
+# output ("see src/foo.py" vs "rename module.py to ...").
+_DIR_PATH_PATTERN = re.compile(
+    r"(?:[a-zA-Z0-9_.\-]+/)+[a-zA-Z0-9_\-]+\.[a-zA-Z]{1,10}",
+)
+_BARE_FILE_PATTERN = re.compile(
+    rf"\b[a-zA-Z0-9_\-]+\.(?:{_SOURCE_FILE_EXTENSIONS_RE})\b",
+    re.IGNORECASE,
+)
+
+# Cap on assistant messages to scan after a review's tool_result when
+# checking whether the parent acted on the review's findings. An edit
+# 150 messages later is almost certainly unrelated — capping at 15
+# matches the typical "reviewer findings → parent follows up within a
+# few turns" cadence and is calibratable in #274.
+_PARENT_ACTED_WINDOW = 15
+
+
 @dataclass(slots=True)
 class _FileEditStats:
     """Accumulator for a single file's edit activity within a session.
@@ -266,6 +319,114 @@ def _emit_user_correction_signals(
     ]
 
 
+def _extract_files_mentioned(text: str) -> set[str]:
+    """Extract plausible source-file paths from review prose.
+
+    Strict by design (architect review concern #1 on #271): matches
+    require either a directory separator (``src/foo.py``) or a known
+    source-file extension (``.py``, ``.ts``, ``.md``, ...). Strings like
+    ``v1.0``, ``section 3.b``, and ``github.com`` do not match —
+    inflating ``parent_acted = True`` from prose noise would undermine
+    the signal's reliability, and a missed obscure extension is the
+    safer error direction (yields ``parent_acted = False``).
+    """
+    return set(_DIR_PATH_PATTERN.findall(text)) | set(
+        _BARE_FILE_PATTERN.findall(text),
+    )
+
+
+def _files_edited_after(
+    messages: list[SessionMessage],
+    start_idx: int,
+    *,
+    window: int = _PARENT_ACTED_WINDOW,
+) -> set[str]:
+    """File paths edited in the next ``window`` assistant messages
+    after ``start_idx``. Used to compute ``parent_acted`` — capped so
+    edits 100+ messages later cannot be attributed to the review."""
+    edited: set[str] = set()
+    seen_assistants = 0
+    for msg in messages[start_idx + 1:]:
+        if msg.type != "assistant":
+            continue
+        seen_assistants += 1
+        if seen_assistants > window:
+            break
+        for block in msg.tool_use_blocks:
+            if block.name not in _EDIT_TOOL_NAMES:
+                continue
+            fp = block.input.get("file_path")
+            if isinstance(fp, str) and fp:
+                edited.add(fp)
+    return edited
+
+
+def _extract_reviewer_caught_signals(
+    messages: list[SessionMessage],
+    agent_invocations: list[AgentInvocation],
+) -> list[DiagnosticSignal]:
+    """Emit one ``REVIEWER_CAUGHT`` per substantive review.
+
+    A review invocation is "substantive" when the response is at least
+    ``_SUBSTANTIVE_RESPONSE_MIN_CHARS`` long AND mentions at least one
+    finding keyword. ``parent_acted`` is True when any file mentioned
+    in the review's output is edited in the following
+    ``_PARENT_ACTED_WINDOW`` assistant messages.
+    """
+    # tool_use_id -> index of the message containing the corresponding
+    # tool_result block. Lets us scope ``parent_acted`` look-forward to
+    # messages strictly after the review's result.
+    tool_result_idx: dict[str, int] = {}
+    for idx, msg in enumerate(messages):
+        if msg.type != "user":
+            continue
+        for block in msg.content_blocks:
+            if block.type == "tool_result" and block.tool_use_id:
+                tool_result_idx[block.tool_use_id] = idx
+
+    signals: list[DiagnosticSignal] = []
+    for inv in agent_invocations:
+        if inv.agent_type.lower() not in REVIEW_AGENT_TYPES:
+            continue
+        text = inv.output_text
+        if not text or len(text) < _SUBSTANTIVE_RESPONSE_MIN_CHARS:
+            continue
+        keyword_hits = sorted({m.lower() for m in _FINDING_KEYWORDS_PATTERN.findall(text)})
+        if not keyword_hits:
+            continue
+
+        files_mentioned = _extract_files_mentioned(text)
+        files_acted_on: set[str] = set()
+        result_idx = tool_result_idx.get(inv.tool_use_id)
+        if result_idx is not None and files_mentioned:
+            edited = _files_edited_after(messages, result_idx)
+            files_acted_on = files_mentioned & edited
+
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.REVIEWER_CAUGHT,
+                severity=Severity.INFO,
+                agent_type=inv.agent_type,
+                invocation_id=inv.tool_use_id,
+                message=(
+                    f"`{inv.agent_type}` review surfaced "
+                    f"{len(keyword_hits)} finding-keyword(s)"
+                ),
+                detail={
+                    "agent_type": inv.agent_type,
+                    "finding_count": len(keyword_hits),
+                    "finding_keywords": keyword_hits,
+                    "parent_acted": bool(files_acted_on),
+                    "response_length": len(text),
+                    "review_invocation_id": inv.tool_use_id,
+                    "files_mentioned": sorted(files_mentioned),
+                    "files_acted_on": sorted(files_acted_on),
+                },
+            ),
+        )
+    return signals
+
+
 def _emit_file_rework_signals(
     edit_stats: dict[str, _FileEditStats],
 ) -> list[DiagnosticSignal]:
@@ -297,15 +458,18 @@ def extract_quality_signals(
 ) -> list[DiagnosticSignal]:
     """Extract quality-axis signals from parent-thread messages.
 
-    Emits ``USER_CORRECTION`` (#269) and ``FILE_REWORK`` (#270);
-    ``REVIEWER_CAUGHT`` (#271) will land here. ``agent_invocations`` is
-    accepted but unused by the current detectors — locked in this
-    signature so #271 can plug in without breaking the existing
-    callers.
+    Emits ``USER_CORRECTION`` (#269), ``FILE_REWORK`` (#270), and
+    ``REVIEWER_CAUGHT`` (#271). The first two are cross-cutting
+    (``agent_type=None``) parent-thread observations; ``REVIEWER_CAUGHT``
+    is per-agent (``agent_type`` carries the named review subagent) so
+    aggregation can group findings under each review agent rather than
+    lumping them globally.
 
-    Returns an empty list when ``messages`` is empty. ``agent_type`` is
-    ``None`` on every emitted signal: these are cross-cutting
-    parent-thread observations, not subagent-scoped findings.
+    ``agent_invocations`` drives the REVIEWER_CAUGHT detector; the
+    other two detectors only need ``messages``. Pass ``None`` (or omit)
+    to skip review-agent analysis when invocations aren't available.
+
+    Returns an empty list when ``messages`` is empty.
     """
     if not messages:
         return []
@@ -363,9 +527,15 @@ def extract_quality_signals(
             (category, matched_phrase, _build_snippet(text), preceding),
         )
 
+    reviewer_signals = (
+        _extract_reviewer_caught_signals(messages, agent_invocations)
+        if agent_invocations
+        else []
+    )
     return [
         *_emit_user_correction_signals(
             correction_detections, total_user_messages,
         ),
         *_emit_file_rework_signals(edit_stats),
+        *reviewer_signals,
     ]

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -373,6 +373,15 @@ def _extract_reviewer_caught_signals(
     in the review's output is edited in the following
     ``_PARENT_ACTED_WINDOW`` assistant messages.
     """
+    # Skip the per-message walk when no review-style agents ran at all
+    # — the most common case in non-review-using projects.
+    review_invocations = [
+        inv for inv in agent_invocations
+        if inv.agent_type.lower() in REVIEW_AGENT_TYPES
+    ]
+    if not review_invocations:
+        return []
+
     # tool_use_id -> index of the message containing the corresponding
     # tool_result block. Lets us scope ``parent_acted`` look-forward to
     # messages strictly after the review's result.
@@ -385,9 +394,7 @@ def _extract_reviewer_caught_signals(
                 tool_result_idx[block.tool_use_id] = idx
 
     signals: list[DiagnosticSignal] = []
-    for inv in agent_invocations:
-        if inv.agent_type.lower() not in REVIEW_AGENT_TYPES:
-            continue
+    for inv in review_invocations:
         text = inv.output_text
         if not text or len(text) < _SUBSTANTIVE_RESPONSE_MIN_CHARS:
             continue
@@ -413,12 +420,9 @@ def _extract_reviewer_caught_signals(
                     f"{len(keyword_hits)} finding-keyword(s)"
                 ),
                 detail={
-                    "agent_type": inv.agent_type,
-                    "finding_count": len(keyword_hits),
                     "finding_keywords": keyword_hits,
                     "parent_acted": bool(files_acted_on),
                     "response_length": len(text),
-                    "review_invocation_id": inv.tool_use_id,
                     "files_mentioned": sorted(files_mentioned),
                     "files_acted_on": sorted(files_acted_on),
                 },

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -725,3 +725,60 @@ class TestFileReworkRule:
         action = recs[0].action.lower()
         assert "architect" in action
         assert "tester" in action
+
+
+class TestReviewerCaughtRule:
+    """REVIEWER_CAUGHT -> per-agent ``target='subagent'`` recommendation."""
+
+    @staticmethod
+    def _signal(
+        agent_type: str = "architect",
+        finding_count: int = 3,
+        parent_acted: bool = True,
+    ) -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.REVIEWER_CAUGHT,
+            severity=Severity.INFO,
+            agent_type=agent_type,
+            invocation_id="toolu_review",
+            message=(
+                f"`{agent_type}` review surfaced {finding_count} finding-keyword(s)"
+            ),
+            detail={
+                "agent_type": agent_type,
+                "finding_count": finding_count,
+                "finding_keywords": ["blocker", "issue", "must"],
+                "parent_acted": parent_acted,
+                "response_length": 1000,
+                "review_invocation_id": "toolu_review",
+                "files_mentioned": ["src/foo.py"],
+                "files_acted_on": ["src/foo.py"] if parent_acted else [],
+            },
+        )
+
+    def test_emits_subagent_target_per_agent(self) -> None:
+        recs = correlate([self._signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "subagent"
+        assert rec.agent_type == "architect"
+        assert rec.invocation_id == "toolu_review"
+        assert rec.signal_types == [SignalType.REVIEWER_CAUGHT]
+
+    def test_message_carries_quality_prefix(self) -> None:
+        recs = correlate([self._signal()])
+        assert "[quality]" in recs[0].message
+
+    def test_parent_acted_branch_routes_more_sessions(self) -> None:
+        recs = correlate([self._signal(parent_acted=True)])
+        action = recs[0].action.lower()
+        assert "more sessions" in action or "routing" in action
+
+    def test_parent_did_not_act_branch_suggests_investigation(self) -> None:
+        recs = correlate([self._signal(parent_acted=False)])
+        action = recs[0].action.lower()
+        assert "investigate" in action or "follow-through" in action
+
+    def test_agent_name_appears_in_action(self) -> None:
+        recs = correlate([self._signal(agent_type="code-reviewer")])
+        assert "code-reviewer" in recs[0].action

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -733,24 +733,24 @@ class TestReviewerCaughtRule:
     @staticmethod
     def _signal(
         agent_type: str = "architect",
-        finding_count: int = 3,
+        finding_keywords: list[str] | None = None,
         parent_acted: bool = True,
     ) -> DiagnosticSignal:
+        kw = finding_keywords if finding_keywords is not None else [
+            "blocker", "issue", "must",
+        ]
         return DiagnosticSignal(
             signal_type=SignalType.REVIEWER_CAUGHT,
             severity=Severity.INFO,
             agent_type=agent_type,
             invocation_id="toolu_review",
             message=(
-                f"`{agent_type}` review surfaced {finding_count} finding-keyword(s)"
+                f"`{agent_type}` review surfaced {len(kw)} finding-keyword(s)"
             ),
             detail={
-                "agent_type": agent_type,
-                "finding_count": finding_count,
-                "finding_keywords": ["blocker", "issue", "must"],
+                "finding_keywords": kw,
                 "parent_acted": parent_acted,
                 "response_length": 1000,
-                "review_invocation_id": "toolu_review",
                 "files_mentioned": ["src/foo.py"],
                 "files_acted_on": ["src/foo.py"] if parent_acted else [],
             },

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -767,3 +767,89 @@ class TestQualitySignalsWiring:
         kinds = {s.signal_type for s in result.signals}
         assert SignalType.USER_CORRECTION in kinds
         assert SignalType.FILE_REWORK in kinds
+
+    def test_all_three_quality_signals_coexist(self) -> None:
+        """USER_CORRECTION + FILE_REWORK + REVIEWER_CAUGHT all fire on
+        the same session when the evidence is present. Confirms #271
+        plugged into the pipeline without breaking the existing
+        cross-cutting detectors."""
+        edit_block = ContentBlock(
+            type="tool_use",
+            id="toolu_e",
+            name="Edit",
+            input={"file_path": "/src/foo.py"},
+        )
+        substantive = (
+            "I reviewed the change and found several blocker issues "
+            "that must be addressed before merge. The function in "
+            "src/foo.py does not handle the empty-input case and "
+            "will raise an unexpected exception at runtime. Second "
+            "concern: there is a security risk in the auth flow — "
+            "credentials are logged at debug level which is a real "
+            "vulnerability if log levels are misconfigured. Third "
+            "warning: the test fixture in tests/test_foo.py mocks "
+            "behavior that contradicts the production code path. "
+            "Recommended fix: add input validation and redact "
+            "credentials before logging."
+        )
+        review_inv = AgentInvocation(
+            agent_type="architect",
+            description="review",
+            prompt="review the diff",
+            tool_use_id="toolu_review",
+            output_text=substantive,
+        )
+
+        messages: list[SessionMessage] = []
+        for _ in range(4):
+            messages.append(
+                SessionMessage(type="assistant", content_blocks=[edit_block]),
+            )
+        messages.append(
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(type="text", text="that's wrong, undo it"),
+                ],
+            ),
+        )
+        # The review's tool_result and the architect invocation must
+        # both be present in the messages so the pipeline's own
+        # extract_agent_invocations sees the review.
+        messages.append(
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_review",
+                        name="Agent",
+                        input={
+                            "subagent_type": "architect",
+                            "description": "review",
+                            "prompt": "review the diff",
+                        },
+                    ),
+                ],
+            ),
+        )
+        messages.append(
+            SessionMessage(
+                type="user",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_result",
+                        tool_use_id="toolu_review",
+                        text=substantive,
+                    ),
+                ],
+            ),
+        )
+
+        result = run_diagnostics(
+            [_inv(), review_inv], parent_messages=messages,
+        )
+        kinds = {s.signal_type for s in result.signals}
+        assert SignalType.USER_CORRECTION in kinds
+        assert SignalType.FILE_REWORK in kinds
+        assert SignalType.REVIEWER_CAUGHT in kinds

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -456,3 +456,202 @@ class TestEditToolNamesContract:
 
     def test_edit_tool_names_subset_of_write_tools(self) -> None:
         assert _EDIT_TOOL_NAMES <= WRITE_TOOLS
+
+
+def _review_invocation(
+    agent_type: str = "architect",
+    output_text: str = "",
+    tool_use_id: str = "toolu_review",
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        description="review",
+        prompt="review the diff",
+        tool_use_id=tool_use_id,
+        output_text=output_text,
+    )
+
+
+def _user_with_tool_result(
+    tool_use_id: str, content: str = "review complete",
+) -> SessionMessage:
+    return SessionMessage(
+        type="user",
+        content_blocks=[
+            ContentBlock(
+                type="tool_result", tool_use_id=tool_use_id, text=content,
+            ),
+        ],
+    )
+
+
+_SUBSTANTIVE_REVIEW = (
+    "I reviewed the change and found several blocker issues that must "
+    "be addressed before merge. First concern: the new function in "
+    "src/foo.py does not handle the empty-input case and will raise "
+    "an unexpected exception at runtime. Second issue: a security risk "
+    "in the auth flow — credentials are logged at debug level which "
+    "is a real vulnerability if log levels are misconfigured. Third "
+    "warning: the test fixture in tests/test_foo.py mocks behavior "
+    "that contradicts the production code path; the test should "
+    "exercise the real implementation. Recommended fix: add input "
+    "validation, redact credentials before logging, and rewrite the "
+    "fixture against the real code path."
+)
+
+
+class TestReviewerCaughtDetection:
+    """REVIEWER_CAUGHT fires when a review-style subagent (architect,
+    code-reviewer, security-review, tester) produces a substantive
+    response (>= 500 chars + finding keywords). Per-agent attribution
+    — ``agent_type`` carries the named review agent."""
+
+    def test_substantive_review_fires(self) -> None:
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        rev = [s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT]
+        assert len(rev) == 1
+        sig = rev[0]
+        assert sig.agent_type == "architect"
+        assert sig.detail["finding_count"] >= 1
+        assert "blocker" in sig.detail["finding_keywords"]
+
+    def test_lgtm_pass_does_not_fire(self) -> None:
+        inv = _review_invocation(output_text="LGTM, no concerns.")
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        assert not any(
+            s.signal_type == SignalType.REVIEWER_CAUGHT for s in signals
+        )
+
+    def test_long_response_without_keywords_does_not_fire(self) -> None:
+        inv = _review_invocation(output_text="x" * 1000)
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        assert not any(
+            s.signal_type == SignalType.REVIEWER_CAUGHT for s in signals
+        )
+
+    def test_parent_acted_when_mentioned_file_subsequently_edited(self) -> None:
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages = [
+            _user_with_tool_result(inv.tool_use_id),
+            _assistant_with_edits("src/foo.py"),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is True
+        assert "src/foo.py" in rev.detail["files_acted_on"]
+
+    def test_parent_not_acted_when_no_followup_edits(self) -> None:
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is False
+
+    def test_parent_acted_window_caps_lookforward(self) -> None:
+        """Edits beyond the look-forward window do not count toward
+        ``parent_acted``. Defends against attributing unrelated edits
+        100+ messages later to a review (architect concern #2)."""
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages: list[SessionMessage] = [_user_with_tool_result(inv.tool_use_id)]
+        for i in range(20):
+            messages.append(_assistant_text(f"step {i}"))
+        messages.append(_assistant_with_edits("src/foo.py"))
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is False
+
+    def test_built_in_code_reviewer_fires(self) -> None:
+        inv = _review_invocation(
+            agent_type="code-reviewer", output_text=_SUBSTANTIVE_REVIEW,
+        )
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        rev = [s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT]
+        assert len(rev) == 1
+        assert rev[0].agent_type == "code-reviewer"
+
+    def test_non_review_agent_ignored(self) -> None:
+        inv = _review_invocation(
+            agent_type="general-purpose", output_text=_SUBSTANTIVE_REVIEW,
+        )
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        assert not any(
+            s.signal_type == SignalType.REVIEWER_CAUGHT for s in signals
+        )
+
+    def test_no_invocations_yields_no_reviewer_signals(self) -> None:
+        """When ``agent_invocations`` is None or empty, the detector
+        is silently skipped."""
+        signals = extract_quality_signals(messages=[], agent_invocations=None)
+        assert signals == []
+
+    def test_files_mentioned_uses_strict_pattern(self) -> None:
+        """``v1.0``, ``github.com``, ``section 3.b`` should NOT be
+        classified as files (architect concern #1 on #271)."""
+        review = _SUBSTANTIVE_REVIEW + (
+            " See v1.0 release notes at github.com/foo/bar — "
+            "section 3.b for context."
+        )
+        inv = _review_invocation(output_text=review)
+        signals = extract_quality_signals(
+            messages=[_user_with_tool_result(inv.tool_use_id)],
+            agent_invocations=[inv],
+        )
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert "src/foo.py" in rev.detail["files_mentioned"]
+        assert "tests/test_foo.py" in rev.detail["files_mentioned"]
+        assert "v1.0" not in rev.detail["files_mentioned"]
+        assert "3.b" not in rev.detail["files_mentioned"]
+        assert "github.com" not in rev.detail["files_mentioned"]
+
+    def test_parent_acted_skips_user_messages_between(self) -> None:
+        """Look-forward over assistant edits ignores intervening user
+        messages — defensive ``continue`` branch."""
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages: list[SessionMessage] = [
+            _user_with_tool_result(inv.tool_use_id),
+            _user("interjection from the user"),
+            _assistant_with_edits("src/foo.py"),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is True
+
+    def test_parent_acted_ignores_non_edit_tool_blocks(self) -> None:
+        """Bash and other non-edit tools in the look-forward window
+        do not count toward ``files_acted_on``."""
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages = [
+            _user_with_tool_result(inv.tool_use_id),
+            SessionMessage(
+                type="assistant",
+                content_blocks=[
+                    ContentBlock(
+                        type="tool_use",
+                        id="toolu_b",
+                        name="Bash",
+                        input={"command": "ls src/"},
+                    ),
+                ],
+            ),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is False

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -516,7 +516,7 @@ class TestReviewerCaughtDetection:
         assert len(rev) == 1
         sig = rev[0]
         assert sig.agent_type == "architect"
-        assert sig.detail["finding_count"] >= 1
+        assert len(sig.detail["finding_keywords"]) >= 1
         assert "blocker" in sig.detail["finding_keywords"]
 
     def test_lgtm_pass_does_not_fire(self) -> None:


### PR DESCRIPTION
## Summary
- Adds **REVIEWER_CAUGHT** detection — the third Tier 1 quality signal in the v0.6 quality-axis epic (#268). The only signal that scores **positive evidence** (review subagents demonstrably catching issues) rather than negative evidence (parent struggles) — closes the under-recommendation gap that motivated the epic.
- Extracts a shared **\`_QualityRule(ABC)\`** base class for the three \`[quality]\` rules now that three concrete instances exist. Eliminates ~30 lines × 3 of identical \`DiagnosticRecommendation\` boilerplate and normalizes the message format. \`TARGET = \"subagent\"\` is a \`ClassVar\` so future quality rules can override if needed.
- \`ReviewerCaughtRule\` is **per-agent** (\`agent_type\` carries the named review agent) — aggregation groups findings under each review subagent rather than the global bucket. Branches on \`parent_acted\`: True → route more sessions through it; False → investigate why findings aren't being acted on.

Closes #271. Architect review (1 blocking + 1 important + 1 suggestion, all folded in): https://github.com/frederick-douglas-pearce/agentfluent/issues/271#issuecomment-4386428093

## Architect-review action items folded in
- **Blocking #1** — strict file-path regex pair (\`_DIR_PATH_PATTERN\` + \`_BARE_FILE_PATTERN\`) replaces the original permissive pattern. Paths require either a directory separator OR a known source-file extension (\`.py\`, \`.ts\`, \`.md\`, ...). Without this, \`v1.0\`, \`github.com\`, and \`section 3.b\` would have inflated \`parent_acted = True\` from prose noise. Verified by \`test_files_mentioned_uses_strict_pattern\`.
- **Important #2** — capped \`parent_acted\` look-forward at 15 assistant messages via \`_PARENT_ACTED_WINDOW\` constant. Edits 100+ messages later cannot be misattributed to the review. Verified by \`test_parent_acted_window_caps_lookforward\`.
- **Suggestion #3** — \`_QualityRule.TARGET\` is a \`ClassVar[str]\` so a future quality rule needing \`target=\"prompt\"\` (e.g., recommending the parent's own prompt include review instructions) can override without modifying the base.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` — 1077 passed
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New behavior has test coverage — 100% line coverage on \`quality_signals.py\`. 10 new \`TestReviewerCaughtDetection\` cases + 5 \`TestReviewerCaughtRule\` cases + 1 pipeline coexistence test (all three quality signals fire together). Existing \`TestUserCorrectionRule\` / \`TestFileReworkRule\` cases pass unchanged against the refactored base class.
- [ ] Manual smoke test via \`uv run agentfluent ...\` — not required (output rendering changes land in #273).

## Security review
- [x] **Skip review** — pure rule-based regex / dict counting on parent-thread message data already parsed by the existing JSONL parser. No shell, subprocess, network, path resolution, hooks, secret handling, or user-controlled string rendering. The new file-path regex only extracts path-shaped strings from review prose; it does not open or operate on those paths.
- [ ] **Needs review**

## Breaking changes
None. Additive: new detection logic in an existing extractor, new correlator rule appended to \`RULES\`. The \`_QualityRule\` base extraction is internal — no public interface changed; \`UserCorrectionRule\` and \`FileReworkRule\` retain their public class identity (now subclasses). \`SIGNAL_AXIS_MAP[REVIEWER_CAUGHT] = Axis.QUALITY\` was added in #269 so the new signal flows into the quality axis without further wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)