### PR TITLE
docs(specs): add v0.7 PRD + backlog and log D029, D030

### DIFF
--- a/.claude/specs/backlog-v0.7.md
+++ b/.claude/specs/backlog-v0.7.md
@@ -1,0 +1,371 @@
+# AgentFluent v0.7 Backlog
+
+Ordered backlog for v0.7 (From Signals to Answers). Issues are sequenced by dependency chain, not by issue number.
+
+**Theme:** Trust what you see. Share what you find. Drill into what matters.
+
+**Milestone:** v0.7.0
+
+---
+
+## Triage Summary
+
+| Disposition | Count | Issues |
+|-------------|-------|--------|
+| Already shipped | 4 | #342, #344, #345, #347 |
+| In scope (open) | 13 | #343, #346, #353, #354, #355, #356, #357, #358, #359, #360, #352, #275, #326 |
+| Stretch | 1 | #275 |
+| Total in milestone | 18 | (including parent issues #198, #201, #349, #350, #351) |
+
+---
+
+## Already Shipped
+
+Four stories merged on 2026-05-09, before this backlog was drafted. No further work needed.
+
+### S1. #342 -- Propagate baseline/current window metadata into diff table + JSON
+
+**Status:** SHIPPED (PR #361, merged 2026-05-09)
+**Epic:** #349 (Diff hardening)
+**Summary:** Diff table shows `Baseline: <date range> (N sessions) | Current: ...` header. JSON carries `baseline_window` / `current_window`. Legacy envelopes render `(window not recorded, N sessions)`.
+
+---
+
+### S2. #347 -- Stamp + warn on diagnostics-version drift between baseline and current
+
+**Status:** SHIPPED (PR #361, merged 2026-05-09)
+**Epic:** #349 (Diff hardening)
+**Summary:** `analyze --json` envelopes carry `diagnostics_version`. Diff emits yellow warning when versions differ; dim "version unknown" when one side predates the field; silent when both unknown. Decision D034.
+
+---
+
+### S3. #344 -- Filter or relabel offload candidates with negative savings
+
+**Status:** SHIPPED (PR #363, merged 2026-05-09)
+**Epic:** #350 (Diagnostics presentation)
+**Summary:** Negative-savings rows hidden in CLI by default. `--show-negative-savings` flag opts back in. JSON unchanged. Empty-positive case renders informational footnote.
+
+---
+
+### S4. #345 -- Cluster auto-names: stopword filter for issue numbers / version refs
+
+**Status:** SHIPPED (PR #363, merged 2026-05-09)
+**Epic:** #350 (Diagnostics presentation)
+**Summary:** Stopword filter strips pure-numeric, version-ref (`v0`, `v06`), and 7+ hex-char SHA-prefix tokens from cluster slug names. `top_terms` in JSON kept raw.
+
+---
+
+## Stream A: Diff Hardening -- Epic #349
+
+One story remaining after PR #361 shipped #342 and #347.
+
+### A1. #343 -- Token Metrics by Model: deduplicate rows when (model, origin) pairs collide
+
+**Priority:** medium
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-diff-hardening`
+**Sizing:** S (1-2 days)
+**Dependencies:** None
+**Status:** IN SCOPE
+
+**Summary:** Diff table shows visually identical model rows when `(model, origin)` pairs exist for the same model (e.g., `claude-opus-4-7` appearing twice: once for parent, once for subagent). Add `Origin` column between Model and Baseline cost. Table key matches `analyze` JSON's `(model, origin)` natural key.
+
+**Acceptance criteria:**
+- Diff table no longer shows visually-duplicate model rows
+- `Origin` column visible in table output
+- Table key matches `(model, origin)` from analyze JSON
+
+**Blocks:** Nothing
+
+---
+
+## Stream B: Diagnostics Presentation -- Epic #350
+
+One story remaining after PR #363 shipped #344 and #345.
+
+### B1. #346 -- Detect 'agent defined but never delegated to' (unused agent)
+
+**Priority:** medium
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-diagnostics-presentation`
+**Sizing:** M (2-3 days)
+**Dependencies:** None
+**Status:** IN SCOPE
+
+**Summary:** New `unused_agent` diagnostic signal. Fires when a custom agent is present in config-scanner output but has zero invocations in `agent_metrics.by_agent_type` over the analyzed window. Severity: `info`. Recommendation includes the agent's current `description` and remediation suggestions (rewrite description, check delegation triggers, accept it's unused). Built-in agents (Explore, Plan, general-purpose) silently excluded per D033.
+
+**Key considerations:**
+- Cross-references config scanner output with agent metrics -- needs both data sources available
+- Partial-window confound acknowledged in message for recently added agents
+- `agentfluent explain unused_agent` output required
+- Unit test with fixture where one custom agent has invocations and another doesn't
+
+**Blocks:** Nothing
+
+---
+
+## Stream C: Output Scope + Shareability -- Epic #351
+
+The largest stream. Two independent sub-epics: Markdown report (#198) and per-session diagnostics (#201). The user wants the report command implemented first.
+
+### Sub-epic: Markdown Report (#198)
+
+Dependency chain: #353 -> #354 -> #355 + #356 (parallel).
+
+### C1. #353 -- `agentfluent report` command skeleton + JSON ingestion
+
+**Priority:** high (user wants this first)
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-output-shareability`
+**Sizing:** S-M (2-3 days)
+**Dependencies:** None
+**Status:** IN SCOPE
+
+**Summary:** Create the `agentfluent report` subcommand. New `cli/report_cmd.py` module with Typer command. Accepts positional argument (path to `analyze --json` output file). Optional `--output` flag for file output (default: stdout). Loads and validates the JSON envelope (required fields: `data`, `metadata`). Section renderers are stubs in this story. Decision D031.
+
+**Acceptance criteria:**
+- `agentfluent report snap.json` produces Markdown output to stdout
+- `agentfluent report snap.json --output report.md` writes to file
+- Invalid JSON / missing file / wrong envelope format produce clear error messages
+- `agentfluent report --help` shows usage with examples
+- Composable: `analyze --json > snap.json && report snap.json` works end-to-end
+- Unit tests: valid ingestion, missing file, invalid JSON, wrong envelope
+
+**Blocks:** #354
+
+---
+
+### C2. #354 -- Section renderers: token/cost, agent table, diagnostics, offload
+
+**Priority:** high
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-output-shareability`
+**Sizing:** M (3-4 days)
+**Dependencies:** #353 (command skeleton)
+**Status:** IN SCOPE
+
+**Summary:** Implement Markdown section renderers. Each renderer is a standalone function: `render_summary(data) -> str`, `render_token_metrics(data) -> str`, etc. Sections: header/summary, token/cost metrics (table), agent metrics (table), diagnostics/recommendations (severity-grouped), offload candidates (if present), footer (reproduction command + timestamp).
+
+**Key considerations:**
+- Tables must render correctly in GitHub Markdown preview
+- Empty sections produce "No findings" note, not empty output
+- Axis labels appear on recommendations (`[cost]`, `[speed]`, `[quality]`)
+- Use string formatting, not a template engine (minimal dependencies)
+- Each renderer is independently testable
+
+**Blocks:** #355, #356
+
+---
+
+### C3. #355 -- Tests + golden Markdown fixture
+
+**Priority:** medium
+**Labels:** `testing`, `epic:v07-output-shareability`
+**Sizing:** S-M (1-2 days)
+**Dependencies:** #354 (renderers must exist)
+**Status:** IN SCOPE
+
+**Summary:** Comprehensive test coverage for `agentfluent report`. Golden Markdown fixture in `tests/fixtures/` for snapshot testing. Unit tests per renderer with edge cases (empty diagnostics, zero agents, single session). Integration test: end-to-end `analyze --json | report` pipeline. Backward compatibility test: report handles analyze JSON from v0.6 gracefully.
+
+**Blocks:** Nothing
+
+---
+
+### C4. #356 -- docs: report command GLOSSARY entry + README update + CLI help
+
+**Priority:** low
+**Labels:** `documentation`, `epic:v07-output-shareability`
+**Sizing:** S (1 day)
+**Dependencies:** #354 (docs describe what shipped)
+**Status:** IN SCOPE
+
+**Summary:** GLOSSARY entry for `report` subcommand. README: command overview table + workflow example (`analyze --json > snap.json && report snap.json > report.md`). CLI help epilog with common invocations. No references to the rejected `analyze --format markdown` approach.
+
+**Blocks:** Nothing
+
+---
+
+### Sub-epic: Per-Session Diagnostics Scope (#201)
+
+Dependency chain: #357 -> #358 -> #359 + #360 (parallel).
+
+### C5. #357 -- Plumb `--session` through to diagnostics aggregator
+
+**Priority:** medium
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-output-shareability`
+**Sizing:** M (2-3 days)
+**Dependencies:** None
+**Status:** IN SCOPE
+
+**Summary:** When `--session <uuid>` is provided, restrict the diagnostics aggregation to that session's invocations only. The change is in how the session list is constructed for the aggregation pass, not in per-session signal extraction. The simplest approach: filter the session list before it reaches `run_diagnostics()`. Decision D032.
+
+**Acceptance criteria:**
+- Token/cost metrics scoped to named session (existing, verify preserved)
+- Diagnostics signals extracted only from named session
+- Aggregated recommendations reflect only that session's signals
+- Offload candidates scoped to named session
+- Quality signals (USER_CORRECTION, FILE_REWORK, REVIEWER_CAUGHT) scoped
+- JSON `data.diagnostics_result` reflects single-session scope
+- Session UUID appears in output metadata
+- Without `--session`, behavior unchanged (all sessions aggregated)
+
+**Blocks:** #358
+
+---
+
+### C6. #358 -- Update CLI to flow `--session` semantics consistently
+
+**Priority:** medium
+**Labels:** `enhancement`, `priority:medium`, `epic:v07-output-shareability`
+**Sizing:** S-M (1-2 days)
+**Dependencies:** #357 (pipeline plumbing)
+**Status:** IN SCOPE
+
+**Summary:** CLI output consistently reflects per-session scope. Table header shows "Session: <uuid>" not "Project: P (N sessions)". JSON envelope `metadata` includes `session` field. Flag interactions: `--session` + `--since`/`--until` errors (mutually exclusive per D024); `--session` + `--latest N` errors.
+
+**Blocks:** #359, #360
+
+---
+
+### C7. #359 -- Tests for single-session and full-window cases
+
+**Priority:** medium
+**Labels:** `testing`, `epic:v07-output-shareability`
+**Sizing:** S-M (1-2 days)
+**Dependencies:** #357, #358
+**Status:** IN SCOPE
+
+**Summary:** Test coverage for per-session diagnostics scope. Key assertion: run diagnostics on all sessions, run on single session, verify single-session output is a subset. Multi-session fixture where sessions have different diagnostics profiles. Edge case: single session with no findings produces empty result, not error.
+
+**Blocks:** Nothing
+
+---
+
+### C8. #360 -- CHANGELOG breaking-change note for --session diagnostics auto-scope
+
+**Priority:** low
+**Labels:** `documentation`, `epic:v07-output-shareability`
+**Sizing:** XS (<1 day)
+**Dependencies:** #357 or #358 (document alongside implementation)
+**Status:** IN SCOPE
+
+**Summary:** CHANGELOG entry with `BREAKING CHANGE:` notation. Explains: old behavior (diagnostics rolled up all sessions even with `--session`), new behavior (diagnostics auto-scoped), rationale (consistency with metrics scope). References D032.
+
+**Blocks:** Nothing
+
+---
+
+## Stream D: Research
+
+### D1. #352 -- Tier 3 GitHub enrichment scoping spike
+
+**Priority:** medium
+**Labels:** `enhancement`
+**Sizing:** M (2-3 days)
+**Dependencies:** None
+**Status:** IN SCOPE
+
+**Summary:** Time-boxed design spike producing `.claude/specs/prd-tier3-github-enrichment.md`. Covers: auth model (`gh` CLI vs MCP vs PAT), optional dependency strategy, rate-limit/caching, signal selection and prioritization, privacy model. No implementation code. Acceptance criteria prohibit code artifacts.
+
+**Key constraint:** Bounded to 2-3 dev days. The deliverable is a design document actionable enough that a developer starting v0.8 can begin implementation without additional design conversations.
+
+**Blocks:** v0.8 Tier 3 implementation (not v0.7 work)
+
+---
+
+## Stream E: Docs
+
+### E1. #326 -- docs: catch up README + GLOSSARY + CHANGELOG for v0.7.0
+
+**Priority:** required-for-release
+**Labels:** `documentation`, `enhancement`, `priority:medium`
+**Sizing:** M (2-3 days)
+**Dependencies:** All feature work complete (docs reflect what shipped)
+**Status:** IN SCOPE
+
+**Summary:** Update README (roadmap, command table, sample output, JSON example, screenshots), GLOSSARY (new terms: `report`, `unused_agent`, per-session scope), CHANGELOG (prose expansion beyond release-please auto-entries). Verify `.claude/specs/` PRDs reflect what shipped. Append decision log entries for scope changes during implementation.
+
+---
+
+## Stretch Scope
+
+### S1. #275 -- Local git feat-then-fix proximity signal (Tier 2)
+
+**Priority:** low (within stretch)
+**Labels:** `enhancement`, `priority:low`
+**Sizing:** M (2-3 days)
+**Dependencies:** None for implementation; conceptually builds on Tier 1 quality signals (shipped in v0.6)
+**Status:** STRETCH
+
+**Summary:** Detect `feat:` commit followed by `fix:` on same files within N days using `git log` subprocess. Correlate to session review-agent usage. New `SignalType.FEAT_FIX_PROXIMITY`. Gated behind `--git` flag. Deferred from v0.6 per D028.
+
+**Why stretch:** Introduces a new data source (git subprocess), a new CLI flag, and heuristic timestamp linkage. Risk surface unlike anything else in v0.7. Natural companion to v0.8 Tier 3 work.
+
+---
+
+## Implementation Priority Order
+
+### Wave 1 -- Report command skeleton (start immediately)
+
+The user has signaled the report command is the next implementation target.
+
+1. **#353** -- Report command skeleton + JSON ingestion (S-M, no deps, entry point)
+
+### Wave 2 -- Report renderers + parallel independents (days 3-8)
+
+2. **#354** -- Section renderers (M, depends on #353)
+3. **#343** -- Diff model row deduplication (S, independent, can parallel)
+4. **#346** -- Unused agent signal (M, independent, can parallel)
+
+### Wave 3 -- Report validation + per-session scope (days 7-14)
+
+5. **#355** -- Report tests + golden fixture (S-M, depends on #354)
+6. **#356** -- Report docs (S, depends on #354)
+7. **#357** -- `--session` diagnostics plumbing (M, independent of report)
+8. **#358** -- CLI `--session` semantics (S-M, depends on #357)
+
+### Wave 4 -- Per-session validation + research (days 12-18)
+
+9. **#359** -- Per-session tests (S-M, depends on #357, #358)
+10. **#360** -- CHANGELOG breaking-change note (XS, depends on #357 or #358)
+11. **#352** -- Tier 3 design spike (M, independent, time-boxed)
+
+### Wave 5 -- Stretch (if time allows)
+
+12. **#275** -- Git feat-fix proximity (M, independent)
+
+### Wave 6 -- Release prep (days 18-24)
+
+13. **#326** -- Docs catch-up (M, depends on all features being final)
+14. Dogfood validation runs (report + per-session scope)
+15. Release prep (changelog, version bump, CI green)
+
+---
+
+## Ordered Backlog (flat view)
+
+| Order | # | Title | In/Out | Priority | Deps | Stream |
+|-------|---|-------|--------|----------|------|--------|
+| -- | #342 | Window metadata in diff | SHIPPED | -- | -- | A |
+| -- | #347 | Diagnostics-version drift | SHIPPED | -- | -- | A |
+| -- | #344 | Negative-savings filter | SHIPPED | -- | -- | B |
+| -- | #345 | Cluster-name stopwords | SHIPPED | -- | -- | B |
+| 1 | #353 | Report command skeleton | IN | high | none | C |
+| 2 | #354 | Report section renderers | IN | high | #353 | C |
+| 3 | #343 | Diff model deduplication | IN | medium | none | A |
+| 4 | #346 | Unused agent signal | IN | medium | none | B |
+| 5 | #355 | Report tests + golden fixture | IN | medium | #354 | C |
+| 6 | #356 | Report docs | IN | low | #354 | C |
+| 7 | #357 | --session diagnostics plumbing | IN | medium | none | C |
+| 8 | #358 | CLI --session semantics | IN | medium | #357 | C |
+| 9 | #359 | Per-session tests | IN | medium | #357, #358 | C |
+| 10 | #360 | CHANGELOG breaking-change note | IN | low | #357 | C |
+| 11 | #352 | Tier 3 design spike | IN | medium | none | D |
+| 12 | #275 | Git feat-fix proximity | STRETCH | low | none | -- |
+| 13 | #326 | Docs catch-up | IN | required | all features | E |
+
+---
+
+## Estimated Total
+
+**Must-include (remaining): 13 open issues, ~18-24 dev days (3-4 weeks)**
+**Already shipped: 4 issues (via PRs #361, #363)**
+**With stretch: +1 issue, ~2-3 additional dev days**
+
+The three epic streams (diff hardening, diagnostics presentation, output shareability) are fully independent. The report sub-epic and per-session sub-epic within Stream C are also independent. A solo developer can interleave: start with report skeleton (#353), then parallelize #354 with #343/#346, then shift to per-session scope while report tests/docs settle.

--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -537,3 +537,45 @@ primary_axis = max(AXIS_TIEBREAKER, key=lambda a: axis_scores[a])
 **Reference:** PM scope decision comment on #275 (issuecomment-4403479791).
 
 ---
+
+## D029: `--session` semantics breaking change — communicate via CHANGELOG, keep minor bump
+
+**Date:** 2026-05-09
+**Context:** D032 (in epic #351 body) changed `--session <uuid>` to auto-scope diagnostics, not just token/cost metrics. The same command (`analyze --session <uuid> --diagnostics`) now produces different output in v0.7 than v0.6: diagnostics aggregate over the named session only, instead of rolling up the entire window. This is a semantics-level breaking change that needs an explicit communication strategy. Surfaced as OQ1 in `prd-v0.7.md`.
+
+**Options considered:**
+- A) Conventional Commit `feat!:` to trigger a major version bump via release-please. Rejected on the grounds that 0.x explicitly reserves majors for 1.0.
+- B) Document under `BREAKING CHANGE:` in CHANGELOG, keep as a 0.7.0 minor bump.
+- C) Deprecation period: v0.7 keeps v0.6 behavior + emits a deprecation warning when `--session` is used without an explicit scope flag; v0.8 flips the default.
+
+**Decision:** Option B. Document the behavior change in CHANGELOG with `BREAKING CHANGE:` notation and a clear before/after example. Keep release-please's minor bump (0.7.0). Tracked by issue #360.
+
+**Rationale:**
+- The 0.x series leading zero already signals "expect breaking changes." A pre-1.0 deprecation period adds friction without buying meaningful safety, since AgentFluent has no external API consumers locked to v0.6 semantics.
+- The change makes `--session` consistent with how token/cost metrics already scope. The current rollup-with-session-flag behavior is a latent bug, not a feature anyone depends on.
+- Option C carries real cost: a temporary scope-disambiguation flag in v0.7 that gets removed in v0.8, plus the warning machinery and tests. Not worth it for a 0.x change.
+
+**Reference:** `prd-v0.7.md` §5 OQ1; epic #351 body (D032).
+
+---
+
+## D030: `agentfluent report` section ordering — metrics first, then diagnostics
+
+**Date:** 2026-05-09
+**Context:** Issue #354 specifies the section renderers for the new `agentfluent report` Markdown output (epic #351). The proposed order is summary → token metrics → agent metrics → diagnostics → offload → footer. An alternative is to lead with diagnostics (the actionable content) and place metrics after as supporting evidence. Surfaced as OQ2 in `prd-v0.7.md`.
+
+**Options considered:**
+- A) Metrics first, then diagnostics. Mirrors the `analyze` table order.
+- B) Diagnostics first, then metrics. Leads with actionable findings.
+
+**Decision:** Option A. Section order: Summary → Token Metrics → Agent Metrics → Diagnostics → Offload → Footer.
+
+**Rationale:**
+- Matches the `analyze` table order users already know, so a Markdown report reads as a faithful rendering of the same content rather than a re-ordered view.
+- Grounds the reader in the data before they encounter recommendations. The diagnostics section's findings reference metric values; reading metrics first means those references resolve immediately.
+- Diagnostics are not buried — the summary at the top can surface headline findings if needed without requiring the full diagnostics section to lead.
+- Reviewers who skim from the top of a PR comment get the headline summary first either way; the metrics-vs-diagnostics ordering matters more for full-document reads where the analyze-parity argument wins.
+
+**Reference:** `prd-v0.7.md` §5 OQ2; epic #351 body; issue #354.
+
+---

--- a/.claude/specs/prd-v0.7.md
+++ b/.claude/specs/prd-v0.7.md
@@ -1,0 +1,253 @@
+# PRD: AgentFluent v0.7 -- From Signals to Answers
+
+**Status:** Draft
+**Date:** 2026-05-09
+**Author:** PM Agent
+**Decision log:** See `decisions.md` D028-D034 for scoping and design decisions.
+**Backlog:** See `backlog-v0.7.md` for the full sequenced backlog.
+
+---
+
+## 1. Theme
+
+**"From signals to answers."**
+
+v0.6 completed the analytical core: three diagnostics axes (cost, speed, quality), temporal filtering, and before/after comparison via `diff`. AgentFluent now detects what to change. But the output stays trapped in a terminal session -- there is no way to share findings in a PR comment, archive them in CI, or drill into a single session for post-mortem. And trust issues surfaced during v0.6 dogfood show that `diff` output is not yet self-documenting enough for production use.
+
+v0.7 closes three gaps:
+
+1. **Diff hardening for production trust.** Diff output becomes self-documenting: window context shows what time ranges were compared, duplicate model rows are eliminated, and a version-drift warning prevents silent conflation of detector-sensitivity changes with real behavior changes. CI consumers and humans reading archived diffs can trust what they see.
+
+2. **Diagnostics presentation and config effectiveness.** Anti-recommendations (negative-savings offload candidates) are filtered from display, cluster auto-names strip noise tokens, and a new `unused_agent` signal detects custom agents that are defined but never delegated to -- the first config-effectiveness diagnostic that bridges the gap between "what is configured" and "what actually runs."
+
+3. **Output scope and shareability.** Two long-deferred features land together: `agentfluent report` produces structured Markdown from any `analyze --json` snapshot (shareable in PRs, Slack, archives), and `--session <uuid>` auto-scopes diagnostics to that session (enabling single-session post-mortems without noise from unrelated sessions).
+
+A design spike for Tier 3 GitHub enrichment prepares the ground for v0.8 without adding implementation risk to v0.7.
+
+One-line pitch: **"Trust what you see. Share what you find. Drill into what matters."**
+
+### Why this theme
+
+The alternative was to continue adding detection capability (Tier 2 git signals, Tier 3 GitHub enrichment). That path was rejected because:
+
+1. **Output trust gaps are blocking adoption.** The v0.6 dogfood surfaced concrete trust failures: duplicate rows, missing context, anti-recommendations displayed as recommendations. These erode confidence in the tool before any new detection capability matters.
+
+2. **Shareability unlocks a new user loop.** Until v0.7, AgentFluent output is a terminal-only experience. `report` makes findings portable -- a developer can run `analyze`, generate a Markdown report, and attach it to a PR. This is the minimal surface for team adoption beyond a single user.
+
+3. **Per-session scope is the #1 usability request.** The original codefluent CLI review ranked both `report` (#198) and per-session diagnostics (#201) as P1. Both have been deferred through v0.4, v0.5, and v0.6 while the output format stabilized. No remaining blockers.
+
+4. **Detection expansion (Tier 2/3) benefits from a stable output layer.** `report` needs a settled JSON envelope. Per-session scope needs stable pipeline plumbing. Shipping both now means Tier 2/3 signals land on a surface that already handles sharing and scoping correctly.
+
+## 2. Goals
+
+1. **Make diff output production-ready** with self-documenting window context, deduplicated model rows, and version-drift warnings (#342, #343, #347 -- two already shipped)
+2. **Clean up diagnostics presentation** by filtering anti-recommendations and stripping noise from cluster names (#344, #345 -- both already shipped)
+3. **Ship the first config-effectiveness signal** detecting unused custom agents (#346)
+4. **Ship `agentfluent report`** as a composable subcommand producing structured Markdown (#353, #354, #355, #356)
+5. **Auto-scope diagnostics to `--session`** for single-session post-mortems (#357, #358, #359, #360)
+6. **Scope Tier 3 GitHub enrichment** via a time-boxed design spike (#352)
+7. **Ship docs that reflect what shipped** (#326)
+
+## 3. Non-Goals
+
+- LLM-powered analysis (stays rule-based)
+- Auto-applying recommended fixes
+- Webapp dashboard
+- Cross-project aggregation
+- Tier 2 git signals (FEAT_FIX_PROXIMITY) -- deferred per D028; stretch scope only
+- Tier 3 GitHub enrichment implementation -- spike only, implementation deferred to v0.8
+- `report` for `diff` output -- v0.7 `report` handles `analyze` snapshots; diff-report is a future extension
+- `--strict` mode for diagnostics-version drift -- D034 says warn-only for now
+- Negative recommendations ("remove this subagent") -- deferred per D020
+
+## 4. In Scope (Must-Include) -- 18 issues
+
+### Already Shipped in v0.7
+
+Two PRs merged on 2026-05-09 before the PRD was drafted. They are part of v0.7's scope but require no further implementation work.
+
+| # | Title | Epic | What shipped |
+|---|-------|------|--------------|
+| #342 | Propagate baseline/current window metadata into diff table + JSON | #349 | Window context header on diff table; `baseline_window` / `current_window` in JSON |
+| #347 | Stamp + warn on diagnostics-version drift between baseline and current | #349 | `diagnostics_version` in analyze JSON envelope; yellow drift warning in diff output |
+| #344 | Filter or relabel offload candidates with negative savings | #350 | Negative-savings rows hidden in CLI; `--show-negative-savings` flag; JSON unchanged |
+| #345 | Cluster auto-names: stopword filter for issue numbers / version refs | #350 | Stopword filter strips pure-numeric, version-ref, SHA-prefix tokens from cluster slugs |
+
+PR #361 closed #342 and #347. PR #363 closed #344 and #345.
+
+### Epic 1: Diff Hardening for Production Trust -- #349
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #342 | Propagate window metadata into diff table + JSON | S | SHIPPED (PR #361) |
+| #343 | Token Metrics by Model: deduplicate rows when (model, origin) pairs collide | S | Open |
+| #347 | Stamp + warn on diagnostics-version drift | S-M | SHIPPED (PR #361) |
+
+**Remaining work:** #343 only. Add `Origin` column to diff Token Metrics by Model table to eliminate visually duplicate rows.
+
+### Epic 2: Diagnostics Presentation + Config Effectiveness -- #350
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #344 | Filter negative-savings offload candidates from CLI | S | SHIPPED (PR #363) |
+| #345 | Cluster auto-names: stopword filter | XS-S | SHIPPED (PR #363) |
+| #346 | Detect 'agent defined but never delegated to' (unused agent) | M | Open |
+
+**Remaining work:** #346 only. New `unused_agent` diagnostic signal. Built-in agents excluded per D033.
+
+### Epic 3: Output Scope + Shareability -- #351
+
+#### Sub-epic: Markdown Report (#198)
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #353 | `agentfluent report` command skeleton + JSON ingestion | S-M | Open |
+| #354 | Section renderers: token/cost, agent table, diagnostics, offload | M | Open |
+| #355 | Tests + golden Markdown fixture | S-M | Open |
+| #356 | docs: GLOSSARY entry + README update + CLI help | S | Open |
+
+Decision D031: `report` is a new subcommand (composable: `analyze --json > snap.json && report snap.json > report.md`), not `analyze --format markdown`.
+
+#### Sub-epic: Per-Session Diagnostics Scope (#201)
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #357 | Plumb `--session` through to diagnostics aggregator | M | Open |
+| #358 | Update CLI to flow `--session` semantics consistently | S-M | Open |
+| #359 | Tests for single-session and full-window cases | S-M | Open |
+| #360 | CHANGELOG breaking-change note | XS | Open |
+
+Decision D032: `--session <uuid>` auto-scopes diagnostics. **Behavior change from v0.6** -- in v0.6, `--session` scoped token/cost metrics but diagnostics rolled up all sessions. In v0.7, diagnostics respect the session scope.
+
+### Research
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #352 | Tier 3 GitHub enrichment scoping spike | M (2-3 days) | Open |
+
+Design-only deliverable: `.claude/specs/prd-tier3-github-enrichment.md` covering auth model, optional dependency strategy, rate-limit/caching, signal selection, and privacy model. No implementation code. Gates v0.8.
+
+### Docs
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #326 | docs: catch up README + GLOSSARY + CHANGELOG for v0.7.0 | M | Open |
+
+Auto-created by the docs workflow when the v0.7.0 milestone was opened.
+
+### Stretch
+
+| # | Title | Effort | Status |
+|---|-------|--------|--------|
+| #275 | Local git feat-then-fix proximity signal (Tier 2) | M (2-3 days) | Open |
+
+Deferred from v0.6 per D028. Introduces a new data source (git subprocess). Pull in only if all must-include scope completes ahead of schedule. Gated behind `--git` flag.
+
+**Total in-scope: 18 issues (4 shipped, 14 open), ~18-24 dev days remaining**
+
+## 5. Open Questions / Decisions Needed
+
+### ~~OQ1~~ — Resolved as D029: `--session` breaking change → CHANGELOG + minor bump
+
+The `--session` behavior change (D032) is a semantics-level breaking change. **Resolved 2026-05-09:** Document under `BREAKING CHANGE:` in CHANGELOG, keep release-please's minor bump (0.7.0). Tracked by #360. Rejected: `feat!:` major bump (0.x reserves majors for 1.0); deprecation period (added complexity without benefit pre-1.0). See `decisions.md` D029.
+
+### ~~OQ2~~ — Resolved as D030: report section ordering → metrics first
+
+**Resolved 2026-05-09:** Section order is Summary → Token Metrics → Agent Metrics → Diagnostics → Offload → Footer. Mirrors the `analyze` table order; grounds readers in data before recommendations resolve metric references. See `decisions.md` D030.
+
+### OQ3: Should `report` handle `diff` JSON in addition to `analyze` JSON?
+
+The current scope (D031) explicitly limits `report` to `analyze --json` snapshots. A natural follow-up is `report diff.json` producing a Markdown diff report. This is NOT in v0.7 scope but should be flagged so the report architecture does not foreclose it.
+
+**Recommendation:** Defer to v0.8. Ensure the report skeleton has an extensible dispatch pattern (envelope type detection) so adding diff-report is additive. No action needed now beyond noting it in the PRD.
+
+## 6. Decisions Made (Referenced)
+
+| ID | Summary | Date | Reference |
+|----|---------|------|-----------|
+| D028 | FEAT_FIX_PROXIMITY deferred from v0.6 to v0.7 stretch | 2026-05-08 | `decisions.md` |
+| D029 | `--session` breaking change communicated via CHANGELOG, minor bump | 2026-05-09 | `decisions.md` |
+| D030 | `report` section ordering: metrics first, then diagnostics | 2026-05-09 | `decisions.md` |
+| D031 | `report` is a new subcommand, not `--format markdown` | 2026-05-09 | #351 body |
+| D032 | `--session` auto-scopes diagnostics (behavior change) | 2026-05-09 | #351 body |
+| D033 | Built-in agents excluded from unused-agent signal | 2026-05-09 | #350 body |
+| D034 | Diagnostics-version drift is warn-only (no `--strict`) | 2026-05-09 | #349 body |
+
+## 7. Dependencies
+
+```
+SHIPPED:
+[#342 window metadata] ──> DONE (PR #361)
+[#347 version drift]   ──> DONE (PR #361)
+[#344 negative-savings] ─> DONE (PR #363)
+[#345 stopword filter]  ─> DONE (PR #363)
+
+REMAINING:
+[#343 deduplicate model rows] -- independent (last #349 story)
+
+[#346 unused_agent signal] -- independent (last #350 story)
+
+[#353 report skeleton] ──> [#354 section renderers] ──> [#355 tests + golden fixture]
+                                                    └──> [#356 docs]
+
+[#357 --session pipeline] ──> [#358 CLI semantics] ──> [#359 tests]
+                                                   └──> [#360 CHANGELOG note]
+
+[#352 Tier 3 spike] -- independent
+
+[#326 docs catch-up] -- last (reflects what shipped)
+
+[#275 git feat-fix] -- STRETCH (no deps on must-include work)
+```
+
+### Cross-epic independence
+
+The three epics and the research spike have zero cross-dependencies. They can be implemented in any order. The user has signaled that the report command (epic #351) should start first.
+
+## 8. Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `report` Markdown format is hard to get right for all GitHub/Slack renderers | Report looks broken in target environments; users lose trust in the feature | Test against GitHub Markdown preview specifically (#355 golden fixture). Use simple tables, no HTML. Iterate on format in v0.7.x patches. |
+| Per-session scope breaks existing scripts that relied on project-level diagnostics with `--session` | CI pipelines produce different output after upgrade | CHANGELOG breaking-change note (#360). The 0.x version posture permits this. The old behavior was inconsistent (metrics scoped, diagnostics not), so the "breakage" is a bug fix. |
+| `unused_agent` signal has high false-positive rate for new agents | Users dismiss config-effectiveness signals | Conservative approach: severity `info` not `warning`. Message acknowledges partial-window confound. Built-in agents excluded (D033). |
+| Tier 3 spike scope creeps into implementation | Research consumes implementation time | Spike is explicitly time-boxed (2-3 days) with a design-document deliverable. Acceptance criteria prohibit implementation code. |
+| #275 stretch scope is never pulled in | Tier 2 quality signal remains unshipped | Acceptable. Tier 1 signals (shipped in v0.6) cover the under-recommendation gap. #275 adds confirming evidence but is not needed for the product goal. Natural fit for v0.8 alongside Tier 3 implementation. |
+
+## 9. Success Criteria
+
+v0.7 is successful when:
+
+1. **Diff output is self-documenting.** `agentfluent diff baseline.json current.json` shows window context, has no visually duplicate model rows, and warns when diagnostics versions differ. A CI consumer reading the diff artifact can understand what was compared without re-running commands.
+2. **Diagnostics presentation is clean.** No negative-savings candidates appear as recommendations. Cluster auto-names describe behavior patterns, not issue numbers. The `unused_agent` signal fires when a custom agent is defined but never delegated to in the analyzed window.
+3. **`agentfluent report snap.json` produces well-formed Markdown.** The output is readable as a standalone document, renders correctly in GitHub Markdown preview, and includes all analyze sections (summary, token metrics, agent metrics, diagnostics, offload candidates, footer with reproduction command).
+4. **`--session <uuid>` auto-scopes diagnostics.** Token/cost metrics AND diagnostics are both restricted to the named session. Recommendations reflect only that session's signals. JSON output includes session metadata.
+5. **The Tier 3 spike is complete.** A design document exists at `.claude/specs/prd-tier3-github-enrichment.md` covering auth, dependencies, rate limits, signal selection, and privacy. A developer starting v0.8 can begin implementation without additional design conversations.
+6. **All new code has >80% test coverage.** No regressions.
+7. **Docs reflect what shipped.** README, GLOSSARY, CHANGELOG all updated (#326).
+
+## 10. Release Checklist
+
+- [x] #342 merged: window metadata in diff table + JSON (PR #361)
+- [x] #347 merged: diagnostics-version stamp + drift warning (PR #361)
+- [x] #344 merged: negative-savings offload candidates hidden (PR #363)
+- [x] #345 merged: cluster auto-name stopword filter (PR #363)
+- [ ] #343 merged: Token Metrics by Model deduplicated with Origin column
+- [ ] #346 merged: `unused_agent` diagnostic signal
+- [ ] #353 merged: `agentfluent report` command skeleton + JSON ingestion
+- [ ] #354 merged: report section renderers
+- [ ] #355 merged: report tests + golden Markdown fixture
+- [ ] #356 merged: report docs (GLOSSARY, README, CLI help)
+- [ ] #357 merged: `--session` plumbed through diagnostics aggregator
+- [ ] #358 merged: CLI `--session` semantics updated
+- [ ] #359 merged: per-session scope tests
+- [ ] #360 merged: CHANGELOG breaking-change note for `--session`
+- [ ] #352 merged: Tier 3 GitHub enrichment design spike
+- [ ] #326 merged: docs catch-up (README, GLOSSARY, CHANGELOG)
+- [ ] Dogfood run: `agentfluent analyze --project agentfluent --json > snap.json && agentfluent report snap.json` produces clean Markdown
+- [ ] Dogfood run: `agentfluent analyze --project agentfluent --session <uuid> --diagnostics` shows session-scoped results
+- [ ] `uv run pytest --cov=agentfluent` passes with >80% coverage
+- [ ] `uv run ruff check src/` clean
+- [ ] `uv run mypy src/agentfluent/` clean
+- [ ] CHANGELOG updated via release-please
+- [ ] Version bump to 0.7.0


### PR DESCRIPTION
## Summary
- Adds `prd-v0.7.md` and `backlog-v0.7.md` so the v0.7 milestone (18 issues across epics #349, #350, #351) has the same artifact pattern as v0.3/v0.5/v0.6. Release theme: *from signals to answers* — diff hardening builds production trust, diagnostics presentation closes config gaps, the new `report` command + per-session scope make output shareable.
- Logs `D029` (`--session` breaking change communicated via CHANGELOG note + minor bump; not `feat!`, not deprecation period) and `D030` (report Markdown section ordering: Summary → Token Metrics → Agent Metrics → Diagnostics → Offload → Footer) in `decisions.md`. Both unblock implementation of #353/#354.
- Documents-only; no code changes. Backlog sequences `report` skeleton (#353) first.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — N/A, docs-only
- [x] Lint clean: `uv run ruff check src/ tests/` — N/A, docs-only
- [x] Type check clean: `uv run mypy src/agentfluent/` — N/A, docs-only
- [x] New/changed behavior has test coverage — N/A, docs-only
- [x] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI changes

## Security review
- [x] **Skip review** — docs-only (PRD, backlog, decision-log entries). No hooks, secrets, parsing, CLI args, paths, network, or subprocess surface touched.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None in this PR. The PRD itself documents an upcoming v0.7 breaking change (`--session` semantics, D029/D032) which will be communicated via `BREAKING CHANGE:` in the v0.7 CHANGELOG when the implementing stories land (#357–#360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)