### PR TITLE
fix(diagnostics): tighten USER_CORRECTION precision (#321)

### DIFF
--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -106,14 +106,41 @@ _NEGATION_PATTERNS = _ci(
     r"\bno\s+don'?t\b",
     r"\bthat'?s\s+not\s+what\s+I\b",
 )
-_INTERRUPTION_PATTERNS = _ci(r"\bstop\b", r"\bwait\b", r"\bhold\s+on\b")
+# Imperative-anchored: trigger word must start the message or follow a
+# sentence boundary. Bare ``\bstop\b`` / ``\bwait\b`` matched questions
+# like "can you wait until I finish?" — see #321 dogfood findings.
+_INTERRUPTION_PATTERNS = _ci(
+    r"(?:^|[.!?]\s+)(?:please\s+)?stop\b",
+    r"(?:^|[.!?]\s+)(?:please\s+)?wait\b",
+    r"(?:^|[.!?]\s+)(?:please\s+)?hold\s+on\b",
+)
+# ``instead`` requires an imperative continuation (``of``, ``please``,
+# ``let's``, ``do``, ``use``, ``try``). Bare ``\binstead,?\s`` fired on
+# suggestion/comparison prose (#321: "...from a database query instead").
+# Sentence-final "instead" is intentionally dropped — calibration
+# philosophy is precision-over-recall.
 _REDIRECTION_PATTERNS = _ci(
     r"\bactually,?\s",
-    r"\binstead,?\s",
+    r"\binstead\b,?\s+(?:of\b|please\b|let'?s\b|do\b|use\b|try\b)",
     r"\bI\s+meant\b",
     r"\bwhat\s+I\s+wanted\s+was\b",
 )
 _UNDO_PATTERNS = _ci(r"\bgo\s+back\s+to\b", r"\brestore\b")
+
+# Claude Code injects wrappers into user messages (``<task-notification>``,
+# ``<system-reminder>``, session-resumption preamble) that can contain
+# correction-trigger words. The dogfood corpus showed ~85% FP rate on
+# USER_CORRECTION before stripping (#321). Wrappers span multiple lines,
+# so the tag-based alternatives use ``[\s\S]*?`` (DOTALL) to cross
+# newlines. The session-resumption preamble is stripped from its known
+# opening sentence up to the next blank line or end of text.
+_SYSTEM_WRAPPER_RE = re.compile(
+    r"<task-notification>[\s\S]*?</task-notification>"
+    r"|<system-reminder>[\s\S]*?</system-reminder>"
+    r"|This\s+session\s+is\s+being\s+continued\s+from\s+a\s+previous\s+"
+    r"conversation[\s\S]*?(?=\n\n|\Z)",
+    re.IGNORECASE,
+)
 
 # Strong-correction overlay: a strict subset of high-confidence phrases
 # that fire regardless of the preceding-message gate. ``revert`` and
@@ -291,6 +318,17 @@ def _classify_assistant(message: SessionMessage) -> tuple[bool, bool]:
         not had_write_tool and message.text.rstrip().endswith("?")
     )
     return had_write_tool, is_question_only
+
+
+def _strip_system_wrappers(text: str) -> str:
+    """Remove Claude Code system-injected wrappers from user-message text.
+
+    Scoped to USER_CORRECTION extraction — file-rework detection doesn't
+    read user text, so this can't bleed into the assistant-side path.
+    Applied before pattern matching so trigger words inside wrappers
+    don't generate false-positive signals.
+    """
+    return _SYSTEM_WRAPPER_RE.sub("", text)
 
 
 def _match_correction(
@@ -597,6 +635,13 @@ def extract_quality_signals(
             continue
         text = msg.text
         if not text:
+            continue
+        # Strip Claude Code wrappers before pattern matching. Messages
+        # whose content is purely a system wrapper become empty here
+        # and are skipped — they're not user prose, so they shouldn't
+        # inflate the ``total_user_messages`` denominator either.
+        text = _strip_system_wrappers(text)
+        if not text.strip():
             continue
         total_user_messages += 1
 

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -279,6 +279,181 @@ class TestUserCorrectionDetection:
         assert len(snippet) <= 141  # 140 + ellipsis
 
 
+class TestUserCorrectionSystemWrapperStripping:
+    """System-injected wrappers (#321) are stripped before pattern
+    matching. Trigger words inside ``<task-notification>``,
+    ``<system-reminder>``, or the session-resumption preamble must not
+    fire USER_CORRECTION — the dogfood corpus had ~85% FP rate before
+    these were filtered."""
+
+    def test_task_notification_wrapper_does_not_fire(self) -> None:
+        """A user message that is purely a ``<task-notification>``
+        wrapper containing trigger words must not fire — even with the
+        write-tool primary gate open. Two such messages would be
+        suppressed, so the OR-gate (count >= 2) cannot lift them."""
+        wrapped = (
+            "<task-notification><task-id>abc</task-id>"
+            "<status>stop the world, revert everything</status>"
+            "</task-notification>"
+        )
+        messages = [
+            _assistant_with_write_tool(),
+            _user(wrapped),
+            _assistant_with_write_tool(),
+            _user(wrapped),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_system_reminder_wrapper_does_not_fire(self) -> None:
+        """``<system-reminder>`` blocks are stripped — the multi-line
+        wrapper from real Claude Code sessions must not surface even
+        when it contains a trigger word like 'wait'."""
+        wrapped = (
+            "<system-reminder>\n"
+            "Please wait for the user to confirm before proceeding.\n"
+            "</system-reminder>"
+        )
+        messages = [
+            _assistant_with_write_tool(),
+            _user(wrapped),
+            _assistant_with_write_tool(),
+            _user(wrapped),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_session_resumption_preamble_does_not_fire(self) -> None:
+        """Claude Code's session-resumption preamble can contain
+        trigger words ("revert", "stop", "instead") in the recap. The
+        preamble is stripped from its known opening sentence up to the
+        next blank line."""
+        preamble = (
+            "This session is being continued from a previous conversation "
+            "that ran out of context. The user asked me to revert the "
+            "earlier change and stop using the deprecated API instead.\n\n"
+            "actual user prose continues here."
+        )
+        messages = [
+            _assistant_with_write_tool(),
+            _user(preamble),
+            _assistant_with_write_tool(),
+            _user(preamble),
+        ]
+        # "actual user prose continues here." has no trigger word, so no fire.
+        assert extract_quality_signals(messages) == []
+
+    def test_real_user_text_after_stripped_wrapper_still_fires(self) -> None:
+        """When a user message contains both a system wrapper AND
+        genuine correction prose, only the wrapper is stripped — the
+        real correction still fires."""
+        mixed = (
+            "<task-notification><status>ok</status></task-notification>"
+            "no, that's wrong"
+        )
+        messages = [
+            _assistant_with_write_tool(),
+            _user(mixed),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "strong"
+
+    def test_pure_wrapper_message_not_counted_in_denominator(self) -> None:
+        """A message whose stripped text is empty must not inflate
+        ``total_user_messages`` — wrapper-only messages aren't user
+        prose and shouldn't dilute the correction-rate denominator."""
+        messages: list[SessionMessage] = [
+            _assistant_with_write_tool(),
+            _user("<system-reminder>noop</system-reminder>"),
+            _assistant_with_write_tool(),
+            _user("no, that's wrong"),
+        ]
+        # Without stripping, total_user_messages would be 2 with 1
+        # correction (rate=0.5, count=1). With stripping, only the real
+        # correction message counts: total=1, rate=1.0, count=1.
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["total_user_messages"] == 1
+        assert signals[0].detail["session_correction_rate"] == 1.0
+
+
+class TestUserCorrectionTightenedPatterns:
+    """Tightened soft patterns (#321): interruption requires imperative
+    anchoring, ``instead`` requires an imperative continuation."""
+
+    def test_wait_inside_question_does_not_fire(self) -> None:
+        """``\\bwait\\b`` previously matched mid-sentence trigger words
+        even after a write-tool message. Imperative-anchored form
+        suppresses 'can you wait until I finish?'-style prose."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("can you wait until I finish reviewing the diff?"),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_wait_at_sentence_start_still_fires(self) -> None:
+        """Imperative ``wait`` at start-of-message still fires under
+        the new pattern."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("wait, let me re-check the spec first"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "interruption"
+
+    def test_stop_after_sentence_boundary_fires(self) -> None:
+        """Sentence-internal trigger words still fire after a
+        ``.``/``!``/``?`` boundary — preserves the imperative form."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("Let me think. Stop the edit, I want to review first."),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "interruption"
+
+    def test_please_stop_fires(self) -> None:
+        """Polite-prefix ``please stop`` is still imperative."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("please stop editing that file"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+
+    def test_instead_at_sentence_end_does_not_fire(self) -> None:
+        """``instead`` with no imperative continuation is suggestion or
+        comparison prose — it must not fire (#321 case #5 trade-off)."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user(
+                "I think it would be better to get the list of acceptable "
+                "labels from a database query instead.",
+            ),
+        ]
+        assert extract_quality_signals(messages) == []
+
+    def test_instead_of_fires(self) -> None:
+        """``instead of <X>`` is the canonical imperative redirection."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("instead of using a list, let's use a dict here"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "redirection"
+
+    def test_instead_comma_please_fires(self) -> None:
+        """``instead, please`` is a polite imperative redirection."""
+        messages = [
+            _assistant_with_write_tool(),
+            _user("instead, please consider option B before proceeding"),
+        ]
+        signals = extract_quality_signals(messages)
+        assert len(signals) == 1
+        assert signals[0].detail["matched_category"] == "redirection"
+
+
 class TestExtractQualitySignalsSignature:
     """Signature contract is locked per architect blocker on #269.
 


### PR DESCRIPTION
## Summary
- Three independent root causes from #274 dogfood calibration (~85% FP rate, 6 of 7 detections false positives)
- (1) Strip `<task-notification>` / `<system-reminder>` / session-resumption preamble before pattern matching; (2) imperative-anchor `_INTERRUPTION_PATTERNS` so mid-sentence `wait`/`stop` no longer fires on questions; (3) require imperative continuation after `instead` so suggestion/comparison prose ("...from a database query instead") no longer fires
- Architect-ratified plan ([#321 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/321#issuecomment-4403330131)); precision-over-recall trade-off on sentence-final "instead" approved

Fixes #321.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1217 passed, +12 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage:
  - `TestUserCorrectionSystemWrapperStripping` — task-notification, system-reminder, session-resumption preamble do not fire; mixed wrapper+real-prose still fires; pure wrapper messages don't inflate `total_user_messages`
  - `TestUserCorrectionTightenedPatterns` — mid-sentence `wait` in a question does not fire; sentence-start `wait` and `please stop` still fire; sentence-final "instead" does not fire; "instead of", "instead, please" still fire
- [x] Manual smoke test via `uv run agentfluent ...` — N/A (signal-internal precision tuning, no CLI output change)

Calibration §12.5 drill-down re-run (acceptance criterion 4 on the issue) is bookkeeping follow-up — not blocking the fix.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — internal pattern tightening in a single diagnostics module; no new I/O, no parser change, no new CLI surface, no user-controlled string interpolation paths added. The new regex (`_SYSTEM_WRAPPER_RE`) is applied to user-message text already in memory and is not user-controlled by an external caller.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. The `USER_CORRECTION` signal shape is unchanged. Behavior change: detection is strictly more conservative — fewer signals fire on the same input. Downstream aggregation that counted historical USER_CORRECTION volumes will see lower numbers post-merge; that's the intended outcome (the prior numbers were dominated by FP noise per #274 calibration).