### PR TITLE
fix(core): extract text from list-shape tool_result content (#319)

### DIFF
--- a/src/agentfluent/core/parser.py
+++ b/src/agentfluent/core/parser.py
@@ -126,12 +126,25 @@ def _normalize_content(raw_content: str | list[dict[str, Any]] | None) -> list[C
                     )
                 )
             elif block_type == "tool_result":
-                # `content` can be a string or a list of sub-blocks; richer
-                # sub-block shapes are captured as None pending a use case.
+                # ``content`` is either a string (single-line tool output) or
+                # a list of sub-blocks. Agent results in particular use the
+                # list form ``[{"type": "text", "text": "..."}]``; the prior
+                # implementation dropped them as None, leaving downstream
+                # consumers (e.g. REVIEWER_CAUGHT detection) with no input.
+                # Concatenate the text-typed sub-blocks; non-text shapes
+                # remain unsupported but are preserved as a fallback.
                 result_content = item.get("content")
-                result_text = (
-                    result_content if isinstance(result_content, str) else None
-                )
+                if isinstance(result_content, str):
+                    result_text: str | None = result_content
+                elif isinstance(result_content, list):
+                    parts = [
+                        sub.get("text", "")
+                        for sub in result_content
+                        if isinstance(sub, dict) and sub.get("type") == "text"
+                    ]
+                    result_text = "\n".join(p for p in parts if p) or None
+                else:
+                    result_text = None
                 blocks.append(
                     ContentBlock(
                         type="tool_result",

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -358,6 +358,101 @@ class TestToolUseResultOnUserMessage:
         messages = parse_session(path)
         assert messages[0].metadata is None
 
+    def test_tool_result_list_content_concatenated(self, tmp_path: Path) -> None:
+        """Real Agent invocations carry ``content`` as a list of sub-blocks
+        (``[{"type": "text", "text": "..."}]``) rather than a flat string.
+        The parser must extract and concatenate ``text``-typed sub-blocks
+        so consumers like REVIEWER_CAUGHT detection see the full reply.
+        Regression for #319."""
+        path = self._write(
+            tmp_path,
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_agent_list",
+                                "content": [
+                                    {"type": "text", "text": "First paragraph."},
+                                    {"type": "text", "text": "Second paragraph."},
+                                ],
+                            },
+                        ],
+                    },
+                    "toolUseResult": {"agentId": "u", "totalTokens": 1},
+                },
+            ],
+        )
+        messages = parse_session(path)
+        block = messages[0].content_blocks[0]
+        assert block.type == "tool_result"
+        assert block.text == "First paragraph.\nSecond paragraph."
+
+    def test_tool_result_list_content_skips_non_text_subblocks(
+        self, tmp_path: Path,
+    ) -> None:
+        """Non-text sub-blocks (e.g. image references) are skipped; the
+        text-typed sub-blocks join with newlines."""
+        path = self._write(
+            tmp_path,
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_mixed",
+                                "content": [
+                                    {"type": "text", "text": "Visible text."},
+                                    {"type": "image", "source": {"data": "..."}},
+                                    {"type": "text", "text": "More visible text."},
+                                ],
+                            },
+                        ],
+                    },
+                    "toolUseResult": {"agentId": "u", "totalTokens": 1},
+                },
+            ],
+        )
+        messages = parse_session(path)
+        block = messages[0].content_blocks[0]
+        assert block.text == "Visible text.\nMore visible text."
+
+    def test_tool_result_list_content_all_non_text_yields_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """A list with no text-typed sub-blocks yields ``text=None`` —
+        consumers that read ``block.text or ''`` get an empty string,
+        matching the prior behaviour for unknown shapes."""
+        path = self._write(
+            tmp_path,
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_no_text",
+                                "content": [
+                                    {"type": "image", "source": {"data": "..."}},
+                                ],
+                            },
+                        ],
+                    },
+                    "toolUseResult": {"agentId": "u", "totalTokens": 1},
+                },
+            ],
+        )
+        messages = parse_session(path)
+        assert messages[0].content_blocks[0].text is None
+
     def test_is_error_flows_from_normalize_content(self, tmp_path: Path) -> None:
         """The `is_error` field on a tool_result JSONL block propagates to ContentBlock."""
         path = self._write(


### PR DESCRIPTION
## Summary
- `_normalize_content` in `core/parser.py` dropped `tool_result.content` whenever it was a list of sub-blocks, only keeping the flat-string form. Agent invocations return their final text via `[{"type": "text", "text": "..."}]` — the list form — so `ContentBlock.text` ended up `None` for every Agent result on real data.
- Concatenate `text`-typed sub-blocks with newlines; non-text shapes (e.g. image references) are skipped. Falls back to `None` for unknown shapes.
- Verified on dogfood data: **60/60 architect invocations now have non-empty `output_text` (was 0/60)**. This unblocks #274's calibration of the REVIEWER_CAUGHT thresholds.

Closes #319.

## Why existing tests didn't catch this
The synthetic JSONL fixtures in `tests/fixtures/session_with_agent.jsonl` happen to use the flat-string `content` form. Real Claude Code sessions use the list form. Three new tests in `test_parser.py` exercise the list form directly, including the mixed-content (text + image) case.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1193 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior has test coverage — 3 new tests in `test_parser.py::TestToolUseResultOnUserMessage` (list concat, mixed-type skipping, all-non-text fallback)
- [x] Manual smoke test on real data: enumerated review-style invocations across `~/.claude/projects/`; all 60 now expose non-empty `output_text`

## Security review
- [x] **Skip review** — internal parser change. No new path handling, no rendering, no subprocess; fix narrows what the parser drops on the floor (more text reaches consumers, none of it newly trusted).

## Breaking changes
None of the public surface. Behaviour change for existing callers: any consumer that read `tool_result.text` for an Agent result was previously seeing `None`; they will now see the concatenated text. The only known consumer relying on this is `index_tool_results_by_id` → `agents/extractor.py` (`output_text`) and `mcp_assessment.py` (`is_error` only, unaffected). Surfacing real text to those callers is the intended consequence — this is a bug fix, not a contract change.

## Follow-up
Once this lands, PR #318 (#274 — quality-signal calibration) will be rebased on main and re-execute the calibration notebook with REVIEWER_CAUGHT now firing. Threshold tunings for the three REVIEWER_CAUGHT gates may follow in a subsequent commit on that branch.