### PR TITLE
feat(cli): redesign Top-N priority fixes block as a pointer list (#285)

### DIFF
--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -417,17 +417,16 @@ def _format_top_recommendations(
     *,
     top_n: int,
 ) -> None:
-    """Render a compact "Top N priority fixes" block above the full table.
+    """Render a compact "Top N priority fixes" pointer block above the full table.
 
-    Each row uses the same index that appears in the full
-    Recommendations table's leading ``#`` column, so users can scan the
-    summary and find the matching detail row by number. Suppressed when
-    ``top_n == 0`` or no aggregated rows exist.
-
-    Format: ``  N. [axis] [severity] agent (count×): representative_message``.
-    The aggregated list is already sorted by ``priority_score`` desc
-    (see ``aggregation.aggregate_recommendations``), so the top N rows
-    are the top N priorities by definition.
+    Each row's ``#N`` index matches the same row's index in the
+    Recommendations table below — the summary is a pointer list, not a
+    second copy of the table. Drops ``representative_message`` (the
+    table immediately below carries it) and surfaces only the
+    load-bearing scan signals: severity, agent, count, target, axis.
+    Suppressed when ``top_n == 0`` or no aggregated rows exist. The
+    aggregated list is already sorted by ``priority_score`` desc, so
+    the top N rows are the top N priorities by definition.
     """
     if top_n <= 0:
         return
@@ -436,16 +435,29 @@ def _format_top_recommendations(
         return
     shown = min(top_n, len(aggs))
 
-    console.print(f"\n[bold]Top {shown} priority fixes[/bold]")
+    console.print(
+        f"\n[bold]Top {shown} priority fixes "
+        "(see Recommendations table below for detail):[/bold]",
+    )
+
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("#", style="dim", justify="right")
+    table.add_column("Severity")
+    table.add_column("Agent", style="cyan")
+    table.add_column("Count", justify="right")
+    table.add_column("Target")
+    table.add_column("Axis")
+
     for idx, agg in enumerate(aggs[:shown], start=1):
-        axis = axis_label(Axis(agg.primary_axis))
-        severity = severity_cell(agg.severity)
-        agent = escape(agg.agent_type or GLOBAL_AGENT_LABEL)
-        count_suffix = f" ({agg.count}×)" if agg.count > 1 else ""
-        message = escape(agg.representative_message)
-        console.print(
-            f"  {idx}. {axis} {severity} [cyan]{agent}[/cyan]{count_suffix}: {message}",
+        table.add_row(
+            f"#{idx}",
+            severity_cell(agg.severity),
+            escape(agg.agent_type or GLOBAL_AGENT_LABEL),
+            f"{agg.count}×",
+            f"target: {escape(agg.target)}",
+            axis_label(Axis(agg.primary_axis)),
         )
+    console.print(table)
 
 
 def _format_deep_diagnostics(

--- a/tests/unit/cli/_recommendation_helpers.py
+++ b/tests/unit/cli/_recommendation_helpers.py
@@ -19,7 +19,7 @@ from agentfluent.diagnostics.models import (
 
 def make_agg(
     *,
-    agent_type: str = "pm",
+    agent_type: str | None = "pm",
     severity: Severity = Severity.WARNING,
     target: str = "prompt",
     count: int = 1,

--- a/tests/unit/cli/test_recommendations_top_n.py
+++ b/tests/unit/cli/test_recommendations_top_n.py
@@ -1,9 +1,10 @@
-"""Tests for the Top-N priority-fixes summary block (#172).
+"""Tests for the Top-N priority-fixes pointer block (#172, redesigned in #285).
 
 Covers the `_format_top_recommendations` block that renders above the
 full Recommendations table and the index column on the full table that
-matches the summary numbers. Suppression rules (top_n=0, no aggregated
-rows, verbose mode) are exercised via `_format_diagnostics_table`.
+matches the summary numbers. The block is a pointer list, not a copy
+of the table — it surfaces severity/agent/count/target/axis only and
+relies on the table below for the recommendation prose.
 """
 
 from __future__ import annotations
@@ -31,8 +32,10 @@ class TestTopRecommendationsBlock:
         )
         text = render_top_only(diag, top_n=5)
         assert "Top 5 priority fixes" in text
+        assert "see Recommendations table below for detail" in text
         for i in range(5):
             assert f"agent-{i}" in text
+            assert f"#{i + 1}" in text
         # 6th, 7th, 8th NOT in summary.
         assert "agent-5" not in text
         assert "agent-7" not in text
@@ -61,7 +64,7 @@ class TestTopRecommendationsBlock:
         text = render_top_only(diag, top_n=5)
         assert text == ""
 
-    def test_count_suffix_only_when_gt_one(self) -> None:
+    def test_count_always_rendered_in_column(self) -> None:
         diag = DiagnosticsResult(
             aggregated_recommendations=[
                 make_agg(agent_type="single", count=1),
@@ -69,15 +72,55 @@ class TestTopRecommendationsBlock:
             ],
         )
         text = render_top_only(diag, top_n=5)
-        # No count suffix on count=1 rows (the "(1×)" would be noise).
         single_line = next(
             line for line in text.split("\n") if "single" in line
         )
         multi_line = next(
             line for line in text.split("\n") if "multi" in line
         )
-        assert "(1×)" not in single_line
-        assert "(4×)" in multi_line
+        assert "1×" in single_line
+        assert "4×" in multi_line
+
+    def test_does_not_duplicate_representative_message(self) -> None:
+        # The whole point of #285: the pointer block must not repeat
+        # the prose that the Recommendations table below already carries.
+        unique_prose = "Pin the model to claude-haiku-4-5 to cap unit cost."
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                make_agg(agent_type="pm", representative_message=unique_prose),
+            ],
+        )
+        text = render_top_only(diag, top_n=5)
+        assert unique_prose not in text
+
+    def test_pointer_row_contains_severity_agent_target_and_axis(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[
+                make_agg(
+                    agent_type="distinct-agent",
+                    severity=Severity.CRITICAL,
+                    target="tools",
+                    count=3,
+                    primary_axis="quality",
+                ),
+            ],
+        )
+        text = render_top_only(diag, top_n=5)
+        row_line = next(
+            line for line in text.split("\n") if "distinct-agent" in line
+        )
+        assert "#1" in row_line
+        assert "critical" in row_line
+        assert "3×" in row_line
+        assert "target: tools" in row_line
+        assert "[quality]" in row_line
+
+    def test_global_agent_label_renders_when_agent_type_none(self) -> None:
+        diag = DiagnosticsResult(
+            aggregated_recommendations=[make_agg(agent_type=None)],
+        )
+        text = render_top_only(diag, top_n=5)
+        assert "(global)" in text
 
 
 class TestFullTableIndexColumn:
@@ -102,11 +145,16 @@ class TestFullTableIndexColumn:
             ],
         )
         text = render_section(diag, top_n=2, width=120)
-        summary_alpha_idx = text.index("1. ")
-        rec_section = text[text.index("Recommendations"):]
-        assert "alpha" in rec_section
+        # The header now contains "see Recommendations table" inline, so
+        # locate the actual table by its rightmost occurrence (the
+        # centered title rendered by Rich).
+        table_idx = text.rindex("Recommendations")
+        summary_text = text[text.index("Top 2 priority fixes"):table_idx]
+        rec_section = text[table_idx:]
+        assert "alpha" in summary_text
+        assert "beta" in summary_text
         # gamma is NOT in the summary (top_n=2) but IS in the full table.
-        assert "gamma" not in text[:summary_alpha_idx]
+        assert "gamma" not in summary_text
         assert "gamma" in rec_section
 
 


### PR DESCRIPTION
## Summary
- Replaces the Top-N priority-fixes block with a Rich `Table` pointer list whose `#N` index matches the row in the Recommendations table below — drops the duplicated `representative_message` prose.
- Six columns: `#N`, severity, agent, count (always rendered), `target: <target>`, axis label. Uses the existing `Table(show_header=False, box=None, padding=(0, 1))` idiom shared with `_render_trace_signal_evidence`.
- Tests assert the load-bearing invariant — `representative_message` text from any agg is NOT present in the summary block — plus structural assertions covering severity/agent/count/target/axis per row.

Closes #285. Architect review: https://github.com/frederick-douglas-pearce/agentfluent/issues/285#issuecomment-4394223249.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1190 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — 11 tests in `test_recommendations_top_n.py` (3 new structural tests added, 1 rewritten for always-print-count, 1 rewritten for new header text)
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent --diagnostics --top-n 5` — block renders five scannable lines, no prose duplication

## Security review
- [x] **Skip review** — CLI presentation-only change. JSONL-derived strings (`agent_type`, `target`) continue to flow through `escape()` before reaching Rich, identical to the prior code path.

## Breaking changes
None. CLI output shape changes (intentional) but no public contract: JSON output is untouched, all flags behave the same, no model fields renamed.