### PR TITLE
feat(diff): propagate window + diagnostics-version into diff output

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -91,6 +91,12 @@ class AnalysisResult(BaseModel):
     session_count: int = 0
     diagnostics: DiagnosticsResult | None = None
     window: WindowMetadata | None = None
+    diagnostics_version: str | None = None
+    """Package version that produced this envelope. Stamped by the CLI
+    at emit time so ``diff`` can warn when baseline and current were
+    analyzed with different rule sets / calibration constants (#347).
+    ``None`` on legacy envelopes; populated as ``agentfluent.__version__``
+    by :mod:`agentfluent.cli.commands.analyze`."""
 
 
 def analyze_session(

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -9,6 +9,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from agentfluent import __version__
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
 from agentfluent.cli._time_args import parse_time_window
 from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
@@ -359,6 +360,7 @@ def analyze(
         _apply_min_severity(result, min_severity)
 
     result.window = window_metadata
+    result.diagnostics_version = __version__
 
     if format == "json":
         _print_json(result, quiet=quiet, project_name=project_info.display_name)

--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -25,6 +25,7 @@ from agentfluent.cli.formatters.helpers import (
 if TYPE_CHECKING:
     from rich.console import Console
 
+    from agentfluent.core.filtering import WindowMetadata
     from agentfluent.diff.models import (
         DiffResult,
         ModelTokenDelta,
@@ -58,13 +59,81 @@ def _render_summary(console: Console, result: DiffResult) -> None:
         f"[bold]Resolved:[/bold] {result.resolved_count}",
         f"[bold]Persisting:[/bold] {result.persisting_count}",
     ]
-    if result.baseline_session_count or result.current_session_count:
+    has_window = (
+        result.baseline_window is not None or result.current_window is not None
+    )
+    if not has_window and (
+        result.baseline_session_count or result.current_session_count
+    ):
         pieces.append(
             f"[dim]Sessions: {result.baseline_session_count} "
             f"→ {result.current_session_count}[/dim]",
         )
     console.print("  ".join(pieces))
+
+    if has_window:
+        baseline_label = _format_window_side(
+            result.baseline_window, result.baseline_session_count,
+        )
+        current_label = _format_window_side(
+            result.current_window, result.current_session_count,
+        )
+        console.print(
+            f"[dim]Baseline: {baseline_label}  |  Current: {current_label}[/dim]",
+        )
+
+    version_line = _version_drift_line(result)
+    if version_line is not None:
+        console.print(version_line)
+
     console.print()
+
+
+def _format_window_side(
+    window: WindowMetadata | None, session_count: int,
+) -> str:
+    """Render one half of the baseline/current window summary line.
+
+    ``None`` window means the input envelope predates window stamping
+    (#316) or was an unfiltered run with no window block at all — we
+    can't disambiguate, so both render as ``(window not recorded)`` per
+    #342's acceptance criterion.
+    """
+    if window is None:
+        return f"(window not recorded, {session_count} sessions)"
+    since = window.since.date().isoformat() if window.since else "*"
+    until = window.until.date().isoformat() if window.until else "*"
+    return f"{since} → {until} ({window.session_count_after_filter} sessions)"
+
+
+def _version_drift_line(result: DiffResult) -> str | None:
+    """Return the diagnostics-version warning line, or ``None`` if silent.
+
+    Three cases:
+      * both versions present and equal — return ``None`` (no warning).
+      * both present and differ — yellow drift warning with both versions.
+      * either missing — dim "(version unknown)" line so a CI consumer
+        comparing a v0.6 baseline against a v0.7 current sees that detector
+        sensitivity may have shifted, without claiming the magnitude.
+    """
+    baseline = result.baseline_diagnostics_version
+    current = result.current_diagnostics_version
+    if baseline is None or current is None:
+        if baseline is None and current is None:
+            return None  # both legacy: no information either way
+        which = "baseline" if baseline is None else "current"
+        return (
+            f"[dim]⚠ Diagnostics version unknown for {which} "
+            "envelope — signal counts may include detector-sensitivity "
+            "changes.[/dim]"
+        )
+    if baseline == current:
+        return None
+    return (
+        f"[yellow]⚠ Diagnostics version drift:[/yellow] baseline "
+        f"v{baseline}, current v{current} — signal counts may not be "
+        "directly comparable."
+    )
 
 
 def _render_recommendations(

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import SEVERITY_RANK, Severity
+from agentfluent.core.filtering import WindowMetadata
 from agentfluent.diagnostics.models import Axis, SignalType
 from agentfluent.diff.models import (
     AgentTypeDelta,
@@ -73,9 +74,35 @@ def compute_diff(
         by_agent_type=agent_deltas,
         baseline_session_count=int(baseline.get("session_count", 0) or 0),
         current_session_count=int(current.get("session_count", 0) or 0),
+        baseline_window=_load_window(baseline),
+        current_window=_load_window(current),
+        baseline_diagnostics_version=_load_version(baseline),
+        current_diagnostics_version=_load_version(current),
         fail_on=fail_on,
         regression_detected=regression,
     )
+
+
+def _load_window(envelope: dict[str, Any]) -> WindowMetadata | None:
+    """Deserialize ``envelope['window']`` to ``WindowMetadata``.
+
+    Returns ``None`` for unfiltered runs (key present but value is
+    ``None``) and for legacy envelopes that predate #316 (key absent).
+    """
+    raw = envelope.get("window")
+    if not isinstance(raw, dict):
+        return None
+    return WindowMetadata.model_validate(raw)
+
+
+def _load_version(envelope: dict[str, Any]) -> str | None:
+    """Read ``diagnostics_version`` from envelope, returning ``None``
+    when absent (legacy v0.6 envelopes) or empty.
+    """
+    raw = envelope.get("diagnostics_version")
+    if not isinstance(raw, str) or not raw:
+        return None
+    return raw
 
 
 def has_regression(result: DiffResult) -> bool:

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field, computed_field
 
 from agentfluent.analytics.tokens import Origin
 from agentfluent.config.models import Severity
+from agentfluent.core.filtering import WindowMetadata
 from agentfluent.diagnostics.models import Axis, SignalType
 
 DeltaStatus = Literal["new", "resolved", "persisting"]
@@ -156,6 +157,36 @@ class DiffResult(BaseModel):
 
     baseline_session_count: int = 0
     current_session_count: int = 0
+
+    baseline_window: WindowMetadata | None = None
+    current_window: WindowMetadata | None = None
+    """Time-filter window metadata copied from each input envelope (#342).
+    ``None`` for unfiltered runs and for legacy envelopes that predate
+    ``analyze --since/--until`` (#316). Renderers print
+    ``(window not recorded)`` in the latter case."""
+
+    baseline_diagnostics_version: str | None = None
+    current_diagnostics_version: str | None = None
+    """Package version that produced each input envelope (#347). ``None``
+    for envelopes that predate v0.7. ``diff`` warns when both are present
+    and differ — signal counts may not be directly comparable across
+    rule-set / calibration changes."""
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def diagnostics_version_drift(self) -> bool:
+        """``True`` iff both versions are present and differ.
+
+        ``None`` on either side does not count as drift — the warning copy
+        differentiates "unknown" from "mismatched" so a v0.6 baseline
+        being re-diffed against a v0.7 current doesn't fire a false alarm
+        about regressions in detector sensitivity it can't actually
+        attest to."""
+        baseline = self.baseline_diagnostics_version
+        current = self.current_diagnostics_version
+        if baseline is None or current is None:
+            return False
+        return baseline != current
 
     fail_on: Severity | None = None
     """The severity threshold the diff was evaluated against (``None``

--- a/tests/unit/cli/test_analyze_since_until.py
+++ b/tests/unit/cli/test_analyze_since_until.py
@@ -253,3 +253,21 @@ class TestWindowMetadataInJsonOutput:
         assert window["until"].startswith("2026-05-01")
         assert window["session_count_before_filter"] == 1
         assert window["session_count_after_filter"] == 1
+
+
+class TestDiagnosticsVersionStamp:
+    """``analyze --json`` envelopes carry ``diagnostics_version`` so
+    ``diff`` can warn on detector-version drift between runs (#347)."""
+
+    def test_envelope_includes_package_version(
+        self, runner: CliRunner, cli_app: typer.Typer, populated_home: Path,
+    ) -> None:
+        from agentfluent import __version__
+
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--json"],
+        )
+        assert result.exit_code == EXIT_OK
+        data = parse_json_output(result.stdout, expected_command="analyze")
+        assert isinstance(data, dict)
+        assert data.get("diagnostics_version") == __version__

--- a/tests/unit/cli/test_diff_cmd.py
+++ b/tests/unit/cli/test_diff_cmd.py
@@ -296,6 +296,49 @@ class TestOutputFormats:
         assert "New Recommendations" in result.output
         assert "Token Metrics" in result.output
 
+    def test_json_carries_window_and_version_fields(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        tmp_path: Path,
+    ) -> None:
+        """#342/#347: ``diff --json`` surfaces baseline/current window
+        and diagnostics_version at the top of ``data`` so CI consumers
+        can branch on detector-version drift without re-running analyze."""
+        window_v1 = {
+            "since": "2026-04-25T00:00:00+00:00",
+            "until": "2026-05-03T00:00:00+00:00",
+            "session_count_before_filter": 12,
+            "session_count_after_filter": 6,
+        }
+        window_v2 = {
+            **window_v1,
+            "since": "2026-05-03T00:00:00+00:00",
+            "until": "2026-05-09T00:00:00+00:00",
+            "session_count_after_filter": 11,
+        }
+        baseline = _write_envelope(
+            tmp_path / "baseline.json",
+            _data() | {"window": window_v1, "diagnostics_version": "0.6.1"},
+        )
+        current = _write_envelope(
+            tmp_path / "current.json",
+            _data() | {"window": window_v2, "diagnostics_version": "0.7.0"},
+        )
+
+        result = runner.invoke(
+            cli_app,
+            ["diff", str(baseline), str(current), "--json", "--fail-on", "off"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)["data"]
+
+        assert data["baseline_window"]["session_count_after_filter"] == 6
+        assert data["current_window"]["session_count_after_filter"] == 11
+        assert data["baseline_diagnostics_version"] == "0.6.1"
+        assert data["current_diagnostics_version"] == "0.7.0"
+        assert data["diagnostics_version_drift"] is True
+
     def test_help_includes_examples(
         self,
         runner: CliRunner,

--- a/tests/unit/cli/test_diff_summary.py
+++ b/tests/unit/cli/test_diff_summary.py
@@ -1,0 +1,171 @@
+"""Diff-table summary line rendering for #342 (window) + #347 (version).
+
+Locks the user-visible copy: the window summary line must surface dates
+and session counts; the diagnostics-version drift warning must
+distinguish "drift" from "unknown" so a v0.6 baseline diffed against a
+v0.7 current doesn't trigger a false alarm about detector sensitivity.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime
+
+from rich.console import Console
+
+from agentfluent.cli.formatters.diff_table import (
+    _format_window_side,
+    _render_summary,
+    _version_drift_line,
+)
+from agentfluent.core.filtering import WindowMetadata
+from agentfluent.diff.models import DiffResult
+
+
+def _capture(width: int = 200) -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, width=width, force_terminal=False, no_color=True), buf
+
+
+def _window(
+    *,
+    since: str | None = "2026-04-25T00:00:00+00:00",
+    until: str | None = "2026-05-03T00:00:00+00:00",
+    after: int = 6,
+    before: int = 12,
+) -> WindowMetadata:
+    return WindowMetadata(
+        since=datetime.fromisoformat(since) if since else None,
+        until=datetime.fromisoformat(until) if until else None,
+        session_count_before_filter=before,
+        session_count_after_filter=after,
+    )
+
+
+class TestFormatWindowSide:
+    def test_renders_dates_and_session_count(self) -> None:
+        rendered = _format_window_side(_window(after=6), session_count=6)
+        assert rendered == "2026-04-25 → 2026-05-03 (6 sessions)"
+
+    def test_open_left_bound_shows_asterisk(self) -> None:
+        rendered = _format_window_side(_window(since=None, after=4), session_count=4)
+        assert rendered == "* → 2026-05-03 (4 sessions)"
+
+    def test_open_right_bound_shows_asterisk(self) -> None:
+        rendered = _format_window_side(_window(until=None, after=4), session_count=4)
+        assert rendered == "2026-04-25 → * (4 sessions)"
+
+    def test_none_window_uses_session_count_fallback(self) -> None:
+        rendered = _format_window_side(None, session_count=11)
+        assert rendered == "(window not recorded, 11 sessions)"
+
+
+class TestVersionDriftLine:
+    def _result(
+        self, *, baseline: str | None = None, current: str | None = None,
+    ) -> DiffResult:
+        return DiffResult(
+            baseline_diagnostics_version=baseline,
+            current_diagnostics_version=current,
+        )
+
+    def test_silent_when_versions_match(self) -> None:
+        assert _version_drift_line(
+            self._result(baseline="0.7.0", current="0.7.0"),
+        ) is None
+
+    def test_silent_when_both_versions_missing(self) -> None:
+        assert _version_drift_line(self._result()) is None
+
+    def test_drift_warning_includes_both_versions(self) -> None:
+        rendered = _version_drift_line(
+            self._result(baseline="0.6.1", current="0.7.0"),
+        )
+        assert rendered is not None
+        assert "v0.6.1" in rendered
+        assert "v0.7.0" in rendered
+        assert "drift" in rendered.lower()
+        assert "yellow" in rendered
+
+    def test_unknown_baseline_warns_dim(self) -> None:
+        rendered = _version_drift_line(self._result(current="0.7.0"))
+        assert rendered is not None
+        assert "unknown" in rendered.lower()
+        assert "baseline" in rendered.lower()
+        assert "[dim]" in rendered
+
+    def test_unknown_current_warns_dim(self) -> None:
+        rendered = _version_drift_line(self._result(baseline="0.7.0"))
+        assert rendered is not None
+        assert "unknown" in rendered.lower()
+        assert "current" in rendered.lower()
+
+
+class TestRenderSummary:
+    def test_session_line_only_when_no_windows(self) -> None:
+        console, buf = _capture()
+        result = DiffResult(
+            new_count=1, resolved_count=0, persisting_count=2,
+            baseline_session_count=6, current_session_count=11,
+        )
+        _render_summary(console, result)
+        out = buf.getvalue()
+        assert "Sessions: 6 → 11" in out
+        assert "Baseline:" not in out
+
+    def test_window_line_replaces_session_fallback(self) -> None:
+        """When at least one envelope carries a window, the
+        ``Sessions: A → B`` fallback is suppressed so the dates carry the
+        load — keeps the header tight rather than duplicating cardinality."""
+        console, buf = _capture()
+        result = DiffResult(
+            new_count=1, resolved_count=0, persisting_count=2,
+            baseline_session_count=6, current_session_count=11,
+            baseline_window=_window(after=6),
+            current_window=_window(
+                since="2026-05-03T00:00:00+00:00",
+                until="2026-05-09T00:00:00+00:00",
+                after=11,
+            ),
+        )
+        _render_summary(console, result)
+        out = buf.getvalue()
+        assert "Sessions: 6 → 11" not in out
+        assert "Baseline: 2026-04-25 → 2026-05-03 (6 sessions)" in out
+        assert "Current: 2026-05-03 → 2026-05-09 (11 sessions)" in out
+
+    def test_window_line_handles_legacy_baseline(self) -> None:
+        console, buf = _capture()
+        result = DiffResult(
+            new_count=0, resolved_count=0, persisting_count=0,
+            baseline_session_count=8, current_session_count=11,
+            current_window=_window(after=11),
+        )
+        _render_summary(console, result)
+        out = buf.getvalue()
+        assert "Baseline: (window not recorded, 8 sessions)" in out
+        assert "Current: 2026-04-25" in out
+
+    def test_drift_warning_appears_below_window_line(self) -> None:
+        console, buf = _capture()
+        result = DiffResult(
+            baseline_window=_window(),
+            current_window=_window(),
+            baseline_diagnostics_version="0.6.1",
+            current_diagnostics_version="0.7.0",
+        )
+        _render_summary(console, result)
+        out = buf.getvalue()
+        baseline_idx = out.index("Baseline:")
+        drift_idx = out.lower().index("drift")
+        assert baseline_idx < drift_idx
+
+    def test_no_drift_line_when_versions_match(self) -> None:
+        console, buf = _capture()
+        result = DiffResult(
+            baseline_diagnostics_version="0.7.0",
+            current_diagnostics_version="0.7.0",
+        )
+        _render_summary(console, result)
+        assert "drift" not in buf.getvalue().lower()
+        assert "unknown" not in buf.getvalue().lower()

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -565,3 +565,109 @@ class TestDiffResultSerialization:
         round_tripped = DiffResult.model_validate(dumped)
         assert round_tripped.resolved_count == 1
         assert round_tripped.fail_on == Severity.WARNING
+
+
+class TestWindowPropagation:
+    """#342: ``diff`` carries the time-filter window from each input
+    envelope into the result so JSON consumers and the table renderer
+    can show what was compared without re-running analyze."""
+
+    _WINDOW = {
+        "since": "2026-04-25T00:00:00+00:00",
+        "until": "2026-05-03T00:00:00+00:00",
+        "session_count_before_filter": 12,
+        "session_count_after_filter": 6,
+    }
+
+    def test_window_present_on_both_sides(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"window": self._WINDOW}
+        current_window = self._WINDOW | {
+            "since": "2026-05-03T00:00:00+00:00",
+            "until": "2026-05-09T00:00:00+00:00",
+            "session_count_after_filter": 11,
+        }
+        current = _envelope(aggregated_recs=[]) | {"window": current_window}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_window is not None
+        assert result.baseline_window.session_count_after_filter == 6
+        assert result.current_window is not None
+        assert result.current_window.session_count_after_filter == 11
+
+    def test_window_missing_on_one_side_yields_none(self) -> None:
+        """A v0.6 baseline diffed against a v0.7 current: missing-side
+        stays ``None`` so the renderer can show ``(window not recorded)``
+        without fabricating dates."""
+        baseline = _envelope(aggregated_recs=[])
+        current = _envelope(aggregated_recs=[]) | {"window": self._WINDOW}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_window is None
+        assert result.current_window is not None
+
+    def test_window_explicit_null_yields_none(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"window": None}
+        current = _envelope(aggregated_recs=[]) | {"window": None}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_window is None
+        assert result.current_window is None
+
+    def test_window_serializes_through_json_roundtrip(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"window": self._WINDOW}
+        current = _envelope(aggregated_recs=[]) | {"window": self._WINDOW}
+
+        result = compute_diff(baseline, current)
+        round_tripped = DiffResult.model_validate(result.model_dump(mode="json"))
+
+        assert round_tripped.baseline_window is not None
+        assert round_tripped.baseline_window.session_count_after_filter == 6
+
+
+class TestDiagnosticsVersionPropagation:
+    """#347: ``diff`` reads ``diagnostics_version`` from each envelope
+    and exposes it on the result. Drift detection is silent when both
+    sides are unknown (avoids false alarms when comparing two pre-v0.7
+    envelopes)."""
+
+    def test_versions_present_and_equal(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.7.0"}
+        current = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.7.0"}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_diagnostics_version == "0.7.0"
+        assert result.current_diagnostics_version == "0.7.0"
+        assert result.diagnostics_version_drift is False
+
+    def test_versions_present_and_differ(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.6.1"}
+        current = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.7.0"}
+
+        result = compute_diff(baseline, current)
+
+        assert result.diagnostics_version_drift is True
+
+    def test_version_missing_on_one_side_does_not_count_as_drift(self) -> None:
+        """Drift is meaningful only when both sides attest a version. A
+        mixed pair could be different *or* the same — without the
+        baseline saying so, we can't claim drift."""
+        baseline = _envelope(aggregated_recs=[])
+        current = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.7.0"}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_diagnostics_version is None
+        assert result.current_diagnostics_version == "0.7.0"
+        assert result.diagnostics_version_drift is False
+
+    def test_version_empty_string_treated_as_missing(self) -> None:
+        baseline = _envelope(aggregated_recs=[]) | {"diagnostics_version": ""}
+        current = _envelope(aggregated_recs=[]) | {"diagnostics_version": "0.7.0"}
+
+        result = compute_diff(baseline, current)
+
+        assert result.baseline_diagnostics_version is None


### PR DESCRIPTION
## Summary
- Closes #342: `analyze --json`'s `window` block flows through `compute_diff` to `baseline_window` / `current_window` on `DiffResult`. Diff table prints `Baseline: 2026-04-25 → 2026-05-03 (6 sessions)  |  Current: ...` above recommendation tables; legacy envelopes that predate window stamping render `(window not recorded, N sessions)`.
- Closes #347: `analyze --json` envelopes now carry `diagnostics_version` (stamped as `agentfluent.__version__` at emit time). `diff` emits a yellow drift warning when baseline and current versions differ; a dim "version unknown" line when one side is missing; silent when both are unknown so a v0.6 baseline diffed against another v0.6 doesn't fire false alarms.
- All envelope additions are non-breaking — schema version unchanged, defaults `None`, older AgentFluent reading newer JSON ignores the fields. README/CHANGELOG catch-up tracked under #326 (final wave).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1275 passed, 24 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `tests/unit/diff/test_compute.py::TestWindowPropagation`, `::TestDiagnosticsVersionPropagation`; `tests/unit/cli/test_diff_summary.py` covers `_format_window_side`, `_version_drift_line`, and `_render_summary` integration; `test_diff_cmd.py::test_json_carries_window_and_version_fields` locks the JSON envelope; `test_analyze_since_until.py::TestDiagnosticsVersionStamp` confirms `analyze --json` stamps the field.
- [x] Manual smoke test — verified table output for: both envelopes have window + matching version (silent), drift case (yellow warning), legacy baseline against current (window-not-recorded + version-unknown). Legacy-only pair stays silent on version drift.

## Security review
- [x] **Skip review** — additive Pydantic fields on internal models and additional rendered text in CLI output. No new file/path/network surface, no user-controlled string interpolation, no JSON parsing changes (still routes through `parse_json_output`'s versioned envelope check).

## Breaking changes
None. JSON envelope schema version unchanged (additive fields with `None` defaults). Behavior change is purely additive: extra header line in diff table output, new fields visible in `diff --json`. Older AgentFluent binaries reading a newer JSON ignore the new fields per the existing forward-compat posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)