### PR TITLE
feat(diagnostics): hide negative-savings offload + filter cluster-name stopwords

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -257,6 +257,16 @@ def analyze(
             "Diagnostic Signals are not affected."
         ),
     ),
+    show_negative_savings: bool = typer.Option(
+        False,
+        "--show-negative-savings",
+        help=(
+            "Include offload candidates whose savings is zero or negative "
+            "(offloading would cost MORE than staying on the parent thread). "
+            "Hidden by default — these patterns are informational, not "
+            "actionable. JSON output always carries the full list."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
@@ -369,5 +379,5 @@ def analyze(
     else:
         format_analysis_table(
             console, result, verbose=verbose, show_diagnostics=diagnostics,
-            top_n=top_n,
+            top_n=top_n, show_negative_savings=show_negative_savings,
         )

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -597,58 +597,35 @@ def _format_offload_candidates(
 ) -> None:
     """Render the "Offload Candidates" section (#189).
 
-    By default (``show_negative_savings=False``) suppresses rows where
-    ``estimated_savings_usd <= 0``: those represent patterns where
-    offloading would cost MORE than staying on the parent thread because
-    parent-thread cache is load-bearing — they're informational, not
-    actionable, and a section named "Offload Candidates" full of
-    "do not offload" rows misleads at a glance (#344). The full set
-    remains in JSON for consumers who want to see everything.
-
-    When all candidates were filtered, render a one-line footnote
-    pointing at ``--show-negative-savings`` so the user knows the
-    section wasn't silently empty.
-
-    Compact table sorted by ``estimated_savings_usd`` descending —
-    biggest dollar wins first. With ``--show-negative-savings``,
-    negative rows sort to the bottom under existing semantics.
-    Verbose adds the offload-flavored ``yaml_draft`` (parent → alt
-    model preamble + cost note + frontmatter + prompt) below each row.
-
-    Negative-savings rendering (only with the flag):
-      - savings cell: ``[red]+$X.XX[/red]`` (positive magnitude with a
-        ``+`` mnemonic for "this many additional dollars")
-      - Note column: includes ``"offload would cost MORE"`` so the
-        sign-flip in the savings cell isn't easy to misread
-
-    All JSONL/trace-derived strings (name, tools, cost_note, dedup_note)
-    pass through ``escape`` before hitting Rich.
+    Negative-savings rows ("offloading would cost MORE — parent-thread
+    cache is load-bearing") are hidden by default since #344: a section
+    named "Offload Candidates" full of "do not offload" rows misleads at
+    a glance. ``show_negative_savings=True`` opts back in; JSON output
+    is unaffected either way. When every row is filtered, the section
+    renders a one-line footnote so the diagnostic stays discoverable.
     """
-    all_candidates = sorted(
+    candidates = sorted(
         diag.offload_candidates,
         key=lambda c: c.estimated_savings_usd,
         reverse=True,
     )
-    if not all_candidates:
+    if not candidates:
         return
 
-    if show_negative_savings:
-        candidates = all_candidates
-        hidden_count = 0
-    else:
-        candidates = [c for c in all_candidates if c.estimated_savings_usd > 0]
-        hidden_count = len(all_candidates) - len(candidates)
+    visible = (
+        candidates if show_negative_savings
+        else [c for c in candidates if c.estimated_savings_usd > 0]
+    )
 
-    if not candidates:
-        console.print("\n[bold]Offload Candidates[/bold]")
+    console.print("\n[bold]Offload Candidates[/bold]")
+    if not visible:
         console.print(
-            f"[dim]No offload candidates surfaced ({hidden_count} "
+            f"[dim]No offload candidates surfaced ({len(candidates)} "
             "negative-savings rows hidden — pass --show-negative-savings "
             "to inspect).[/dim]",
         )
         return
 
-    console.print("\n[bold]Offload Candidates[/bold]")
     cand_table = Table(show_header=True, title_style="")
     cand_table.add_column("Name", style="cyan")
     cand_table.add_column("Confidence")
@@ -657,7 +634,7 @@ def _format_offload_candidates(
     cand_table.add_column("Est. savings", justify="right")
     cand_table.add_column("Note")
 
-    for cand in candidates:
+    for cand in visible:
         color = CONFIDENCE_COLORS.get(cand.confidence, "white")
         # Read tools/tools_note FLAT off the candidate, mirroring how
         # every other column reads from `OffloadCandidate` directly.
@@ -702,7 +679,7 @@ def _format_offload_candidates(
     console.print(cand_table)
 
     if verbose:
-        for cand in candidates:
+        for cand in visible:
             console.print()
             console.print(escape(cand.yaml_draft))
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -129,6 +129,7 @@ def format_analysis_table(
     verbose: bool = False,
     show_diagnostics: bool = False,
     top_n: int = 5,
+    show_negative_savings: bool = False,
 ) -> None:
     """Render analyze output: token, cost, tool, agent, and diagnostics tables.
 
@@ -278,6 +279,7 @@ def format_analysis_table(
         if show_diagnostics:
             _format_diagnostics_table(
                 console, diag, verbose=verbose, top_n=top_n,
+                show_negative_savings=show_negative_savings,
             )
         else:
             _format_diagnostics_summary(console, diag)
@@ -325,6 +327,7 @@ def _format_diagnostics_table(
     *,
     verbose: bool = False,
     top_n: int = 5,
+    show_negative_savings: bool = False,
 ) -> None:
     """Render diagnostic signals and recommendations tables.
 
@@ -380,7 +383,11 @@ def _format_diagnostics_table(
 
     _format_deep_diagnostics(console, diag, verbose=verbose)
     _format_delegation_suggestions(console, diag, verbose=verbose)
-    _format_offload_candidates(console, diag, verbose=verbose)
+    _format_offload_candidates(
+        console, diag,
+        verbose=verbose,
+        show_negative_savings=show_negative_savings,
+    )
 
     console.print(GLOSSARY_FOOTNOTE, style="dim")
 
@@ -586,33 +593,59 @@ def _format_offload_candidates(
     diag: DiagnosticsResult,
     *,
     verbose: bool,
+    show_negative_savings: bool = False,
 ) -> None:
     """Render the "Offload Candidates" section (#189).
 
-    Compact table by default sorted by ``estimated_savings_usd``
-    descending — biggest dollar wins first; negative-savings rows
-    (offloading would cost MORE than staying on the parent because
-    the parent-thread cache is load-bearing) sink to the bottom.
+    By default (``show_negative_savings=False``) suppresses rows where
+    ``estimated_savings_usd <= 0``: those represent patterns where
+    offloading would cost MORE than staying on the parent thread because
+    parent-thread cache is load-bearing — they're informational, not
+    actionable, and a section named "Offload Candidates" full of
+    "do not offload" rows misleads at a glance (#344). The full set
+    remains in JSON for consumers who want to see everything.
+
+    When all candidates were filtered, render a one-line footnote
+    pointing at ``--show-negative-savings`` so the user knows the
+    section wasn't silently empty.
+
+    Compact table sorted by ``estimated_savings_usd`` descending —
+    biggest dollar wins first. With ``--show-negative-savings``,
+    negative rows sort to the bottom under existing semantics.
     Verbose adds the offload-flavored ``yaml_draft`` (parent → alt
     model preamble + cost note + frontmatter + prompt) below each row.
 
-    Negative-savings rendering:
+    Negative-savings rendering (only with the flag):
       - savings cell: ``[red]+$X.XX[/red]`` (positive magnitude with a
         ``+`` mnemonic for "this many additional dollars")
       - Note column: includes ``"offload would cost MORE"`` so the
         sign-flip in the savings cell isn't easy to misread
-      The same phrasing appears in the model's ``yaml_draft`` preamble,
-      so terminology stays consistent across compact + verbose views.
 
     All JSONL/trace-derived strings (name, tools, cost_note, dedup_note)
     pass through ``escape`` before hitting Rich.
     """
-    candidates = sorted(
+    all_candidates = sorted(
         diag.offload_candidates,
         key=lambda c: c.estimated_savings_usd,
         reverse=True,
     )
+    if not all_candidates:
+        return
+
+    if show_negative_savings:
+        candidates = all_candidates
+        hidden_count = 0
+    else:
+        candidates = [c for c in all_candidates if c.estimated_savings_usd > 0]
+        hidden_count = len(all_candidates) - len(candidates)
+
     if not candidates:
+        console.print("\n[bold]Offload Candidates[/bold]")
+        console.print(
+            f"[dim]No offload candidates surfaced ({hidden_count} "
+            "negative-savings rows hidden — pass --show-negative-savings "
+            "to inspect).[/dim]",
+        )
         return
 
     console.print("\n[bold]Offload Candidates[/bold]")

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -269,6 +269,24 @@ def cluster_delegations(
 
 _SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]")
 
+_NAME_STOPWORD_RE = re.compile(
+    r"^(?:\d+|v\d+|[0-9a-f]{7,})$",
+)
+"""Tokens that look like accidental identifiers rather than reusable
+workflow terms (#345). Run against the slug-sanitized form (lowercase,
+non-``[a-z0-9-]`` stripped — so ``v0.6`` arrives as ``v06`` and matches
+``^v\\d+$``). Three alternatives:
+
+* pure-numeric — issue/PR numbers, occasionally HTTP status codes (TF-IDF
+  co-occurrence keeps companion terms descriptive in the latter case);
+* ``v``-prefix numeric — version refs like ``v0``, ``v06`` (post-slug
+  ``v0.6``), ``v1``;
+* seven-plus hex chars — SHA-prefix tokens.
+
+Filter applies only to cluster auto-naming. ``synthesize_description``,
+``_synthesize_prompt``, and the JSON ``top_terms`` array stay raw so a
+human / CI consumer can still see the unfiltered signal."""
+
 
 def synthesize_name(top_terms: list[str]) -> str:
     """Build a kebab-case agent name from the top TF-IDF terms.
@@ -276,9 +294,20 @@ def synthesize_name(top_terms: list[str]) -> str:
     Prefers the first two terms when available; otherwise falls back to
     a generic placeholder. Not unique across clusters — the caller is
     expected to show these as *drafts*, not final names.
+
+    Stopword filter runs after slug sanitization (so ``v0.6`` lowercase
+    is matched directly, and ``272`` survives ``_SLUG_STRIP_RE``
+    unchanged) but before first-two selection — getting the order wrong
+    produces empty names or wrong terms.
     """
-    cleaned = [_SLUG_STRIP_RE.sub("", t.lower().replace("_", "-")) for t in top_terms]
-    cleaned = [c for c in cleaned if c]
+    cleaned: list[str] = []
+    for term in top_terms:
+        slug = _SLUG_STRIP_RE.sub("", term.lower().replace("_", "-"))
+        if not slug:
+            continue
+        if _NAME_STOPWORD_RE.match(slug):
+            continue
+        cleaned.append(slug)
     if not cleaned:
         return "custom-agent"
     if len(cleaned) == 1:

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -272,20 +272,11 @@ _SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]")
 _NAME_STOPWORD_RE = re.compile(
     r"^(?:\d+|v\d+|[0-9a-f]{7,})$",
 )
-"""Tokens that look like accidental identifiers rather than reusable
-workflow terms (#345). Run against the slug-sanitized form (lowercase,
-non-``[a-z0-9-]`` stripped — so ``v0.6`` arrives as ``v06`` and matches
-``^v\\d+$``). Three alternatives:
-
-* pure-numeric — issue/PR numbers, occasionally HTTP status codes (TF-IDF
-  co-occurrence keeps companion terms descriptive in the latter case);
-* ``v``-prefix numeric — version refs like ``v0``, ``v06`` (post-slug
-  ``v0.6``), ``v1``;
-* seven-plus hex chars — SHA-prefix tokens.
-
-Filter applies only to cluster auto-naming. ``synthesize_description``,
-``_synthesize_prompt``, and the JSON ``top_terms`` array stay raw so a
-human / CI consumer can still see the unfiltered signal."""
+"""Accidental identifiers (issue/PR numbers, version refs, SHA
+prefixes) — strip from auto-names but leave raw in JSON ``top_terms``
+and the description / prompt scaffold (#345). Run against the
+slug-sanitized form, so ``v0.6`` arrives as ``v06`` and matches
+``^v\\d+$``."""
 
 
 def synthesize_name(top_terms: list[str]) -> str:
@@ -293,12 +284,8 @@ def synthesize_name(top_terms: list[str]) -> str:
 
     Prefers the first two terms when available; otherwise falls back to
     a generic placeholder. Not unique across clusters — the caller is
-    expected to show these as *drafts*, not final names.
-
-    Stopword filter runs after slug sanitization (so ``v0.6`` lowercase
-    is matched directly, and ``272`` survives ``_SLUG_STRIP_RE``
-    unchanged) but before first-two selection — getting the order wrong
-    produces empty names or wrong terms.
+    expected to show these as *drafts*, not final names. Stopword
+    filter runs after slug sanitization but before first-two selection.
     """
     cleaned: list[str] = []
     for term in top_terms:

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -36,10 +36,7 @@ def render_section(
     ``Console(record=True, width=120, force_terminal=False)`` →
     formatter call → ``export_text()`` lives in one place. ``force_terminal``
     is fixed to ``False`` so the renderer doesn't pick up pytest's TTY
-    state (#265).
-
-    Extra keyword arguments are forwarded to ``formatter`` — used for
-    flag-gated rendering paths like ``show_negative_savings`` (#344).
+    state (#265). Extra keyword arguments are forwarded to ``formatter``.
     """
     console = Console(record=True, width=width, force_terminal=False)
     formatter(console, diag, verbose=verbose, **formatter_kwargs)

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -27,6 +27,7 @@ def render_section(
     *,
     verbose: bool = False,
     width: int = 120,
+    **formatter_kwargs: Any,
 ) -> str:
     """Run a CLI formatter against a recording ``Console`` and return text.
 
@@ -36,9 +37,12 @@ def render_section(
     formatter call → ``export_text()`` lives in one place. ``force_terminal``
     is fixed to ``False`` so the renderer doesn't pick up pytest's TTY
     state (#265).
+
+    Extra keyword arguments are forwarded to ``formatter`` — used for
+    flag-gated rendering paths like ``show_negative_savings`` (#344).
     """
     console = Console(record=True, width=width, force_terminal=False)
-    formatter(console, diag, verbose=verbose)
+    formatter(console, diag, verbose=verbose, **formatter_kwargs)
     return console.export_text()
 
 

--- a/tests/unit/cli/test_help.py
+++ b/tests/unit/cli/test_help.py
@@ -64,17 +64,13 @@ class TestHelp:
     def test_analyze_accepts_show_negative_savings_flag(
         self, runner: CliRunner, cli_app: typer.Typer,
     ) -> None:
-        """``--show-negative-savings`` is wired (#344). Click's CliRunner
-        truncates the rendered ``--help`` block past a certain option
-        count, so asserting on help-text presence is unreliable; instead,
-        invoke with a known-bad project and check the flag itself doesn't
-        produce a 'No such option' parse error before the project lookup
-        fails."""
+        # CliRunner truncates --help past a certain option count, so
+        # check the parser accepts the flag instead of asserting on the
+        # rendered help block.
         result = runner.invoke(
             cli_app,
             ["analyze", "--project", "__nonexistent__", "--show-negative-savings"],
         )
-        # Project not found, but the flag was accepted by the parser.
         assert "No such option" not in result.output
         assert "Unknown option" not in result.output
 

--- a/tests/unit/cli/test_help.py
+++ b/tests/unit/cli/test_help.py
@@ -61,6 +61,23 @@ class TestHelp:
         assert result.exit_code == 0
         assert "Examples" in result.stdout
 
+    def test_analyze_accepts_show_negative_savings_flag(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        """``--show-negative-savings`` is wired (#344). Click's CliRunner
+        truncates the rendered ``--help`` block past a certain option
+        count, so asserting on help-text presence is unreliable; instead,
+        invoke with a known-bad project and check the flag itself doesn't
+        produce a 'No such option' parse error before the project lookup
+        fails."""
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "__nonexistent__", "--show-negative-savings"],
+        )
+        # Project not found, but the flag was accepted by the parser.
+        assert "No such option" not in result.output
+        assert "Unknown option" not in result.output
+
     def test_analyze_help_documents_since_until(
         self, runner: CliRunner, cli_app: typer.Typer,
     ) -> None:

--- a/tests/unit/cli/test_offload_candidates_formatting.py
+++ b/tests/unit/cli/test_offload_candidates_formatting.py
@@ -109,6 +109,10 @@ class TestOffloadCandidatesSection:
         # yaml_draft preamble phrasing. The verbose cost_note ("cache
         # load-bearing...") lives in the --verbose YAML preamble, not
         # the compact table — duplicating would just bloat the row.
+        # Negative-savings rows are hidden by default since #344;
+        # opt in with ``show_negative_savings=True`` to exercise the
+        # legacy rendering path that still has to render correctly when
+        # the user explicitly asked for it.
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(
@@ -121,19 +125,20 @@ class TestOffloadCandidatesSection:
                 ),
             ],
         )
-        text = _render(diag)
+        text = _render(diag, show_negative_savings=True)
         # Sign flip in the savings cell — magnitude with a `+` prefix.
         assert "+$2.50" in text
         # Short warning in the Note column.
         assert OFFLOAD_COST_MORE_NOTE in text
         # The verbose cost_note appears ONLY in --verbose mode.
         assert "load-bearing" not in text
-        verbose_text = _render(diag, verbose=True)
+        verbose_text = _render(diag, verbose=True, show_negative_savings=True)
         assert "load-bearing" in verbose_text
 
     def test_sorts_by_savings_descending_negatives_at_bottom(self) -> None:
         # Architect Q2 verdict: biggest dollar wins first; negative-savings
-        # rows naturally sink to the bottom.
+        # rows naturally sink to the bottom — verified with
+        # ``show_negative_savings=True`` so all rows render.
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(name="middle-row", estimated_savings_usd=0.50),
@@ -141,7 +146,7 @@ class TestOffloadCandidatesSection:
                 _candidate(name="bottom-row", estimated_savings_usd=-1.00),
             ],
         )
-        text = _render(diag)
+        text = _render(diag, show_negative_savings=True)
         top_idx = text.index("top-row")
         mid_idx = text.index("middle-row")
         bot_idx = text.index("bottom-row")
@@ -158,6 +163,58 @@ class TestOffloadCandidatesSection:
         assert "parent-thread offload candidate" in text
         assert "claude-opus-4-7" in text  # parent model
         assert "claude-sonnet-4-6" in text  # alt model
+
+    def test_negative_savings_hidden_by_default(self) -> None:
+        """#344: a section named "Offload Candidates" full of "do not
+        offload" rows misleads at a glance, so negative-savings rows are
+        suppressed by default. Mixing positive + negative renders only
+        the positives."""
+        diag = DiagnosticsResult(
+            offload_candidates=[
+                _candidate(name="positive-row", estimated_savings_usd=2.00),
+                _candidate(name="negative-row", estimated_savings_usd=-1.50),
+            ],
+        )
+        text = _render(diag)
+        assert "positive-row" in text
+        assert "negative-row" not in text
+        assert "+$1.50" not in text  # the cost-MORE flip never renders
+        # No footnote when at least one positive row remains — the
+        # actionable content carries on its own.
+        assert "negative-savings rows hidden" not in text
+
+    def test_all_negative_renders_footnote(self) -> None:
+        """#344: when every candidate is anti-actionable, render a one-line
+        footnote pointing at the opt-in flag rather than silently empty
+        — keeps the diagnostic discoverable."""
+        diag = DiagnosticsResult(
+            offload_candidates=[
+                _candidate(name="anti-1", estimated_savings_usd=-3.40),
+                _candidate(name="anti-2", estimated_savings_usd=-1.10),
+                _candidate(name="anti-3", estimated_savings_usd=-0.50),
+            ],
+        )
+        text = _render(diag)
+        assert "Offload Candidates" in text
+        assert "3 negative-savings rows hidden" in text
+        assert "--show-negative-savings" in text
+        # Bodies of the rows should not appear.
+        for name in ("anti-1", "anti-2", "anti-3"):
+            assert name not in text
+
+    def test_show_negative_savings_passthrough_renders_all(self) -> None:
+        """#344: ``--show-negative-savings`` must include the negative rows
+        AND keep them sorted by savings descending (no new ordering)."""
+        diag = DiagnosticsResult(
+            offload_candidates=[
+                _candidate(name="positive-row", estimated_savings_usd=2.00),
+                _candidate(name="negative-row", estimated_savings_usd=-1.50),
+            ],
+        )
+        text = _render(diag, show_negative_savings=True)
+        pos_idx = text.index("positive-row")
+        neg_idx = text.index("negative-row")
+        assert pos_idx < neg_idx  # positives still sort above negatives
 
     def test_dedup_note_surfaces_in_compact_view(self) -> None:
         diag = DiagnosticsResult(

--- a/tests/unit/cli/test_offload_candidates_formatting.py
+++ b/tests/unit/cli/test_offload_candidates_formatting.py
@@ -104,15 +104,8 @@ class TestOffloadCandidatesSection:
         assert "8" in text  # cluster size
 
     def test_negative_savings_flips_sign_and_carries_warning(self) -> None:
-        # Architect Q1 verdict: render `+$X.XX` in red savings cell with
-        # the short `offload would cost MORE` note, matching the model's
-        # yaml_draft preamble phrasing. The verbose cost_note ("cache
-        # load-bearing...") lives in the --verbose YAML preamble, not
-        # the compact table — duplicating would just bloat the row.
         # Negative-savings rows are hidden by default since #344;
-        # opt in with ``show_negative_savings=True`` to exercise the
-        # legacy rendering path that still has to render correctly when
-        # the user explicitly asked for it.
+        # opt in to exercise the rendering path.
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(
@@ -136,9 +129,6 @@ class TestOffloadCandidatesSection:
         assert "load-bearing" in verbose_text
 
     def test_sorts_by_savings_descending_negatives_at_bottom(self) -> None:
-        # Architect Q2 verdict: biggest dollar wins first; negative-savings
-        # rows naturally sink to the bottom — verified with
-        # ``show_negative_savings=True`` so all rows render.
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(name="middle-row", estimated_savings_usd=0.50),
@@ -165,10 +155,6 @@ class TestOffloadCandidatesSection:
         assert "claude-sonnet-4-6" in text  # alt model
 
     def test_negative_savings_hidden_by_default(self) -> None:
-        """#344: a section named "Offload Candidates" full of "do not
-        offload" rows misleads at a glance, so negative-savings rows are
-        suppressed by default. Mixing positive + negative renders only
-        the positives."""
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(name="positive-row", estimated_savings_usd=2.00),
@@ -179,14 +165,12 @@ class TestOffloadCandidatesSection:
         assert "positive-row" in text
         assert "negative-row" not in text
         assert "+$1.50" not in text  # the cost-MORE flip never renders
-        # No footnote when at least one positive row remains — the
-        # actionable content carries on its own.
+        # Footnote suppressed when at least one positive row remains.
         assert "negative-savings rows hidden" not in text
 
     def test_all_negative_renders_footnote(self) -> None:
-        """#344: when every candidate is anti-actionable, render a one-line
-        footnote pointing at the opt-in flag rather than silently empty
-        — keeps the diagnostic discoverable."""
+        # When every candidate is anti-actionable, footnote points at
+        # the opt-in flag rather than rendering an empty section.
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(name="anti-1", estimated_savings_usd=-3.40),
@@ -198,13 +182,10 @@ class TestOffloadCandidatesSection:
         assert "Offload Candidates" in text
         assert "3 negative-savings rows hidden" in text
         assert "--show-negative-savings" in text
-        # Bodies of the rows should not appear.
         for name in ("anti-1", "anti-2", "anti-3"):
             assert name not in text
 
     def test_show_negative_savings_passthrough_renders_all(self) -> None:
-        """#344: ``--show-negative-savings`` must include the negative rows
-        AND keep them sorted by savings descending (no new ordering)."""
         diag = DiagnosticsResult(
             offload_candidates=[
                 _candidate(name="positive-row", estimated_savings_usd=2.00),

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -252,6 +252,65 @@ class TestGenerateDraft:
         draft = generate_draft(self._cluster(top_terms=[]))
         assert draft.name == "custom-agent"
 
+    def test_pure_numeric_terms_skipped_in_name(self) -> None:
+        """#345: pure-numeric tokens (issue/PR numbers) are accidental
+        identifiers, not reusable workflow terms — strip from the name
+        but keep raw in JSON ``top_terms`` so a consumer can still see
+        the unfiltered signal."""
+        draft = generate_draft(
+            self._cluster(top_terms=["272", "axis", "bash", "review"]),
+        )
+        assert draft.name == "axis-bash"
+        # JSON ``top_terms`` array stays raw — consumers can re-derive
+        # naming policy if they want a different one.
+        assert draft.top_terms == ["272", "axis", "bash", "review"]
+
+    def test_version_ref_terms_skipped_in_name(self) -> None:
+        """#345: version refs like ``v0`` and ``v0.6`` (post-slug ``v06``)
+        get stripped — they describe a one-off task that won't repeat,
+        not a reusable workflow pattern."""
+        draft = generate_draft(
+            self._cluster(top_terms=["v0", "v0.6", "diagnostics", "review"]),
+        )
+        assert draft.name == "diagnostics-review"
+
+    def test_sha_prefix_terms_skipped_in_name(self) -> None:
+        """#345: 7+ hex char tokens are likely SHA prefixes — accidental
+        commit references, not workflow descriptors."""
+        draft = generate_draft(
+            self._cluster(top_terms=["abcdef0", "deadbeef", "bash", "review"]),
+        )
+        assert draft.name == "bash-review"
+
+    def test_short_hex_words_not_stripped(self) -> None:
+        """#345: 6-char-or-shorter hex-shaped tokens (``cab``, ``add``,
+        ``bed``) are real words; only the SHA-shaped 7+ alternative
+        applies. Ensures the regex doesn't over-strip everyday English."""
+        draft = generate_draft(
+            self._cluster(top_terms=["add", "cab", "review"]),
+        )
+        assert draft.name == "add-cab"
+
+    def test_all_terms_stripped_falls_back_to_custom(self) -> None:
+        """#345: when every top-term is a stopword, the synthesizer
+        falls back to ``custom-agent`` rather than producing an empty
+        slug or a silently-misleading partial name."""
+        draft = generate_draft(
+            self._cluster(top_terms=["272", "v0", "deadbeef"]),
+        )
+        assert draft.name == "custom-agent"
+
+    def test_description_keeps_raw_top_terms(self) -> None:
+        """#345: the stopword filter applies *only* to the slug name.
+        Description is a verbose blob that absorbs the noise — stripping
+        there would drop information without helping readability."""
+        draft = generate_draft(
+            self._cluster(top_terms=["272", "axis", "bash"]),
+        )
+        # Description contains the raw first three terms.
+        assert "272" in draft.description
+        assert "axis" in draft.description
+
     def test_read_only_low_volume_recommends_haiku(self) -> None:
         # Read-only tools with observable low-volume token data → "simple"
         # tier → Haiku. Tokens stay under the 2k simple ceiling.

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -253,61 +253,44 @@ class TestGenerateDraft:
         assert draft.name == "custom-agent"
 
     def test_pure_numeric_terms_skipped_in_name(self) -> None:
-        """#345: pure-numeric tokens (issue/PR numbers) are accidental
-        identifiers, not reusable workflow terms — strip from the name
-        but keep raw in JSON ``top_terms`` so a consumer can still see
-        the unfiltered signal."""
         draft = generate_draft(
             self._cluster(top_terms=["272", "axis", "bash", "review"]),
         )
         assert draft.name == "axis-bash"
-        # JSON ``top_terms`` array stays raw — consumers can re-derive
+        # JSON ``top_terms`` stays raw so consumers can re-derive
         # naming policy if they want a different one.
         assert draft.top_terms == ["272", "axis", "bash", "review"]
 
     def test_version_ref_terms_skipped_in_name(self) -> None:
-        """#345: version refs like ``v0`` and ``v0.6`` (post-slug ``v06``)
-        get stripped — they describe a one-off task that won't repeat,
-        not a reusable workflow pattern."""
         draft = generate_draft(
             self._cluster(top_terms=["v0", "v0.6", "diagnostics", "review"]),
         )
         assert draft.name == "diagnostics-review"
 
     def test_sha_prefix_terms_skipped_in_name(self) -> None:
-        """#345: 7+ hex char tokens are likely SHA prefixes — accidental
-        commit references, not workflow descriptors."""
         draft = generate_draft(
             self._cluster(top_terms=["abcdef0", "deadbeef", "bash", "review"]),
         )
         assert draft.name == "bash-review"
 
     def test_short_hex_words_not_stripped(self) -> None:
-        """#345: 6-char-or-shorter hex-shaped tokens (``cab``, ``add``,
-        ``bed``) are real words; only the SHA-shaped 7+ alternative
-        applies. Ensures the regex doesn't over-strip everyday English."""
+        # Guard against the SHA-prefix regex over-stripping everyday
+        # English: ``add`` / ``cab`` are <7 chars so don't match.
         draft = generate_draft(
             self._cluster(top_terms=["add", "cab", "review"]),
         )
         assert draft.name == "add-cab"
 
     def test_all_terms_stripped_falls_back_to_custom(self) -> None:
-        """#345: when every top-term is a stopword, the synthesizer
-        falls back to ``custom-agent`` rather than producing an empty
-        slug or a silently-misleading partial name."""
         draft = generate_draft(
             self._cluster(top_terms=["272", "v0", "deadbeef"]),
         )
         assert draft.name == "custom-agent"
 
     def test_description_keeps_raw_top_terms(self) -> None:
-        """#345: the stopword filter applies *only* to the slug name.
-        Description is a verbose blob that absorbs the noise — stripping
-        there would drop information without helping readability."""
         draft = generate_draft(
             self._cluster(top_terms=["272", "axis", "bash"]),
         )
-        # Description contains the raw first three terms.
         assert "272" in draft.description
         assert "axis" in draft.description
 


### PR DESCRIPTION
## Summary
- Closes #344: `Offload Candidates` hides rows with `estimated_savings_usd <= 0` by default (those are "do not offload" patterns — informational, not actionable). New `--show-negative-savings` flag opts back in. JSON unchanged. Empty-positive case renders `"No offload candidates surfaced (N negative-savings rows hidden — pass --show-negative-savings to inspect)"` so the diagnostic stays discoverable.
- Closes #345: `synthesize_name` strips pure-numeric, version-ref (`v0`, `v06`), and 7+ hex-char SHA-prefix tokens from the slug used to name a delegation cluster. JSON `top_terms` and description / prompt scaffold stay raw. Real dogfood names like `axis-272` / `v0-199` now render as `axis-bash` / `diagnostics-review`.
- Architect-reviewed before implementation (comments on #344 + #345); flag named after the metric (not internal jargon), filter ordering locked to "after slug sanitization, before first-two selection," `top_terms` in JSON kept raw per the issue's open question.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1285 passed, 10 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `tests/unit/cli/test_offload_candidates_formatting.py` adds `test_negative_savings_hidden_by_default`, `test_all_negative_renders_footnote`, `test_show_negative_savings_passthrough_renders_all`; existing negative-savings tests now opt into the flag explicitly. `tests/unit/test_delegation.py` adds six tests for the stopword filter (pure-numeric, version-ref, SHA-prefix, short-hex non-stripped, all-stopword fallback, raw description preservation). `tests/unit/cli/test_help.py::test_analyze_accepts_show_negative_savings_flag` confirms the flag is wired (CliRunner truncates `--help` past a certain option count, so direct invocation is more reliable than help-text scraping).
- [x] Manual smoke test — verified on the agentfluent repo's own sessions: hidden case shows `"No offload candidates surfaced (2 negative-savings rows hidden ...)"`; `--show-negative-savings` reveals the rows; cluster names previously like `axis-272` / `v0-199` now render as `quality-comments` / `efficiency-cost`; raw JSON `top_terms` includes the unfiltered tokens (`["272", "axis", ...]` shape preserved when present in source data).

## Security review
- [x] **Skip review** — additive CLI flag and presentation-layer filtering. No new file/path/network surface, no user-controlled string interpolation (slug regex only matches `[a-z0-9-]` + structured patterns), no JSON parsing changes.

## Breaking changes
None for JSON consumers — `top_terms` array kept raw, `offload_candidates` list unchanged. Behavior change for table-only consumers: negative-savings rows hidden by default. The change is intentional UX (the v0.6 dogfood surfaced 10 anti-candidates labeled as "candidates" — misleading); `--show-negative-savings` restores the previous output for any user who depended on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)