### PR TITLE
feat(diagnostics): multi-axis scoring + axis attribution (#272)

### DIFF
--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -52,6 +52,7 @@ from agentfluent.diagnostics.models import (
     DiagnosticRecommendation,
     DiagnosticSignal,
     SignalType,
+    zero_axis_scores,
 )
 
 # Single-axis classification per D022. Every ``SignalType`` maps to
@@ -197,12 +198,7 @@ def _compute_priority_score(
     has_trace_evidence: bool,
     quality_evidence_factor: float = 0.0,
 ) -> float:
-    """Composite score per the formula in this module's docstring.
-
-    ``quality_evidence_factor`` defaults to ``0.0`` so callers from
-    before #272 (none in-tree, but defensive) and any test fixture that
-    omits it produce the v0.5 score unchanged.
-    """
+    """Composite score per the formula in this module's docstring."""
     return (
         _SEVERITY_RANK[severity] * _PRIORITY_WEIGHT_SEVERITY
         + math.log1p(count) * _PRIORITY_WEIGHT_COUNT
@@ -213,15 +209,30 @@ def _compute_priority_score(
 
 
 def _signal_axis_contribution(signal: DiagnosticSignal) -> float:
-    """Per-signal contribution to its axis bucket in ``axis_scores``.
+    """Per-signal contribution to its axis bucket — Tier 1 = severity rank.
 
-    Tier 1 (#272) uses the severity rank as the single contribution
-    factor — count of signals naturally accumulates as the loop iterates.
-    Calibration deferred to #274; the function is co-located with
-    ``_compute_priority_score`` and shares ``_SEVERITY_RANK`` so weight
-    constants cannot drift between the two scoring entry points.
+    Calibration of the per-signal factor is deferred to #274.
     """
     return float(_SEVERITY_RANK[signal.severity])
+
+
+def _compute_axis_attribution(
+    signals: list[DiagnosticSignal],
+) -> tuple[dict[str, float], str]:
+    """Sum per-signal axis contributions and resolve ``primary_axis``.
+
+    Returns ``(axis_scores, primary_axis)``. ``axis_scores`` keys are
+    bare axis strings for stable JSON serialization. ``primary_axis``
+    breaks ties via D027 (quality > speed > cost).
+    """
+    axis_scores = zero_axis_scores()
+    for sig in signals:
+        axis = SIGNAL_AXIS_MAP[sig.signal_type]
+        axis_scores[axis.value] += _signal_axis_contribution(sig)
+    primary_axis = max(
+        _AXIS_TIEBREAKER, key=lambda a: axis_scores[a.value],
+    ).value
+    return axis_scores, primary_axis
 
 
 def aggregate_recommendations(
@@ -251,24 +262,16 @@ def aggregate_recommendations(
             sig.signal_type in TRACE_SIGNAL_TYPES for sig in signals
         )
         summed_savings = _summed_savings_usd(signals)
-
-        axis_scores: dict[str, float] = {a.value: 0.0 for a in Axis}
-        has_quality_evidence = False
-        for sig in signals:
-            axis = SIGNAL_AXIS_MAP[sig.signal_type]
-            axis_scores[axis.value] += _signal_axis_contribution(sig)
-            if axis is Axis.QUALITY:
-                has_quality_evidence = True
-        primary_axis = max(
-            _AXIS_TIEBREAKER, key=lambda a: axis_scores[a.value],
-        ).value
-
+        axis_scores, primary_axis = _compute_axis_attribution(signals)
+        quality_evidence_factor = (
+            1.0 if axis_scores[Axis.QUALITY.value] > 0.0 else 0.0
+        )
         priority_score = _compute_priority_score(
             severity,
             count,
             summed_savings,
             has_trace_evidence,
-            quality_evidence_factor=1.0 if has_quality_evidence else 0.0,
+            quality_evidence_factor=quality_evidence_factor,
         )
 
         aggregated.append(

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -1,38 +1,40 @@
 """Aggregate per-invocation recommendations into distinct findings.
 
-``correlate`` emits one recommendation per matched signal, which produces
-N near-identical rows when N invocations of the same agent trigger the
-same rule (e.g., four Explore invocations each firing TOKEN_OUTLIER).
-The default Recommendations table is far more actionable when those N
-rows collapse to a single aggregated row with an occurrence count and
-(for signal types that carry scalar metrics) a min–max range.
+``correlate`` emits one recommendation per matched signal, producing
+N near-identical rows when N invocations trigger the same rule. The
+default Recommendations table is more actionable when those rows
+collapse to a single row with an occurrence count and (for signal
+types with scalar metrics) a min–max range. Aggregation runs after
+``correlate`` so every output format benefits; per-invocation
+recommendations are preserved on ``DiagnosticsResult`` for
+``--verbose`` and JSON drill-down.
 
-Aggregation happens in the pipeline, after ``correlate``, so every
-output format benefits — not just the table formatter. The raw
-per-invocation list is preserved alongside the aggregated list on
-``DiagnosticsResult`` so ``--verbose`` and JSON consumers can drill in.
-
-**Priority scoring (#172).** Each aggregated row carries a
-``priority_score: float`` so the default table can sort by impact.
-The score is a weighted composite:
+**Priority scoring (#172, #272).** Each aggregated row carries a
+``priority_score`` for sort-by-impact:
 
     score = severity_rank * W_SEVERITY
           + log1p(count) * W_COUNT
           + summed_savings_usd * W_COST
           + has_trace_evidence * W_TRACE
+          + quality_evidence_factor * W_QUALITY
 
-Severity dominates: ``W_SEVERITY = 100`` is large enough that a
-single CRITICAL outranks any volume of WARNINGs. ``log1p(count)``
-gives diminishing returns so 100 occurrences score ~5x a single
-one, not 100x. ``summed_savings_usd`` is summed across contributing
-``MODEL_MISMATCH`` signals; each signal's ``estimated_savings_usd``
-is **already an agent-type aggregate** (model_routing emits one
-signal per agent_type), so summing across contributors only
-double-counts when multiple agent_types share the same
-``(target, signal_types)`` shape — vanishing-rare. Trace-signal
-evidence (``STUCK_PATTERN``, ``RETRY_LOOP``, ``PERMISSION_FAILURE``,
-``TOOL_ERROR_SEQUENCE``) adds a modest boost so deep findings
-outrank metadata-only ones at the same severity + count.
+Severity dominates (``W_SEVERITY = 100``): one CRITICAL outranks any
+volume of WARNINGs. ``log1p(count)`` damps repeats. Trace evidence
+(``STUCK_PATTERN``, ``RETRY_LOOP``, ``PERMISSION_FAILURE``,
+``TOOL_ERROR_SEQUENCE``) gets a modest boost over metadata-only
+signals.
+
+The ``quality_evidence_factor`` (D021) is ``1.0`` when any
+contributing signal maps to ``Axis.QUALITY``, else ``0.0``. The
+annotations approach preserves backward compatibility: recommendations
+without quality signals score identically to v0.5, so post-upgrade
+``diff`` shows zero ``priority_score_delta`` for persisting
+non-quality recommendations.
+
+**Axis attribution (#272, D021/D022/D027).** ``axis_scores`` sums
+each signal's severity-rank contribution into the axis bucket assigned
+by ``SIGNAL_AXIS_MAP``. ``primary_axis`` is the largest bucket; ties
+resolve via ``_AXIS_TIEBREAKER`` (quality > speed > cost) per D027.
 """
 
 from __future__ import annotations
@@ -56,15 +58,10 @@ from agentfluent.diagnostics.models import (
 # exactly one ``Axis``; cross-cutting reduced-weight contributions were
 # rejected for Tier 1. ``ERROR_PATTERN``, ``PERMISSION_FAILURE``, and
 # ``MCP_MISSING_SERVER`` land on ``SPEED`` as the closest existing axis
-# for operational-health signals.
-#
-# Defined here (rather than alongside ``SignalType`` in ``models.py``)
-# because aggregation is the natural consumer — ``axis_scores`` and
-# ``primary_axis`` annotations on ``AggregatedRecommendation`` will be
-# computed by reading this map (#272). Defined-but-not-yet-consumed in
-# v0.6 #269; the drift-prevention test in
-# ``tests/unit/test_recommendation_aggregation.py`` ensures any new
-# ``SignalType`` lacking an entry fails CI.
+# for operational-health signals. Defined here rather than in
+# ``models.py`` because aggregation is the natural consumer; the
+# drift-prevention test in ``tests/unit/test_recommendation_aggregation``
+# ensures any new ``SignalType`` lacking an entry fails CI.
 SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.TOKEN_OUTLIER: Axis.COST,
     SignalType.MODEL_MISMATCH: Axis.COST,
@@ -87,14 +84,21 @@ _SCALAR_METRIC_SIGNALS: frozenset[SignalType] = frozenset(
     {SignalType.TOKEN_OUTLIER, SignalType.DURATION_OUTLIER},
 )
 
-# Priority-score weights (#172). Tuned so severity dominates: a single
-# CRITICAL (rank 3) outranks any volume of WARNING (rank 2). Calibration
-# pass against multi-contributor data is a v0.6 follow-up if dogfood
-# shows the ranking is off.
+# Priority-score weights (#172, #272). Tuned so severity dominates: a
+# single CRITICAL (rank 3) outranks any volume of WARNING (rank 2).
+# Calibration pass against multi-contributor data is a v0.6 follow-up
+# if dogfood shows the ranking is off (#274).
 _PRIORITY_WEIGHT_SEVERITY = 100.0
 _PRIORITY_WEIGHT_COUNT = 10.0
 _PRIORITY_WEIGHT_COST = 1.0
 _PRIORITY_WEIGHT_TRACE = 5.0
+_PRIORITY_WEIGHT_QUALITY = 5.0
+
+# D027: deterministic tiebreaker for ``primary_axis`` when two or more
+# axes carry equal ``axis_scores``. Quality wins ties so the v0.6
+# headline axis stays visible by default; see decisions.md D027 for
+# the product rationale and tradeoffs.
+_AXIS_TIEBREAKER: tuple[Axis, ...] = (Axis.QUALITY, Axis.SPEED, Axis.COST)
 
 # Shape key for grouping per-invocation recommendations. ``agent_type``
 # is ``None`` for cross-cutting recommendations (MCP audit) which form
@@ -191,14 +195,33 @@ def _compute_priority_score(
     count: int,
     summed_savings: float,
     has_trace_evidence: bool,
+    quality_evidence_factor: float = 0.0,
 ) -> float:
-    """Composite score per the formula in this module's docstring."""
+    """Composite score per the formula in this module's docstring.
+
+    ``quality_evidence_factor`` defaults to ``0.0`` so callers from
+    before #272 (none in-tree, but defensive) and any test fixture that
+    omits it produce the v0.5 score unchanged.
+    """
     return (
         _SEVERITY_RANK[severity] * _PRIORITY_WEIGHT_SEVERITY
         + math.log1p(count) * _PRIORITY_WEIGHT_COUNT
         + summed_savings * _PRIORITY_WEIGHT_COST
         + (1.0 if has_trace_evidence else 0.0) * _PRIORITY_WEIGHT_TRACE
+        + quality_evidence_factor * _PRIORITY_WEIGHT_QUALITY
     )
+
+
+def _signal_axis_contribution(signal: DiagnosticSignal) -> float:
+    """Per-signal contribution to its axis bucket in ``axis_scores``.
+
+    Tier 1 (#272) uses the severity rank as the single contribution
+    factor — count of signals naturally accumulates as the loop iterates.
+    Calibration deferred to #274; the function is co-located with
+    ``_compute_priority_score`` and shares ``_SEVERITY_RANK`` so weight
+    constants cannot drift between the two scoring entry points.
+    """
+    return float(_SEVERITY_RANK[signal.severity])
 
 
 def aggregate_recommendations(
@@ -228,8 +251,24 @@ def aggregate_recommendations(
             sig.signal_type in TRACE_SIGNAL_TYPES for sig in signals
         )
         summed_savings = _summed_savings_usd(signals)
+
+        axis_scores: dict[str, float] = {a.value: 0.0 for a in Axis}
+        has_quality_evidence = False
+        for sig in signals:
+            axis = SIGNAL_AXIS_MAP[sig.signal_type]
+            axis_scores[axis.value] += _signal_axis_contribution(sig)
+            if axis is Axis.QUALITY:
+                has_quality_evidence = True
+        primary_axis = max(
+            _AXIS_TIEBREAKER, key=lambda a: axis_scores[a.value],
+        ).value
+
         priority_score = _compute_priority_score(
-            severity, count, summed_savings, has_trace_evidence,
+            severity,
+            count,
+            summed_savings,
+            has_trace_evidence,
+            quality_evidence_factor=1.0 if has_quality_evidence else 0.0,
         )
 
         aggregated.append(
@@ -246,6 +285,8 @@ def aggregate_recommendations(
                 is_builtin=recs[0].is_builtin,
                 contributing_recommendations=recs,
                 priority_score=priority_score,
+                axis_scores=axis_scores,
+                primary_axis=primary_axis,
             ),
         )
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -201,10 +201,33 @@ class AggregatedRecommendation(BaseModel):
     priority_score: float = 0.0
     """Composite priority score (#172). Combines severity, occurrence
     count, cost impact (for ``target='model'`` MODEL_MISMATCH recs),
-    and trace-evidence boost. Computed in
+    trace-evidence boost, and (#272) a quality-evidence boost when any
+    contributing signal is quality-typed. Computed in
     ``aggregation.aggregate_recommendations``; the default Recommendations
     table is sorted by this value descending. See ``aggregation.py``
     module docstring for the formula and weight rationale."""
+
+    axis_scores: dict[str, float] = Field(
+        default_factory=lambda: {
+            Axis.COST.value: 0.0,
+            Axis.SPEED.value: 0.0,
+            Axis.QUALITY.value: 0.0,
+        },
+    )
+    """Per-axis evidence scores (#272). Keys are bare axis strings
+    (``"cost"``, ``"speed"``, ``"quality"``) for stable JSON
+    serialization; values are summed per-signal contributions per D021's
+    annotations approach. ``primary_axis`` is derived from this map with
+    a deterministic tiebreaker (D027). Drives axis labels in CLI/JSON
+    output (#273) without changing the sort key (``priority_score``)."""
+
+    primary_axis: str = Axis.COST.value
+    """Axis that triggered this recommendation (#272). One of
+    ``"cost"``, ``"speed"``, ``"quality"``. Derived from ``axis_scores``
+    using the D027 tiebreaker (``quality > speed > cost``) so labels are
+    stable across runs and Python versions. Default ``"cost"`` matches
+    the v0.5 cost/speed-only baseline so deserialized pre-v0.6 envelopes
+    parse without surprises."""
 
 
 class DelegationSuggestion(BaseModel):

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -34,6 +34,16 @@ class Axis(StrEnum):
     QUALITY = "quality"
 
 
+def zero_axis_scores() -> dict[str, float]:
+    """Build a zero-initialized ``axis_scores`` dict keyed by ``Axis`` values.
+
+    Shared default for ``AggregatedRecommendation.axis_scores`` and the
+    accumulator in ``aggregation._compute_axis_attribution`` so adding a
+    new ``Axis`` member is a one-line change.
+    """
+    return {a.value: 0.0 for a in Axis}
+
+
 class SignalType(StrEnum):
     """Types of behavior signals detected in agent invocations.
 
@@ -207,13 +217,7 @@ class AggregatedRecommendation(BaseModel):
     table is sorted by this value descending. See ``aggregation.py``
     module docstring for the formula and weight rationale."""
 
-    axis_scores: dict[str, float] = Field(
-        default_factory=lambda: {
-            Axis.COST.value: 0.0,
-            Axis.SPEED.value: 0.0,
-            Axis.QUALITY.value: 0.0,
-        },
-    )
+    axis_scores: dict[str, float] = Field(default_factory=zero_axis_scores)
     """Per-axis evidence scores (#272). Keys are bare axis strings
     (``"cost"``, ``"speed"``, ``"quality"``) for stable JSON
     serialization; values are summed per-signal contributions per D021's

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -8,6 +8,8 @@ remain available for verbose drill-down.
 
 import math
 
+import pytest
+
 from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.diagnostics.aggregation import (
     SIGNAL_AXIS_MAP,
@@ -596,8 +598,8 @@ class TestMultiAxisScoring:
         aggregated = aggregate_recommendations([cost_pair, quality_pair])
         by_agent = {a.agent_type: a for a in aggregated}
         assert by_agent["pm"].priority_score > by_agent["explore"].priority_score
-        # The quality-axis row carries the +5.0 boost.
-        assert by_agent["pm"].priority_score - by_agent["explore"].priority_score == 5.0
+        delta = by_agent["pm"].priority_score - by_agent["explore"].priority_score
+        assert delta == pytest.approx(5.0)
 
     def test_axis_scores_keys_are_bare_strings(self) -> None:
         # JSON-serializable: dict keys must be plain ``str`` for
@@ -623,23 +625,39 @@ class TestMultiAxisScoring:
         assert agg.axis_scores == {"cost": 0.0, "speed": 0.0, "quality": 0.0}
         assert agg.primary_axis == "cost"
 
-    def test_tiebreaker_quality_wins_equal_scores(self) -> None:
-        # When axis_scores tie exactly, primary_axis resolves to quality
-        # per D027. Construct one quality + one cost signal in a single
-        # aggregated row at identical severity → identical axis contribution.
+    @pytest.mark.parametrize(
+        ("sig_a_type", "sig_b_type", "expected_primary"),
+        [
+            # D027: quality wins over cost on equal scores.
+            (SignalType.TOKEN_OUTLIER, SignalType.USER_CORRECTION, "quality"),
+            # D027: quality also wins over speed.
+            (SignalType.RETRY_LOOP, SignalType.USER_CORRECTION, "quality"),
+            # D027: speed beats cost when no quality evidence.
+            (SignalType.TOKEN_OUTLIER, SignalType.RETRY_LOOP, "speed"),
+        ],
+    )
+    def test_tiebreaker_resolves_per_d027(
+        self,
+        sig_a_type: SignalType,
+        sig_b_type: SignalType,
+        expected_primary: str,
+    ) -> None:
+        # Two signals at identical severity contribute equal axis scores,
+        # so primary_axis is decided by the D027 tiebreaker tuple
+        # (quality > speed > cost). One aggregated row carries both signals.
         agent = "explore"
-        cost_sig = DiagnosticSignal(
-            signal_type=SignalType.TOKEN_OUTLIER,
+        sig_a = DiagnosticSignal(
+            signal_type=sig_a_type,
             severity=Severity.WARNING,
             agent_type=agent,
-            message="cost",
+            message="a",
             detail={},
         )
-        quality_sig = DiagnosticSignal(
-            signal_type=SignalType.USER_CORRECTION,
+        sig_b = DiagnosticSignal(
+            signal_type=sig_b_type,
             severity=Severity.WARNING,
             agent_type=agent,
-            message="quality",
+            message="b",
             detail={},
         )
         rec_template = DiagnosticRecommendation(
@@ -647,46 +665,13 @@ class TestMultiAxisScoring:
             severity=Severity.WARNING,
             message="tied",
             agent_type=agent,
-            signal_types=[SignalType.TOKEN_OUTLIER, SignalType.USER_CORRECTION],
+            signal_types=[sig_a_type, sig_b_type],
         )
         aggregated = aggregate_recommendations(
-            [(cost_sig, rec_template), (quality_sig, rec_template)],
+            [(sig_a, rec_template), (sig_b, rec_template)],
         )
         assert len(aggregated) == 1
-        # Equal severity → equal axis contributions.
-        assert aggregated[0].axis_scores["cost"] == aggregated[0].axis_scores["quality"]
-        # Tiebreaker resolves to quality.
-        assert aggregated[0].primary_axis == "quality"
-
-    def test_tiebreaker_speed_wins_over_cost(self) -> None:
-        # Verify the second tiebreaker step: speed beats cost on equal
-        # scores (per ``_AXIS_TIEBREAKER`` order).
-        agent = "explore"
-        cost_sig = DiagnosticSignal(
-            signal_type=SignalType.TOKEN_OUTLIER,
-            severity=Severity.WARNING,
-            agent_type=agent,
-            message="cost",
-            detail={},
-        )
-        speed_sig = DiagnosticSignal(
-            signal_type=SignalType.RETRY_LOOP,
-            severity=Severity.WARNING,
-            agent_type=agent,
-            message="speed",
-            detail={},
-        )
-        rec_template = DiagnosticRecommendation(
-            target="prompt",
-            severity=Severity.WARNING,
-            message="tied",
-            agent_type=agent,
-            signal_types=[SignalType.TOKEN_OUTLIER, SignalType.RETRY_LOOP],
-        )
-        aggregated = aggregate_recommendations(
-            [(cost_sig, rec_template), (speed_sig, rec_template)],
-        )
-        assert aggregated[0].primary_axis == "speed"
+        assert aggregated[0].primary_axis == expected_primary
 
     def test_quality_recommendation_surfaces_above_cost_in_sort(self) -> None:
         # Closes the v0.5 under-recommendation gap: a pure-quality WARNING

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -6,7 +6,9 @@ round-trip through ``DiagnosticsResult`` so the raw recommendations
 remain available for verbose drill-down.
 """
 
-from agentfluent.config.models import Severity
+import math
+
+from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.diagnostics.aggregation import (
     SIGNAL_AXIS_MAP,
     aggregate_recommendations,
@@ -455,3 +457,244 @@ class TestPriorityScore:
         assert scores == sorted(scores, reverse=True)
         # Critical first.
         assert aggregated[0].severity == Severity.CRITICAL
+
+
+def _quality_pair(
+    signal_type: SignalType,
+    agent_type: str,
+    severity: Severity = Severity.WARNING,
+    target: str = "prompt",
+) -> tuple[DiagnosticSignal, DiagnosticRecommendation]:
+    """Helper for quality-axis signals (USER_CORRECTION, FILE_REWORK,
+    REVIEWER_CAUGHT). Mirrors the structure used by the production
+    quality_signals module — agent_type-scoped, target=prompt by default."""
+    signal = DiagnosticSignal(
+        signal_type=signal_type,
+        severity=severity,
+        agent_type=agent_type,
+        message=f"[quality] {signal_type.value} signal for '{agent_type}'.",
+        detail={},
+    )
+    rec = DiagnosticRecommendation(
+        target=target,
+        severity=severity,
+        message=f"[quality] {signal_type.value}: tighten '{agent_type}' prompt.",
+        observation=f"{signal_type.value} pattern observed.",
+        reason="Quality signal indicates a configuration gap.",
+        action="Tighten the agent's prompt.",
+        agent_type=agent_type,
+        signal_types=[signal_type],
+    )
+    return signal, rec
+
+
+class TestMultiAxisScoring:
+    """Multi-axis scoring (#272). Quality signals contribute additive
+    boost via ``quality_evidence_factor``; ``axis_scores`` and
+    ``primary_axis`` are post-hoc annotations per D021. Backward compat
+    invariant: non-quality recommendations score identically to v0.5."""
+
+    def test_quality_recommendation_primary_axis_is_quality(self) -> None:
+        # USER_CORRECTION-only → primary_axis="quality" and the quality
+        # bucket carries all the evidence.
+        pair = _quality_pair(SignalType.USER_CORRECTION, "explore")
+        aggregated = aggregate_recommendations([pair])
+        assert len(aggregated) == 1
+        assert aggregated[0].primary_axis == "quality"
+        assert aggregated[0].axis_scores["quality"] > 0.0
+        assert aggregated[0].axis_scores["cost"] == 0.0
+        assert aggregated[0].axis_scores["speed"] == 0.0
+
+    def test_cost_recommendation_primary_axis_is_cost(self) -> None:
+        # TOKEN_OUTLIER → cost axis.
+        pair = _token_outlier_pair("explore", 4.0)
+        aggregated = aggregate_recommendations([pair])
+        assert aggregated[0].primary_axis == "cost"
+        assert aggregated[0].axis_scores["cost"] > 0.0
+        assert aggregated[0].axis_scores["quality"] == 0.0
+
+    def test_speed_recommendation_primary_axis_is_speed(self) -> None:
+        # STUCK_PATTERN → speed axis.
+        pair = _stuck_pattern_pair("architect")
+        aggregated = aggregate_recommendations([pair])
+        assert aggregated[0].primary_axis == "speed"
+        assert aggregated[0].axis_scores["speed"] > 0.0
+        assert aggregated[0].axis_scores["quality"] == 0.0
+
+    def test_mixed_signal_recommendation_picks_dominant_axis(self) -> None:
+        # Construct a single recommendation whose signal_types list spans
+        # cost + speed + quality (e.g., a hypothetical multi-evidence rec).
+        # The aggregation grouping key is shared, so all signals contribute
+        # to the same axis_scores. Two cost signals + one speed = cost wins.
+        agent = "pm"
+        cost_sig_a = DiagnosticSignal(
+            signal_type=SignalType.TOKEN_OUTLIER,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="cost a",
+            detail={},
+        )
+        cost_sig_b = DiagnosticSignal(
+            signal_type=SignalType.MODEL_MISMATCH,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="cost b",
+            detail={},
+        )
+        speed_sig = DiagnosticSignal(
+            signal_type=SignalType.RETRY_LOOP,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="speed",
+            detail={},
+        )
+        # All three roll up into a single aggregated row because they
+        # share (agent_type, target, signal_types). Use the same
+        # signal_types list on each recommendation.
+        signal_types = [
+            SignalType.TOKEN_OUTLIER,
+            SignalType.MODEL_MISMATCH,
+            SignalType.RETRY_LOOP,
+        ]
+        rec_template = DiagnosticRecommendation(
+            target="prompt",
+            severity=Severity.WARNING,
+            message="multi",
+            agent_type=agent,
+            signal_types=signal_types,
+        )
+        aggregated = aggregate_recommendations(
+            [(cost_sig_a, rec_template), (cost_sig_b, rec_template), (speed_sig, rec_template)],
+        )
+        assert len(aggregated) == 1
+        # Two cost signals (rank 2 each = 4.0) vs one speed signal (2.0).
+        assert aggregated[0].axis_scores["cost"] > aggregated[0].axis_scores["speed"]
+        assert aggregated[0].primary_axis == "cost"
+
+    def test_backward_compat_non_quality_score_unchanged(self) -> None:
+        # The diff-stability invariant. A pure-cost recommendation must
+        # produce the same priority_score as the v0.5 formula
+        # (severity_rank * W_SEVERITY + log1p(count) * W_COUNT + ...
+        #  with quality_evidence_factor = 0). Computed manually here.
+        pair = _model_mismatch_pair("explore", 25.0)
+        aggregated = aggregate_recommendations([pair])
+        expected = (
+            SEVERITY_RANK[Severity.WARNING] * 100.0  # W_SEVERITY
+            + math.log1p(1) * 10.0                    # W_COUNT
+            + 25.0 * 1.0                              # W_COST
+            + 0.0 * 5.0                               # W_TRACE (no trace)
+            + 0.0 * 5.0                               # W_QUALITY (no quality)
+        )
+        assert aggregated[0].priority_score == expected
+
+    def test_quality_signal_elevates_priority_score(self) -> None:
+        # A pure-quality WARNING outranks a pure-cost WARNING with no
+        # cost savings, because the quality_evidence_factor adds
+        # W_QUALITY = 5.0 to the composite.
+        cost_pair = _token_outlier_pair("explore", 2.0)  # no savings
+        quality_pair = _quality_pair(SignalType.USER_CORRECTION, "pm")
+        aggregated = aggregate_recommendations([cost_pair, quality_pair])
+        by_agent = {a.agent_type: a for a in aggregated}
+        assert by_agent["pm"].priority_score > by_agent["explore"].priority_score
+        # The quality-axis row carries the +5.0 boost.
+        assert by_agent["pm"].priority_score - by_agent["explore"].priority_score == 5.0
+
+    def test_axis_scores_keys_are_bare_strings(self) -> None:
+        # JSON-serializable: dict keys must be plain ``str`` for
+        # downstream consumers (#273 CLI labels). Pydantic dump round-trip
+        # confirms axis_scores survives as a string-keyed dict.
+        pair = _quality_pair(SignalType.FILE_REWORK, "explore")
+        aggregated = aggregate_recommendations([pair])
+        dumped = aggregated[0].model_dump(mode="json")
+        assert dumped["primary_axis"] == "quality"
+        assert set(dumped["axis_scores"].keys()) == {"cost", "speed", "quality"}
+        assert all(isinstance(k, str) for k in dumped["axis_scores"].keys())
+
+    def test_default_axis_scores_when_no_signals(self) -> None:
+        # The model default — used when JSON consumers deserialize a
+        # v0.5 envelope that lacks axis_scores. All zeros, primary_axis
+        # falls back to "cost".
+        agg = AggregatedRecommendation(
+            agent_type="pm",
+            target="prompt",
+            severity=Severity.WARNING,
+            representative_message="ok",
+        )
+        assert agg.axis_scores == {"cost": 0.0, "speed": 0.0, "quality": 0.0}
+        assert agg.primary_axis == "cost"
+
+    def test_tiebreaker_quality_wins_equal_scores(self) -> None:
+        # When axis_scores tie exactly, primary_axis resolves to quality
+        # per D027. Construct one quality + one cost signal in a single
+        # aggregated row at identical severity → identical axis contribution.
+        agent = "explore"
+        cost_sig = DiagnosticSignal(
+            signal_type=SignalType.TOKEN_OUTLIER,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="cost",
+            detail={},
+        )
+        quality_sig = DiagnosticSignal(
+            signal_type=SignalType.USER_CORRECTION,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="quality",
+            detail={},
+        )
+        rec_template = DiagnosticRecommendation(
+            target="prompt",
+            severity=Severity.WARNING,
+            message="tied",
+            agent_type=agent,
+            signal_types=[SignalType.TOKEN_OUTLIER, SignalType.USER_CORRECTION],
+        )
+        aggregated = aggregate_recommendations(
+            [(cost_sig, rec_template), (quality_sig, rec_template)],
+        )
+        assert len(aggregated) == 1
+        # Equal severity → equal axis contributions.
+        assert aggregated[0].axis_scores["cost"] == aggregated[0].axis_scores["quality"]
+        # Tiebreaker resolves to quality.
+        assert aggregated[0].primary_axis == "quality"
+
+    def test_tiebreaker_speed_wins_over_cost(self) -> None:
+        # Verify the second tiebreaker step: speed beats cost on equal
+        # scores (per ``_AXIS_TIEBREAKER`` order).
+        agent = "explore"
+        cost_sig = DiagnosticSignal(
+            signal_type=SignalType.TOKEN_OUTLIER,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="cost",
+            detail={},
+        )
+        speed_sig = DiagnosticSignal(
+            signal_type=SignalType.RETRY_LOOP,
+            severity=Severity.WARNING,
+            agent_type=agent,
+            message="speed",
+            detail={},
+        )
+        rec_template = DiagnosticRecommendation(
+            target="prompt",
+            severity=Severity.WARNING,
+            message="tied",
+            agent_type=agent,
+            signal_types=[SignalType.TOKEN_OUTLIER, SignalType.RETRY_LOOP],
+        )
+        aggregated = aggregate_recommendations(
+            [(cost_sig, rec_template), (speed_sig, rec_template)],
+        )
+        assert aggregated[0].primary_axis == "speed"
+
+    def test_quality_recommendation_surfaces_above_cost_in_sort(self) -> None:
+        # Closes the v0.5 under-recommendation gap: a pure-quality WARNING
+        # ranks above a pure-cost WARNING with no savings, so quality
+        # findings are visible in the default top-N table.
+        cost_pair = _token_outlier_pair("explore", 2.0)
+        quality_pair = _quality_pair(SignalType.REVIEWER_CAUGHT, "pm")
+        aggregated = aggregate_recommendations([cost_pair, quality_pair])
+        # Quality row sorts first by priority_score desc.
+        assert aggregated[0].agent_type == "pm"
+        assert aggregated[0].primary_axis == "quality"


### PR DESCRIPTION
## Summary
- Adds ``quality_evidence_factor * W_QUALITY`` term to the priority-score formula plus post-hoc ``axis_scores`` and ``primary_axis`` annotations on ``AggregatedRecommendation`` (D021 annotations approach; D022 single-axis classification; D027 tiebreaker).
- Quality signals (``USER_CORRECTION``, ``FILE_REWORK``, ``REVIEWER_CAUGHT``) now contribute additive priority boost so they surface in the default top-N. Cost and speed rows are unchanged.
- ``aggregation.py`` held at **296 lines** (under the architect's 300-line budget); ``_QUALITY_SIGNAL_TYPES`` derived constant was dropped after the inline ``axis is Axis.QUALITY`` check made it redundant.

Closes #272.

## Backward-compatibility invariant
Recommendations without any quality signal get ``quality_evidence_factor = 0.0`` and produce **identical** ``priority_score`` values as v0.5. This is the contract that keeps ``diff`` semantics stable: the first post-upgrade ``diff`` between a pre-quality and post-quality baseline shows zero ``priority_score_delta`` for persisting non-quality recommendations. Anchored by ``test_backward_compat_non_quality_score_unchanged`` (computes the v0.5 formula manually and asserts equality).

The ``axis_scores`` and ``primary_axis`` fields are additive on the JSON envelope; the diff loader (``compute._index_recommendations``) keys on ``(agent_type, target, signal_types)`` only and ignores unknown fields, so v0.5 baselines deserialize cleanly.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1112 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior covered: ``TestMultiAxisScoring`` (10 tests) — pure-axis assignment, mixed-signal dominance, backward-compat formula, quality elevation in sort order, JSON round-trip, default-when-empty, two-step tiebreaker (quality > speed > cost)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI output change in this story (#273 wires axis labels into formatters)

## Security review
- [x] **Skip review** — pure scoring/aggregation logic, no new I/O, no path resolution, no user-controlled string rendering. New JSON fields (``axis_scores``, ``primary_axis``) are computed from internal data.

## Breaking changes
None. Two new optional fields on ``AggregatedRecommendation`` with safe defaults (``axis_scores`` zeroed, ``primary_axis="cost"``) so v0.5 deserialization succeeds. ``_compute_priority_score`` gained a defaulted ``quality_evidence_factor`` parameter; existing callers pass through unchanged.