### PR TITLE
refactor(tests): consolidate CLI formatter test helpers (#265)

### DIFF
--- a/tests/_builders.py
+++ b/tests/_builders.py
@@ -191,18 +191,30 @@ def delegation_suggestion(
     dedup_note: str = "",
     top_terms: list[str] | None = None,
     cohesion_score: float = 0.85,
+    tools_observed: list[str] | None = None,
 ) -> DelegationSuggestion:
-    """Build a ``DelegationSuggestion`` with project-consistent defaults."""
-    return DelegationSuggestion(
-        name=name,
-        description=description,
-        model="claude-sonnet-4-6",
-        tools=tools if tools is not None else ["Read", "Grep"],
-        tools_note=tools_note,
-        prompt_template="You run pytest tests and report results.",
-        confidence=confidence,
-        cluster_size=10,
-        cohesion_score=cohesion_score,
-        top_terms=top_terms if top_terms is not None else ["pytest", "tests", "run"],
-        dedup_note=dedup_note,
-    )
+    """Build a ``DelegationSuggestion`` with project-consistent defaults.
+
+    ``tools_observed`` defaults to ``None`` and is omitted from the model
+    constructor when unset — preserves the Pydantic ``default_factory=list``
+    behavior. Tests that exercise the unfiltered observed-tools surface
+    pass it explicitly.
+    """
+    kwargs: dict[str, object] = {
+        "name": name,
+        "description": description,
+        "model": "claude-sonnet-4-6",
+        "tools": tools if tools is not None else ["Read", "Grep"],
+        "tools_note": tools_note,
+        "prompt_template": "You run pytest tests and report results.",
+        "confidence": confidence,
+        "cluster_size": 10,
+        "cohesion_score": cohesion_score,
+        "top_terms": (
+            top_terms if top_terms is not None else ["pytest", "tests", "run"]
+        ),
+        "dedup_note": dedup_note,
+    }
+    if tools_observed is not None:
+        kwargs["tools_observed"] = tools_observed
+    return DelegationSuggestion(**kwargs)

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 import typer
+from rich.console import Console
 from typer.testing import CliRunner
 
 from agentfluent.cli.main import app
@@ -16,6 +19,27 @@ from tests._builders import (
     user_with_tool_result,
     write_project_layout,
 )
+
+
+def render_section(
+    formatter: Callable[..., Any],
+    diag: Any,
+    *,
+    verbose: bool = False,
+    width: int = 120,
+) -> str:
+    """Run a CLI formatter against a recording ``Console`` and return text.
+
+    Shared by the formatter test files (``test_offload_candidates_formatting``,
+    ``test_deep_diagnostics_formatting``) so the boilerplate
+    ``Console(record=True, width=120, force_terminal=False)`` →
+    formatter call → ``export_text()`` lives in one place. ``force_terminal``
+    is fixed to ``False`` so the renderer doesn't pick up pytest's TTY
+    state (#265).
+    """
+    console = Console(record=True, width=width, force_terminal=False)
+    formatter(console, diag, verbose=verbose)
+    return console.export_text()
 
 
 @pytest.fixture()

--- a/tests/unit/cli/test_deep_diagnostics_formatting.py
+++ b/tests/unit/cli/test_deep_diagnostics_formatting.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rich.console import Console
+from functools import partial
 
 from agentfluent.cli.formatters.table import (
     _format_deep_diagnostics,
@@ -16,6 +16,17 @@ from agentfluent.diagnostics.models import (
     SignalType,
 )
 from tests._builders import delegation_suggestion as _suggestion
+from tests.unit.cli.conftest import render_section
+
+_render = partial(render_section, _format_deep_diagnostics)
+
+
+def _render_suggestions(diag: DiagnosticsResult, *, verbose: bool) -> str:
+    """Suggestions table needs the wider 140-char terminal for layout —
+    ``render_section`` is the same shape with an explicit ``width``."""
+    return render_section(
+        _format_delegation_suggestions, diag, verbose=verbose, width=140,
+    )
 
 
 def _trace_signal(
@@ -45,12 +56,6 @@ def _trace_signal(
 
 def _result(signals: list[DiagnosticSignal]) -> DiagnosticsResult:
     return DiagnosticsResult(signals=signals, recommendations=[])
-
-
-def _render(diag: DiagnosticsResult, *, verbose: bool) -> str:
-    console = Console(record=True, width=120)
-    _format_deep_diagnostics(console, diag, verbose=verbose)
-    return console.export_text()
 
 
 class TestDeepDiagnosticsSection:
@@ -174,12 +179,6 @@ def _result_with_suggestions(
     suggestions: list[DelegationSuggestion],
 ) -> DiagnosticsResult:
     return DiagnosticsResult(delegation_suggestions=suggestions)
-
-
-def _render_suggestions(diag: DiagnosticsResult, *, verbose: bool) -> str:
-    console = Console(record=True, width=140)
-    _format_delegation_suggestions(console, diag, verbose=verbose)
-    return console.export_text()
 
 
 class TestDelegationSuggestionsSection:

--- a/tests/unit/cli/test_offload_candidates_formatting.py
+++ b/tests/unit/cli/test_offload_candidates_formatting.py
@@ -8,40 +8,20 @@ suggestions).
 
 from __future__ import annotations
 
-from rich.console import Console
+from functools import partial
 
 from agentfluent.cli.formatters.table import (
     OFFLOAD_COST_MORE_NOTE,
     _format_offload_candidates,
 )
 from agentfluent.diagnostics.models import (
-    DelegationSuggestion,
     DiagnosticsResult,
     OffloadCandidate,
 )
+from tests._builders import delegation_suggestion
+from tests.unit.cli.conftest import render_section
 
-
-def _draft(
-    *,
-    name: str = "pytest-runner",
-    tools: list[str] | None = None,
-    confidence: str = "medium",
-) -> DelegationSuggestion:
-    return DelegationSuggestion(
-        name=name,
-        description=f"Handles delegations related to: {name}.",
-        model="claude-sonnet-4-6",
-        tools=tools if tools is not None else ["Bash", "Read"],
-        tools_observed=tools if tools is not None else ["Bash", "Read"],
-        prompt_template=(
-            "You handle the recurring workflow described above. "
-            "Return concise, structured output."
-        ),
-        confidence=confidence,  # type: ignore[arg-type]
-        cluster_size=6,
-        cohesion_score=0.55,
-        top_terms=["pytest", "tests", "run"],
-    )
+_render = partial(render_section, _format_offload_candidates)
 
 
 def _candidate(
@@ -79,17 +59,16 @@ def _candidate(
         alternative_model=alternative_model,
         cost_note=cost_note,
         target_kind="subagent",
-        subagent_draft=_draft(name=name, tools=resolved_tools, confidence=confidence),
+        subagent_draft=delegation_suggestion(
+            name=name,
+            tools=resolved_tools,
+            tools_observed=resolved_tools,
+            confidence=confidence,
+        ),
         skill_draft=None,
         dedup_note=dedup_note,
         matched_agent=matched_agent,
     )
-
-
-def _render(diag: DiagnosticsResult, *, verbose: bool = False) -> str:
-    console = Console(record=True, width=120, force_terminal=False)
-    _format_offload_candidates(console, diag, verbose=verbose)
-    return console.export_text()
 
 
 class TestOffloadCandidatesSection:


### PR DESCRIPTION
## Summary
- Consolidates two minor test-utility duplications surfaced during `/simplify` on PR #261 and deferred at the time as out-of-scope.
- Adds `render_section(formatter, diag, *, verbose=False, width=120)` to `tests/unit/cli/conftest.py`. Both formatter test files now use `functools.partial(render_section, _format_X)` for the one-line bind. The 140-char `_render_suggestions` becomes a thin wrapper that just passes `width=140`.
- Extends `tests._builders.delegation_suggestion` with a `tools_observed: list[str] | None = None` kwarg (omitted from the model constructor when unset, preserving the Pydantic `default_factory=list` behavior). The local `_draft` in `test_offload_candidates_formatting.py` is gone.

Closes #265.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1238 passed — same total as pre-refactor; pure consolidation)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] Targeted: both touched test files pass (`test_offload_candidates_formatting` 7/7, `test_deep_diagnostics_formatting` 19/19)
- [x] Manual smoke test via `uv run agentfluent ...` — N/A (test-only refactor; no source changes)

## Notes

The deep-diagnostics `_render` previously omitted `force_terminal=False`; the new helper always sets it, which is the safer/more-deterministic option for tests (decouples output from pytest's TTY state). All existing assertions continue to pass — empirically the change is transparent.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — test-only refactor. No source code changed; no new I/O, no parser change, no CLI surface, no rendering of user-controlled strings outside the existing test scope.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Pure test refactor; no public API change.