### PR TITLE
feat(cli): analyze --since/--until time filtering (#297)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -16,7 +17,7 @@ from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.config.mcp_discovery import resolve_project_disk_path
 from agentfluent.config.models import SEVERITY_RANK, Severity
-from agentfluent.core.discovery import find_project
+from agentfluent.core.discovery import SessionInfo, find_project
 from agentfluent.core.filtering import filter_sessions_by_time
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
@@ -25,6 +26,40 @@ from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_SIMILARITY,
     SKLEARN_AVAILABLE,
 )
+
+
+def _apply_time_window(
+    session_infos: list[SessionInfo],
+    parsed_since: datetime | None,
+    parsed_until: datetime | None,
+    *,
+    verbose: bool,
+    err_console: Console,
+) -> list[SessionInfo]:
+    """Filter to ``[parsed_since, parsed_until)``; raise ``EXIT_NO_DATA`` on empty.
+
+    No-op when both bounds are ``None``. Verbose mode prints a dim
+    stderr note with resolved bounds + in-window/total counts.
+    """
+    if parsed_since is None and parsed_until is None:
+        return session_infos
+    pre_filter_count = len(session_infos)
+    filtered = filter_sessions_by_time(session_infos, parsed_since, parsed_until)
+    if not filtered:
+        err_console.print(
+            "[yellow]No sessions found in the specified time window.[/yellow] "
+            "Use [bold]agentfluent list --project P --since X --until Y[/bold] "
+            "to preview which sessions fall in a window.",
+        )
+        raise typer.Exit(code=EXIT_NO_DATA)
+    if verbose:
+        since_label = parsed_since.isoformat() if parsed_since else "—"
+        until_label = parsed_until.isoformat() if parsed_until else "—"
+        err_console.print(
+            f"[dim]Filtering: sessions from {since_label} to {until_label} "
+            f"({len(filtered)} of {pre_filter_count} sessions)[/dim]",
+        )
+    return filtered
 
 
 def _apply_min_severity(result: AnalysisResult, min_severity: Severity) -> None:
@@ -261,25 +296,10 @@ def analyze(
             err_console.print(f"[red]Session not found:[/red] {session}")
             raise typer.Exit(code=EXIT_USER_ERROR)
 
-    if parsed_since is not None or parsed_until is not None:
-        pre_filter_count = len(session_infos)
-        session_infos = filter_sessions_by_time(
-            session_infos, parsed_since, parsed_until,
-        )
-        if not session_infos:
-            err_console.print(
-                "[yellow]No sessions found in the specified time window.[/yellow] "
-                "Use [bold]agentfluent list --project P --since X --until Y[/bold] "
-                "to preview which sessions fall in a window.",
-            )
-            raise typer.Exit(code=EXIT_NO_DATA)
-        if verbose:
-            since_label = parsed_since.isoformat() if parsed_since else "—"
-            until_label = parsed_until.isoformat() if parsed_until else "—"
-            err_console.print(
-                f"[dim]Filtering: sessions from {since_label} to {until_label} "
-                f"({len(session_infos)} of {pre_filter_count} sessions)[/dim]",
-            )
+    session_infos = _apply_time_window(
+        session_infos, parsed_since, parsed_until,
+        verbose=verbose, err_console=err_console,
+    )
 
     if latest is not None and latest > 0:
         session_infos = session_infos[:latest]

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
+from agentfluent.cli._time_args import parse_time_window
 from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
 from agentfluent.cli.formatters.helpers import format_cost, format_tokens
 from agentfluent.cli.formatters.json_output import format_json_output
@@ -16,6 +17,7 @@ from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.config.mcp_discovery import resolve_project_disk_path
 from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.core.discovery import find_project
+from agentfluent.core.filtering import filter_sessions_by_time
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
 from agentfluent.diagnostics.delegation import (
@@ -54,6 +56,12 @@ Examples:
 
   agentfluent analyze --project codefluent --latest 5 --diagnostics
       Analyze the 5 most recent sessions with behavior diagnostics.
+
+  agentfluent analyze --project codefluent --since 7d
+      Analyze sessions whose first message landed in the last 7 days.
+
+  agentfluent analyze --project codefluent --since 2026-05-01 --until 2026-05-08
+      Analyze sessions in the half-open interval [2026-05-01, 2026-05-08).
 
   agentfluent analyze --project codefluent --format json | jq '.data.token_metrics.total_cost'
       Extract total cost programmatically.
@@ -124,6 +132,24 @@ def analyze(
         "-n",
         help="Analyze only the N most recent sessions.",
     ),
+    since: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--since",
+        help=(
+            "Restrict to sessions whose first message landed at or after "
+            "this time. Accepts ISO 8601, date-only, or relative (7d, "
+            "12h, 30m). Mutually exclusive with --session."
+        ),
+    ),
+    until: Optional[str] = typer.Option(  # noqa: UP007, UP045
+        None,
+        "--until",
+        help=(
+            "Restrict to sessions whose first message landed strictly "
+            "before this time (half-open interval). Same formats as "
+            "--since. Mutually exclusive with --session."
+        ),
+    ),
     diagnostics: bool = typer.Option(
         True,
         "--diagnostics/--no-diagnostics",
@@ -188,6 +214,17 @@ def analyze(
     if verbose and quiet:
         raise typer.BadParameter("--verbose and --quiet are mutually exclusive")
 
+    if session is not None and (since is not None or until is not None):
+        err_console.print(
+            "[red]Error:[/red] --since/--until cannot be combined with "
+            "--session (which selects a specific file).",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
+
+    parsed_since, parsed_until = parse_time_window(
+        since, until, err_console=err_console,
+    )
+
     if json_flag:
         format = "json"
 
@@ -223,6 +260,26 @@ def analyze(
         if not session_infos:
             err_console.print(f"[red]Session not found:[/red] {session}")
             raise typer.Exit(code=EXIT_USER_ERROR)
+
+    if parsed_since is not None or parsed_until is not None:
+        pre_filter_count = len(session_infos)
+        session_infos = filter_sessions_by_time(
+            session_infos, parsed_since, parsed_until,
+        )
+        if not session_infos:
+            err_console.print(
+                "[yellow]No sessions found in the specified time window.[/yellow] "
+                "Use [bold]agentfluent list --project P --since X --until Y[/bold] "
+                "to preview which sessions fall in a window.",
+            )
+            raise typer.Exit(code=EXIT_NO_DATA)
+        if verbose:
+            since_label = parsed_since.isoformat() if parsed_since else "—"
+            until_label = parsed_until.isoformat() if parsed_until else "—"
+            err_console.print(
+                f"[dim]Filtering: sessions from {since_label} to {until_label} "
+                f"({len(session_infos)} of {pre_filter_count} sessions)[/dim]",
+            )
 
     if latest is not None and latest > 0:
         session_infos = session_infos[:latest]

--- a/tests/unit/cli/test_analyze_since_until.py
+++ b/tests/unit/cli/test_analyze_since_until.py
@@ -1,4 +1,4 @@
-"""Tests for ``agentfluent analyze --since/--until`` (#297).
+"""Tests for ``agentfluent analyze --since/--until``.
 
 Seeded fixture session has its first message at 2026-04-10T10:00:00Z.
 Tests pick boundaries on either side of that anchor.
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -18,29 +19,24 @@ class TestFlagInteractionErrors:
     """Mutually-exclusive flag combinations and inverted intervals must
     surface ``EXIT_USER_ERROR`` with a clear message."""
 
-    def test_session_and_since_mutually_exclusive(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    @pytest.mark.parametrize(
+        ("flag", "value"),
+        [("--since", "7d"), ("--until", "2026-05-01")],
+    )
+    def test_session_and_time_flags_mutually_exclusive(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,
+        flag: str,
+        value: str,
     ) -> None:
         result = runner.invoke(
             cli_app,
             [
                 "analyze", "--project", "project",
                 "--session", "session-1.jsonl",
-                "--since", "7d",
-            ],
-        )
-        assert result.exit_code == EXIT_USER_ERROR
-        assert "--since/--until cannot be combined with --session" in result.stderr
-
-    def test_session_and_until_mutually_exclusive(
-        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
-    ) -> None:
-        result = runner.invoke(
-            cli_app,
-            [
-                "analyze", "--project", "project",
-                "--session", "session-1.jsonl",
-                "--until", "2026-05-01",
+                flag, value,
             ],
         )
         assert result.exit_code == EXIT_USER_ERROR

--- a/tests/unit/cli/test_analyze_since_until.py
+++ b/tests/unit/cli/test_analyze_since_until.py
@@ -1,0 +1,188 @@
+"""Tests for ``agentfluent analyze --since/--until`` (#297).
+
+Seeded fixture session has its first message at 2026-04-10T10:00:00Z.
+Tests pick boundaries on either side of that anchor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_OK, EXIT_USER_ERROR
+
+
+class TestFlagInteractionErrors:
+    """Mutually-exclusive flag combinations and inverted intervals must
+    surface ``EXIT_USER_ERROR`` with a clear message."""
+
+    def test_session_and_since_mutually_exclusive(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--session", "session-1.jsonl",
+                "--since", "7d",
+            ],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "--since/--until cannot be combined with --session" in result.stderr
+
+    def test_session_and_until_mutually_exclusive(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--session", "session-1.jsonl",
+                "--until", "2026-05-01",
+            ],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "cannot be combined with --session" in result.stderr
+
+    def test_inverted_interval_rejected(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-05-08",
+                "--until", "2026-05-01",
+            ],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "swap" in result.stderr
+
+    def test_unparseable_since(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--since", "not-a-date"],
+        )
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "--since" in result.stderr
+
+
+class TestEmptyWindow:
+    def test_window_with_no_sessions_exits_no_data(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # Session is at 2026-04-10; --since 2026-12-31 puts it before
+        # the window → empty filtered list → EXIT_NO_DATA.
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-12-31",
+            ],
+        )
+        assert result.exit_code == EXIT_NO_DATA
+        assert "No sessions found in the specified time window" in result.stderr
+
+
+class TestFilterApplied:
+    def test_window_brackets_session(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # Session at 2026-04-10 falls inside [2026-04-01, 2026-05-01).
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--until", "2026-05-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+
+    def test_session_excluded_by_until(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # --until 2026-04-01 cuts off before the session → empty.
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--until", "2026-04-01",
+            ],
+        )
+        assert result.exit_code == EXIT_NO_DATA
+
+
+class TestVerboseWindowNote:
+    def test_verbose_prints_resolved_window(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--until", "2026-05-01",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        # Verbose-mode dim note shows the resolved window and counts.
+        assert "Filtering: sessions from" in result.stderr
+        assert "1 of 1 sessions" in result.stderr
+
+    def test_quiet_does_not_print_window_note(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--until", "2026-05-01",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "Filtering: sessions from" not in result.stderr
+
+
+class TestSinceAndLatestComposition:
+    """``--since`` filters first; ``--latest N`` then takes the N most
+    recent of the post-filter set (per PRD Section 5)."""
+
+    def test_since_then_latest(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # One session in window; --latest 5 still resolves to that one.
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--latest", "5",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+
+
+class TestNoChangeWhenFlagsAbsent:
+    """No regressions when --since/--until are not supplied."""
+
+    def test_default_invocation_unchanged(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        # Baseline analyze with no time flags must still succeed and
+        # NOT print the filtering note even with --verbose.
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--verbose"],
+        )
+        assert result.exit_code == EXIT_OK
+        assert "Filtering: sessions from" not in result.stderr


### PR DESCRIPTION
## Summary
- Adds ``--since`` / ``--until`` to ``agentfluent analyze`` — the v0.6 epic's primary user-facing story.
- Filters via the shared ``core.filtering.filter_sessions_by_time`` utility (#301); parsing and inverted-interval validation reuse ``cli/_time_args.parse_time_window`` introduced in #296.
- Flag interactions per PRD Section 5: mutually exclusive with ``--session``; composes with ``--latest`` (filter first, then take N most recent of post-filter set); empty window → ``EXIT_NO_DATA`` with a hint to use ``agentfluent list --since X --until Y`` to preview.
- ``--verbose`` prints a dim stderr note showing the resolved UTC window and in-window vs. total counts.

Closes #297.

## Stacked on #296
This branch is **stacked on** ``feature/296-list-since-until`` (PR #312) because it consumes the ``cli/_time_args.parse_time_window`` helper introduced there. **Merge #296 first, then update this PR's base to ``main``.** Alternatively, both can be reviewed in parallel — the diff against #296 is just the analyze-side changes.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1160 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior covered: ``test_analyze_since_until.py`` (11 tests across 6 classes):
  - Flag-interaction errors (``--session`` + ``--since/--until`` rejected; inverted interval rejected; unparseable input)
  - Empty window → ``EXIT_NO_DATA`` with helpful hint
  - Filter applied (window brackets session; ``--until`` cuts off before session)
  - Verbose-mode window note printed; quiet mode does not print it
  - ``--since`` + ``--latest`` composition
  - No regression when flags are absent (verbose run with no time flags does not print the filtering note)
- [x] Manual smoke tests:
  - ``analyze --project agentfluent --since 7d --quiet`` → succeeds with summary line
  - ``analyze --project agentfluent --session foo.jsonl --since 7d`` → ``EXIT_USER_ERROR`` "cannot be combined with --session"
  - ``analyze --project agentfluent --since 2026-12-31`` → ``EXIT_NO_DATA`` with hint

## Security review
- [x] **Skip review** — re-uses #295's ``parse_datetime`` and #296's ``parse_time_window`` helpers (already validated upstream); no new path resolution, shell interpolation, or rendering of untrusted strings beyond Typer's own echo of flag values in error messages.

## Breaking changes
None. Two new optional flags; existing ``analyze`` behavior unchanged when flags are absent.