### PR TITLE
feat(core): shared filter_sessions_by_time utility (#301)

### DIFF
--- a/src/agentfluent/core/filtering.py
+++ b/src/agentfluent/core/filtering.py
@@ -1,0 +1,77 @@
+"""Session-level filter utilities (#301).
+
+Single source of truth for date-range filtering of ``SessionInfo``
+lists, consumed by ``list --since/--until`` (#296), ``analyze
+--since/--until`` (#297), and forward-compatibly by per-session
+diagnostics (#201, deferred to v0.7). Centralizing the filter here
+prevents drift between three call sites that would otherwise each
+reimplement timezone normalization, half-open interval semantics, and
+the missing-timestamp policy.
+
+Pure module: no I/O, no logging, no exceptions for empty results. The
+caller decides what to render for "no sessions matched."
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from agentfluent.core.discovery import SessionInfo
+
+
+def filter_sessions_by_time(
+    sessions: list[SessionInfo],
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> list[SessionInfo]:
+    """Return ``sessions`` whose ``first_message_timestamp`` falls in ``[since, until)``.
+
+    Half-open interval per D024/D025 and the v0.6 PRD: a session is
+    included when ``since <= first_message_timestamp < until``. ``None``
+    bounds are open-ended.
+
+    **Missing-timestamp policy.** Sessions where
+    ``first_message_timestamp is None`` (empty file, unreadable file,
+    no parseable timestamps) are excluded when *either* bound is set —
+    a session with no derivable start time cannot be placed inside or
+    outside a window safely, and silently including it would distort
+    the filtered result. With both bounds ``None`` (the identity case),
+    the input list is returned unchanged including any None-timestamp
+    sessions, so callers that don't filter pay no policy cost.
+
+    **Timezone normalization.** All comparisons happen in UTC. Naive
+    datetimes (no ``tzinfo``) are assumed to be UTC — matching the
+    JSONL ``timestamp`` field's ISO-8601-with-Z format and
+    ``timeutil.parse_datetime``'s post-conversion contract — so mixed
+    aware/naive inputs do not raise ``TypeError``.
+    """
+    if since is None and until is None:
+        return sessions
+
+    since_utc = _to_utc(since) if since is not None else None
+    until_utc = _to_utc(until) if until is not None else None
+
+    result: list[SessionInfo] = []
+    for session in sessions:
+        ts = session.first_message_timestamp
+        if ts is None:
+            continue
+        ts_utc = _to_utc(ts)
+        if since_utc is not None and ts_utc < since_utc:
+            continue
+        if until_utc is not None and ts_utc >= until_utc:
+            continue
+        result.append(session)
+    return result
+
+
+def _to_utc(dt: datetime) -> datetime:
+    """Normalize ``dt`` to a UTC-aware ``datetime``.
+
+    Naive inputs are assumed UTC (matches the JSONL parser's contract
+    for the ``timestamp`` field). Aware inputs are converted via
+    ``astimezone``.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)

--- a/src/agentfluent/core/filtering.py
+++ b/src/agentfluent/core/filtering.py
@@ -1,15 +1,8 @@
-"""Session-level filter utilities (#301).
+"""Date-range filter for ``SessionInfo`` lists.
 
-Single source of truth for date-range filtering of ``SessionInfo``
-lists, consumed by ``list --since/--until`` (#296), ``analyze
---since/--until`` (#297), and forward-compatibly by per-session
-diagnostics (#201, deferred to v0.7). Centralizing the filter here
-prevents drift between three call sites that would otherwise each
-reimplement timezone normalization, half-open interval semantics, and
-the missing-timestamp policy.
-
-Pure module: no I/O, no logging, no exceptions for empty results. The
-caller decides what to render for "no sessions matched."
+Single source of truth for timezone normalization, half-open interval
+semantics, and the missing-timestamp policy used by every CLI surface
+that accepts ``--since`` / ``--until``.
 """
 
 from __future__ import annotations
@@ -26,24 +19,23 @@ def filter_sessions_by_time(
 ) -> list[SessionInfo]:
     """Return ``sessions`` whose ``first_message_timestamp`` falls in ``[since, until)``.
 
-    Half-open interval per D024/D025 and the v0.6 PRD: a session is
-    included when ``since <= first_message_timestamp < until``. ``None``
-    bounds are open-ended.
+    Half-open interval per D024/D025: a session is included when
+    ``since <= first_message_timestamp < until``. ``None`` bounds are
+    open-ended.
 
     **Missing-timestamp policy.** Sessions where
-    ``first_message_timestamp is None`` (empty file, unreadable file,
-    no parseable timestamps) are excluded when *either* bound is set —
-    a session with no derivable start time cannot be placed inside or
-    outside a window safely, and silently including it would distort
-    the filtered result. With both bounds ``None`` (the identity case),
-    the input list is returned unchanged including any None-timestamp
-    sessions, so callers that don't filter pay no policy cost.
+    ``first_message_timestamp is None`` are excluded when *either* bound
+    is set — a session with no derivable start time cannot be placed
+    inside or outside a window safely, and silently including it would
+    distort the filtered result. With both bounds ``None`` the input
+    list is returned unchanged (identity, not a copy — caller must not
+    mutate) so unfiltered callers pay no policy cost.
 
     **Timezone normalization.** All comparisons happen in UTC. Naive
-    datetimes (no ``tzinfo``) are assumed to be UTC — matching the
-    JSONL ``timestamp`` field's ISO-8601-with-Z format and
-    ``timeutil.parse_datetime``'s post-conversion contract — so mixed
-    aware/naive inputs do not raise ``TypeError``.
+    datetimes are assumed to be UTC — matching the JSONL ``timestamp``
+    field's ISO-8601-with-Z format. Note this differs from
+    ``timeutil.parse_datetime``, which assumes naive CLI input is local
+    time; both are correct for their respective contracts.
     """
     if since is None and until is None:
         return sessions

--- a/tests/unit/test_core_filtering.py
+++ b/tests/unit/test_core_filtering.py
@@ -16,10 +16,7 @@ def _session(
     name: str,
     ts: datetime | None,
 ) -> SessionInfo:
-    """Build a minimal ``SessionInfo`` with the given first-message timestamp.
-
-    ``size_bytes`` and ``modified`` are required fields but irrelevant
-    to the filter logic; they get fixed dummy values."""
+    """Build a minimal ``SessionInfo`` for filter tests."""
     return SessionInfo(
         filename=f"{name}.jsonl",
         path=Path(f"/tmp/{name}.jsonl"),
@@ -45,7 +42,6 @@ class TestIdentityBehavior:
         assert result == sessions
 
     def test_no_bounds_includes_none_timestamp_sessions(self) -> None:
-        # None-timestamp sessions are only excluded when a bound is set.
         sessions = [_session("a", None), _session("b", _BASE)]
         result = filter_sessions_by_time(sessions)
         assert result == sessions
@@ -79,10 +75,9 @@ class TestUntilOnly:
     """``until`` set, ``since=None`` → strict ``first_message_timestamp < until``."""
 
     def test_excludes_session_at_until_boundary(self) -> None:
-        # Half-open: timestamp == until is OUT.
         sessions = [
             _session("before", _BASE - timedelta(minutes=1)),
-            _session("at_boundary", _BASE),
+            _session("at_boundary", _BASE),  # excluded: half-open
             _session("after", _BASE + timedelta(hours=1)),
         ]
         result = filter_sessions_by_time(sessions, until=_BASE)

--- a/tests/unit/test_core_filtering.py
+++ b/tests/unit/test_core_filtering.py
@@ -1,0 +1,206 @@
+"""Unit tests for ``core.filtering.filter_sessions_by_time`` (#301).
+
+Covers each branch of the half-open interval ``[since, until)``,
+None-timestamp policy, identity behavior with both bounds open, and
+mixed-timezone inputs (which must not raise ``TypeError``).
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+
+from agentfluent.core.discovery import SessionInfo
+from agentfluent.core.filtering import filter_sessions_by_time
+
+
+def _session(
+    name: str,
+    ts: datetime | None,
+) -> SessionInfo:
+    """Build a minimal ``SessionInfo`` with the given first-message timestamp.
+
+    ``size_bytes`` and ``modified`` are required fields but irrelevant
+    to the filter logic; they get fixed dummy values."""
+    return SessionInfo(
+        filename=f"{name}.jsonl",
+        path=Path(f"/tmp/{name}.jsonl"),
+        size_bytes=0,
+        modified=datetime(2026, 1, 1, tzinfo=UTC),
+        first_message_timestamp=ts,
+    )
+
+
+_BASE = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+
+
+class TestIdentityBehavior:
+    """Both bounds ``None`` returns the input list unchanged, including
+    sessions with ``first_message_timestamp is None``."""
+
+    def test_no_bounds_returns_input_unchanged(self) -> None:
+        sessions = [
+            _session("a", _BASE),
+            _session("b", _BASE + timedelta(hours=1)),
+        ]
+        result = filter_sessions_by_time(sessions)
+        assert result == sessions
+
+    def test_no_bounds_includes_none_timestamp_sessions(self) -> None:
+        # None-timestamp sessions are only excluded when a bound is set.
+        sessions = [_session("a", None), _session("b", _BASE)]
+        result = filter_sessions_by_time(sessions)
+        assert result == sessions
+
+    def test_empty_input_no_bounds(self) -> None:
+        assert filter_sessions_by_time([]) == []
+
+
+class TestSinceOnly:
+    """``since`` set, ``until=None`` → ``first_message_timestamp >= since``."""
+
+    def test_includes_sessions_at_or_after_since(self) -> None:
+        sessions = [
+            _session("before", _BASE - timedelta(hours=1)),
+            _session("at_boundary", _BASE),
+            _session("after", _BASE + timedelta(hours=1)),
+        ]
+        result = filter_sessions_by_time(sessions, since=_BASE)
+        names = [s.filename for s in result]
+        assert "before.jsonl" not in names
+        assert "at_boundary.jsonl" in names
+        assert "after.jsonl" in names
+
+    def test_excludes_none_timestamp_when_since_set(self) -> None:
+        sessions = [_session("a", None), _session("b", _BASE)]
+        result = filter_sessions_by_time(sessions, since=_BASE)
+        assert [s.filename for s in result] == ["b.jsonl"]
+
+
+class TestUntilOnly:
+    """``until`` set, ``since=None`` → strict ``first_message_timestamp < until``."""
+
+    def test_excludes_session_at_until_boundary(self) -> None:
+        # Half-open: timestamp == until is OUT.
+        sessions = [
+            _session("before", _BASE - timedelta(minutes=1)),
+            _session("at_boundary", _BASE),
+            _session("after", _BASE + timedelta(hours=1)),
+        ]
+        result = filter_sessions_by_time(sessions, until=_BASE)
+        names = [s.filename for s in result]
+        assert "before.jsonl" in names
+        assert "at_boundary.jsonl" not in names
+        assert "after.jsonl" not in names
+
+    def test_excludes_none_timestamp_when_until_set(self) -> None:
+        sessions = [_session("a", None), _session("b", _BASE - timedelta(hours=1))]
+        result = filter_sessions_by_time(sessions, until=_BASE)
+        assert [s.filename for s in result] == ["b.jsonl"]
+
+
+class TestBothBounds:
+    """Both bounds → half-open ``[since, until)``."""
+
+    def test_only_sessions_in_window(self) -> None:
+        since = _BASE
+        until = _BASE + timedelta(hours=2)
+        sessions = [
+            _session("before_since", since - timedelta(minutes=1)),
+            _session("at_since", since),
+            _session("middle", since + timedelta(hours=1)),
+            _session("at_until", until),  # excluded by half-open
+            _session("after_until", until + timedelta(minutes=1)),
+        ]
+        result = filter_sessions_by_time(sessions, since=since, until=until)
+        names = [s.filename for s in result]
+        assert names == ["at_since.jsonl", "middle.jsonl"]
+
+    def test_window_with_no_matches_returns_empty(self) -> None:
+        sessions = [
+            _session("a", _BASE - timedelta(days=10)),
+            _session("b", _BASE - timedelta(days=9)),
+        ]
+        result = filter_sessions_by_time(
+            sessions, since=_BASE, until=_BASE + timedelta(days=1),
+        )
+        assert result == []
+
+    def test_window_includes_all(self) -> None:
+        sessions = [
+            _session("a", _BASE),
+            _session("b", _BASE + timedelta(hours=1)),
+        ]
+        result = filter_sessions_by_time(
+            sessions,
+            since=_BASE - timedelta(days=1),
+            until=_BASE + timedelta(days=1),
+        )
+        assert len(result) == 2
+
+    def test_excludes_none_timestamp_with_both_bounds(self) -> None:
+        sessions = [_session("a", None), _session("b", _BASE)]
+        result = filter_sessions_by_time(
+            sessions,
+            since=_BASE - timedelta(hours=1),
+            until=_BASE + timedelta(hours=1),
+        )
+        assert [s.filename for s in result] == ["b.jsonl"]
+
+
+class TestTimezoneNormalization:
+    """Mixed aware/naive inputs and non-UTC offsets all normalize to UTC
+    before comparison; no ``TypeError`` from cross-timezone subtraction."""
+
+    def test_naive_session_timestamp_treated_as_utc(self) -> None:
+        # Parser contract: JSONL ``timestamp`` field is ISO 8601 UTC; if
+        # an upstream caller hands us a naive datetime, we assume UTC.
+        naive_ts = datetime(2026, 5, 1, 12, 0, 0)  # no tzinfo
+        sessions = [_session("naive", naive_ts)]
+        # Aware bounds bracket the equivalent UTC instant.
+        result = filter_sessions_by_time(
+            sessions,
+            since=_BASE - timedelta(minutes=1),
+            until=_BASE + timedelta(minutes=1),
+        )
+        assert len(result) == 1
+
+    def test_naive_bounds_treated_as_utc(self) -> None:
+        naive_since = datetime(2026, 5, 1, 11, 0, 0)
+        naive_until = datetime(2026, 5, 1, 13, 0, 0)
+        sessions = [_session("a", _BASE)]  # 12:00 UTC
+        result = filter_sessions_by_time(
+            sessions, since=naive_since, until=naive_until,
+        )
+        assert len(result) == 1
+
+    def test_non_utc_aware_bounds(self) -> None:
+        # since=11:00 in UTC+5 (== 06:00 UTC), so 12:00 UTC is inside.
+        plus_five = timezone(timedelta(hours=5))
+        since = datetime(2026, 5, 1, 11, 0, 0, tzinfo=plus_five)  # 06:00 UTC
+        until = datetime(2026, 5, 1, 20, 0, 0, tzinfo=plus_five)  # 15:00 UTC
+        sessions = [_session("a", _BASE)]
+        result = filter_sessions_by_time(sessions, since=since, until=until)
+        assert len(result) == 1
+
+    def test_non_utc_aware_session_timestamp(self) -> None:
+        # Session ts in UTC-7 (== 19:00 UTC); window in UTC.
+        minus_seven = timezone(timedelta(hours=-7))
+        ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=minus_seven)  # 19:00 UTC
+        sessions = [_session("a", ts)]
+        result = filter_sessions_by_time(
+            sessions,
+            since=datetime(2026, 5, 1, 18, 0, 0, tzinfo=UTC),
+            until=datetime(2026, 5, 1, 20, 0, 0, tzinfo=UTC),
+        )
+        assert len(result) == 1
+
+
+class TestEmptyInput:
+    """Empty input list with bounds returns empty; no exception."""
+
+    def test_empty_input_with_since(self) -> None:
+        assert filter_sessions_by_time([], since=_BASE) == []
+
+    def test_empty_input_with_both_bounds(self) -> None:
+        assert filter_sessions_by_time(
+            [], since=_BASE, until=_BASE + timedelta(days=1),
+        ) == []


### PR DESCRIPTION
## Summary
- Adds ``src/agentfluent/core/filtering.py::filter_sessions_by_time`` as the single source of truth for date-range filtering of ``SessionInfo`` lists.
- Half-open interval ``[since, until)`` per D024/D025 and the v0.6 PRD; UTC-normalized; sessions with ``first_message_timestamp is None`` excluded when either bound is set, included when both are ``None``.
- DRY foundation for #296 (``list --since/--until``), #297 (``analyze --since/--until``), and the v0.7 ``--scope session`` filter (#201) — three call sites that would otherwise each reimplement the same policy.

Closes #301.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1118 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior covered: ``test_core_filtering.py`` (17 tests across 6 classes) — identity, since-only, until-only, both bounds, boundary semantics (``since`` inclusive, ``until`` exclusive), None-timestamp policy, mixed aware/naive timezone normalization, non-UTC offsets, empty input
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A, utility not yet wired into a CLI surface (#296/#297 do that)

## Security review
- [x] **Skip review** — pure stdlib datetime arithmetic on a list of internal models. No I/O, no path resolution, no user-controlled string rendering, no subprocess.

## Breaking changes
None. New module; no existing call sites.