### PR TITLE
fix(diagnostics): suffix-match REVIEWER_CAUGHT mentioned vs edited paths (#322)

### DIFF
--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -405,6 +405,30 @@ def _files_edited_after(
     return edited
 
 
+def _match_mentioned_to_edited(
+    mentioned: set[str], edited: set[str],
+) -> set[str]:
+    """Return the subset of ``mentioned`` tokens that any ``edited`` path matches.
+
+    Bridges the relative-vs-absolute mismatch between review prose
+    (``"see src/foo.py"``) and ``Edit.input.file_path`` (absolute, e.g.
+    ``/home/u/repo/src/foo.py``). A mentioned token ``m`` matches an
+    edited path ``e`` when ``e == m`` or ``e.endswith("/" + m)``.
+
+    ``m`` is assumed to be a relative path or bare filename without a
+    leading ``/`` — guaranteed by ``_DIR_PATH_PATTERN`` and
+    ``_BARE_FILE_PATTERN``. The result preserves the mentioned form
+    (more readable than absolute paths in signal detail and stable
+    across users with different repo locations).
+    """
+    if not mentioned or not edited:
+        return set()
+    return {
+        m for m in mentioned
+        if any(e == m or e.endswith("/" + m) for e in edited)
+    }
+
+
 def _extract_reviewer_caught_signals(
     messages: list[SessionMessage],
     agent_invocations: list[AgentInvocation],
@@ -457,7 +481,7 @@ def _extract_reviewer_caught_signals(
         result_idx = tool_result_idx.get(inv.tool_use_id)
         if result_idx is not None and files_mentioned:
             edited = _files_edited_after(messages, result_idx)
-            files_acted_on = files_mentioned & edited
+            files_acted_on = _match_mentioned_to_edited(files_mentioned, edited)
 
         candidates_by_agent[inv.agent_type].append(
             DiagnosticSignal(

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -661,6 +661,68 @@ class TestReviewerCaughtDetection:
         rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
         assert rev.detail["parent_acted"] is False
 
+    def test_parent_acted_relative_mention_matches_absolute_edit(self) -> None:
+        """Review prose carries relative paths (``src/foo.py``); Edit
+        tool calls carry absolute paths (``/home/u/repo/src/foo.py``).
+        Suffix-match bridges the two — without it ``parent_acted`` is
+        always False on real Claude Code data (#322)."""
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages = [
+            _user_with_tool_result(inv.tool_use_id),
+            _assistant_with_edits("/home/u/repo/src/foo.py"),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is True
+        assert "src/foo.py" in rev.detail["files_acted_on"]
+
+    def test_parent_acted_bare_filename_matches_absolute_edit(self) -> None:
+        """Bare-filename mentions (``quality_signals.py``) match any
+        absolute edit whose basename matches — verifies the suffix
+        match handles the no-directory case via ``e.endswith("/" + m)``."""
+        review = (
+            "I reviewed the change and found a blocker issue that must "
+            "be addressed before merge. The function in quality_signals.py "
+            "does not handle the empty-input case and will raise an "
+            "unexpected exception at runtime. This is a real risk to "
+            "production behavior under any code path that funnels "
+            "user-supplied data into this function without a prior "
+            "non-empty check. Recommended fix: add input validation "
+            "and a defensive guard before the loop. Additional concern: "
+            "the test fixture is missing for this path — please add "
+            "coverage for the empty-input case so this regression cannot "
+            "recur silently. A second issue worth flagging is that the "
+            "error message itself does not include the offending field "
+            "name, which makes downstream debugging harder than it "
+            "needs to be; that should be tightened up too."
+        )
+        inv = _review_invocation(output_text=review)
+        messages = [
+            _user_with_tool_result(inv.tool_use_id),
+            _assistant_with_edits(
+                "/home/u/repo/src/agentfluent/diagnostics/quality_signals.py",
+            ),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is True
+        assert "quality_signals.py" in rev.detail["files_acted_on"]
+
+    def test_parent_acted_false_when_no_filename_overlap(self) -> None:
+        """Suffix match still gates on filename — an edit to an
+        entirely unrelated file (``unrelated_module.py``) does NOT
+        satisfy ``parent_acted`` even when other mentioned files exist
+        in the review prose. Guards against the regression where the
+        suffix change accidentally makes everything fire."""
+        inv = _review_invocation(output_text=_SUBSTANTIVE_REVIEW)
+        messages = [
+            _user_with_tool_result(inv.tool_use_id),
+            _assistant_with_edits("/home/u/repo/src/unrelated_module.py"),
+        ]
+        signals = extract_quality_signals(messages, [inv])
+        rev = next(s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT)
+        assert rev.detail["parent_acted"] is False
+
 
 class TestUserCorrectionEmissionGates:
     """OR-gated session-level gates on USER_CORRECTION (#274 calibration).


### PR DESCRIPTION
## Summary
- `REVIEWER_CAUGHT.detail['parent_acted']` was `False` on 51/51 dogfood events despite the parent acting; review prose carries relative paths but `Edit.input.file_path` carries absolute paths, so the raw set intersection was empty by construction
- Replace with `_match_mentioned_to_edited`: suffix-match a mentioned token `m` against any edited path `e` where `e == m` or `e.endswith("/" + m)`
- Architect-ratified plan ([#322 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/322#issuecomment-4403329055)); no blocking concerns

Fixes #322.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1205 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — three new tests on `TestReviewerCaughtDetection`:
  - relative mention (`src/foo.py`) + absolute edit (`/home/u/repo/src/foo.py`) → `parent_acted=True`
  - bare mention (`quality_signals.py`) + absolute edit ending in basename → `parent_acted=True`
  - unrelated edit (`/abs/.../unrelated_module.py`) → `parent_acted=False` (suffix gate still works)
- [x] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI output change; signal-internal behavior)

Calibration §12.5 drill-down re-run (acceptance criterion 4 on the issue) is bookkeeping follow-up — not blocking the fix.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — internal logic change in a single diagnostics module; no new I/O, no parser change, no new external surface, no user-controlled string interpolation paths added.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. The `REVIEWER_CAUGHT` signal shape is unchanged (`detail['parent_acted']` and `detail['files_acted_on']` still present and correctly-typed). The behavior change makes `parent_acted` actually fire on real data — i.e., previously-always-False detail flips to True for the genuine cases. Downstream aggregation that counted on `parent_acted=False` everywhere as a no-op is the only thing that could notice; that count is internal-only and not part of any public contract.