### PR TITLE
fix(diagnostics): bound ERROR_REGEX scan to leading window in two sites (#281)

### DIFF
--- a/src/agentfluent/diagnostics/_complexity.py
+++ b/src/agentfluent/diagnostics/_complexity.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 
 from agentfluent.agents.models import WRITE_TOOLS
-from agentfluent.diagnostics.signals import ERROR_REGEX
+from agentfluent.diagnostics.signals import iter_error_matches
 
 if TYPE_CHECKING:
     from agentfluent.agents.models import AgentInvocation
@@ -77,9 +77,11 @@ def compute_error_rate(inv: AgentInvocation) -> float:
     """Observed error rate for a single invocation.
 
     Trace is preferred when linked — counts concrete tool errors.
-    Metadata fallback scans ``output_text`` for ``ERROR_REGEX`` keywords
-    and divides by ``tool_uses``. Returns 0.0 when no signal is
-    available either way.
+    Metadata fallback counts ``ERROR_REGEX`` matches in the leading
+    window of ``output_text`` (via ``iter_error_matches``) and divides
+    by ``tool_uses``. Returns 0.0 when no signal is available either
+    way. The window bound is the FP defense for long agent outputs
+    that discuss error-handling code as a topic (#281).
     """
     trace = inv.trace
     if trace is not None and trace.tool_calls:
@@ -87,7 +89,7 @@ def compute_error_rate(inv: AgentInvocation) -> float:
     tool_uses = inv.tool_uses or 0
     if tool_uses == 0 or not inv.output_text:
         return 0.0
-    matches = len(ERROR_REGEX.findall(inv.output_text))
+    matches = sum(1 for _ in iter_error_matches(inv.output_text))
     return matches / tool_uses
 
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 import statistics
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.models import Severity
@@ -60,6 +60,32 @@ def detect_is_error_from_text(text: str | None) -> bool:
     return bool(ERROR_REGEX.search(text[:ERROR_DETECTION_WINDOW_CHARS]))
 
 
+def iter_error_matches(
+    text: str | None,
+    *,
+    window: int = ERROR_DETECTION_WINDOW_CHARS,
+) -> Iterator[re.Match[str]]:
+    """Yield ``ERROR_REGEX`` matches from the bounded leading window of ``text``.
+
+    Shared shape consumed by ``compute_error_rate`` (count) and
+    ``_extract_error_signals`` (iterate for snippet extraction). The
+    bound is the FP defense — agent ``output_text`` runs thousands of
+    chars and frequently discusses error-handling code as a topic,
+    inflating an unbounded ``findall`` count. #281 dogfood research:
+    98% of full-text matches across 447 invocations were mid-text
+    code identifiers (``tool_error_sequence``, ``RetrySequence``) and
+    schema field mentions (``is_error?``), not error events.
+
+    Match positions are within the sliced prefix and therefore valid
+    indices into the original text — callers extracting snippets via
+    ``match.start()`` / ``match.end()`` get correct offsets without
+    further translation.
+    """
+    if not text:
+        return
+    yield from ERROR_REGEX.finditer(text[:window])
+
+
 # Map matched text back to severity
 _KEYWORD_SEVERITY: dict[str, Severity] = {kw.lower(): sev for kw, sev in ERROR_PATTERNS}
 
@@ -82,11 +108,14 @@ def _extract_error_signals(invocations: list[AgentInvocation]) -> list[Diagnosti
         if not inv.output_text:
             continue
 
-        for match in ERROR_REGEX.finditer(inv.output_text):
+        for match in iter_error_matches(inv.output_text):
             keyword = match.group(0).lower()
             severity = _KEYWORD_SEVERITY.get(keyword, Severity.WARNING)
 
-            # Extract context around the match
+            # Extract context around the match. ``iter_error_matches``
+            # bounds the search to the leading window, but the snippet
+            # context is allowed to extend past the window into the full
+            # text so the user sees natural surrounding prose.
             start = max(0, match.start() - 50)
             end = min(len(inv.output_text), match.end() + 50)
             snippet = inv.output_text[start:end].strip()

--- a/tests/unit/test_model_routing.py
+++ b/tests/unit/test_model_routing.py
@@ -373,6 +373,43 @@ class TestHelpers:
         inv = _inv(tool_uses=0, output_text="")
         assert compute_error_rate(inv) == 0.0
 
+    def test_error_rate_ignores_mid_text_keywords(self) -> None:
+        """#281: ``compute_error_rate`` only counts ``ERROR_REGEX``
+        matches in the leading window. Long agent outputs that mention
+        error-handling topics in the body (code identifiers like
+        ``tool_error_sequence``, schema fields like ``is_error?``)
+        previously inflated the rate via unbounded ``findall`` —
+        biasing complexity classification toward 'complex' on prose
+        that wasn't reporting actual errors."""
+        # 800-char benign prefix (no keywords), then four mid-text
+        # mentions of error-related topics. Pre-fix this would compute
+        # error_rate = 4 / tool_uses. Post-fix the count is 0.
+        prefix = "The implementation completed cleanly. " * 25  # ~975 chars
+        body = (
+            " The is_error field on tool_result is set when a permission "
+            "denied or other failure occurs. The retry logic handles "
+            "transient errors gracefully."
+        )
+        inv = _inv(tool_uses=4, output_text=prefix + body)
+        assert compute_error_rate(inv) == 0.0
+
+    def test_error_rate_counts_leading_keywords(self) -> None:
+        """Real errors leading the response still count toward the rate."""
+        # Two distinct keywords in the leading 200 chars; tool_uses=4 →
+        # rate=0.5.
+        inv = _inv(
+            tool_uses=4,
+            output_text=(
+                "Permission denied: cannot access /etc/shadow. "
+                "Retry attempted but failed. Long trailing prose…"
+                + (" filler" * 100)
+            ),
+        )
+        rate = compute_error_rate(inv)
+        # Exact match count depends on regex tokenization; assert
+        # non-zero and bounded by 1.0 (sanity).
+        assert 0.0 < rate <= 1.0
+
     def test_classify_model_tier_short_aliases(self) -> None:
         assert classify_model_tier(MODEL_HAIKU) == "simple"
         assert classify_model_tier(MODEL_SONNET) == "moderate"

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -74,6 +74,61 @@ class TestErrorPatternDetection:
         signals = extract_signals(invocations)
         assert signals[0].detail["snippet"]
 
+    def test_mid_text_keyword_beyond_window_does_not_fire(self) -> None:
+        """#281: ``_extract_error_signals`` only scans the leading
+        ``ERROR_DETECTION_WINDOW_CHARS`` of ``output_text``. Successful
+        agent outputs that mention error-handling topics mid-text
+        (issue titles, code identifiers like ``tool_error_sequence``)
+        no longer surface as ``ERROR_PATTERN`` signals."""
+        # Long benign prefix (well past the 200-char window), then a
+        # keyword. Pre-fix this fired a signal; post-fix it does not.
+        text = (
+            "The implementation completed cleanly with all tests "
+            "passing. " * 30  # ~900 chars of benign prose, no keywords
+        ) + "but a permission denied marker appears here mid-text."
+        assert len(text) > 500
+        invocations = [_inv(output_text=text)]
+        signals = extract_signals(invocations)
+        error_signals = [
+            s for s in signals if s.signal_type == SignalType.ERROR_PATTERN
+        ]
+        assert error_signals == []
+
+    def test_leading_keyword_within_window_still_fires(self) -> None:
+        """Real error reports tend to lead the response — the bounded
+        scan must still catch them."""
+        text = (
+            "Permission denied: cannot read /etc/shadow.\n\n"
+            + ("Retried with elevated permissions and now everything works. "
+               * 20)  # long trailing prose, irrelevant
+        )
+        invocations = [_inv(output_text=text)]
+        signals = extract_signals(invocations)
+        error_signals = [
+            s for s in signals if s.signal_type == SignalType.ERROR_PATTERN
+        ]
+        assert any(s.detail["keyword"] == "permission denied" for s in error_signals)
+
+    def test_window_boundary_keyword_just_inside_fires(self) -> None:
+        """Keyword ending right at the window boundary fires; just past
+        it does not. Pins the boundary semantics."""
+        from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
+        # "failed" ends exactly at position 200 (within window).
+        kw = "failed"
+        text = "x " * ((ERROR_DETECTION_WINDOW_CHARS - len(kw)) // 2) + kw
+        assert len(text) <= ERROR_DETECTION_WINDOW_CHARS
+        signals = extract_signals([_inv(output_text=text)])
+        assert any(
+            s.detail["keyword"] == "failed"
+            for s in signals if s.signal_type == SignalType.ERROR_PATTERN
+        )
+        # Same keyword pushed just past the window: no signal.
+        text_just_past = "x" * ERROR_DETECTION_WINDOW_CHARS + " failed"
+        signals = extract_signals([_inv(output_text=text_just_past)])
+        assert not any(
+            s.signal_type == SignalType.ERROR_PATTERN for s in signals
+        )
+
 
 class TestTokenOutlierDetection:
     """IQR-based detection (#186 P2): val > Q3 + 1.5*IQR. Requires


### PR DESCRIPTION
## Summary
- `compute_error_rate` (in `_complexity.py`) and `_extract_error_signals` (in `signals.py`) both scanned the **full** `output_text` for `ERROR_REGEX` matches. Long agent outputs that discuss error-handling code as a topic (code identifiers, schema fields, issue titles) inflated counts and produced spurious diagnostic signals.
- Adds `iter_error_matches(text, *, window=ERROR_DETECTION_WINDOW_CHARS) -> Iterator[re.Match[str]]` helper in `signals.py`. Both call sites consume it. Reuses the existing 200-char constant calibrated in #241 for `is_error` synthesis — same shape applies here per the dogfood research.
- Architect-ratified ([review on #281](https://github.com/frederick-douglas-pearce/agentfluent/issues/281)) bound-and-ship; residual FP-rate concern on bounded matches tracked separately as **#333** follow-up.

Closes #281.

## Research summary (full table on the issue)

| | total matches | invs with ≥1 |
|---|---:|---:|
| full text (pre-fix) | **1386** | 188 |
| leading 200 (post-fix) | **27** | 24 |

98% of full-text matches are mid-text. Sampled top divergence cases all show code identifiers (`tool_error_sequence`, `RetrySequence`, `is_error?`) and architectural prose, not error events.

Dogfood re-verify with the patched code: `ERROR_PATTERN` signals drop **1386 → 28** on the same corpus.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1227 passed, +5 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New regression tests cover:
  - `_extract_error_signals`: mid-text keyword beyond window does NOT fire; leading keyword still fires; window-boundary semantics pinned
  - `compute_error_rate`: mid-text keywords ignored (rate stays 0.0 on prose-heavy benign output); leading keywords still count
- [x] Dogfood smoke: re-extracted across `~/.claude/projects/`. `ERROR_PATTERN` count 1386 → 28.
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (signal-internal precision tuning, no CLI surface or data envelope change)

## Known residual concern (non-blocking)

Architect's review noted that even bounded, the ~80% residual FP rate on leading-200 matches in code-discussion prose can flow through the correlator into user-visible recommendations for nonexistent problems. Filed as **#333** for follow-up evaluation (anchored patterns, code-block stripping, confidence field, or trust-trace-only hypotheses). Tracking explicitly so it doesn't get lost; not blocking this fix because the 98% volume cut is the load-bearing improvement.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — internal regex bounding in two diagnostics modules. The new helper applies to text already in memory and is not user-controlled by an external caller. No new I/O, no parser change, no path resolution, no new CLI surface.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None on public contracts. The `ERROR_PATTERN` `DiagnosticSignal` shape is unchanged. Behavior change: detection is strictly more conservative — fewer matches at fewer positions. Downstream consumers that counted historical `ERROR_PATTERN` signal volume will see lower numbers post-merge; that's the intended outcome (the prior numbers were dominated by mid-text FP noise per the research).