### PR TITLE
feat(cli): window metadata in analyze --json output (#298)

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -31,6 +31,7 @@ from agentfluent.analytics.tools import (
     ToolMetrics,
     compute_tool_metrics,
 )
+from agentfluent.core.filtering import WindowMetadata
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import SessionMessage
 from agentfluent.diagnostics.mcp_assessment import (
@@ -89,6 +90,7 @@ class AnalysisResult(BaseModel):
     agent_metrics: AgentMetrics = Field(default_factory=AgentMetrics)
     session_count: int = 0
     diagnostics: DiagnosticsResult | None = None
+    window: WindowMetadata | None = None
 
 
 def analyze_session(

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -18,7 +18,7 @@ from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.config.mcp_discovery import resolve_project_disk_path
 from agentfluent.config.models import SEVERITY_RANK, Severity
 from agentfluent.core.discovery import SessionInfo, find_project
-from agentfluent.core.filtering import filter_sessions_by_time
+from agentfluent.core.filtering import WindowMetadata, filter_sessions_by_time
 from agentfluent.core.paths import projects_dir_for
 from agentfluent.diagnostics import run_diagnostics
 from agentfluent.diagnostics.delegation import (
@@ -35,14 +35,17 @@ def _apply_time_window(
     *,
     verbose: bool,
     err_console: Console,
-) -> list[SessionInfo]:
+) -> tuple[list[SessionInfo], WindowMetadata | None]:
     """Filter to ``[parsed_since, parsed_until)``; raise ``EXIT_NO_DATA`` on empty.
 
-    No-op when both bounds are ``None``. Verbose mode prints a dim
-    stderr note with resolved bounds + in-window/total counts.
+    No-op when both bounds are ``None`` (returns ``(session_infos, None)``).
+    Verbose mode prints a dim stderr note with resolved bounds +
+    in-window/total counts. The returned :class:`WindowMetadata` echoes
+    the resolved exclusive UTC bounds matching ``[since, until)``
+    semantics so JSON consumers can self-document the window.
     """
     if parsed_since is None and parsed_until is None:
-        return session_infos
+        return session_infos, None
     pre_filter_count = len(session_infos)
     filtered = filter_sessions_by_time(session_infos, parsed_since, parsed_until)
     if not filtered:
@@ -59,7 +62,13 @@ def _apply_time_window(
             f"[dim]Filtering: sessions from {since_label} to {until_label} "
             f"({len(filtered)} of {pre_filter_count} sessions)[/dim]",
         )
-    return filtered
+    window = WindowMetadata(
+        since=parsed_since,
+        until=parsed_until,
+        session_count_before_filter=pre_filter_count,
+        session_count_after_filter=len(filtered),
+    )
+    return filtered, window
 
 
 def _apply_min_severity(result: AnalysisResult, min_severity: Severity) -> None:
@@ -296,7 +305,7 @@ def analyze(
             err_console.print(f"[red]Session not found:[/red] {session}")
             raise typer.Exit(code=EXIT_USER_ERROR)
 
-    session_infos = _apply_time_window(
+    session_infos, window_metadata = _apply_time_window(
         session_infos, parsed_since, parsed_until,
         verbose=verbose, err_console=err_console,
     )
@@ -343,6 +352,8 @@ def analyze(
 
     if min_severity is not None:
         _apply_min_severity(result, min_severity)
+
+    result.window = window_metadata
 
     if format == "json":
         _print_json(result, quiet=quiet, project_name=project_info.display_name)

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -38,11 +38,9 @@ def _apply_time_window(
 ) -> tuple[list[SessionInfo], WindowMetadata | None]:
     """Filter to ``[parsed_since, parsed_until)``; raise ``EXIT_NO_DATA`` on empty.
 
-    No-op when both bounds are ``None`` (returns ``(session_infos, None)``).
-    Verbose mode prints a dim stderr note with resolved bounds +
-    in-window/total counts. The returned :class:`WindowMetadata` echoes
-    the resolved exclusive UTC bounds matching ``[since, until)``
-    semantics so JSON consumers can self-document the window.
+    Returns ``(session_infos, None)`` when neither bound is supplied so
+    JSON consumers see ``window: null`` for unfiltered runs. Verbose
+    mode prints a dim stderr note derived from the same metadata.
     """
     if parsed_since is None and parsed_until is None:
         return session_infos, None
@@ -55,19 +53,20 @@ def _apply_time_window(
             "to preview which sessions fall in a window.",
         )
         raise typer.Exit(code=EXIT_NO_DATA)
-    if verbose:
-        since_label = parsed_since.isoformat() if parsed_since else "—"
-        until_label = parsed_until.isoformat() if parsed_until else "—"
-        err_console.print(
-            f"[dim]Filtering: sessions from {since_label} to {until_label} "
-            f"({len(filtered)} of {pre_filter_count} sessions)[/dim]",
-        )
     window = WindowMetadata(
         since=parsed_since,
         until=parsed_until,
         session_count_before_filter=pre_filter_count,
         session_count_after_filter=len(filtered),
     )
+    if verbose:
+        since_label = window.since.isoformat() if window.since else "—"
+        until_label = window.until.isoformat() if window.until else "—"
+        err_console.print(
+            f"[dim]Filtering: sessions from {since_label} to {until_label} "
+            f"({window.session_count_after_filter} of "
+            f"{window.session_count_before_filter} sessions)[/dim]",
+        )
     return filtered, window
 
 

--- a/src/agentfluent/core/filtering.py
+++ b/src/agentfluent/core/filtering.py
@@ -9,7 +9,27 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from pydantic import BaseModel
+
 from agentfluent.core.discovery import SessionInfo
+
+
+class WindowMetadata(BaseModel):
+    """Resolved time-filter window metadata for self-documenting JSON output.
+
+    Populated by the CLI ``analyze`` (and later ``list``) commands when
+    ``--since`` / ``--until`` are supplied. ``since``/``until`` are the
+    resolved absolute UTC bounds the filter actually applied (matching
+    the half-open ``[since, until)`` semantics of
+    :func:`filter_sessions_by_time`); ``None`` mirrors an open-ended
+    bound. Counts let downstream consumers see filter cardinality
+    without re-walking session metadata.
+    """
+
+    since: datetime | None = None
+    until: datetime | None = None
+    session_count_before_filter: int = 0
+    session_count_after_filter: int = 0
 
 
 def filter_sessions_by_time(

--- a/src/agentfluent/core/filtering.py
+++ b/src/agentfluent/core/filtering.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from agentfluent.core.discovery import SessionInfo
 
@@ -24,7 +24,12 @@ class WindowMetadata(BaseModel):
     :func:`filter_sessions_by_time`); ``None`` mirrors an open-ended
     bound. Counts let downstream consumers see filter cardinality
     without re-walking session metadata.
+
+    ``extra="ignore"`` keeps an older AgentFluent reading a newer envelope
+    forward-compatible — same posture as ``ToolResultMetadata``.
     """
+
+    model_config = ConfigDict(extra="ignore")
 
     since: datetime | None = None
     until: datetime | None = None

--- a/tests/unit/cli/test_analyze_since_until.py
+++ b/tests/unit/cli/test_analyze_since_until.py
@@ -13,6 +13,7 @@ import typer
 from typer.testing import CliRunner
 
 from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_OK, EXIT_USER_ERROR
+from agentfluent.cli.formatters.json_output import parse_json_output
 
 
 class TestFlagInteractionErrors:
@@ -182,3 +183,73 @@ class TestNoChangeWhenFlagsAbsent:
         )
         assert result.exit_code == EXIT_OK
         assert "Filtering: sessions from" not in result.stderr
+
+
+class TestWindowMetadataInJsonOutput:
+    """``data.window`` echoes the resolved exclusive UTC bounds plus
+    pre-/post-filter session counts when ``--since``/``--until`` are
+    supplied; ``None`` (JSON null) when no filter is applied (#298).
+    """
+
+    def test_since_only_populates_window_with_null_until(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        data = parse_json_output(result.stdout, expected_command="analyze")
+        assert isinstance(data, dict)
+        window = data.get("window")
+        assert window is not None, "window must be populated when --since is set"
+        assert isinstance(window["since"], str)
+        assert window["since"].startswith("2026-04-01")
+        assert window["until"] is None
+        # Fixture has exactly one session, and it falls inside the window.
+        assert window["session_count_before_filter"] == 1
+        assert window["session_count_after_filter"] == 1
+
+    def test_no_time_flags_yields_null_window(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--json"],
+        )
+        assert result.exit_code == EXIT_OK
+        data = parse_json_output(result.stdout, expected_command="analyze")
+        assert isinstance(data, dict)
+        # Field is present but null when no time filter is applied.
+        assert "window" in data
+        assert data["window"] is None
+
+    def test_since_and_until_populate_both_bounds(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--since", "2026-04-01",
+                "--until", "2026-05-01",
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+        data = parse_json_output(result.stdout, expected_command="analyze")
+        assert isinstance(data, dict)
+        window = data.get("window")
+        assert window is not None
+        assert isinstance(window["since"], str)
+        assert window["since"].startswith("2026-04-01")
+        # `until` echoes the resolved exclusive UTC bound matching the
+        # half-open `[since, until)` semantics.
+        assert isinstance(window["until"], str)
+        assert window["until"].startswith("2026-05-01")
+        assert window["session_count_before_filter"] == 1
+        assert window["session_count_after_filter"] == 1

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -401,9 +401,9 @@ class TestForwardCompat:
         assert result.recommendations[0].priority_score_delta == 0.0
 
     def test_window_field_on_one_side_does_not_break_diff(self) -> None:
-        """``window`` (#298) is an additive optional envelope field;
-        ``compute_diff`` ignores it. Pre-#298 baselines without ``window``
-        must still diff cleanly against current envelopes that include it.
+        """``window`` is additive on the envelope; ``compute_diff`` ignores
+        it. A pre-window baseline diffs cleanly against a current envelope
+        that includes one.
         """
         baseline = _envelope(aggregated_recs=[
             _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
@@ -411,9 +411,6 @@ class TestForwardCompat:
         current = _envelope(aggregated_recs=[
             _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
         ])
-        # Simulate a current envelope produced after #298 landed: the
-        # caller adds a window block; the loader and compute layer must
-        # not care.
         current["window"] = {
             "since": "2026-04-01T00:00:00+00:00",
             "until": "2026-05-01T00:00:00+00:00",

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -400,6 +400,33 @@ class TestForwardCompat:
         result = compute_diff(baseline, current)
         assert result.recommendations[0].priority_score_delta == 0.0
 
+    def test_window_field_on_one_side_does_not_break_diff(self) -> None:
+        """``window`` (#298) is an additive optional envelope field;
+        ``compute_diff`` ignores it. Pre-#298 baselines without ``window``
+        must still diff cleanly against current envelopes that include it.
+        """
+        baseline = _envelope(aggregated_recs=[
+            _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
+        ])
+        current = _envelope(aggregated_recs=[
+            _agg_rec(agent_type="pm", target="prompt", signal_types=["retry_loop"]),
+        ])
+        # Simulate a current envelope produced after #298 landed: the
+        # caller adds a window block; the loader and compute layer must
+        # not care.
+        current["window"] = {
+            "since": "2026-04-01T00:00:00+00:00",
+            "until": "2026-05-01T00:00:00+00:00",
+            "session_count_before_filter": 5,
+            "session_count_after_filter": 1,
+        }
+
+        result = compute_diff(baseline, current)
+
+        assert result.persisting_count == 1
+        assert result.new_count == 0
+        assert result.resolved_count == 0
+
 
 class TestDiffResultSerialization:
     def test_model_dump_round_trips(self) -> None:

--- a/tests/unit/test_core_filtering.py
+++ b/tests/unit/test_core_filtering.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 from agentfluent.core.discovery import SessionInfo
-from agentfluent.core.filtering import filter_sessions_by_time
+from agentfluent.core.filtering import WindowMetadata, filter_sessions_by_time
 
 
 def _session(
@@ -199,3 +199,72 @@ class TestEmptyInput:
         assert filter_sessions_by_time(
             [], since=_BASE, until=_BASE + timedelta(days=1),
         ) == []
+
+
+class TestWindowMetadata:
+    """Pydantic round-trip for the JSON-output ``window`` envelope field
+    (#298). ``model_dump(mode="json")`` must serialize aware datetimes as
+    ISO-8601 strings and ``None`` bounds as JSON ``null``."""
+
+    def test_aware_datetimes_round_trip_as_iso_strings(self) -> None:
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        until = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+        window = WindowMetadata(
+            since=since,
+            until=until,
+            session_count_before_filter=12,
+            session_count_after_filter=4,
+        )
+
+        dumped = window.model_dump(mode="json")
+
+        assert isinstance(dumped["since"], str)
+        assert isinstance(dumped["until"], str)
+        # Pydantic v2 emits ISO-8601 with timezone for aware datetimes.
+        assert dumped["since"].startswith("2026-05-01T12:00:00")
+        assert dumped["until"].startswith("2026-05-08T12:00:00")
+        assert dumped["session_count_before_filter"] == 12
+        assert dumped["session_count_after_filter"] == 4
+
+    def test_naive_datetimes_serialize_as_iso(self) -> None:
+        # Naive UTC datetimes are also dumpable as ISO-8601 strings;
+        # they just lack the timezone suffix.
+        since = datetime(2026, 5, 1, 12, 0, 0)
+        window = WindowMetadata(
+            since=since,
+            until=None,
+            session_count_before_filter=1,
+            session_count_after_filter=1,
+        )
+
+        dumped = window.model_dump(mode="json")
+
+        assert isinstance(dumped["since"], str)
+        assert dumped["since"].startswith("2026-05-01T12:00:00")
+        assert dumped["until"] is None
+
+    def test_none_bounds_serialize_as_null(self) -> None:
+        window = WindowMetadata(
+            since=None,
+            until=None,
+            session_count_before_filter=0,
+            session_count_after_filter=0,
+        )
+        dumped = window.model_dump(mode="json")
+        assert dumped["since"] is None
+        assert dumped["until"] is None
+
+    def test_round_trip_via_model_validate(self) -> None:
+        original = WindowMetadata(
+            since=datetime(2026, 5, 1, tzinfo=UTC),
+            until=datetime(2026, 5, 8, tzinfo=UTC),
+            session_count_before_filter=10,
+            session_count_after_filter=3,
+        )
+        roundtripped = WindowMetadata.model_validate(
+            original.model_dump(mode="json"),
+        )
+        assert roundtripped.since == original.since
+        assert roundtripped.until == original.until
+        assert roundtripped.session_count_before_filter == 10
+        assert roundtripped.session_count_after_filter == 3


### PR DESCRIPTION
## Summary
- Adds `WindowMetadata` (in `core/filtering`) with `since` / `until` (resolved exclusive UTC bounds) plus pre/post filter session counts; surfaced as `data.window` in the `analyze --json` envelope when `--since` / `--until` are applied. Without time flags, `data.window` is JSON `null`. Closes #298.
- `_apply_time_window` returns `tuple[list[SessionInfo], WindowMetadata | None]`; the call site assigns `result.window` before format dispatch.
- No SCHEMA_VERSION bump — additive optional field, ignored by older consumers and outside `diff/loader._REQUIRED_KEYS`.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1168 passed in worktree)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (4-case `TestWindowMetadata` round-trip suite, 3-case `TestWindowMetadataInJsonOutput` CLI suite, diff-mixed-window compat test)
- [x] CLI exercised via `CliRunner` JSON-output assertions; manual smoke deferred (deterministic JSON shape).

## Security review
- [x] **Skip review** — additive Pydantic model echoing already-validated `--since`/`--until` inputs (parsed via existing `parse_time_window`). No new ingress surface, no shell/path/JSON-parse changes, no rendering of user-controlled strings.
- [ ] Needs review

## Breaking changes
None. `AnalysisResult.window` defaults to `None`; pre-v0.6 saved envelopes deserialize cleanly. JSON envelope `version` unchanged at `"2"`.

Follow-up filed separately: extend the same `window` field to `agentfluent list --json` (per architect review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)