### PR TITLE
feat(diagnostics): capture tool_result.is_error per burst (#264)

### DIFF
--- a/src/agentfluent/diagnostics/parent_workload.py
+++ b/src/agentfluent/diagnostics/parent_workload.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -46,7 +47,12 @@ except ImportError:  # pragma: no cover — exercised via install-path test
 from agentfluent.agents.models import WRITE_TOOLS
 from agentfluent.analytics.pricing import ModelPricing, compute_cost, get_pricing
 from agentfluent.config.models import AgentConfig
-from agentfluent.core.session import SessionMessage, ToolUseBlock, Usage
+from agentfluent.core.session import (
+    SessionMessage,
+    ToolUseBlock,
+    Usage,
+    index_tool_results_by_id,
+)
 from agentfluent.diagnostics._clustering import (
     SKLEARN_AVAILABLE,
     SklearnMissingError,
@@ -105,6 +111,14 @@ class ToolBurst:
     """Tool calls in original order. NOT de-duplicated — repeated tool use
     IS a discriminative signal that sub-issue D's TF-IDF clustering will
     weight."""
+    tool_result_errors: int = 0
+    """Count of paired ``tool_result`` blocks with ``is_error=True`` for
+    the tools in :attr:`tool_use_blocks`. Computed at extract time via
+    ``index_tool_results_by_id``; consumed by ``_aggregate_burst_stats``
+    to drive the burst-cluster ``error_rate`` that feeds
+    ``classify_complexity``. Defaults to 0 when the paired ``tool_result``
+    is missing (interrupted session) or its ``is_error`` is None/False
+    (#264)."""
     usage: Usage = field(default_factory=Usage)
     model: str = ""
     """Model id from the first contributing assistant message. All messages
@@ -134,13 +148,19 @@ class _OpenBurst:
         if text:
             self.assistant_texts.append(text)
 
-    def finalize(self) -> ToolBurst | None:
+    def finalize(
+        self,
+        count_errors: Callable[[list[ToolUseBlock]], int] | None = None,
+    ) -> ToolBurst | None:
         if not self.tool_blocks:
             return None
         return ToolBurst(
             preceding_user_text=self.preceding_user_text,
             assistant_text="\n".join(t for t in self.assistant_texts if t),
             tool_use_blocks=list(self.tool_blocks),
+            tool_result_errors=(
+                count_errors(self.tool_blocks) if count_errors is not None else 0
+            ),
             usage=sum(self.usages, Usage()),
             model=self.model,
         )
@@ -166,14 +186,32 @@ def extract_bursts(messages: list[SessionMessage]) -> list[ToolBurst]:
     See module docstring for the boundary rule. No filtering applied here —
     use :func:`filter_bursts` to drop too-small / too-large / too-short
     bursts before clustering.
+
+    Pairs each tool_use to its tool_result via
+    :func:`agentfluent.core.session.index_tool_results_by_id` and stamps
+    the per-burst error count on ``ToolBurst.tool_result_errors``. The
+    index is built once over all messages so an interrupted-session
+    pair (tool_use without a paired tool_result) silently falls back to
+    "not an error" for that tool — see #264.
     """
+    tool_results = index_tool_results_by_id(messages)
+
+    def _count_errors(blocks: list[ToolUseBlock]) -> int:
+        # ``is True`` rather than truthy: ``is_error`` is ``bool | None``
+        # on ``ContentBlock``; missing field stays out of the error count.
+        return sum(
+            1 for b in blocks
+            if (entry := tool_results.get(b.id)) is not None
+            and entry[2] is True
+        )
+
     bursts: list[ToolBurst] = []
     last_real_user_text = ""
     cur: _OpenBurst | None = None
 
     for msg in messages:
         if _is_real_user_text(msg):
-            if cur is not None and (b := cur.finalize()) is not None:
+            if cur is not None and (b := cur.finalize(_count_errors)) is not None:
                 bursts.append(b)
             cur = None
             last_real_user_text = msg.text
@@ -205,7 +243,7 @@ def extract_bursts(messages: list[SessionMessage]) -> list[ToolBurst]:
 
         cur.add_assistant_message(msg)
 
-    if cur is not None and (b := cur.finalize()) is not None:
+    if cur is not None and (b := cur.finalize(_count_errors)) is not None:
         bursts.append(b)
     return bursts
 
@@ -470,11 +508,13 @@ def _filter_tools_from_bursts(
 def _aggregate_burst_stats(bursts: list[ToolBurst]) -> AgentStats:
     """Build ``AgentStats`` for ``classify_complexity`` from a burst cluster.
 
-    ``error_rate`` defaults to 0.0 — bursts don't carry paired
-    ``tool_result.is_error`` data today (the extractor only captures
-    ``tool_use_blocks`` from assistant messages). If dogfood shows
-    error-prone clusters being misclassified as moderate, the extractor
-    can be extended in a follow-up to capture per-tool error counts.
+    ``error_rate`` is the **mean of per-burst rates** rather than the
+    cluster-pooled rate, matching the convention used for invocation-
+    based stats in ``model_routing.py`` and ``_complexity.py`` so the
+    same ``_COMPLEX_MIN_ERROR_RATE = 0.20`` threshold means the same
+    thing on both surfaces. Per-burst error data comes from
+    :attr:`ToolBurst.tool_result_errors` populated at extract time
+    (#264).
     """
     if not bursts:
         return AgentStats(
@@ -489,12 +529,16 @@ def _aggregate_burst_stats(bursts: list[ToolBurst]) -> AgentStats:
     tool_counts = [len(b.tool_use_blocks) for b in bursts]
     token_totals = [b.usage.total_tokens for b in bursts]
     all_tools = {b.name for burst in bursts for b in burst.tool_use_blocks}
+    per_burst_rates = [
+        b.tool_result_errors / n if (n := len(b.tool_use_blocks)) else 0.0
+        for b in bursts
+    ]
     return AgentStats(
         agent_type=_BURST_AGENT_TYPE,
         invocation_count=len(bursts),
         mean_tool_calls=sum(tool_counts) / len(tool_counts),
         mean_tokens=sum(token_totals) / len(token_totals),
-        error_rate=0.0,
+        error_rate=sum(per_burst_rates) / len(per_burst_rates),
         has_write_tools=bool(all_tools & WRITE_TOOLS),
         current_model=None,
     )

--- a/tests/unit/test_parent_workload_cluster.py
+++ b/tests/unit/test_parent_workload_cluster.py
@@ -60,12 +60,14 @@ def _burst(
     cache_creation_input_tokens: int = 0,
     cache_read_input_tokens: int = 0,
     model: str = "claude-opus-4-7",
+    tool_result_errors: int = 0,
 ) -> ToolBurst:
     blocks = [_tool(t, i) for i, t in enumerate(tools or [])]
     return ToolBurst(
         preceding_user_text=user_text,
         assistant_text=assistant_text,
         tool_use_blocks=blocks,
+        tool_result_errors=tool_result_errors,
         usage=Usage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -176,6 +178,78 @@ class TestAggregateBurstStats:
         stats = _aggregate_burst_stats([])
         assert stats.invocation_count == 0
         assert stats.mean_tokens == 0.0
+
+    def test_error_rate_zero_for_all_success_cluster(self) -> None:
+        """All bursts have ``tool_result_errors=0`` → ``error_rate=0.0``
+        (preserves prior behavior on clusters without errors)."""
+        bursts = [
+            _burst(tools=["Read", "Read"], tool_result_errors=0),
+            _burst(tools=["Read", "Bash"], tool_result_errors=0),
+        ]
+        assert _aggregate_burst_stats(bursts).error_rate == 0.0
+
+    def test_error_rate_mean_of_per_burst_rates(self) -> None:
+        """``error_rate`` is the mean of per-burst rates, not pooled
+        (matches ``model_routing.py:166-167`` and
+        ``_complexity.py:177-178`` conventions so the same
+        ``_COMPLEX_MIN_ERROR_RATE = 0.20`` threshold means the same
+        thing on both surfaces)."""
+        # Burst A: 1 error / 4 tools → rate 0.25
+        # Burst B: 1 error / 2 tools → rate 0.5
+        # Mean of rates = 0.375. Pooled would be 2/6 = 0.333. They differ.
+        bursts = [
+            _burst(tools=["Read"] * 4, tool_result_errors=1),
+            _burst(tools=["Read"] * 2, tool_result_errors=1),
+        ]
+        assert _aggregate_burst_stats(bursts).error_rate == 0.375
+
+    def test_error_rate_one_for_all_error_cluster(self) -> None:
+        bursts = [
+            _burst(tools=["Bash"] * 3, tool_result_errors=3),
+            _burst(tools=["Bash"] * 2, tool_result_errors=2),
+        ]
+        assert _aggregate_burst_stats(bursts).error_rate == 1.0
+
+    def test_error_rate_zero_for_burst_with_no_tools(self) -> None:
+        """Defensive: a burst with empty ``tool_use_blocks`` contributes
+        rate 0.0 to the mean (avoids division by zero). In practice
+        ``_OpenBurst.finalize`` won't emit such a burst, but guard the
+        aggregation function regardless."""
+        empty = ToolBurst(
+            preceding_user_text="x",
+            assistant_text="y",
+            tool_use_blocks=[],
+            usage=Usage(),
+        )
+        bursts = [
+            _burst(tools=["Read"] * 2, tool_result_errors=2),
+            empty,
+        ]
+        # Mean of [1.0, 0.0] = 0.5
+        assert _aggregate_burst_stats(bursts).error_rate == 0.5
+
+    def test_error_rate_triggers_complex_classification(self) -> None:
+        """Issue #264 motivation: a cluster with mean tool calls and
+        mean tokens below the complex thresholds but ``error_rate`` above
+        ``_COMPLEX_MIN_ERROR_RATE`` should classify as ``complex``.
+        Pre-fix this never fired because ``error_rate`` was always 0.0."""
+        from agentfluent.diagnostics._complexity import (
+            _COMPLEX_MIN_ERROR_RATE,
+            classify_complexity,
+        )
+        # Two bursts, each with 3 tools, 2 of which errored → per-burst
+        # rate 2/3 ≈ 0.667 each → mean 0.667 (well above 0.20 threshold).
+        # mean_tool_calls=3 is below the complex tool-count gate; the
+        # error_rate is what should drive the "complex" classification.
+        bursts = [
+            _burst(tools=["Bash"] * 3, tool_result_errors=2,
+                   input_tokens=50, output_tokens=50),
+            _burst(tools=["Bash"] * 3, tool_result_errors=2,
+                   input_tokens=50, output_tokens=50),
+        ]
+        stats = _aggregate_burst_stats(bursts)
+        assert stats.error_rate > _COMPLEX_MIN_ERROR_RATE
+        assert classify_complexity(stats) == "complex"
 
 
 class TestToolSequenceSummary:

--- a/tests/unit/test_parent_workload_extract.py
+++ b/tests/unit/test_parent_workload_extract.py
@@ -214,6 +214,145 @@ class TestExtractBurstsBoundaries:
 
 
 # ---------------------------------------------------------------------------
+# extract_bursts — tool_result pairing for error-rate (#264)
+# ---------------------------------------------------------------------------
+
+
+def _assistant_tools_with_ids(
+    tool_ids: list[tuple[str, str]],
+    *,
+    text: str = "",
+    model: str = "claude-opus-4-7",
+) -> SessionMessage:
+    """Build an assistant message with caller-specified ``(tool_name, id)``
+    pairs so tests can pair specific tool_use ids to tool_result blocks
+    by id."""
+    blocks: list[ContentBlock] = []
+    if text:
+        blocks.append(ContentBlock(type="text", text=text))
+    for name, tool_id in tool_ids:
+        blocks.append(
+            ContentBlock(type="tool_use", id=tool_id, name=name, input={}),
+        )
+    return SessionMessage(
+        type="assistant",
+        content_blocks=blocks,
+        model=model,
+        usage=Usage(),
+    )
+
+
+def _user_tool_result(
+    tool_use_id: str, *, is_error: bool | None = False, text: str = "ok",
+) -> SessionMessage:
+    return SessionMessage(
+        type="user",
+        content_blocks=[
+            ContentBlock(
+                type="tool_result",
+                tool_use_id=tool_use_id,
+                text=text,
+                is_error=is_error,
+            ),
+        ],
+    )
+
+
+class TestExtractBurstsToolResultPairing:
+    """``extract_bursts`` pairs each tool_use to its tool_result via
+    ``index_tool_results_by_id`` and stamps the per-burst error count
+    on ``ToolBurst.tool_result_errors`` — driving the cluster
+    ``error_rate`` in ``_aggregate_burst_stats`` (#264)."""
+
+    def test_no_paired_results_yields_zero_errors(self) -> None:
+        """Backward-compat: a session with no tool_result blocks (or
+        an interrupted session where pairs are missing) still produces
+        bursts with ``tool_result_errors=0`` — the default fall-through."""
+        msgs = [
+            _user("read it"),
+            _assistant_tools_with_ids([("Read", "toolu_a")]),
+        ]
+        bursts = extract_bursts(msgs)
+        assert len(bursts) == 1
+        assert bursts[0].tool_result_errors == 0
+
+    def test_all_success_results_yields_zero_errors(self) -> None:
+        msgs = [
+            _user("read both"),
+            _assistant_tools_with_ids(
+                [("Read", "toolu_a"), ("Read", "toolu_b")],
+            ),
+            _user_tool_result("toolu_a", is_error=False),
+            _user_tool_result("toolu_b", is_error=False),
+        ]
+        bursts = extract_bursts(msgs)
+        assert bursts[0].tool_result_errors == 0
+
+    def test_partial_errors_counted(self) -> None:
+        """1-of-3 paired tool_results is_error=True → tool_result_errors=1."""
+        msgs = [
+            _user("run three"),
+            _assistant_tools_with_ids(
+                [
+                    ("Bash", "toolu_a"),
+                    ("Bash", "toolu_b"),
+                    ("Bash", "toolu_c"),
+                ],
+            ),
+            _user_tool_result("toolu_a", is_error=False),
+            _user_tool_result("toolu_b", is_error=True),
+            _user_tool_result("toolu_c", is_error=False),
+        ]
+        bursts = extract_bursts(msgs)
+        assert bursts[0].tool_result_errors == 1
+        assert len(bursts[0].tool_use_blocks) == 3
+
+    def test_is_error_none_not_counted(self) -> None:
+        """``is_error`` is ``bool | None``; missing field (``None``)
+        must not count as an error — checked via ``is True`` rather
+        than truthy."""
+        msgs = [
+            _user("read it"),
+            _assistant_tools_with_ids([("Read", "toolu_a")]),
+            _user_tool_result("toolu_a", is_error=None),
+        ]
+        bursts = extract_bursts(msgs)
+        assert bursts[0].tool_result_errors == 0
+
+    def test_missing_pair_not_counted_as_error(self) -> None:
+        """Tool_use without a paired tool_result (interrupted session)
+        is treated as 'not an error' rather than an error — defensive
+        default that preserves the prior 0.0 baseline."""
+        msgs = [
+            _user("two tools"),
+            _assistant_tools_with_ids(
+                [("Bash", "toolu_a"), ("Bash", "toolu_b")],
+            ),
+            _user_tool_result("toolu_a", is_error=True),
+            # toolu_b never paired (interrupted)
+        ]
+        bursts = extract_bursts(msgs)
+        # Only the paired error counts; the missing pair contributes 0.
+        assert bursts[0].tool_result_errors == 1
+
+    def test_errors_segregated_by_burst(self) -> None:
+        """Two bursts separated by a real user message: errors only
+        attribute to the burst they belong to."""
+        msgs = [
+            _user("first job"),
+            _assistant_tools_with_ids([("Bash", "toolu_a")]),
+            _user_tool_result("toolu_a", is_error=True),
+            _user("second job"),
+            _assistant_tools_with_ids([("Read", "toolu_b")]),
+            _user_tool_result("toolu_b", is_error=False),
+        ]
+        bursts = extract_bursts(msgs)
+        assert len(bursts) == 2
+        assert bursts[0].tool_result_errors == 1
+        assert bursts[1].tool_result_errors == 0
+
+
+# ---------------------------------------------------------------------------
 # burst_text
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Pair `tool_use` to `tool_result` via the existing `index_tool_results_by_id` helper, so burst-classified clusters' `error_rate` reflects real paired error data instead of being hardcoded to 0.0.
- Adds `ToolBurst.tool_result_errors: int` (additive, internal-only — `ToolBurst` is never serialized and never crosses the diagnostics/CLI boundary).
- Computes `_aggregate_burst_stats.error_rate` as **mean of per-burst rates**, matching the convention used by `model_routing.py` and `compute_error_rate` in `_complexity.py` so the same `_COMPLEX_MIN_ERROR_RATE = 0.20` threshold means the same thing on both surfaces.
- Architect-ratified plan ([review on #264](https://github.com/frederick-douglas-pearce/agentfluent/issues/264)) on three judgment calls (pooled-vs-mean, int-vs-list[bool], closure-vs-stored-dict).

Closes #264.

## Why this matters

Pre-fix, `_aggregate_burst_stats.error_rate=0.0` was hardcoded with a comment exactly framing this issue. The `_COMPLEX_MIN_ERROR_RATE = 0.20` gate in `classify_complexity` therefore never fired for burst-classified clusters — error-prone clusters with low tool-call counts and low token volume were systematically misclassified as `moderate` (Sonnet recommendation) when `complex` (Opus) was the right call.

## Dogfood verification

| | Pre-fix | Post-fix |
|---|---|---|
| Bursts with `tool_result_errors > 0` | 0/778 (0.0%) | **157/778 (20.2%)** |
| Total paired errors | 0 | 218 |
| Pooled error rate | 0.00% | 4.26% |
| Tool calls in bursts | 5112 | 5112 |

20% of dogfood bursts now carry at least one paired tool error. Whether any specific cluster's classification flips from `moderate` to `complex` depends on the cluster's mean — that's the calibration story `model_routing` is in charge of.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1238 passed, +11 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New regression coverage:
  - `TestExtractBurstsToolResultPairing` (extract): no paired results → 0 errors; all-success → 0; partial errors counted; `is_error=None` not counted; missing pair not counted; errors segregated by burst boundary
  - `TestAggregateBurstStats` (aggregate): all-success → 0.0; mean-of-per-burst-rates (vs pooled, distinguishes 0.375 from 0.333); all-error → 1.0; empty-tool-blocks burst → 0.0; **synthetic regression on the issue's "trigger" scenario** (mean_tool_calls=3 + error_rate≈0.667 → `classify_complexity == "complex"`)
- [x] Dogfood smoke (script in `~`, not committed): 778 bursts post-filter; 157 (20.2%) carry ≥1 paired error
- [x] Manual smoke test via `uv run agentfluent ...` — N/A (signal-internal additive change; no CLI surface or JSON envelope change)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — internal additive schema change to `ToolBurst` (verified internal-only by docstring assertion and architect review). No new I/O, no parser change, no CLI surface, no JSON envelope change. Helper reused from `core/session.py` (already used by `mcp_assessment.py` and `quality_signals.py`).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None on public contracts. `ToolBurst` is internal — never serialized in JSON output, never crosses the diagnostics/CLI boundary (per its docstring). The cross-boundary types (`OffloadCandidate`, `DelegationSuggestion`) are unaffected. Existing tests with synthetic `ToolBurst` values that didn't set `tool_result_errors` continue to work via the `=0` default.

The behavior change is in `_aggregate_burst_stats.error_rate`: it now reflects real paired-error data instead of always returning 0.0. Downstream consumers (`classify_complexity`, model recommendations) will see different — and more accurate — results on burst-classified clusters that have errors. That's the intended outcome.