### PR TITLE
feat(cli): axis labels on recommendations in CLI/JSON/diff (#273)

### DIFF
--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -13,9 +13,9 @@ from rich.markup import escape
 from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
-    AXIS_COLORS,
     GLOBAL_AGENT_LABEL,
     axis_label,
+    axis_shift_label,
     format_cost,
     format_tokens,
     severity_cell,
@@ -281,31 +281,13 @@ def _render_regression_footer(console: Console, result: DiffResult) -> None:
 def _axis_prefix(row: RecommendationDelta) -> str:
     """Render the axis-attribution prefix for a delta's message cell.
 
-    Three shapes:
-
-    - ``status='new'``: ``[<current_axis>]`` using the current axis color.
-    - ``status='resolved'``: ``[<baseline_axis>]`` using the baseline axis
-      color (the side that has the rec).
-    - ``status='persisting'``: ``[<axis>]`` when both sides agree, or
-      ``[<baseline> → <current>]`` when ``axis_shifted``. Both axes
-      retain their respective colors so the shift is visually scannable.
-
     Returns an empty string when neither side carries a ``primary_axis``
-    (e.g., diffing two pre-v0.6 envelopes — no info to show).
+    (e.g., diffing two pre-v0.6 envelopes).
     """
     if row.axis_shifted:
-        # ``axis_shifted`` is only True when both sides are non-None.
-        # The leading ``[`` is escaped via ``\[`` so Rich emits it as
-        # plain text instead of consuming ``[<axis-name>`` as an unknown
-        # style tag. The trailing ``]`` is fine as-is.
-        baseline = row.baseline_primary_axis or ""
-        current = row.current_primary_axis or ""
-        baseline_color = AXIS_COLORS.get(baseline, "white")
-        current_color = AXIS_COLORS.get(current, "white")
-        return (
-            f"\\[[{baseline_color}]{baseline}[/{baseline_color}] → "
-            f"[{current_color}]{current}[/{current_color}]]"
-        )
+        assert row.baseline_primary_axis is not None
+        assert row.current_primary_axis is not None
+        return axis_shift_label(row.baseline_primary_axis, row.current_primary_axis)
     axis = row.current_primary_axis or row.baseline_primary_axis
     if axis is None:
         return ""

--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -13,7 +13,9 @@ from rich.markup import escape
 from rich.table import Table
 
 from agentfluent.cli.formatters.helpers import (
+    AXIS_COLORS,
     GLOBAL_AGENT_LABEL,
+    axis_label,
     format_cost,
     format_tokens,
     severity_cell,
@@ -144,13 +146,18 @@ def _print_rec_table(
             count_cell = str(base_count)
             priority_cell = f"{base_priority:.1f}"
 
+        prefix = _axis_prefix(row)
+        message_body = truncate(escape(row.representative_message), 80)
+        message_cell = (
+            f"{prefix} {message_body}" if prefix else message_body
+        )
         table.add_row(
             severity_cell(row.severity),
             agent,
             row.target,
             count_cell,
             priority_cell,
-            truncate(escape(row.representative_message), 80),
+            message_cell,
         )
 
     console.print(table)
@@ -269,6 +276,40 @@ def _render_regression_footer(console: Console, result: DiffResult) -> None:
 # ---------------------------------------------------------------------------
 # Cell formatters
 # ---------------------------------------------------------------------------
+
+
+def _axis_prefix(row: RecommendationDelta) -> str:
+    """Render the axis-attribution prefix for a delta's message cell.
+
+    Three shapes:
+
+    - ``status='new'``: ``[<current_axis>]`` using the current axis color.
+    - ``status='resolved'``: ``[<baseline_axis>]`` using the baseline axis
+      color (the side that has the rec).
+    - ``status='persisting'``: ``[<axis>]`` when both sides agree, or
+      ``[<baseline> → <current>]`` when ``axis_shifted``. Both axes
+      retain their respective colors so the shift is visually scannable.
+
+    Returns an empty string when neither side carries a ``primary_axis``
+    (e.g., diffing two pre-v0.6 envelopes — no info to show).
+    """
+    if row.axis_shifted:
+        # ``axis_shifted`` is only True when both sides are non-None.
+        # The leading ``[`` is escaped via ``\[`` so Rich emits it as
+        # plain text instead of consuming ``[<axis-name>`` as an unknown
+        # style tag. The trailing ``]`` is fine as-is.
+        baseline = row.baseline_primary_axis or ""
+        current = row.current_primary_axis or ""
+        baseline_color = AXIS_COLORS.get(baseline, "white")
+        current_color = AXIS_COLORS.get(current, "white")
+        return (
+            f"\\[[{baseline_color}]{baseline}[/{baseline_color}] → "
+            f"[{current_color}]{current}[/{current_color}]]"
+        )
+    axis = row.current_primary_axis or row.baseline_primary_axis
+    if axis is None:
+        return ""
+    return axis_label(axis)
 
 
 def _signed(value: float, formatted_abs: str) -> str:

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import Axis
 
 if TYPE_CHECKING:
     from agentfluent.config.models import ConfigScore
@@ -16,15 +17,11 @@ SEVERITY_COLORS: dict[Severity, str] = {
     Severity.INFO: "cyan",
 }
 
-AXIS_COLORS: dict[str, str] = {
-    "cost": "yellow",
-    "speed": "cyan",
-    "quality": "magenta",
+AXIS_COLORS: dict[Axis, str] = {
+    Axis.COST: "yellow",
+    Axis.SPEED: "cyan",
+    Axis.QUALITY: "magenta",
 }
-"""Color map for axis attribution labels (#273). Keys mirror the bare
-strings used by ``AggregatedRecommendation.primary_axis`` and
-``axis_scores``. Unknown axes fall back to ``white`` via
-:func:`axis_label`."""
 
 GLOBAL_AGENT_LABEL = "(global)"
 """Display string for cross-cutting findings whose ``agent_type`` is
@@ -44,22 +41,29 @@ def severity_cell(severity: Severity) -> str:
     return f"[{color}]{severity.value}[/{color}]"
 
 
-def axis_label(axis: str) -> str:
-    """Rich-markup ``[axis]`` prefix for recommendation rows (#273).
-
-    Centralizes the markup so CLI table, top-N summary, and diff output
-    stay visually consistent. Unknown axes render in white so a future
-    axis added without updating ``AXIS_COLORS`` still appears (just
-    uncolored) instead of crashing.
+def axis_label(axis: Axis) -> str:
+    """Rich-markup ``[axis]`` prefix for recommendation rows.
 
     The literal opening ``[`` is escaped via ``\\[`` so Rich emits it
-    as plain text instead of consuming ``[axis]`` as an unknown style
-    tag (which would silently drop the label entirely from the rendered
-    output). The closing ``]`` is fine as-is — Rich only treats it
-    specially when it closes an open tag.
+    as plain text instead of consuming ``[<name>`` as an unknown style
+    tag (which would silently drop the label from the rendered output).
     """
-    color = AXIS_COLORS.get(axis, "white")
-    return f"[{color}]\\[{axis}][/{color}]"
+    color = AXIS_COLORS[axis]
+    return f"[{color}]\\[{axis.value}][/{color}]"
+
+
+def axis_shift_label(baseline: Axis, current: Axis) -> str:
+    """Rich-markup ``[old → new]`` indicator for axis-shifted diff rows.
+
+    Shares the ``\\[`` escape rule with :func:`axis_label`; both axes
+    keep their respective colors so the shift is visually scannable.
+    """
+    baseline_color = AXIS_COLORS[baseline]
+    current_color = AXIS_COLORS[current]
+    return (
+        f"\\[[{baseline_color}]{baseline.value}[/{baseline_color}] → "
+        f"[{current_color}]{current.value}[/{current_color}]]"
+    )
 
 
 def format_cost(cost: float) -> str:

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -16,6 +16,16 @@ SEVERITY_COLORS: dict[Severity, str] = {
     Severity.INFO: "cyan",
 }
 
+AXIS_COLORS: dict[str, str] = {
+    "cost": "yellow",
+    "speed": "cyan",
+    "quality": "magenta",
+}
+"""Color map for axis attribution labels (#273). Keys mirror the bare
+strings used by ``AggregatedRecommendation.primary_axis`` and
+``axis_scores``. Unknown axes fall back to ``white`` via
+:func:`axis_label`."""
+
 GLOBAL_AGENT_LABEL = "(global)"
 """Display string for cross-cutting findings whose ``agent_type`` is
 ``None`` (e.g., MCP audit). JSON output keeps ``null``; tables substitute
@@ -32,6 +42,24 @@ def severity_cell(severity: Severity) -> str:
     """Rich-markup cell for a ``Severity`` value."""
     color = SEVERITY_COLORS[severity]
     return f"[{color}]{severity.value}[/{color}]"
+
+
+def axis_label(axis: str) -> str:
+    """Rich-markup ``[axis]`` prefix for recommendation rows (#273).
+
+    Centralizes the markup so CLI table, top-N summary, and diff output
+    stay visually consistent. Unknown axes render in white so a future
+    axis added without updating ``AXIS_COLORS`` still appears (just
+    uncolored) instead of crashing.
+
+    The literal opening ``[`` is escaped via ``\\[`` so Rich emits it
+    as plain text instead of consuming ``[axis]`` as an unknown style
+    tag (which would silently drop the label entirely from the rendered
+    output). The closing ``]`` is fine as-is — Rich only treats it
+    specially when it closes an open tag.
+    """
+    color = AXIS_COLORS.get(axis, "white")
+    return f"[{color}]\\[{axis}][/{color}]"
 
 
 def format_cost(cost: float) -> str:

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -19,6 +19,7 @@ from agentfluent.cli.formatters.helpers import (
     GLOBAL_AGENT_LABEL,
     SEVERITY_COLORS,
     average_score,
+    axis_label,
     format_cost,
     format_date,
     format_size,
@@ -329,9 +330,17 @@ def _format_diagnostics_table(
 
     ``top_n`` controls the "Top priority fixes" summary block that
     renders above the aggregated Recommendations table (#172). The
-    summary is suppressed in ``--verbose`` (the unaggregated raw table
-    is shown instead) and when ``top_n == 0`` or no aggregated rows
-    exist.
+    summary is suppressed in ``--verbose`` (where per-row priority
+    breakdown lines convey the same info at higher granularity) and
+    when ``top_n == 0`` or no aggregated rows exist.
+
+    Verbose mode (#273): replaces the legacy raw unaggregated
+    ``recommendations`` rendering with the aggregated table plus a
+    per-row dim breakdown line showing the composite ``priority_score``
+    and per-axis contributions. The raw, unaggregated list is dropped
+    intentionally — its structural duplication of aggregated rows
+    confused users more than it helped, and the breakdown line gives a
+    finer-grained view of the same data without that redundancy.
     """
     if diag.signals:
         sig_table = Table(title="Diagnostic Signals", show_header=True)
@@ -350,25 +359,9 @@ def _format_diagnostics_table(
             )
         console.print(sig_table)
 
-    if verbose and diag.recommendations:
-        rec_table = Table(title="Recommendations", show_header=True)
-        rec_table.add_column("Agent", style="cyan")
-        rec_table.add_column("Target")
-        rec_table.add_column("Severity")
-        rec_table.add_column("Observation")
-        rec_table.add_column("Action")
-
-        for rec in diag.recommendations:
-            rec_table.add_row(
-                escape(rec.agent_type or GLOBAL_AGENT_LABEL),
-                escape(rec.target),
-                severity_cell(rec.severity),
-                escape(rec.observation),
-                escape(rec.action),
-            )
-        console.print(rec_table)
-    elif diag.aggregated_recommendations:
-        _format_top_recommendations(console, diag, top_n=top_n)
+    if diag.aggregated_recommendations:
+        if not verbose:
+            _format_top_recommendations(console, diag, top_n=top_n)
 
         rec_table = Table(title="Recommendations", show_header=True)
         rec_table.add_column("#", style="dim", justify="right")
@@ -379,21 +372,51 @@ def _format_diagnostics_table(
         rec_table.add_column("Recommendation")
 
         for idx, agg in enumerate(diag.aggregated_recommendations, start=1):
+            message = f"{axis_label(agg.primary_axis)} {escape(agg.representative_message)}"
             rec_table.add_row(
                 str(idx),
                 escape(agg.agent_type or GLOBAL_AGENT_LABEL),
                 escape(agg.target),
                 severity_cell(agg.severity),
                 str(agg.count),
-                escape(agg.representative_message),
+                message,
             )
         console.print(rec_table)
+
+        if verbose:
+            _print_priority_breakdowns(console, diag)
 
     _format_deep_diagnostics(console, diag, verbose=verbose)
     _format_delegation_suggestions(console, diag, verbose=verbose)
     _format_offload_candidates(console, diag, verbose=verbose)
 
     console.print(GLOSSARY_FOOTNOTE, style="dim")
+
+
+def _print_priority_breakdowns(
+    console: Console,
+    diag: DiagnosticsResult,
+) -> None:
+    """Render per-row dim priority breakdown lines under verbose mode.
+
+    Format: ``  N. Priority: 312.4 (cost: 12.4, speed: 0.0, quality: 300.0)``
+
+    Printed below the aggregated Recommendations table so the
+    composite ``priority_score`` and per-axis contributions are
+    visible without bloating the table itself.
+    """
+    if not diag.aggregated_recommendations:
+        return
+    console.print("\n[dim]Priority breakdown[/dim]")
+    for idx, agg in enumerate(diag.aggregated_recommendations, start=1):
+        cost = agg.axis_scores.get("cost", 0.0)
+        speed = agg.axis_scores.get("speed", 0.0)
+        quality = agg.axis_scores.get("quality", 0.0)
+        console.print(
+            f"  [dim]{idx}. Priority: {agg.priority_score:.1f} "
+            f"(cost: {cost:.1f}, speed: {speed:.1f}, "
+            f"quality: {quality:.1f})[/dim]",
+        )
 
 
 def _format_top_recommendations(
@@ -409,10 +432,12 @@ def _format_top_recommendations(
     summary and find the matching detail row by number. Suppressed when
     ``top_n == 0`` or no aggregated rows exist.
 
-    Format: ``  N. [severity] agent (count×): representative_message``.
+    Format: ``  N. [axis] [severity] agent (count×): representative_message``.
     The aggregated list is already sorted by ``priority_score`` desc
     (see ``aggregation.aggregate_recommendations``), so the top N rows
-    are the top N priorities by definition.
+    are the top N priorities by definition. The ``[axis]`` prefix
+    (#273) surfaces ``primary_axis`` attribution at a glance using the
+    ``AXIS_COLORS`` palette.
     """
     if top_n <= 0:
         return
@@ -423,12 +448,13 @@ def _format_top_recommendations(
 
     console.print(f"\n[bold]Top {shown} priority fixes[/bold]")
     for idx, agg in enumerate(aggs[:shown], start=1):
+        axis = axis_label(agg.primary_axis)
         severity = severity_cell(agg.severity)
         agent = escape(agg.agent_type or GLOBAL_AGENT_LABEL)
         count_suffix = f" ({agg.count}×)" if agg.count > 1 else ""
         message = escape(agg.representative_message)
         console.print(
-            f"  {idx}. {severity} [cyan]{agent}[/cyan]{count_suffix}: {message}",
+            f"  {idx}. {axis} {severity} [cyan]{agent}[/cyan]{count_suffix}: {message}",
         )
 
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -28,7 +28,7 @@ from agentfluent.cli.formatters.helpers import (
     severity_cell,
     truncate,
 )
-from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.models import Axis, SignalType
 
 API_RATE_FOOTNOTE = (
     "API rate — pay-per-token equivalent. "
@@ -333,14 +333,6 @@ def _format_diagnostics_table(
     summary is suppressed in ``--verbose`` (where per-row priority
     breakdown lines convey the same info at higher granularity) and
     when ``top_n == 0`` or no aggregated rows exist.
-
-    Verbose mode (#273): replaces the legacy raw unaggregated
-    ``recommendations`` rendering with the aggregated table plus a
-    per-row dim breakdown line showing the composite ``priority_score``
-    and per-axis contributions. The raw, unaggregated list is dropped
-    intentionally — its structural duplication of aggregated rows
-    confused users more than it helped, and the breakdown line gives a
-    finer-grained view of the same data without that redundancy.
     """
     if diag.signals:
         sig_table = Table(title="Diagnostic Signals", show_header=True)
@@ -372,7 +364,7 @@ def _format_diagnostics_table(
         rec_table.add_column("Recommendation")
 
         for idx, agg in enumerate(diag.aggregated_recommendations, start=1):
-            message = f"{axis_label(agg.primary_axis)} {escape(agg.representative_message)}"
+            message = f"{axis_label(Axis(agg.primary_axis))} {escape(agg.representative_message)}"
             rec_table.add_row(
                 str(idx),
                 escape(agg.agent_type or GLOBAL_AGENT_LABEL),
@@ -435,9 +427,7 @@ def _format_top_recommendations(
     Format: ``  N. [axis] [severity] agent (count×): representative_message``.
     The aggregated list is already sorted by ``priority_score`` desc
     (see ``aggregation.aggregate_recommendations``), so the top N rows
-    are the top N priorities by definition. The ``[axis]`` prefix
-    (#273) surfaces ``primary_axis`` attribution at a glance using the
-    ``AXIS_COLORS`` palette.
+    are the top N priorities by definition.
     """
     if top_n <= 0:
         return
@@ -448,7 +438,7 @@ def _format_top_recommendations(
 
     console.print(f"\n[bold]Top {shown} priority fixes[/bold]")
     for idx, agg in enumerate(aggs[:shown], start=1):
-        axis = axis_label(agg.primary_axis)
+        axis = axis_label(Axis(agg.primary_axis))
         severity = severity_cell(agg.severity)
         agent = escape(agg.agent_type or GLOBAL_AGENT_LABEL)
         count_suffix = f" ({agg.count}×)" if agg.count > 1 else ""

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -161,6 +161,14 @@ def _make_delta(
     severity = _coerce_severity(sample.get("severity"))
     representative = str(sample.get("representative_message", ""))
 
+    # Axis attribution (#273). ``.get("primary_axis")`` returns ``None``
+    # when the field is absent (pre-v0.6 envelopes) — we propagate that
+    # ``None`` instead of defaulting to ``"cost"`` so legacy envelopes
+    # don't trigger spurious axis-shift indicators against a current
+    # envelope that does carry the attribution.
+    baseline_axis = _coerce_axis((baseline or {}).get("primary_axis"))
+    current_axis = _coerce_axis((current or {}).get("primary_axis"))
+
     return RecommendationDelta(
         status=status,
         agent_type=agent_type,
@@ -175,7 +183,23 @@ def _make_delta(
         current_priority_score=current_priority,
         priority_score_delta=current_priority - baseline_priority,
         is_builtin=bool(sample.get("is_builtin", False)),
+        baseline_primary_axis=baseline_axis,
+        current_primary_axis=current_axis,
     )
+
+
+def _coerce_axis(value: Any) -> str | None:
+    """Normalize ``primary_axis`` from JSON to ``str | None``.
+
+    Returns ``None`` for missing/blank values so the ``axis_shifted``
+    computed field on ``RecommendationDelta`` stays quiet against
+    pre-v0.6 envelopes that lack the attribution entirely.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    return value or None
 
 
 def _coerce_severity(value: Any) -> Severity:

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import SEVERITY_RANK, Severity
-from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.models import Axis, SignalType
 from agentfluent.diff.models import (
     AgentTypeDelta,
     DeltaStatus,
@@ -161,11 +161,8 @@ def _make_delta(
     severity = _coerce_severity(sample.get("severity"))
     representative = str(sample.get("representative_message", ""))
 
-    # Axis attribution (#273). ``.get("primary_axis")`` returns ``None``
-    # when the field is absent (pre-v0.6 envelopes) — we propagate that
-    # ``None`` instead of defaulting to ``"cost"`` so legacy envelopes
-    # don't trigger spurious axis-shift indicators against a current
-    # envelope that does carry the attribution.
+    # Pre-v0.6 envelopes lack ``primary_axis``; ``None`` propagation keeps
+    # ``axis_shifted`` quiet when one side has no attribution at all.
     baseline_axis = _coerce_axis((baseline or {}).get("primary_axis"))
     current_axis = _coerce_axis((current or {}).get("primary_axis"))
 
@@ -188,18 +185,18 @@ def _make_delta(
     )
 
 
-def _coerce_axis(value: Any) -> str | None:
-    """Normalize ``primary_axis`` from JSON to ``str | None``.
+def _coerce_axis(value: Any) -> Axis | None:
+    """Normalize a JSON ``primary_axis`` value to an :class:`Axis` member.
 
-    Returns ``None`` for missing/blank values so the ``axis_shifted``
-    computed field on ``RecommendationDelta`` stays quiet against
-    pre-v0.6 envelopes that lack the attribution entirely.
+    Returns ``None`` for missing, blank, or unrecognized values so legacy
+    envelopes and forward-compat axes don't crash the diff.
     """
-    if value is None:
+    if not isinstance(value, str) or not value:
         return None
-    if not isinstance(value, str):
+    try:
+        return Axis(value)
+    except ValueError:
         return None
-    return value or None
 
 
 def _coerce_severity(value: Any) -> Severity:

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import Severity
@@ -56,6 +56,31 @@ class RecommendationDelta(BaseModel):
     require a schema change."""
 
     is_builtin: bool = False
+
+    baseline_primary_axis: str | None = None
+    """``primary_axis`` from the baseline envelope's aggregated rec, or
+    ``None`` for ``status='new'`` rows and for legacy pre-v0.6 envelopes
+    that lack the field. Defaulting to ``None`` rather than ``"cost"``
+    avoids spurious ``axis_shifted`` reports when one side is missing
+    the attribution entirely (#273)."""
+
+    current_primary_axis: str | None = None
+    """``primary_axis`` from the current envelope's aggregated rec, or
+    ``None`` for ``status='resolved'`` rows."""
+
+    # mypy + pydantic ``@computed_field`` interaction (pydantic/pydantic#6709).
+    # Mirrors the ``# type: ignore[prop-decorator]`` pattern on
+    # ``DelegationSuggestion.yaml_draft`` and ``OffloadCandidate.yaml_draft``.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def axis_shifted(self) -> bool:
+        """``True`` iff baseline and current both have a non-``None``
+        ``primary_axis`` and the values differ. Pre-v0.6 envelopes
+        (missing ``primary_axis``) deserialize to ``None`` and never
+        report a shift, so a one-sided legacy diff stays quiet."""
+        if self.baseline_primary_axis is None or self.current_primary_axis is None:
+            return False
+        return self.baseline_primary_axis != self.current_primary_axis
 
 
 class ModelTokenDelta(BaseModel):

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, computed_field
 
 from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import Severity
-from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.models import Axis, SignalType
 
 DeltaStatus = Literal["new", "resolved", "persisting"]
 
@@ -57,27 +57,21 @@ class RecommendationDelta(BaseModel):
 
     is_builtin: bool = False
 
-    baseline_primary_axis: str | None = None
-    """``primary_axis`` from the baseline envelope's aggregated rec, or
-    ``None`` for ``status='new'`` rows and for legacy pre-v0.6 envelopes
-    that lack the field. Defaulting to ``None`` rather than ``"cost"``
-    avoids spurious ``axis_shifted`` reports when one side is missing
-    the attribution entirely (#273)."""
+    baseline_primary_axis: Axis | None = None
+    """``None`` for ``status='new'`` rows and for legacy pre-v0.6
+    envelopes that lack the field. Defaulting to ``None`` rather than
+    ``Axis.COST`` keeps ``axis_shifted`` quiet when one side has no
+    attribution at all."""
 
-    current_primary_axis: str | None = None
-    """``primary_axis`` from the current envelope's aggregated rec, or
-    ``None`` for ``status='resolved'`` rows."""
+    current_primary_axis: Axis | None = None
+    """``None`` for ``status='resolved'`` rows."""
 
     # mypy + pydantic ``@computed_field`` interaction (pydantic/pydantic#6709).
-    # Mirrors the ``# type: ignore[prop-decorator]`` pattern on
-    # ``DelegationSuggestion.yaml_draft`` and ``OffloadCandidate.yaml_draft``.
     @computed_field  # type: ignore[prop-decorator]
     @property
     def axis_shifted(self) -> bool:
         """``True`` iff baseline and current both have a non-``None``
-        ``primary_axis`` and the values differ. Pre-v0.6 envelopes
-        (missing ``primary_axis``) deserialize to ``None`` and never
-        report a shift, so a one-sided legacy diff stays quiet."""
+        ``primary_axis`` and the values differ."""
         if self.baseline_primary_axis is None or self.current_primary_axis is None:
             return False
         return self.baseline_primary_axis != self.current_primary_axis

--- a/tests/unit/cli/_recommendation_helpers.py
+++ b/tests/unit/cli/_recommendation_helpers.py
@@ -1,0 +1,60 @@
+"""Shared helpers for tests that exercise the aggregated Recommendations
+table and Top-N priority summary."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from agentfluent.cli.formatters.table import (
+    _format_diagnostics_table,
+    _format_top_recommendations,
+)
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import (
+    AggregatedRecommendation,
+    DiagnosticsResult,
+    SignalType,
+)
+
+
+def make_agg(
+    *,
+    agent_type: str = "pm",
+    severity: Severity = Severity.WARNING,
+    target: str = "prompt",
+    count: int = 1,
+    representative_message: str = "Add fallback guidance.",
+    priority_score: float = 200.0,
+    primary_axis: str = "cost",
+    axis_scores: dict[str, float] | None = None,
+    signal_types: list[SignalType] | None = None,
+) -> AggregatedRecommendation:
+    return AggregatedRecommendation(
+        agent_type=agent_type,
+        target=target,
+        severity=severity,
+        signal_types=signal_types or [SignalType.RETRY_LOOP],
+        count=count,
+        representative_message=representative_message,
+        priority_score=priority_score,
+        primary_axis=primary_axis,
+        axis_scores=axis_scores or {"cost": 0.0, "speed": 0.0, "quality": 0.0},
+    )
+
+
+def render_section(
+    diag: DiagnosticsResult,
+    *,
+    top_n: int = 5,
+    verbose: bool = False,
+    width: int = 160,
+) -> str:
+    console = Console(record=True, width=width, force_terminal=False)
+    _format_diagnostics_table(console, diag, verbose=verbose, top_n=top_n)
+    return console.export_text()
+
+
+def render_top_only(diag: DiagnosticsResult, *, top_n: int, width: int = 120) -> str:
+    console = Console(record=True, width=width, force_terminal=False)
+    _format_top_recommendations(console, diag, top_n=top_n)
+    return console.export_text()

--- a/tests/unit/cli/test_axis_json_contract.py
+++ b/tests/unit/cli/test_axis_json_contract.py
@@ -1,0 +1,54 @@
+"""JSON envelope axis attribution contract (#273).
+
+Locks ``primary_axis`` and ``axis_scores`` on every aggregated
+recommendation in ``analyze --json`` output. JSON consumers
+(CI gates, dashboards, future v0.6 markdown report) depend on these
+fields being present and shaped correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestAnalyzeAxisJsonContract:
+    """Each aggregated recommendation in the analyze envelope MUST
+    expose ``primary_axis`` (str) and ``axis_scores`` (dict[str, float]
+    keyed by ``cost``/``speed``/``quality``)."""
+
+    def test_aggregated_recs_carry_primary_axis_and_axis_scores(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--format", "json"],
+        )
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        diagnostics = payload["data"].get("diagnostics")
+        assert diagnostics is not None, "diagnostics block should be present"
+        aggs = diagnostics.get("aggregated_recommendations") or []
+        assert aggs, "expected at least one aggregated recommendation"
+
+        for agg in aggs:
+            assert "primary_axis" in agg, (
+                f"primary_axis missing from aggregated row: {agg}"
+            )
+            assert isinstance(agg["primary_axis"], str)
+            assert agg["primary_axis"] in {"cost", "speed", "quality"}
+
+            assert "axis_scores" in agg, (
+                f"axis_scores missing from aggregated row: {agg}"
+            )
+            scores = agg["axis_scores"]
+            assert isinstance(scores, dict)
+            assert set(scores.keys()) == {"cost", "speed", "quality"}
+            for value in scores.values():
+                # JSON numerics arrive as int OR float; both are valid.
+                assert isinstance(value, (int, float))

--- a/tests/unit/cli/test_axis_labels.py
+++ b/tests/unit/cli/test_axis_labels.py
@@ -1,0 +1,196 @@
+"""Axis attribution rendering on recommendations (#273).
+
+Locks the [axis] prefix on the aggregated Recommendations table, the
+top-N priority summary, and the verbose-mode per-row breakdown line.
+Also confirms the architect-mandated verbose change: the aggregated
+table renders in verbose mode (the legacy raw unaggregated table no
+longer fires), and the per-row priority breakdown line appears below it.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from agentfluent.cli.formatters.table import _format_diagnostics_table
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import (
+    AggregatedRecommendation,
+    DiagnosticRecommendation,
+    DiagnosticsResult,
+    SignalType,
+)
+
+
+def _agg(
+    *,
+    agent_type: str = "pm",
+    severity: Severity = Severity.WARNING,
+    target: str = "prompt",
+    count: int = 1,
+    representative_message: str = "Add fallback guidance.",
+    priority_score: float = 200.0,
+    primary_axis: str = "cost",
+    axis_scores: dict[str, float] | None = None,
+    signal_types: list[SignalType] | None = None,
+) -> AggregatedRecommendation:
+    return AggregatedRecommendation(
+        agent_type=agent_type,
+        target=target,
+        severity=severity,
+        signal_types=signal_types or [SignalType.RETRY_LOOP],
+        count=count,
+        representative_message=representative_message,
+        priority_score=priority_score,
+        primary_axis=primary_axis,
+        axis_scores=axis_scores or {"cost": 0.0, "speed": 0.0, "quality": 0.0},
+    )
+
+
+def _render(
+    diag: DiagnosticsResult,
+    *,
+    top_n: int = 5,
+    verbose: bool = False,
+) -> str:
+    console = Console(record=True, width=160, force_terminal=False)
+    _format_diagnostics_table(console, diag, verbose=verbose, top_n=top_n)
+    return console.export_text()
+
+
+class TestAxisPrefixOnTopN:
+    """The Top-N priority fixes block prepends the colorized [axis]
+    label per #273 / D020. We assert on plain-text output so the bracket
+    form survives the Rich color stripping done by ``export_text``."""
+
+    def test_quality_axis_appears_in_summary(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(agent_type="explore", primary_axis="quality"),
+            ],
+        )
+        text = _render(diag, top_n=5)
+        assert "[quality]" in text
+
+    def test_cost_axis_appears_in_summary(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(agent_type="pm", primary_axis="cost"),
+            ],
+        )
+        text = _render(diag, top_n=5)
+        assert "[cost]" in text
+
+    def test_speed_axis_appears_in_summary(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(agent_type="architect", primary_axis="speed"),
+            ],
+        )
+        text = _render(diag, top_n=5)
+        assert "[speed]" in text
+
+
+class TestAxisPrefixOnAggregatedTable:
+    """The aggregated Recommendations table prepends the [axis] label to
+    the message cell — not as a new column. PRD-confirmed format."""
+
+    def test_axis_appears_in_message_cell(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(
+                    agent_type="explore",
+                    representative_message="Tighten prompt.",
+                    primary_axis="quality",
+                ),
+            ],
+        )
+        text = _render(diag, top_n=5)
+        # Confirm both the prefix and the message body appear; the row
+        # carries them together.
+        assert "[quality]" in text
+        assert "Tighten prompt" in text
+
+    def test_each_row_carries_its_own_axis_prefix(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(agent_type="explore", primary_axis="quality"),
+                _agg(agent_type="pm", primary_axis="cost"),
+                _agg(agent_type="architect", primary_axis="speed"),
+            ],
+        )
+        text = _render(diag, top_n=0)  # suppress the top-N summary
+        assert "[quality]" in text
+        assert "[cost]" in text
+        assert "[speed]" in text
+
+
+class TestVerboseRendersAggregatedNotRaw:
+    """Architect-mandated change in #273: verbose now renders the
+    aggregated table (with per-row breakdown lines below) instead of
+    the legacy raw unaggregated table."""
+
+    def test_verbose_drops_raw_recommendations_table(self) -> None:
+        # The legacy "Observation" / "Action" columns were the
+        # discriminating headers on the raw recommendations table. They
+        # should no longer appear in verbose output.
+        diag = DiagnosticsResult(
+            recommendations=[
+                DiagnosticRecommendation(
+                    target="prompt",
+                    severity=Severity.WARNING,
+                    message="raw msg",
+                    observation="raw observation text",
+                    action="raw action text",
+                    agent_type="pm",
+                    signal_types=[SignalType.RETRY_LOOP],
+                ),
+            ],
+            aggregated_recommendations=[_agg(agent_type="pm")],
+        )
+        text = _render(diag, top_n=5, verbose=True)
+        # Specifically, the raw observation/action strings shouldn't
+        # appear; the aggregated representative_message should.
+        assert "raw observation text" not in text
+        assert "raw action text" not in text
+        assert "Add fallback guidance" in text
+
+    def test_verbose_renders_priority_breakdown_line(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(
+                    agent_type="pm",
+                    priority_score=312.4,
+                    axis_scores={"cost": 12.4, "speed": 0.0, "quality": 300.0},
+                    primary_axis="quality",
+                ),
+            ],
+        )
+        text = _render(diag, top_n=5, verbose=True)
+        assert "Priority breakdown" in text
+        assert "Priority: 312.4" in text
+        assert "cost: 12.4" in text
+        assert "speed: 0.0" in text
+        assert "quality: 300.0" in text
+
+    def test_non_verbose_omits_priority_breakdown_line(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                _agg(
+                    agent_type="pm",
+                    priority_score=312.4,
+                    axis_scores={"cost": 12.4, "speed": 0.0, "quality": 300.0},
+                ),
+            ],
+        )
+        text = _render(diag, top_n=5, verbose=False)
+        assert "Priority breakdown" not in text
+        assert "Priority: 312.4" not in text
+
+    def test_verbose_still_shows_aggregated_recommendations_header(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[_agg(agent_type="pm")],
+        )
+        text = _render(diag, top_n=5, verbose=True)
+        # The aggregated table title is "Recommendations" (same as
+        # before — the change is what's underneath, not the heading).
+        assert "Recommendations" in text

--- a/tests/unit/cli/test_axis_labels.py
+++ b/tests/unit/cli/test_axis_labels.py
@@ -1,138 +1,87 @@
-"""Axis attribution rendering on recommendations (#273).
+"""Axis attribution rendering on aggregated recommendations.
 
-Locks the [axis] prefix on the aggregated Recommendations table, the
-top-N priority summary, and the verbose-mode per-row breakdown line.
-Also confirms the architect-mandated verbose change: the aggregated
-table renders in verbose mode (the legacy raw unaggregated table no
-longer fires), and the per-row priority breakdown line appears below it.
+Locks the ``[axis]`` prefix on the aggregated Recommendations table,
+the top-N priority summary, and the verbose-mode per-row breakdown
+line. Also confirms that verbose mode renders the aggregated table
+with breakdown lines instead of the legacy raw unaggregated table.
 """
 
 from __future__ import annotations
 
-from rich.console import Console
-
-from agentfluent.cli.formatters.table import _format_diagnostics_table
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import (
-    AggregatedRecommendation,
     DiagnosticRecommendation,
     DiagnosticsResult,
     SignalType,
 )
-
-
-def _agg(
-    *,
-    agent_type: str = "pm",
-    severity: Severity = Severity.WARNING,
-    target: str = "prompt",
-    count: int = 1,
-    representative_message: str = "Add fallback guidance.",
-    priority_score: float = 200.0,
-    primary_axis: str = "cost",
-    axis_scores: dict[str, float] | None = None,
-    signal_types: list[SignalType] | None = None,
-) -> AggregatedRecommendation:
-    return AggregatedRecommendation(
-        agent_type=agent_type,
-        target=target,
-        severity=severity,
-        signal_types=signal_types or [SignalType.RETRY_LOOP],
-        count=count,
-        representative_message=representative_message,
-        priority_score=priority_score,
-        primary_axis=primary_axis,
-        axis_scores=axis_scores or {"cost": 0.0, "speed": 0.0, "quality": 0.0},
-    )
-
-
-def _render(
-    diag: DiagnosticsResult,
-    *,
-    top_n: int = 5,
-    verbose: bool = False,
-) -> str:
-    console = Console(record=True, width=160, force_terminal=False)
-    _format_diagnostics_table(console, diag, verbose=verbose, top_n=top_n)
-    return console.export_text()
+from tests.unit.cli._recommendation_helpers import make_agg, render_section
 
 
 class TestAxisPrefixOnTopN:
-    """The Top-N priority fixes block prepends the colorized [axis]
-    label per #273 / D020. We assert on plain-text output so the bracket
-    form survives the Rich color stripping done by ``export_text``."""
-
     def test_quality_axis_appears_in_summary(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="explore", primary_axis="quality"),
+                make_agg(agent_type="explore", primary_axis="quality"),
             ],
         )
-        text = _render(diag, top_n=5)
+        text = render_section(diag, top_n=5)
         assert "[quality]" in text
 
     def test_cost_axis_appears_in_summary(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="pm", primary_axis="cost"),
+                make_agg(agent_type="pm", primary_axis="cost"),
             ],
         )
-        text = _render(diag, top_n=5)
+        text = render_section(diag, top_n=5)
         assert "[cost]" in text
 
     def test_speed_axis_appears_in_summary(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="architect", primary_axis="speed"),
+                make_agg(agent_type="architect", primary_axis="speed"),
             ],
         )
-        text = _render(diag, top_n=5)
+        text = render_section(diag, top_n=5)
         assert "[speed]" in text
 
 
 class TestAxisPrefixOnAggregatedTable:
-    """The aggregated Recommendations table prepends the [axis] label to
-    the message cell — not as a new column. PRD-confirmed format."""
+    """Axis label is prepended to the message cell, not added as a
+    new column."""
 
     def test_axis_appears_in_message_cell(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(
+                make_agg(
                     agent_type="explore",
                     representative_message="Tighten prompt.",
                     primary_axis="quality",
                 ),
             ],
         )
-        text = _render(diag, top_n=5)
-        # Confirm both the prefix and the message body appear; the row
-        # carries them together.
+        text = render_section(diag, top_n=5)
         assert "[quality]" in text
         assert "Tighten prompt" in text
 
     def test_each_row_carries_its_own_axis_prefix(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="explore", primary_axis="quality"),
-                _agg(agent_type="pm", primary_axis="cost"),
-                _agg(agent_type="architect", primary_axis="speed"),
+                make_agg(agent_type="explore", primary_axis="quality"),
+                make_agg(agent_type="pm", primary_axis="cost"),
+                make_agg(agent_type="architect", primary_axis="speed"),
             ],
         )
-        text = _render(diag, top_n=0)  # suppress the top-N summary
+        text = render_section(diag, top_n=0)
         assert "[quality]" in text
         assert "[cost]" in text
         assert "[speed]" in text
 
 
 class TestVerboseRendersAggregatedNotRaw:
-    """Architect-mandated change in #273: verbose now renders the
-    aggregated table (with per-row breakdown lines below) instead of
-    the legacy raw unaggregated table."""
-
     def test_verbose_drops_raw_recommendations_table(self) -> None:
-        # The legacy "Observation" / "Action" columns were the
-        # discriminating headers on the raw recommendations table. They
-        # should no longer appear in verbose output.
+        # ``observation`` / ``action`` are the discriminating columns of
+        # the legacy raw table; they must not appear in verbose output.
         diag = DiagnosticsResult(
             recommendations=[
                 DiagnosticRecommendation(
@@ -145,11 +94,9 @@ class TestVerboseRendersAggregatedNotRaw:
                     signal_types=[SignalType.RETRY_LOOP],
                 ),
             ],
-            aggregated_recommendations=[_agg(agent_type="pm")],
+            aggregated_recommendations=[make_agg(agent_type="pm")],
         )
-        text = _render(diag, top_n=5, verbose=True)
-        # Specifically, the raw observation/action strings shouldn't
-        # appear; the aggregated representative_message should.
+        text = render_section(diag, top_n=5, verbose=True)
         assert "raw observation text" not in text
         assert "raw action text" not in text
         assert "Add fallback guidance" in text
@@ -157,7 +104,7 @@ class TestVerboseRendersAggregatedNotRaw:
     def test_verbose_renders_priority_breakdown_line(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(
+                make_agg(
                     agent_type="pm",
                     priority_score=312.4,
                     axis_scores={"cost": 12.4, "speed": 0.0, "quality": 300.0},
@@ -165,7 +112,7 @@ class TestVerboseRendersAggregatedNotRaw:
                 ),
             ],
         )
-        text = _render(diag, top_n=5, verbose=True)
+        text = render_section(diag, top_n=5, verbose=True)
         assert "Priority breakdown" in text
         assert "Priority: 312.4" in text
         assert "cost: 12.4" in text
@@ -175,22 +122,20 @@ class TestVerboseRendersAggregatedNotRaw:
     def test_non_verbose_omits_priority_breakdown_line(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(
+                make_agg(
                     agent_type="pm",
                     priority_score=312.4,
                     axis_scores={"cost": 12.4, "speed": 0.0, "quality": 300.0},
                 ),
             ],
         )
-        text = _render(diag, top_n=5, verbose=False)
+        text = render_section(diag, top_n=5, verbose=False)
         assert "Priority breakdown" not in text
         assert "Priority: 312.4" not in text
 
     def test_verbose_still_shows_aggregated_recommendations_header(self) -> None:
         diag = DiagnosticsResult(
-            aggregated_recommendations=[_agg(agent_type="pm")],
+            aggregated_recommendations=[make_agg(agent_type="pm")],
         )
-        text = _render(diag, top_n=5, verbose=True)
-        # The aggregated table title is "Recommendations" (same as
-        # before — the change is what's underneath, not the heading).
+        text = render_section(diag, top_n=5, verbose=True)
         assert "Recommendations" in text

--- a/tests/unit/cli/test_diff_cmd.py
+++ b/tests/unit/cli/test_diff_cmd.py
@@ -304,3 +304,100 @@ class TestOutputFormats:
         result = runner.invoke(cli_app, ["diff", "--help"])
         assert result.exit_code == 0
         assert "Examples" in result.output
+
+
+def _rec_with_axis(
+    *,
+    severity: str = "warning",
+    agent_type: str = "pm",
+    primary_axis: str = "cost",
+) -> dict[str, Any]:
+    """Helper to build an aggregated rec with a primary_axis (#273)."""
+    return {
+        **_rec(severity=severity, agent_type=agent_type),
+        "primary_axis": primary_axis,
+        "axis_scores": {"cost": 0.0, "speed": 0.0, "quality": 0.0},
+    }
+
+
+class TestAxisLabelsInDiffOutput:
+    """The diff table prefixes each delta's message with its axis label
+    and renders a ``[old → new]`` shift indicator on persisting rows
+    where the primary axis changed (#273)."""
+
+    def test_new_rec_renders_axis_prefix(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        baseline = _write_envelope(tmp_path / "baseline.json", _data())
+        current = _write_envelope(
+            tmp_path / "current.json",
+            _data(aggregated_recs=[
+                _rec_with_axis(primary_axis="quality"),
+            ]),
+        )
+        result = runner.invoke(
+            cli_app, ["diff", str(baseline), str(current), "--fail-on", "off"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "[quality]" in result.output
+
+    def test_persisting_axis_shift_renders_arrow(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        baseline = _write_envelope(
+            tmp_path / "baseline.json",
+            _data(aggregated_recs=[_rec_with_axis(primary_axis="cost")]),
+        )
+        current = _write_envelope(
+            tmp_path / "current.json",
+            _data(aggregated_recs=[_rec_with_axis(primary_axis="quality")]),
+        )
+        result = runner.invoke(
+            cli_app, ["diff", str(baseline), str(current), "--fail-on", "off"],
+        )
+        assert result.exit_code == 0, result.output
+        # Same agent + target + signal_types → persisting; different
+        # primary_axis → shift indicator with both axis names present.
+        assert "Persisting Recommendations" in result.output
+        # The shift indicator carries both axes joined by an arrow; we
+        # check both pieces independently to stay resilient to whitespace.
+        assert "cost" in result.output
+        assert "quality" in result.output
+        assert "→" in result.output
+
+    def test_persisting_no_shift_renders_single_axis(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        baseline = _write_envelope(
+            tmp_path / "baseline.json",
+            _data(aggregated_recs=[_rec_with_axis(primary_axis="speed")]),
+        )
+        current = _write_envelope(
+            tmp_path / "current.json",
+            _data(aggregated_recs=[_rec_with_axis(primary_axis="speed")]),
+        )
+        result = runner.invoke(
+            cli_app, ["diff", str(baseline), str(current), "--fail-on", "off"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "[speed]" in result.output
+        # No shift → no arrow indicator inside the recommendations
+        # block. (The summary line has its own ``Sessions: N → N``
+        # arrow we explicitly skip past.)
+        rec_section_start = result.output.index("Persisting Recommendations")
+        rec_section_end = (
+            result.output.index("Token Metrics")
+            if "Token Metrics" in result.output
+            else len(result.output)
+        )
+        rec_section = result.output[rec_section_start:rec_section_end]
+        assert "→" not in rec_section

--- a/tests/unit/cli/test_recommendations_top_n.py
+++ b/tests/unit/cli/test_recommendations_top_n.py
@@ -8,74 +8,28 @@ rows, verbose mode) are exercised via `_format_diagnostics_table`.
 
 from __future__ import annotations
 
-from rich.console import Console
-
-from agentfluent.cli.formatters.table import (
-    _format_diagnostics_table,
-    _format_top_recommendations,
-)
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import (
-    AggregatedRecommendation,
+    DiagnosticRecommendation,
     DiagnosticsResult,
     SignalType,
 )
-
-
-def _agg(
-    *,
-    agent_type: str = "pm",
-    severity: Severity = Severity.WARNING,
-    target: str = "prompt",
-    count: int = 1,
-    representative_message: str = "Add fallback guidance.",
-    priority_score: float = 200.0,
-    signal_types: list[SignalType] | None = None,
-) -> AggregatedRecommendation:
-    return AggregatedRecommendation(
-        agent_type=agent_type,
-        target=target,
-        severity=severity,
-        signal_types=signal_types or [SignalType.RETRY_LOOP],
-        count=count,
-        representative_message=representative_message,
-        priority_score=priority_score,
-    )
-
-
-# NOTE: this file is the third Console-record helper site (after
-# test_deep_diagnostics_formatting.py and test_offload_candidates_formatting.py).
-# Consolidation tracked in #265. The two helpers below differ only in
-# which formatter they invoke; both should fold into a shared
-# `render_section(formatter, ...)` once #265 lands.
-
-
-def _render(
-    diag: DiagnosticsResult,
-    *,
-    top_n: int = 5,
-    verbose: bool = False,
-) -> str:
-    console = Console(record=True, width=120, force_terminal=False)
-    _format_diagnostics_table(console, diag, verbose=verbose, top_n=top_n)
-    return console.export_text()
-
-
-def _render_top_only(diag: DiagnosticsResult, *, top_n: int) -> str:
-    console = Console(record=True, width=120, force_terminal=False)
-    _format_top_recommendations(console, diag, top_n=top_n)
-    return console.export_text()
+from tests.unit.cli._recommendation_helpers import (
+    make_agg,
+    render_section,
+    render_top_only,
+)
 
 
 class TestTopRecommendationsBlock:
     def test_renders_block_with_n_entries(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type=f"agent-{i}", priority_score=300.0 - i)
+                make_agg(agent_type=f"agent-{i}", priority_score=300.0 - i)
                 for i in range(8)
             ],
         )
-        text = _render_top_only(diag, top_n=5)
+        text = render_top_only(diag, top_n=5)
         assert "Top 5 priority fixes" in text
         for i in range(5):
             assert f"agent-{i}" in text
@@ -88,33 +42,34 @@ class TestTopRecommendationsBlock:
         # reflects "Top 3" not "Top 5". Avoids the strict-reading UX
         # gap where users pass --top-n=5 and see no block.
         diag = DiagnosticsResult(
-            aggregated_recommendations=[_agg(agent_type=f"agent-{i}") for i in range(3)],
+            aggregated_recommendations=[
+                make_agg(agent_type=f"agent-{i}") for i in range(3)
+            ],
         )
-        text = _render_top_only(diag, top_n=5)
+        text = render_top_only(diag, top_n=5)
         assert "Top 3 priority fixes" in text
 
     def test_top_n_zero_suppresses_block(self) -> None:
         diag = DiagnosticsResult(
-            aggregated_recommendations=[_agg(agent_type="pm")],
+            aggregated_recommendations=[make_agg(agent_type="pm")],
         )
-        text = _render_top_only(diag, top_n=0)
+        text = render_top_only(diag, top_n=0)
         assert text == ""
 
     def test_no_aggs_suppresses_block(self) -> None:
         diag = DiagnosticsResult(aggregated_recommendations=[])
-        text = _render_top_only(diag, top_n=5)
+        text = render_top_only(diag, top_n=5)
         assert text == ""
 
     def test_count_suffix_only_when_gt_one(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="single", count=1),
-                _agg(agent_type="multi", count=4),
+                make_agg(agent_type="single", count=1),
+                make_agg(agent_type="multi", count=4),
             ],
         )
-        text = _render_top_only(diag, top_n=5)
+        text = render_top_only(diag, top_n=5)
         # No count suffix on count=1 rows (the "(1×)" would be noise).
-        # Use a regex-style structural check via substring presence.
         single_line = next(
             line for line in text.split("\n") if "single" in line
         )
@@ -131,29 +86,23 @@ class TestFullTableIndexColumn:
 
     def test_index_column_present_when_aggs_exist(self) -> None:
         diag = DiagnosticsResult(
-            aggregated_recommendations=[_agg(agent_type="pm")],
+            aggregated_recommendations=[make_agg(agent_type="pm")],
         )
-        text = _render(diag, top_n=5)
-        # Index column header present.
+        text = render_section(diag, top_n=5, width=120)
         assert "#" in text
-        # First row carries index 1.
         rec_section_start = text.index("Recommendations")
         assert "1" in text[rec_section_start:]
 
     def test_index_numbers_match_top_n_entries(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
-                _agg(agent_type="alpha", priority_score=300.0),
-                _agg(agent_type="beta", priority_score=200.0),
-                _agg(agent_type="gamma", priority_score=100.0),
+                make_agg(agent_type="alpha", priority_score=300.0),
+                make_agg(agent_type="beta", priority_score=200.0),
+                make_agg(agent_type="gamma", priority_score=100.0),
             ],
         )
-        text = _render(diag, top_n=2)
-        # Both summary entries start with the same index that appears
-        # in the full table's leading column. We confirm by ordering:
-        # alpha is "1." in the summary AND has "1" in the table row.
+        text = render_section(diag, top_n=2, width=120)
         summary_alpha_idx = text.index("1. ")
-        # First row in the table follows the section header.
         rec_section = text[text.index("Recommendations"):]
         assert "alpha" in rec_section
         # gamma is NOT in the summary (top_n=2) but IS in the full table.
@@ -162,18 +111,12 @@ class TestFullTableIndexColumn:
 
 
 class TestSuppressionInVerboseMode:
-    """Verbose mode (#273) renders the aggregated Recommendations table
-    plus a per-row priority breakdown line; the top-N summary is
-    suppressed because the breakdown line conveys the same priority
-    info at higher granularity."""
+    """Verbose mode renders the aggregated Recommendations table plus a
+    per-row priority breakdown line; the top-N summary is suppressed
+    because the breakdown line conveys the same priority info at higher
+    granularity."""
 
     def test_verbose_skips_top_block(self) -> None:
-        # In verbose mode, _format_diagnostics_table still renders the
-        # aggregated Recommendations table (architect-mandated change in
-        # #273 — the legacy raw `recommendations` table is no longer
-        # rendered). The top-N summary block above the table is
-        # suppressed in favor of the per-row breakdown line below it.
-        from agentfluent.diagnostics.models import DiagnosticRecommendation
         diag = DiagnosticsResult(
             recommendations=[
                 DiagnosticRecommendation(
@@ -186,7 +129,7 @@ class TestSuppressionInVerboseMode:
                     signal_types=[SignalType.RETRY_LOOP],
                 ),
             ],
-            aggregated_recommendations=[_agg()],
+            aggregated_recommendations=[make_agg()],
         )
-        text = _render(diag, top_n=5, verbose=True)
+        text = render_section(diag, top_n=5, verbose=True, width=120)
         assert "Top 5 priority fixes" not in text

--- a/tests/unit/cli/test_recommendations_top_n.py
+++ b/tests/unit/cli/test_recommendations_top_n.py
@@ -162,15 +162,17 @@ class TestFullTableIndexColumn:
 
 
 class TestSuppressionInVerboseMode:
-    """Verbose mode shows the unaggregated raw recommendations table —
-    the top-N summary is irrelevant there because the priority concept
-    only exists at the aggregated level. We confirm the block is
-    suppressed when verbose is on."""
+    """Verbose mode (#273) renders the aggregated Recommendations table
+    plus a per-row priority breakdown line; the top-N summary is
+    suppressed because the breakdown line conveys the same priority
+    info at higher granularity."""
 
     def test_verbose_skips_top_block(self) -> None:
-        # In verbose mode, _format_diagnostics_table renders the raw
-        # `recommendations` list, NOT the aggregated one. The top-N
-        # block lives in the aggregated branch, so it shouldn't fire.
+        # In verbose mode, _format_diagnostics_table still renders the
+        # aggregated Recommendations table (architect-mandated change in
+        # #273 — the legacy raw `recommendations` table is no longer
+        # rendered). The top-N summary block above the table is
+        # suppressed in favor of the per-row breakdown line below it.
         from agentfluent.diagnostics.models import DiagnosticRecommendation
         diag = DiagnosticsResult(
             recommendations=[

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -425,6 +425,133 @@ class TestForwardCompat:
         assert result.resolved_count == 0
 
 
+class TestAxisAttributionInDiff:
+    """Axis attribution propagation (#273). The diff layer reads
+    ``primary_axis`` off each side and exposes ``baseline_primary_axis``
+    / ``current_primary_axis`` plus a derived ``axis_shifted`` flag.
+    Pre-v0.6 envelopes (no ``primary_axis``) deserialize to ``None``
+    on the missing side and never trigger ``axis_shifted``."""
+
+    def test_persisting_carries_both_axes_when_present(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                priority_score=10.0,
+            ) | {"primary_axis": "cost"},
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+                priority_score=15.0,
+            ) | {"primary_axis": "cost"},
+        ])
+
+        result = compute_diff(baseline, current)
+
+        assert result.persisting_count == 1
+        rec = result.recommendations[0]
+        assert rec.baseline_primary_axis == "cost"
+        assert rec.current_primary_axis == "cost"
+        assert rec.axis_shifted is False
+
+    def test_axis_shift_detected_on_persisting(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "cost"},
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "quality"},
+        ])
+
+        result = compute_diff(baseline, current)
+
+        rec = result.recommendations[0]
+        assert rec.status == "persisting"
+        assert rec.baseline_primary_axis == "cost"
+        assert rec.current_primary_axis == "quality"
+        assert rec.axis_shifted is True
+
+    def test_legacy_baseline_no_primary_axis_does_not_trigger_shift(self) -> None:
+        # Pre-v0.6 envelope: no primary_axis key on the rec at all.
+        # Architect-mandated: baseline_primary_axis stays None and
+        # axis_shifted is False even though current has an axis.
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ),  # no primary_axis
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "quality"},
+        ])
+
+        result = compute_diff(baseline, current)
+
+        rec = result.recommendations[0]
+        assert rec.status == "persisting"
+        assert rec.baseline_primary_axis is None
+        assert rec.current_primary_axis == "quality"
+        assert rec.axis_shifted is False
+
+    def test_new_status_baseline_axis_is_none(self) -> None:
+        baseline = _envelope(aggregated_recs=[])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "speed"},
+        ])
+
+        result = compute_diff(baseline, current)
+
+        rec = result.recommendations[0]
+        assert rec.status == "new"
+        assert rec.baseline_primary_axis is None
+        assert rec.current_primary_axis == "speed"
+        assert rec.axis_shifted is False
+
+    def test_resolved_status_current_axis_is_none(self) -> None:
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "quality"},
+        ])
+        current = _envelope(aggregated_recs=[])
+
+        result = compute_diff(baseline, current)
+
+        rec = result.recommendations[0]
+        assert rec.status == "resolved"
+        assert rec.baseline_primary_axis == "quality"
+        assert rec.current_primary_axis is None
+        assert rec.axis_shifted is False
+
+    def test_axis_shifted_serializes_in_json_dump(self) -> None:
+        # Pydantic computed_field must round-trip through model_dump so
+        # JSON envelope consumers see the axis_shifted flag without
+        # having to recompute from the two axis fields.
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "cost"},
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(
+                agent_type="pm", target="prompt", signal_types=["retry_loop"],
+            ) | {"primary_axis": "quality"},
+        ])
+
+        result = compute_diff(baseline, current)
+        dumped = result.model_dump(mode="json")
+        rec_dumped = dumped["recommendations"][0]
+        assert rec_dumped["baseline_primary_axis"] == "cost"
+        assert rec_dumped["current_primary_axis"] == "quality"
+        assert rec_dumped["axis_shifted"] is True
+
+
 class TestDiffResultSerialization:
     def test_model_dump_round_trips(self) -> None:
         baseline = _envelope(aggregated_recs=[


### PR DESCRIPTION
## Summary
- Surfaces `primary_axis` (cost / speed / quality) on every recommendation rendering surface: top-N summary, aggregated Recommendations table, JSON envelope, and `agentfluent diff` output. JSON contract for `axis_scores` + `primary_axis` is now pinned by a test. Closes #273.
- `RecommendationDelta` gains `baseline_primary_axis` / `current_primary_axis` plus an `axis_shifted` `@computed_field`; diff renderer shows `[cost → quality]` shift indicators on persisting rows. Pre-v0.6 envelopes (no `primary_axis` key) deserialize to `None` so the first post-upgrade diff doesn't report spurious shifts.
- Verbose mode now renders the aggregated table with per-row dim priority-breakdown lines instead of the legacy raw unaggregated `recommendations` table — strictly more informative per architect feedback.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1179 passed in worktree)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (8 new tests in `test_axis_labels.py`, 1 in `test_axis_json_contract.py`, 6 in `test_compute.py::TestAxisAttributionInDiff`, 3 in `test_diff_cmd.py::TestAxisLabelsInDiffOutput`)
- [x] CLI rendering exercised via `CliRunner` in the new tests; manual smoke deferred to reviewer (axis colors are visible only on a TTY).

## Security review
- [x] **Needs review** — modifies rendering of user-controlled strings (the aggregated `representative_message` cell in CLI table, top-N summary, and diff output). Existing Rich `escape()` semantics on the user-controlled body are preserved; the new prefix is built from the trusted `Axis` enum value via centralized `axis_label()` / `_axis_prefix()` helpers that escape the leading `[` correctly. **Do not apply the `needs-security-review` label until the PR is dev-complete** — the workflow runs once at label-add time.
- [ ] Skip review

## Breaking changes
None. `RecommendationDelta`'s new `baseline_primary_axis` / `current_primary_axis` fields default to `None` and the `axis_shifted` computed field is additive in JSON output. Verbose-mode CLI output drops the legacy unaggregated `recommendations` table — visible, but strictly an output enhancement (no JSON contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)