### PR TITLE
feat(cli): list --since/--until time filtering (#296)

### DIFF
--- a/src/agentfluent/cli/_time_args.py
+++ b/src/agentfluent/cli/_time_args.py
@@ -1,0 +1,64 @@
+"""Shared CLI helpers for ``--since`` / ``--until`` argument parsing.
+
+Centralizes datetime parsing and inverted-interval validation so every
+command exposing time filters surfaces the same error messages and exit
+code. The downstream filter (``core.filtering.filter_sessions_by_time``)
+already handles half-open semantics and timezone normalization once the
+strings are parsed; this module covers the CLI-layer concerns above it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import typer
+from rich.console import Console
+
+from agentfluent.cli.exit_codes import EXIT_USER_ERROR
+from agentfluent.core.timeutil import parse_datetime
+
+
+def parse_time_window(
+    since: str | None,
+    until: str | None,
+    *,
+    err_console: Console,
+) -> tuple[datetime | None, datetime | None]:
+    """Parse ``--since`` and ``--until`` strings into UTC-aware datetimes.
+
+    Returns ``(parsed_since, parsed_until)`` with ``None`` for omitted
+    bounds. Raises ``typer.Exit(EXIT_USER_ERROR)`` and prints a
+    user-friendly message for:
+
+    - Unparseable input (re-surfaces ``parse_datetime``'s ``ValueError``)
+    - Inverted or empty intervals: when both bounds are supplied and
+      ``parsed_since >= parsed_until``. The half-open ``[since, until)``
+      semantics make ``since == until`` produce an empty result, which
+      is almost always a foot-gun rather than intent — so we reject
+      both ``>`` and ``==``.
+    """
+    parsed_since = _parse_or_exit(since, "--since", err_console)
+    parsed_until = _parse_or_exit(until, "--until", err_console)
+    if (
+        parsed_since is not None
+        and parsed_until is not None
+        and parsed_since >= parsed_until
+    ):
+        err_console.print(
+            f"[red]Error:[/red] --since ({since}) is at or after "
+            f"--until ({until}); did you swap them?",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
+    return parsed_since, parsed_until
+
+
+def _parse_or_exit(
+    value: str | None, flag: str, err_console: Console,
+) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        return parse_datetime(value)
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {flag} {value!r}: {exc}")
+        raise typer.Exit(code=EXIT_USER_ERROR) from None

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -8,6 +8,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from agentfluent.cli._time_args import parse_time_window
 from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import (
@@ -16,9 +17,11 @@ from agentfluent.cli.formatters.table import (
 )
 from agentfluent.core.discovery import (
     ProjectInfo,
+    SessionInfo,
     discover_projects,
     find_project,
 )
+from agentfluent.core.filtering import filter_sessions_by_time
 from agentfluent.core.parser import parse_session
 from agentfluent.core.paths import projects_dir_for
 
@@ -30,6 +33,12 @@ Examples:
 
   agentfluent list --project codefluent
       List sessions in the codefluent project.
+
+  agentfluent list --project codefluent --since 7d
+      Sessions whose first message landed in the last 7 days.
+
+  agentfluent list --project codefluent --since 2026-05-01 --until 2026-05-08
+      Sessions in the half-open interval [2026-05-01, 2026-05-08).
 
   agentfluent list --format json | jq '.data.projects[].name'
       Extract project names (command is "list-projects").
@@ -103,30 +112,45 @@ def _find_or_exit(project_slug: str, config_dir: Path | None) -> ProjectInfo:
 
 
 def _list_sessions_table(
-    project_slug: str, *, config_dir: Path | None, verbose: bool, quiet: bool,
+    project_slug: str,
+    *,
+    config_dir: Path | None,
+    verbose: bool,
+    quiet: bool,
+    sessions_override: list[SessionInfo] | None = None,
 ) -> None:
     """Display sessions for a project as a Rich table."""
     project = _find_or_exit(project_slug, config_dir)
+    sessions_list = (
+        sessions_override if sessions_override is not None else project.sessions
+    )
     if quiet:
-        console.print(f"Project {project.display_name}: {len(project.sessions)} sessions")
+        console.print(f"Project {project.display_name}: {len(sessions_list)} sessions")
         return
-    sessions = [(s, len(parse_session(s.path))) for s in project.sessions]
+    sessions = [(s, len(parse_session(s.path))) for s in sessions_list]
     format_sessions_table(console, project.display_name, sessions, verbose=verbose)
 
 
 def _list_sessions_json(
-    project_slug: str, *, config_dir: Path | None, quiet: bool,
+    project_slug: str,
+    *,
+    config_dir: Path | None,
+    quiet: bool,
+    sessions_override: list[SessionInfo] | None = None,
 ) -> None:
     """Output sessions for a project as JSON."""
     project = _find_or_exit(project_slug, config_dir)
+    sessions_list = (
+        sessions_override if sessions_override is not None else project.sessions
+    )
     if quiet:
         payload: dict[str, object] = {
             "project": project.display_name,
-            "session_count": len(project.sessions),
+            "session_count": len(sessions_list),
         }
     else:
         sessions = []
-        for s in project.sessions:
+        for s in sessions_list:
             messages = parse_session(s.path)
             sessions.append(
                 {
@@ -161,21 +185,58 @@ def list_cmd(
         "--json",
         help="Shortcut for --format json. Overrides --format when set.",
     ),
+    since: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--since",
+        help=(
+            "Include sessions whose first message landed at or after this "
+            "time. Accepts ISO 8601 (2026-05-05T12:00:00), date-only "
+            "(2026-05-05), or relative (7d, 12h, 30m). Requires --project."
+        ),
+    ),
+    until: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--until",
+        help=(
+            "Include sessions whose first message landed strictly before "
+            "this time (half-open interval). Same formats as --since. "
+            "Requires --project."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
     """List available projects, or sessions within a project."""
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
+    if (since is not None or until is not None) and project is None:
+        err_console.print(
+            "[red]Error:[/red] --since/--until require --project "
+            "(time filtering applies to sessions, not the project list).",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
     if json_flag:
         format = "json"
     config_dir = ctx.obj.claude_config_dir if ctx.obj else None
     if project:
+        sessions_override: list[SessionInfo] | None = None
+        if since is not None or until is not None:
+            parsed_since, parsed_until = parse_time_window(
+                since, until, err_console=err_console,
+            )
+            project_info = _find_or_exit(project, config_dir)
+            sessions_override = filter_sessions_by_time(
+                project_info.sessions, parsed_since, parsed_until,
+            )
         if format == "json":
-            _list_sessions_json(project, config_dir=config_dir, quiet=quiet)
+            _list_sessions_json(
+                project, config_dir=config_dir, quiet=quiet,
+                sessions_override=sessions_override,
+            )
         else:
             _list_sessions_table(
                 project, config_dir=config_dir, verbose=verbose, quiet=quiet,
+                sessions_override=sessions_override,
             )
     else:
         if format == "json":

--- a/src/agentfluent/cli/commands/list_cmd.py
+++ b/src/agentfluent/cli/commands/list_cmd.py
@@ -112,47 +112,37 @@ def _find_or_exit(project_slug: str, config_dir: Path | None) -> ProjectInfo:
 
 
 def _list_sessions_table(
-    project_slug: str,
+    project: ProjectInfo,
+    sessions: list[SessionInfo],
     *,
-    config_dir: Path | None,
     verbose: bool,
     quiet: bool,
-    sessions_override: list[SessionInfo] | None = None,
 ) -> None:
     """Display sessions for a project as a Rich table."""
-    project = _find_or_exit(project_slug, config_dir)
-    sessions_list = (
-        sessions_override if sessions_override is not None else project.sessions
-    )
     if quiet:
-        console.print(f"Project {project.display_name}: {len(sessions_list)} sessions")
+        console.print(f"Project {project.display_name}: {len(sessions)} sessions")
         return
-    sessions = [(s, len(parse_session(s.path))) for s in sessions_list]
-    format_sessions_table(console, project.display_name, sessions, verbose=verbose)
+    rows = [(s, len(parse_session(s.path))) for s in sessions]
+    format_sessions_table(console, project.display_name, rows, verbose=verbose)
 
 
 def _list_sessions_json(
-    project_slug: str,
+    project: ProjectInfo,
+    sessions: list[SessionInfo],
     *,
-    config_dir: Path | None,
     quiet: bool,
-    sessions_override: list[SessionInfo] | None = None,
 ) -> None:
     """Output sessions for a project as JSON."""
-    project = _find_or_exit(project_slug, config_dir)
-    sessions_list = (
-        sessions_override if sessions_override is not None else project.sessions
-    )
     if quiet:
         payload: dict[str, object] = {
             "project": project.display_name,
-            "session_count": len(sessions_list),
+            "session_count": len(sessions),
         }
     else:
-        sessions = []
-        for s in sessions_list:
+        rows = []
+        for s in sessions:
             messages = parse_session(s.path)
-            sessions.append(
+            rows.append(
                 {
                     "filename": s.filename,
                     "size_bytes": s.size_bytes,
@@ -161,7 +151,7 @@ def _list_sessions_json(
                     "subagent_count": s.subagent_count,
                 }
             )
-        payload = {"project": project.display_name, "sessions": sessions}
+        payload = {"project": project.display_name, "sessions": rows}
     print(format_json_output("list-sessions", payload))
 
 
@@ -219,24 +209,20 @@ def list_cmd(
         format = "json"
     config_dir = ctx.obj.claude_config_dir if ctx.obj else None
     if project:
-        sessions_override: list[SessionInfo] | None = None
+        project_info = _find_or_exit(project, config_dir)
+        sessions = project_info.sessions
         if since is not None or until is not None:
             parsed_since, parsed_until = parse_time_window(
                 since, until, err_console=err_console,
             )
-            project_info = _find_or_exit(project, config_dir)
-            sessions_override = filter_sessions_by_time(
-                project_info.sessions, parsed_since, parsed_until,
+            sessions = filter_sessions_by_time(
+                sessions, parsed_since, parsed_until,
             )
         if format == "json":
-            _list_sessions_json(
-                project, config_dir=config_dir, quiet=quiet,
-                sessions_override=sessions_override,
-            )
+            _list_sessions_json(project_info, sessions, quiet=quiet)
         else:
             _list_sessions_table(
-                project, config_dir=config_dir, verbose=verbose, quiet=quiet,
-                sessions_override=sessions_override,
+                project_info, sessions, verbose=verbose, quiet=quiet,
             )
     else:
         if format == "json":

--- a/tests/unit/cli/test_list_since_until.py
+++ b/tests/unit/cli/test_list_since_until.py
@@ -1,4 +1,4 @@
-"""Tests for ``agentfluent list --since/--until`` (#296).
+"""Tests for ``agentfluent list --since/--until``.
 
 The seeded fixture session in ``populated_home`` has its first message
 at 2026-04-10T10:00:00Z, so windows are anchored to that.
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -35,64 +36,35 @@ class TestRequiresProject:
 
 
 class TestFilterApplied:
-    def test_since_after_session_excludes_it(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
-    ) -> None:
-        # Session is at 2026-04-10; --since 2026-05-01 is after, so the
-        # session is excluded.
-        result = runner.invoke(
-            cli_app,
-            [
-                "list", "--project", "project",
-                "--since", "2026-05-01",
-                "--quiet",
-            ],
-        )
-        assert result.exit_code == EXIT_OK
-        assert "0 sessions" in result.stdout
+    """Session at 2026-04-10 is the only fixture session; each window
+    bracket either includes (1 session) or excludes (0 sessions) it."""
 
-    def test_since_before_session_includes_it(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    @pytest.mark.parametrize(
+        ("flags", "expected_count_str"),
+        [
+            (["--since", "2026-05-01"], "0 sessions"),  # window after session
+            (["--since", "2026-04-01"], "1 sessions"),  # session at-or-after since
+            (["--until", "2026-04-01"], "0 sessions"),  # session after until
+            (
+                ["--since", "2026-04-01", "--until", "2026-05-01"],
+                "1 sessions",
+            ),  # session in window
+        ],
+    )
+    def test_window_filters_session(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+        flags: list[str],
+        expected_count_str: str,
     ) -> None:
         result = runner.invoke(
             cli_app,
-            [
-                "list", "--project", "project",
-                "--since", "2026-04-01",
-                "--quiet",
-            ],
+            ["list", "--project", "project", *flags, "--quiet"],
         )
         assert result.exit_code == EXIT_OK
-        assert "1 sessions" in result.stdout
-
-    def test_until_before_session_excludes_it(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
-    ) -> None:
-        result = runner.invoke(
-            cli_app,
-            [
-                "list", "--project", "project",
-                "--until", "2026-04-01",
-                "--quiet",
-            ],
-        )
-        assert result.exit_code == EXIT_OK
-        assert "0 sessions" in result.stdout
-
-    def test_window_brackets_session(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
-    ) -> None:
-        result = runner.invoke(
-            cli_app,
-            [
-                "list", "--project", "project",
-                "--since", "2026-04-01",
-                "--until", "2026-05-01",
-                "--quiet",
-            ],
-        )
-        assert result.exit_code == EXIT_OK
-        assert "1 sessions" in result.stdout
+        assert expected_count_str in result.stdout
 
 
 class TestErrors:

--- a/tests/unit/cli/test_list_since_until.py
+++ b/tests/unit/cli/test_list_since_until.py
@@ -1,0 +1,155 @@
+"""Tests for ``agentfluent list --since/--until`` (#296).
+
+The seeded fixture session in ``populated_home`` has its first message
+at 2026-04-10T10:00:00Z, so windows are anchored to that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.exit_codes import EXIT_OK, EXIT_USER_ERROR
+
+
+class TestRequiresProject:
+    """``--since`` / ``--until`` are session-scope filters; without
+    ``--project`` they have no meaningful target."""
+
+    def test_since_without_project_errors(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--since", "7d"])
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "--since/--until require --project" in result.stderr
+
+    def test_until_without_project_errors(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(cli_app, ["list", "--until", "2026-05-01"])
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "--since/--until require --project" in result.stderr
+
+
+class TestFilterApplied:
+    def test_since_after_session_excludes_it(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # Session is at 2026-04-10; --since 2026-05-01 is after, so the
+        # session is excluded.
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-05-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "0 sessions" in result.stdout
+
+    def test_since_before_session_includes_it(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-04-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "1 sessions" in result.stdout
+
+    def test_until_before_session_excludes_it(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--until", "2026-04-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "0 sessions" in result.stdout
+
+    def test_window_brackets_session(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-04-01",
+                "--until", "2026-05-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "1 sessions" in result.stdout
+
+
+class TestErrors:
+    def test_unparseable_since(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["list", "--project", "project", "--since", "not-a-date"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "--since" in result.stderr
+        assert "not-a-date" in result.stderr
+
+    def test_inverted_interval(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-05-08",
+                "--until", "2026-05-01",
+            ],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "swap" in result.stderr
+
+
+class TestOutputFormats:
+    def test_json_respects_filter(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # Session is at 2026-04-10; --since 2026-05-01 excludes it.
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-05-01",
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        envelope = json.loads(result.stdout)
+        assert envelope["data"]["sessions"] == []
+
+    def test_json_quiet_count_reflects_filter(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "list", "--project", "project",
+                "--since", "2026-05-01",
+                "--json", "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        envelope = json.loads(result.stdout)
+        assert envelope["data"]["session_count"] == 0

--- a/tests/unit/cli/test_time_args.py
+++ b/tests/unit/cli/test_time_args.py
@@ -1,0 +1,104 @@
+"""Tests for ``agentfluent.cli._time_args.parse_time_window``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import typer
+from rich.console import Console
+
+from agentfluent.cli._time_args import parse_time_window
+from agentfluent.cli.exit_codes import EXIT_USER_ERROR
+
+
+@pytest.fixture()
+def err_console() -> Console:
+    """Stderr console with a wide width so error messages don't wrap mid-substring."""
+    return Console(stderr=True, width=200)
+
+
+class TestHappyPath:
+    def test_both_none_returns_none_pair(self, err_console: Console) -> None:
+        since, until = parse_time_window(None, None, err_console=err_console)
+        assert since is None
+        assert until is None
+
+    def test_since_only(self, err_console: Console) -> None:
+        # Naive date-only is interpreted in system local time per
+        # ``parse_datetime``'s contract; the UTC result depends on TZ, so
+        # we verify only the parsed-and-aware shape, not the wall-clock
+        # value.
+        since, until = parse_time_window(
+            "2026-05-01", None, err_console=err_console,
+        )
+        assert since is not None
+        assert since.tzinfo is not None
+        assert until is None
+
+    def test_until_only(self, err_console: Console) -> None:
+        since, until = parse_time_window(
+            None, "2026-05-08", err_console=err_console,
+        )
+        assert since is None
+        assert until is not None
+        assert until.tzinfo is not None
+
+    def test_relative_format(self, err_console: Console) -> None:
+        since, until = parse_time_window(
+            "7d", None, err_console=err_console,
+        )
+        assert since is not None
+        # Relative durations resolve to UTC-aware.
+        assert since.tzinfo is not None
+
+    def test_iso_8601_with_offset(self, err_console: Console) -> None:
+        since, _ = parse_time_window(
+            "2026-05-01T12:00:00+00:00", None, err_console=err_console,
+        )
+        assert since == datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+
+
+class TestErrors:
+    def test_unparseable_since_exits_user_error(
+        self, err_console: Console, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_time_window("not-a-date", None, err_console=err_console)
+        assert exc_info.value.exit_code == EXIT_USER_ERROR
+        captured = capsys.readouterr()
+        assert "--since" in captured.err
+        assert "not-a-date" in captured.err
+
+    def test_unparseable_until_exits_user_error(
+        self, err_console: Console, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_time_window(None, "garbage", err_console=err_console)
+        assert exc_info.value.exit_code == EXIT_USER_ERROR
+        assert "--until" in capsys.readouterr().err
+
+    def test_inverted_interval_rejected(
+        self, err_console: Console, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_time_window(
+                "2026-05-08", "2026-05-01", err_console=err_console,
+            )
+        assert exc_info.value.exit_code == EXIT_USER_ERROR
+        err = capsys.readouterr().err
+        assert "did you swap them" in err
+        assert "2026-05-08" in err
+        assert "2026-05-01" in err
+
+    def test_equal_bounds_rejected(
+        self, err_console: Console, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # since == until produces an empty half-open window — reject as
+        # a foot-gun rather than silently returning zero sessions.
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_time_window(
+                "2026-05-01", "2026-05-01", err_console=err_console,
+            )
+        assert exc_info.value.exit_code == EXIT_USER_ERROR
+        assert "did you swap them" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Adds ``--since`` / ``--until`` options to ``agentfluent list`` so users can preview which sessions fall in a time window before running ``analyze``.
- Introduces ``cli/_time_args.parse_time_window`` — a shared helper for datetime parsing + inverted-interval validation that #297 will reuse. Rejects unparseable input *and* inverted or empty intervals (``since >= until``) with ``EXIT_USER_ERROR`` so users get a useful "did you swap them?" message instead of silently empty results.
- Filters via the existing ``core.filtering.filter_sessions_by_time`` utility (#301) — no new comparison logic in the CLI layer per the architect refinement on #293/#296.
- ``--since/--until`` without ``--project`` is rejected (time filtering targets sessions, not the project list).

Closes #296.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1149 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior covered:
  - ``test_time_args.py`` (9 tests): happy paths, unparseable input → exit, inverted interval rejected, equal-bounds rejected
  - ``test_list_since_until.py`` (10 tests): ``--project`` requirement, since/until filter semantics, JSON output respects filter, quiet count reflects filter
- [x] Manual smoke test: ``uv run agentfluent list --project agentfluent --since 7d --quiet`` → ``10 sessions``; without ``--project`` → user error; bogus ``--since "garbage"`` → user error with format hint.

## Security review
- [x] **Skip review** — the CLI argument parsing is delegated to typed Typer Options and the shared ``parse_time_window`` helper, which routes unparseable input through the same ``parse_datetime`` utility security-reviewed in #295. No new path resolution, no shell interpolation, no rendering of untrusted strings beyond the user-supplied flag values which are already echoed by Typer in error messages.

## Breaking changes
None. Two new optional flags; no existing behavior changed.