### PR TITLE
feat(cli): implement `agentfluent report` section renderers (#354)

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -98,6 +98,13 @@ class AnalysisResult(BaseModel):
     ``None`` on legacy envelopes; populated as ``agentfluent.__version__``
     by :mod:`agentfluent.cli.commands.analyze`."""
 
+    project_name: str | None = None
+    """Display name of the analyzed project. Stamped by the CLI so
+    ``report`` can render a standalone document (summary header,
+    reproduction command in the footer) without needing the project
+    re-specified at render time. Additive field — ``None`` on legacy
+    envelopes; renderers fall back to ``"(unknown project)"``."""
+
 
 def analyze_session(
     path: Path,

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -371,6 +371,7 @@ def analyze(
 
     result.window = window_metadata
     result.diagnostics_version = __version__
+    result.project_name = project_info.display_name
 
     if format == "json":
         _print_json(result, quiet=quiet, project_name=project_info.display_name)

--- a/src/agentfluent/cli/commands/report.py
+++ b/src/agentfluent/cli/commands/report.py
@@ -28,6 +28,14 @@ from typing import Any, Optional
 import typer
 from rich.console import Console
 
+from agentfluent.cli.commands.report_renderers import (
+    render_agent_metrics,
+    render_diagnostics,
+    render_footer,
+    render_offload,
+    render_summary,
+    render_token_metrics,
+)
 from agentfluent.cli.exit_codes import EXIT_USER_ERROR
 from agentfluent.cli.formatters.json_output import parse_json_output
 
@@ -103,40 +111,18 @@ def _load_envelope(path: Path) -> tuple[str, dict[str, Any]]:
     return command, data
 
 
-# Section renderer stubs. #354 implements the section bodies; this story
-# emits headers in the D030 order so the dispatch wiring is testable.
-
-def _render_summary(data: dict[str, Any]) -> str:
-    return "## Summary\n"
-
-
-def _render_token_metrics(data: dict[str, Any]) -> str:
-    return "## Token Metrics\n"
-
-
-def _render_agent_metrics(data: dict[str, Any]) -> str:
-    return "## Agent Metrics\n"
-
-
-def _render_diagnostics(data: dict[str, Any]) -> str:
-    return "## Diagnostics\n"
-
-
-def _render_offload(data: dict[str, Any]) -> str:
-    return "## Offload Candidates\n"
-
-
-def _render_footer(data: dict[str, Any]) -> str:
-    return ""
-
+# Section bodies live in ``report_renderers``. Keep dispatch wiring here
+# so adding a renderer for a new envelope command (e.g., ``diff`` in
+# v0.8) stays a one-line change in ``_RENDERERS`` and doesn't pull
+# rendering helpers into this module.
 
 ANALYZE_SECTIONS: tuple[Callable[[dict[str, Any]], str], ...] = (
-    _render_summary,
-    _render_token_metrics,
-    _render_agent_metrics,
-    _render_diagnostics,
-    _render_offload,
-    _render_footer,
+    render_summary,
+    render_token_metrics,
+    render_agent_metrics,
+    render_diagnostics,
+    render_offload,
+    render_footer,
 )
 
 

--- a/src/agentfluent/cli/commands/report_renderers.py
+++ b/src/agentfluent/cli/commands/report_renderers.py
@@ -1,0 +1,402 @@
+"""Markdown section renderers for ``agentfluent report`` (#354).
+
+Each ``render_*`` function takes the envelope's ``data`` payload (a JSON-
+deserialized dict produced by ``AnalysisResult.model_dump(mode="json")``)
+and returns a Markdown string for one section, in the D030 order:
+Summary -> Token Metrics -> Agent Metrics -> Diagnostics -> Offload ->
+Footer. ``report.py`` composes them.
+
+Sharp edge: ``data`` is a dict, not a hydrated ``AnalysisResult``. The
+``@property`` accessors that exist on the source dataclasses
+(``TokenMetrics.total_tokens``, ``ModelTokenBreakdown.total_tokens``,
+``AgentTypeMetrics.avg_tokens_per_invocation``) are NOT serialized by
+``model_dump``. Renderers derive those values explicitly via the
+``_total_tokens`` / ``_avg`` helpers below — reaching for
+``row["total_tokens"]`` would silently get ``None`` / ``KeyError``.
+
+Empty / fallback behavior, per the #354 acceptance criteria:
+- ``render_agent_metrics``: prints "No agent invocations." when none.
+- ``render_diagnostics``: prints "No findings." when no recommendations.
+- ``render_offload``: returns ``""`` (section absent) when no
+  positive-savings candidates — matches the issue's "if present" spec.
+- ``render_footer``: always emits a reproduction command so the report
+  is readable as a standalone document.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+UNKNOWN_PROJECT = "(unknown project)"
+GLOBAL_AGENT_LABEL = "(global)"
+
+DEFAULT_TOP_N = 5
+
+SEVERITY_ORDER = ("critical", "warning", "info")
+SEVERITY_HEADINGS = {
+    "critical": "Critical",
+    "warning": "Warning",
+    "info": "Info",
+}
+
+
+def _total_tokens(row: dict[str, Any]) -> int:
+    """Sum the four token components on a token-metrics dict/row.
+
+    ``TokenMetrics.total_tokens`` and ``ModelTokenBreakdown.total_tokens``
+    are ``@property`` accessors that pydantic's ``model_dump`` does not
+    serialize. Renderers derive the total here so the report's totals
+    column matches what the CLI table prints.
+    """
+    return (
+        int(row.get("input_tokens", 0))
+        + int(row.get("output_tokens", 0))
+        + int(row.get("cache_creation_input_tokens", 0))
+        + int(row.get("cache_read_input_tokens", 0))
+    )
+
+
+def _avg_tokens_per_invocation(row: dict[str, Any]) -> float | None:
+    """Mirror ``AgentTypeMetrics.avg_tokens_per_invocation`` (a property
+    not serialized by ``model_dump``). ``None`` when there's nothing to
+    average over, matching the property's contract."""
+    count = int(row.get("invocation_count", 0))
+    tokens = int(row.get("total_tokens", 0))
+    if count > 0 and tokens > 0:
+        return tokens / count
+    return None
+
+
+def _fmt_cost(cost: float) -> str:
+    if cost < 0.01:
+        return f"${cost:.4f}"
+    return f"${cost:.2f}"
+
+
+def _fmt_tokens(tokens: int) -> str:
+    return f"{tokens:,}"
+
+
+def _fmt_duration_seconds(duration_ms: int) -> str:
+    if duration_ms <= 0:
+        return "—"
+    return f"{duration_ms / 1000:.1f}s"
+
+
+def _md_table(
+    headers: list[str],
+    rows: list[list[str]],
+    align: list[str],
+) -> str:
+    """Render a GitHub-flavored Markdown table.
+
+    ``align`` is a parallel list of one-char codes: ``l`` (left), ``r``
+    (right), ``c`` (center). Numeric columns get ``r`` so the report
+    matches the CLI table's right-aligned cost/token cells.
+    """
+    sep_map = {"l": ":---", "r": "---:", "c": ":---:"}
+    sep = [sep_map[a] for a in align]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(sep) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def _format_window(window: dict[str, Any] | None) -> str:
+    """Human-readable window line for the summary bullet.
+
+    Returns ``"all sessions"`` when no time filter was applied, otherwise
+    ``"<since> -> <until> (N of M sessions)"`` using the resolved UTC
+    timestamps already on ``WindowMetadata``.
+    """
+    if not window:
+        return "all sessions"
+    since = window.get("since") or "—"
+    until = window.get("until") or "—"
+    before = window.get("session_count_before_filter")
+    after = window.get("session_count_after_filter")
+    if before is not None and after is not None:
+        return f"{since} → {until} ({after} of {before} sessions)"
+    return f"{since} → {until}"
+
+
+def render_summary(data: dict[str, Any]) -> str:
+    project = data.get("project_name") or UNKNOWN_PROJECT
+    session_count = data.get("session_count", 0)
+    tm = data.get("token_metrics") or {}
+    diag_version = data.get("diagnostics_version")
+
+    total_tokens = _total_tokens(tm)
+    total_cost = float(tm.get("total_cost", 0.0))
+    input_tokens = int(tm.get("input_tokens", 0))
+    output_tokens = int(tm.get("output_tokens", 0))
+    cache_creation = int(tm.get("cache_creation_input_tokens", 0))
+    cache_read = int(tm.get("cache_read_input_tokens", 0))
+
+    bullets = [
+        f"- **Project:** {project}",
+        f"- **Sessions analyzed:** {session_count}",
+        f"- **Window:** {_format_window(data.get('window'))}",
+        f"- **Total cost (API rate):** {_fmt_cost(total_cost)}",
+        (
+            f"- **Total tokens:** {_fmt_tokens(total_tokens)} "
+            f"(input {_fmt_tokens(input_tokens)}, "
+            f"output {_fmt_tokens(output_tokens)}, "
+            f"cache creation {_fmt_tokens(cache_creation)}, "
+            f"cache read {_fmt_tokens(cache_read)})"
+        ),
+    ]
+    if diag_version:
+        bullets.append(f"- **AgentFluent version:** {diag_version}")
+
+    return "## Summary\n\n" + "\n".join(bullets) + "\n"
+
+
+def render_token_metrics(data: dict[str, Any]) -> str:
+    tm = data.get("token_metrics") or {}
+    by_model = tm.get("by_model") or []
+
+    if not by_model:
+        return "## Token Metrics\n\nNo token usage recorded.\n"
+
+    # Match the CLI table sort: (model, parent-first). origin is a
+    # Literal["parent", "subagent"] so the secondary key is a simple
+    # 0/1 — same logic as ``format_analysis_table``.
+    sorted_rows = sorted(
+        by_model,
+        key=lambda b: (b.get("model", ""), 0 if b.get("origin") == "parent" else 1),
+    )
+
+    headers = ["Model", "Origin", "Input", "Output", "Cache", "Cost"]
+    align = ["l", "l", "r", "r", "r", "r"]
+    rows: list[list[str]] = []
+    for r in sorted_rows:
+        cache = (
+            int(r.get("cache_creation_input_tokens", 0))
+            + int(r.get("cache_read_input_tokens", 0))
+        )
+        rows.append([
+            str(r.get("model", "")),
+            str(r.get("origin", "")),
+            _fmt_tokens(int(r.get("input_tokens", 0))),
+            _fmt_tokens(int(r.get("output_tokens", 0))),
+            _fmt_tokens(cache),
+            _fmt_cost(float(r.get("cost", 0.0))),
+        ])
+
+    total_cache = (
+        int(tm.get("cache_creation_input_tokens", 0))
+        + int(tm.get("cache_read_input_tokens", 0))
+    )
+    rows.append([
+        "**Total**",
+        "",
+        f"**{_fmt_tokens(int(tm.get('input_tokens', 0)))}**",
+        f"**{_fmt_tokens(int(tm.get('output_tokens', 0)))}**",
+        f"**{_fmt_tokens(total_cache)}**",
+        f"**{_fmt_cost(float(tm.get('total_cost', 0.0)))}**",
+    ])
+
+    return "## Token Metrics\n\n" + _md_table(headers, rows, align)
+
+
+def render_agent_metrics(data: dict[str, Any]) -> str:
+    am = data.get("agent_metrics") or {}
+    by_type = am.get("by_agent_type") or {}
+    total_invocations = int(am.get("total_invocations", 0))
+
+    if total_invocations == 0 or not by_type:
+        return "## Agent Metrics\n\nNo agent invocations.\n"
+
+    headers = [
+        "Agent Type", "Count", "Tokens", "Avg Tokens/Call", "Duration",
+    ]
+    align = ["l", "r", "r", "r", "r"]
+    rows: list[list[str]] = []
+    for _key in sorted(by_type.keys()):
+        m = by_type[_key]
+        agent_type = str(m.get("agent_type", ""))
+        if m.get("is_builtin"):
+            agent_type = f"{agent_type} (builtin)"
+        avg = _avg_tokens_per_invocation(m)
+        avg_label = _fmt_tokens(int(avg)) if avg is not None else "—"
+        rows.append([
+            agent_type,
+            str(int(m.get("invocation_count", 0))),
+            _fmt_tokens(int(m.get("total_tokens", 0))),
+            avg_label,
+            _fmt_duration_seconds(int(m.get("total_duration_ms", 0))),
+        ])
+
+    rows.append([
+        "**Total**",
+        f"**{total_invocations}**",
+        "",
+        "",
+        "",
+    ])
+
+    agent_pct = am.get("agent_token_percentage", 0.0)
+    table = _md_table(headers, rows, align)
+    return (
+        "## Agent Metrics\n\n"
+        + table
+        + f"\nAgent token share of session total: **{agent_pct}%**\n"
+    )
+
+
+def _axis_label(primary_axis: str) -> str:
+    """Plain-Markdown axis label. Mirrors the CLI's ``[cost]`` / ``[speed]`` /
+    ``[quality]`` prefix but without Rich color escapes — escaping the
+    leading ``[`` so GitHub Markdown doesn't interpret it as a link."""
+    safe = primary_axis if primary_axis in {"cost", "speed", "quality"} else "cost"
+    return rf"\[{safe}]"
+
+
+def _top_n_summary(
+    aggs: list[dict[str, Any]], top_n: int,
+) -> str:
+    """Top-N priority pointer block above the severity groups.
+
+    Mirrors ``_format_top_recommendations`` in the CLI table formatter
+    but emits Markdown bullets. The aggregated list is already sorted
+    desc by ``priority_score`` (the analyze pipeline guarantees this);
+    the top N rows are the top priorities by definition.
+    """
+    if top_n <= 0 or not aggs:
+        return ""
+    shown = aggs[:top_n]
+    lines = [f"**Top {len(shown)} priority fixes:**\n"]
+    for idx, agg in enumerate(shown, start=1):
+        agent = agg.get("agent_type") or GLOBAL_AGENT_LABEL
+        sev = str(agg.get("severity", ""))
+        count = int(agg.get("count", 1))
+        target = str(agg.get("target", ""))
+        axis = _axis_label(str(agg.get("primary_axis", "cost")))
+        lines.append(
+            f"{idx}. **{sev}** · agent: `{agent}` · {count}× · "
+            f"target: `{target}` · axis: {axis}",
+        )
+    return "\n".join(lines) + "\n\n"
+
+
+def render_diagnostics(data: dict[str, Any]) -> str:
+    diag = data.get("diagnostics") or {}
+    aggs: list[dict[str, Any]] = list(diag.get("aggregated_recommendations") or [])
+
+    if not aggs:
+        return "## Diagnostics\n\nNo findings.\n"
+
+    out = ["## Diagnostics\n", _top_n_summary(aggs, DEFAULT_TOP_N)]
+
+    grouped: dict[str, list[dict[str, Any]]] = {s: [] for s in SEVERITY_ORDER}
+    for agg in aggs:
+        sev = str(agg.get("severity", "info"))
+        grouped.setdefault(sev, []).append(agg)
+
+    for sev in SEVERITY_ORDER:
+        group = grouped.get(sev) or []
+        if not group:
+            continue
+        out.append(f"### {SEVERITY_HEADINGS[sev]} ({len(group)})\n")
+        for agg in group:
+            axis = _axis_label(str(agg.get("primary_axis", "cost")))
+            target = str(agg.get("target", ""))
+            agent = agg.get("agent_type") or GLOBAL_AGENT_LABEL
+            count = int(agg.get("count", 1))
+            msg = str(agg.get("representative_message", ""))
+            out.append(
+                f"- {axis} (target: `{target}`, agent: `{agent}`, "
+                f"count: {count}×) — {msg}",
+            )
+        out.append("")  # blank line between groups
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_offload(data: dict[str, Any]) -> str:
+    """Offload candidates section.
+
+    Per #344, hide negative-savings rows (offloading would cost MORE).
+    If no positive-savings candidates remain, return ``""`` so the
+    section is omitted entirely — issue spec says "Offload Candidates
+    (if present)".
+    """
+    diag = data.get("diagnostics") or {}
+    candidates = diag.get("offload_candidates") or []
+    positive = [
+        c for c in candidates
+        if float(c.get("estimated_savings_usd", 0.0)) > 0
+    ]
+    if not positive:
+        return ""
+
+    positive.sort(
+        key=lambda c: float(c.get("estimated_savings_usd", 0.0)),
+        reverse=True,
+    )
+
+    headers = ["Name", "Confidence", "Cluster size", "Tools", "Est. savings"]
+    align = ["l", "l", "r", "l", "r"]
+    rows: list[list[str]] = []
+    for c in positive:
+        tools_list = c.get("tools") or []
+        if tools_list:
+            tools_display = ", ".join(str(t) for t in tools_list)
+        else:
+            note = str(c.get("tools_note") or "")
+            tools_display = note or "—"
+        rows.append([
+            str(c.get("name", "")),
+            str(c.get("confidence", "")),
+            str(int(c.get("cluster_size", 0))),
+            tools_display,
+            _fmt_cost(float(c.get("estimated_savings_usd", 0.0))),
+        ])
+
+    return "## Offload Candidates\n\n" + _md_table(headers, rows, align)
+
+
+def _reproduction_command(data: dict[str, Any]) -> str:
+    """Build the ``agentfluent analyze ...`` command that produced this snapshot.
+
+    Always emitted (architect review): for the null-window case it
+    degrades to ``agentfluent analyze --project P --json`` so the
+    standalone-readability acceptance criterion is preserved.
+    """
+    project = data.get("project_name") or UNKNOWN_PROJECT
+    # Shell-quote the project name only when it contains whitespace or
+    # other characters that would split it across argv. Project display
+    # names typically don't, but slugs with embedded slashes (older
+    # ``~/.claude/projects/`` slugs) would, and the reader will
+    # copy-paste this verbatim.
+    needs_quote = any(ch in project for ch in " \t'\"\\")
+    project_arg = f'"{project}"' if needs_quote else project
+
+    parts = ["agentfluent analyze", f"--project {project_arg}"]
+    window = data.get("window")
+    if window:
+        since = window.get("since")
+        until = window.get("until")
+        if since:
+            parts.append(f"--since {since}")
+        if until:
+            parts.append(f"--until {until}")
+    parts.append("--json")
+    return " ".join(parts)
+
+
+def render_footer(data: dict[str, Any]) -> str:
+    cmd = _reproduction_command(data)
+    generated = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (
+        "## Reproduction\n\n"
+        "```bash\n"
+        f"{cmd}\n"
+        "```\n\n"
+        f"*Generated: {generated}*\n"
+    )

--- a/src/agentfluent/cli/commands/report_renderers.py
+++ b/src/agentfluent/cli/commands/report_renderers.py
@@ -1,26 +1,16 @@
 """Markdown section renderers for ``agentfluent report`` (#354).
 
-Each ``render_*`` function takes the envelope's ``data`` payload (a JSON-
-deserialized dict produced by ``AnalysisResult.model_dump(mode="json")``)
-and returns a Markdown string for one section, in the D030 order:
-Summary -> Token Metrics -> Agent Metrics -> Diagnostics -> Offload ->
-Footer. ``report.py`` composes them.
+Each ``render_*`` takes the envelope's ``data`` payload (a JSON-
+deserialized dict from ``AnalysisResult.model_dump(mode="json")``) and
+returns one Markdown section. ``report.py`` composes them in the D030
+order: Summary -> Token Metrics -> Agent Metrics -> Diagnostics ->
+Offload -> Footer.
 
-Sharp edge: ``data`` is a dict, not a hydrated ``AnalysisResult``. The
-``@property`` accessors that exist on the source dataclasses
-(``TokenMetrics.total_tokens``, ``ModelTokenBreakdown.total_tokens``,
-``AgentTypeMetrics.avg_tokens_per_invocation``) are NOT serialized by
-``model_dump``. Renderers derive those values explicitly via the
-``_total_tokens`` / ``_avg`` helpers below — reaching for
-``row["total_tokens"]`` would silently get ``None`` / ``KeyError``.
-
-Empty / fallback behavior, per the #354 acceptance criteria:
-- ``render_agent_metrics``: prints "No agent invocations." when none.
-- ``render_diagnostics``: prints "No findings." when no recommendations.
-- ``render_offload``: returns ``""`` (section absent) when no
-  positive-savings candidates — matches the issue's "if present" spec.
-- ``render_footer``: always emits a reproduction command so the report
-  is readable as a standalone document.
+Renderers receive a dict, not a hydrated model — so ``@property``
+accessors (``TokenMetrics.total_tokens``,
+``AgentTypeMetrics.avg_tokens_per_invocation``) aren't in ``data``;
+the ``_total_tokens`` / ``_avg_tokens_per_invocation`` helpers derive
+them.
 """
 
 from __future__ import annotations
@@ -28,54 +18,45 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-UNKNOWN_PROJECT = "(unknown project)"
-GLOBAL_AGENT_LABEL = "(global)"
+from agentfluent.cli.formatters.helpers import (
+    GLOBAL_AGENT_LABEL,
+    format_cost,
+    format_tokens,
+)
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import Axis
 
+UNKNOWN_PROJECT = "(unknown project)"
 DEFAULT_TOP_N = 5
 
-SEVERITY_ORDER = ("critical", "warning", "info")
-SEVERITY_HEADINGS = {
-    "critical": "Critical",
-    "warning": "Warning",
-    "info": "Info",
-}
+SEVERITY_ORDER: tuple[Severity, ...] = (
+    Severity.CRITICAL,
+    Severity.WARNING,
+    Severity.INFO,
+)
 
 
 def _total_tokens(row: dict[str, Any]) -> int:
-    """Sum the four token components on a token-metrics dict/row.
-
-    ``TokenMetrics.total_tokens`` and ``ModelTokenBreakdown.total_tokens``
-    are ``@property`` accessors that pydantic's ``model_dump`` does not
-    serialize. Renderers derive the total here so the report's totals
-    column matches what the CLI table prints.
-    """
-    return (
-        int(row.get("input_tokens", 0))
-        + int(row.get("output_tokens", 0))
-        + int(row.get("cache_creation_input_tokens", 0))
-        + int(row.get("cache_read_input_tokens", 0))
+    """Sum the four token components; pydantic's ``model_dump`` skips the
+    ``total_tokens`` ``@property`` accessor."""
+    # int(...) at the helper boundary satisfies mypy-strict on the
+    # ``dict[str, Any]`` source; callsites stay coercion-free.
+    return int(
+        row.get("input_tokens", 0)
+        + row.get("output_tokens", 0)
+        + row.get("cache_creation_input_tokens", 0)
+        + row.get("cache_read_input_tokens", 0),
     )
 
 
 def _avg_tokens_per_invocation(row: dict[str, Any]) -> float | None:
     """Mirror ``AgentTypeMetrics.avg_tokens_per_invocation`` (a property
-    not serialized by ``model_dump``). ``None`` when there's nothing to
-    average over, matching the property's contract."""
-    count = int(row.get("invocation_count", 0))
-    tokens = int(row.get("total_tokens", 0))
+    not serialized by ``model_dump``)."""
+    count = row.get("invocation_count", 0)
+    tokens = row.get("total_tokens", 0)
     if count > 0 and tokens > 0:
-        return tokens / count
+        return float(tokens) / float(count)
     return None
-
-
-def _fmt_cost(cost: float) -> str:
-    if cost < 0.01:
-        return f"${cost:.4f}"
-    return f"${cost:.2f}"
-
-
-def _fmt_tokens(tokens: int) -> str:
-    return f"{tokens:,}"
 
 
 def _fmt_duration_seconds(duration_ms: int) -> str:
@@ -89,12 +70,8 @@ def _md_table(
     rows: list[list[str]],
     align: list[str],
 ) -> str:
-    """Render a GitHub-flavored Markdown table.
-
-    ``align`` is a parallel list of one-char codes: ``l`` (left), ``r``
-    (right), ``c`` (center). Numeric columns get ``r`` so the report
-    matches the CLI table's right-aligned cost/token cells.
-    """
+    """Render a GitHub-flavored Markdown table; ``align`` is one
+    ``l`` / ``r`` / ``c`` per column."""
     sep_map = {"l": ":---", "r": "---:", "c": ":---:"}
     sep = [sep_map[a] for a in align]
     lines = [
@@ -107,14 +84,10 @@ def _md_table(
 
 
 def _format_window(window: dict[str, Any] | None) -> str:
-    """Human-readable window line for the summary bullet.
-
-    Returns ``"all sessions"`` when no time filter was applied, otherwise
-    ``"<since> -> <until> (N of M sessions)"`` using the resolved UTC
-    timestamps already on ``WindowMetadata``.
-    """
     if not window:
         return "all sessions"
+    # since / until are independently Optional — one-sided filters
+    # (e.g. ``--since`` only) are valid.
     since = window.get("since") or "—"
     until = window.get("until") or "—"
     before = window.get("session_count_before_filter")
@@ -131,23 +104,23 @@ def render_summary(data: dict[str, Any]) -> str:
     diag_version = data.get("diagnostics_version")
 
     total_tokens = _total_tokens(tm)
-    total_cost = float(tm.get("total_cost", 0.0))
-    input_tokens = int(tm.get("input_tokens", 0))
-    output_tokens = int(tm.get("output_tokens", 0))
-    cache_creation = int(tm.get("cache_creation_input_tokens", 0))
-    cache_read = int(tm.get("cache_read_input_tokens", 0))
+    total_cost = tm.get("total_cost", 0.0)
+    input_tokens = tm.get("input_tokens", 0)
+    output_tokens = tm.get("output_tokens", 0)
+    cache_creation = tm.get("cache_creation_input_tokens", 0)
+    cache_read = tm.get("cache_read_input_tokens", 0)
 
     bullets = [
         f"- **Project:** {project}",
         f"- **Sessions analyzed:** {session_count}",
         f"- **Window:** {_format_window(data.get('window'))}",
-        f"- **Total cost (API rate):** {_fmt_cost(total_cost)}",
+        f"- **Total cost (API rate):** {format_cost(total_cost)}",
         (
-            f"- **Total tokens:** {_fmt_tokens(total_tokens)} "
-            f"(input {_fmt_tokens(input_tokens)}, "
-            f"output {_fmt_tokens(output_tokens)}, "
-            f"cache creation {_fmt_tokens(cache_creation)}, "
-            f"cache read {_fmt_tokens(cache_read)})"
+            f"- **Total tokens:** {format_tokens(total_tokens)} "
+            f"(input {format_tokens(input_tokens)}, "
+            f"output {format_tokens(output_tokens)}, "
+            f"cache creation {format_tokens(cache_creation)}, "
+            f"cache read {format_tokens(cache_read)})"
         ),
     ]
     if diag_version:
@@ -163,9 +136,8 @@ def render_token_metrics(data: dict[str, Any]) -> str:
     if not by_model:
         return "## Token Metrics\n\nNo token usage recorded.\n"
 
-    # Match the CLI table sort: (model, parent-first). origin is a
-    # Literal["parent", "subagent"] so the secondary key is a simple
-    # 0/1 — same logic as ``format_analysis_table``.
+    # Mirrors table.py:166 — (model, parent-first) so the report row
+    # order matches the CLI table users already know.
     sorted_rows = sorted(
         by_model,
         key=lambda b: (b.get("model", ""), 0 if b.get("origin") == "parent" else 1),
@@ -176,29 +148,29 @@ def render_token_metrics(data: dict[str, Any]) -> str:
     rows: list[list[str]] = []
     for r in sorted_rows:
         cache = (
-            int(r.get("cache_creation_input_tokens", 0))
-            + int(r.get("cache_read_input_tokens", 0))
+            r.get("cache_creation_input_tokens", 0)
+            + r.get("cache_read_input_tokens", 0)
         )
         rows.append([
-            str(r.get("model", "")),
-            str(r.get("origin", "")),
-            _fmt_tokens(int(r.get("input_tokens", 0))),
-            _fmt_tokens(int(r.get("output_tokens", 0))),
-            _fmt_tokens(cache),
-            _fmt_cost(float(r.get("cost", 0.0))),
+            r.get("model", ""),
+            r.get("origin", ""),
+            format_tokens(r.get("input_tokens", 0)),
+            format_tokens(r.get("output_tokens", 0)),
+            format_tokens(cache),
+            format_cost(r.get("cost", 0.0)),
         ])
 
     total_cache = (
-        int(tm.get("cache_creation_input_tokens", 0))
-        + int(tm.get("cache_read_input_tokens", 0))
+        tm.get("cache_creation_input_tokens", 0)
+        + tm.get("cache_read_input_tokens", 0)
     )
     rows.append([
         "**Total**",
         "",
-        f"**{_fmt_tokens(int(tm.get('input_tokens', 0)))}**",
-        f"**{_fmt_tokens(int(tm.get('output_tokens', 0)))}**",
-        f"**{_fmt_tokens(total_cache)}**",
-        f"**{_fmt_cost(float(tm.get('total_cost', 0.0)))}**",
+        f"**{format_tokens(tm.get('input_tokens', 0))}**",
+        f"**{format_tokens(tm.get('output_tokens', 0))}**",
+        f"**{format_tokens(total_cache)}**",
+        f"**{format_cost(tm.get('total_cost', 0.0))}**",
     ])
 
     return "## Token Metrics\n\n" + _md_table(headers, rows, align)
@@ -207,38 +179,29 @@ def render_token_metrics(data: dict[str, Any]) -> str:
 def render_agent_metrics(data: dict[str, Any]) -> str:
     am = data.get("agent_metrics") or {}
     by_type = am.get("by_agent_type") or {}
-    total_invocations = int(am.get("total_invocations", 0))
+    total_invocations = am.get("total_invocations", 0)
 
     if total_invocations == 0 or not by_type:
         return "## Agent Metrics\n\nNo agent invocations.\n"
 
-    headers = [
-        "Agent Type", "Count", "Tokens", "Avg Tokens/Call", "Duration",
-    ]
+    headers = ["Agent Type", "Count", "Tokens", "Avg Tokens/Call", "Duration"]
     align = ["l", "r", "r", "r", "r"]
     rows: list[list[str]] = []
-    for _key in sorted(by_type.keys()):
-        m = by_type[_key]
-        agent_type = str(m.get("agent_type", ""))
+    for _key, m in sorted(by_type.items()):
+        agent_type = m.get("agent_type", "")
         if m.get("is_builtin"):
             agent_type = f"{agent_type} (builtin)"
         avg = _avg_tokens_per_invocation(m)
-        avg_label = _fmt_tokens(int(avg)) if avg is not None else "—"
+        avg_label = format_tokens(int(avg)) if avg is not None else "—"
         rows.append([
             agent_type,
-            str(int(m.get("invocation_count", 0))),
-            _fmt_tokens(int(m.get("total_tokens", 0))),
+            str(m.get("invocation_count", 0)),
+            format_tokens(m.get("total_tokens", 0)),
             avg_label,
-            _fmt_duration_seconds(int(m.get("total_duration_ms", 0))),
+            _fmt_duration_seconds(m.get("total_duration_ms", 0)),
         ])
 
-    rows.append([
-        "**Total**",
-        f"**{total_invocations}**",
-        "",
-        "",
-        "",
-    ])
+    rows.append(["**Total**", f"**{total_invocations}**", "", "", ""])
 
     agent_pct = am.get("agent_token_percentage", 0.0)
     table = _md_table(headers, rows, align)
@@ -250,33 +213,26 @@ def render_agent_metrics(data: dict[str, Any]) -> str:
 
 
 def _axis_label(primary_axis: str) -> str:
-    """Plain-Markdown axis label. Mirrors the CLI's ``[cost]`` / ``[speed]`` /
-    ``[quality]`` prefix but without Rich color escapes — escaping the
-    leading ``[`` so GitHub Markdown doesn't interpret it as a link."""
-    safe = primary_axis if primary_axis in {"cost", "speed", "quality"} else "cost"
-    return rf"\[{safe}]"
+    """Plain-Markdown axis label; ``[`` is backslash-escaped so GitHub
+    doesn't render it as a link."""
+    try:
+        axis = Axis(primary_axis)
+    except ValueError:
+        axis = Axis.COST
+    return rf"\[{axis.value}]"
 
 
-def _top_n_summary(
-    aggs: list[dict[str, Any]], top_n: int,
-) -> str:
-    """Top-N priority pointer block above the severity groups.
-
-    Mirrors ``_format_top_recommendations`` in the CLI table formatter
-    but emits Markdown bullets. The aggregated list is already sorted
-    desc by ``priority_score`` (the analyze pipeline guarantees this);
-    the top N rows are the top priorities by definition.
-    """
+def _top_n_summary(aggs: list[dict[str, Any]], top_n: int) -> str:
     if top_n <= 0 or not aggs:
         return ""
     shown = aggs[:top_n]
     lines = [f"**Top {len(shown)} priority fixes:**\n"]
     for idx, agg in enumerate(shown, start=1):
         agent = agg.get("agent_type") or GLOBAL_AGENT_LABEL
-        sev = str(agg.get("severity", ""))
-        count = int(agg.get("count", 1))
-        target = str(agg.get("target", ""))
-        axis = _axis_label(str(agg.get("primary_axis", "cost")))
+        sev = agg.get("severity", "")
+        count = agg.get("count", 1)
+        target = agg.get("target", "")
+        axis = _axis_label(agg.get("primary_axis", Axis.COST.value))
         lines.append(
             f"{idx}. **{sev}** · agent: `{agent}` · {count}× · "
             f"target: `{target}` · axis: {axis}",
@@ -286,57 +242,55 @@ def _top_n_summary(
 
 def render_diagnostics(data: dict[str, Any]) -> str:
     diag = data.get("diagnostics") or {}
-    aggs: list[dict[str, Any]] = list(diag.get("aggregated_recommendations") or [])
+    aggs: list[dict[str, Any]] = diag.get("aggregated_recommendations") or []
 
     if not aggs:
         return "## Diagnostics\n\nNo findings.\n"
 
     out = ["## Diagnostics\n", _top_n_summary(aggs, DEFAULT_TOP_N)]
 
-    grouped: dict[str, list[dict[str, Any]]] = {s: [] for s in SEVERITY_ORDER}
+    grouped: dict[Severity, list[dict[str, Any]]] = {s: [] for s in SEVERITY_ORDER}
     for agg in aggs:
-        sev = str(agg.get("severity", "info"))
-        grouped.setdefault(sev, []).append(agg)
+        try:
+            sev = Severity(agg.get("severity", Severity.INFO.value))
+        except ValueError:
+            sev = Severity.INFO
+        grouped[sev].append(agg)
 
     for sev in SEVERITY_ORDER:
-        group = grouped.get(sev) or []
+        group = grouped[sev]
         if not group:
             continue
-        out.append(f"### {SEVERITY_HEADINGS[sev]} ({len(group)})\n")
+        out.append(f"### {sev.value.title()} ({len(group)})\n")
         for agg in group:
-            axis = _axis_label(str(agg.get("primary_axis", "cost")))
-            target = str(agg.get("target", ""))
+            axis = _axis_label(agg.get("primary_axis", Axis.COST.value))
+            target = agg.get("target", "")
             agent = agg.get("agent_type") or GLOBAL_AGENT_LABEL
-            count = int(agg.get("count", 1))
-            msg = str(agg.get("representative_message", ""))
+            count = agg.get("count", 1)
+            msg = agg.get("representative_message", "")
             out.append(
                 f"- {axis} (target: `{target}`, agent: `{agent}`, "
                 f"count: {count}×) — {msg}",
             )
-        out.append("")  # blank line between groups
+        out.append("")
 
     return "\n".join(out).rstrip() + "\n"
 
 
 def render_offload(data: dict[str, Any]) -> str:
-    """Offload candidates section.
-
-    Per #344, hide negative-savings rows (offloading would cost MORE).
-    If no positive-savings candidates remain, return ``""`` so the
-    section is omitted entirely — issue spec says "Offload Candidates
-    (if present)".
-    """
+    """Offload candidates; negative-savings rows hidden per #344, and
+    the section is omitted entirely when no positive candidates
+    remain (issue spec: "if present")."""
     diag = data.get("diagnostics") or {}
     candidates = diag.get("offload_candidates") or []
     positive = [
-        c for c in candidates
-        if float(c.get("estimated_savings_usd", 0.0)) > 0
+        c for c in candidates if c.get("estimated_savings_usd", 0.0) > 0
     ]
     if not positive:
         return ""
 
     positive.sort(
-        key=lambda c: float(c.get("estimated_savings_usd", 0.0)),
+        key=lambda c: c.get("estimated_savings_usd", 0.0),
         reverse=True,
     )
 
@@ -348,32 +302,23 @@ def render_offload(data: dict[str, Any]) -> str:
         if tools_list:
             tools_display = ", ".join(str(t) for t in tools_list)
         else:
-            note = str(c.get("tools_note") or "")
-            tools_display = note or "—"
+            tools_display = c.get("tools_note") or "—"
         rows.append([
-            str(c.get("name", "")),
-            str(c.get("confidence", "")),
-            str(int(c.get("cluster_size", 0))),
+            c.get("name", ""),
+            c.get("confidence", ""),
+            str(c.get("cluster_size", 0)),
             tools_display,
-            _fmt_cost(float(c.get("estimated_savings_usd", 0.0))),
+            format_cost(c.get("estimated_savings_usd", 0.0)),
         ])
 
     return "## Offload Candidates\n\n" + _md_table(headers, rows, align)
 
 
 def _reproduction_command(data: dict[str, Any]) -> str:
-    """Build the ``agentfluent analyze ...`` command that produced this snapshot.
-
-    Always emitted (architect review): for the null-window case it
-    degrades to ``agentfluent analyze --project P --json`` so the
-    standalone-readability acceptance criterion is preserved.
-    """
+    """Always emitted: the null-window case degrades to
+    ``--project P --json`` so the report stays readable as a
+    standalone document."""
     project = data.get("project_name") or UNKNOWN_PROJECT
-    # Shell-quote the project name only when it contains whitespace or
-    # other characters that would split it across argv. Project display
-    # names typically don't, but slugs with embedded slashes (older
-    # ``~/.claude/projects/`` slugs) would, and the reader will
-    # copy-paste this verbatim.
     needs_quote = any(ch in project for ch in " \t'\"\\")
     project_arg = f'"{project}"' if needs_quote else project
 

--- a/tests/unit/cli/test_report_cmd.py
+++ b/tests/unit/cli/test_report_cmd.py
@@ -3,7 +3,8 @@
 Covers the #353 acceptance surface: valid envelope ingestion (stdout +
 ``--output``), all four error paths (missing file, malformed JSON,
 wrong envelope, top-level non-object JSON), and ``--help`` exposing
-the workflow examples.
+the workflow examples. Per-renderer behavior lives in
+``test_report_renderers.py``.
 """
 
 from __future__ import annotations
@@ -21,12 +22,14 @@ from agentfluent.cli.formatters.json_output import format_json_output
 def _analyze_data() -> dict[str, Any]:
     """Minimal valid analyze ``data`` payload.
 
-    Intentionally sparse: the skeleton renderers don't read these
-    fields, so we only need enough structure that the envelope passes
-    the version/command/data check. Section bodies that consume these
-    fields are #354's responsibility.
+    Sparse but valid enough that every renderer can produce output.
+    ``offload`` and ``diagnostics`` are empty, so those renderers take
+    their no-findings paths — exercised by the order assertion below
+    (which uses the always-rendered ``## Reproduction`` footer as the
+    tail).
     """
     return {
+        "project_name": "demo-project",
         "session_count": 1,
         "token_metrics": {
             "input_tokens": 100,
@@ -60,13 +63,16 @@ class TestRender:
         out = result.stdout
         assert "# AgentFluent Report" in out
         # D030: Summary -> Token Metrics -> Agent Metrics -> Diagnostics ->
-        # Offload. Verify ordering by index, not just presence.
+        # Offload -> Footer. Offload is correctly omitted when there are no
+        # positive-savings candidates (#344), so the footer (Reproduction)
+        # is the reliable tail marker here.
         idx_summary = out.index("## Summary")
         idx_tokens = out.index("## Token Metrics")
         idx_agents = out.index("## Agent Metrics")
         idx_diag = out.index("## Diagnostics")
-        idx_offload = out.index("## Offload Candidates")
-        assert idx_summary < idx_tokens < idx_agents < idx_diag < idx_offload
+        idx_footer = out.index("## Reproduction")
+        assert idx_summary < idx_tokens < idx_agents < idx_diag < idx_footer
+        assert "## Offload Candidates" not in out
 
     def test_output_flag_writes_file_and_no_stdout(
         self,

--- a/tests/unit/cli/test_report_renderers.py
+++ b/tests/unit/cli/test_report_renderers.py
@@ -1,0 +1,412 @@
+"""Unit tests for the ``report`` Markdown section renderers (#354).
+
+Each renderer is a pure function from a JSON-deserialized analyze
+``data`` dict to a Markdown string. Tests pass dicts directly — no
+Typer CliRunner needed; dispatch coverage lives in ``test_report_cmd``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentfluent.cli.commands.report_renderers import (
+    UNKNOWN_PROJECT,
+    render_agent_metrics,
+    render_diagnostics,
+    render_footer,
+    render_offload,
+    render_summary,
+    render_token_metrics,
+)
+
+
+def _data(**overrides: Any) -> dict[str, Any]:
+    """Build a baseline ``data`` payload; ``overrides`` replaces top-level keys."""
+    base: dict[str, Any] = {
+        "project_name": "demo-project",
+        "session_count": 3,
+        "diagnostics_version": "0.7.0",
+        "token_metrics": {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 300,
+            "total_cost": 1.2345,
+            "cache_efficiency": 60.0,
+            "by_model": [
+                {
+                    "model": "claude-opus-4-7",
+                    "input_tokens": 800,
+                    "output_tokens": 400,
+                    "cache_creation_input_tokens": 100,
+                    "cache_read_input_tokens": 200,
+                    "cost": 1.0,
+                    "origin": "parent",
+                },
+                {
+                    "model": "claude-opus-4-7",
+                    "input_tokens": 200,
+                    "output_tokens": 100,
+                    "cache_creation_input_tokens": 100,
+                    "cache_read_input_tokens": 100,
+                    "cost": 0.2345,
+                    "origin": "subagent",
+                },
+            ],
+        },
+        "agent_metrics": {
+            "by_agent_type": {
+                "pm": {
+                    "agent_type": "pm",
+                    "is_builtin": False,
+                    "invocation_count": 4,
+                    "total_tokens": 12000,
+                    "total_tool_uses": 20,
+                    "total_duration_ms": 60_000,
+                },
+                "explore": {
+                    "agent_type": "Explore",
+                    "is_builtin": True,
+                    "invocation_count": 2,
+                    "total_tokens": 5000,
+                    "total_tool_uses": 8,
+                    "total_duration_ms": 15_000,
+                },
+            },
+            "total_invocations": 6,
+            "agent_token_percentage": 42.5,
+        },
+        "window": None,
+        "diagnostics": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- render_summary -------------------------------------------------------
+
+
+class TestRenderSummary:
+    def test_includes_project_session_cost_tokens_version(self) -> None:
+        out = render_summary(_data())
+        assert "## Summary" in out
+        assert "demo-project" in out
+        assert "Sessions analyzed:** 3" in out
+        assert "$1.23" in out
+        assert "2,000" in out  # total tokens = 1000+500+200+300
+        assert "0.7.0" in out
+
+    def test_window_null_renders_all_sessions(self) -> None:
+        out = render_summary(_data(window=None))
+        assert "Window:** all sessions" in out
+
+    def test_window_populated_renders_range_and_counts(self) -> None:
+        out = render_summary(
+            _data(
+                window={
+                    "since": "2026-05-01T00:00:00Z",
+                    "until": "2026-05-08T00:00:00Z",
+                    "session_count_before_filter": 10,
+                    "session_count_after_filter": 3,
+                },
+            ),
+        )
+        assert "2026-05-01T00:00:00Z" in out
+        assert "2026-05-08T00:00:00Z" in out
+        assert "3 of 10 sessions" in out
+
+    def test_missing_project_name_falls_back_to_unknown(self) -> None:
+        # Legacy envelope (pre-#354) won't carry ``project_name``.
+        d = _data()
+        d.pop("project_name")
+        out = render_summary(d)
+        assert UNKNOWN_PROJECT in out
+
+    def test_omits_version_line_when_unstamped(self) -> None:
+        out = render_summary(_data(diagnostics_version=None))
+        assert "AgentFluent version" not in out
+
+
+# ---- render_token_metrics -------------------------------------------------
+
+
+class TestRenderTokenMetrics:
+    def test_renders_table_with_totals_row(self) -> None:
+        out = render_token_metrics(_data())
+        assert "## Token Metrics" in out
+        # GitHub-flavored Markdown table separator.
+        assert "| Model" in out
+        assert "---:" in out
+        # Both (model, origin) rows present.
+        assert "parent" in out
+        assert "subagent" in out
+        # Totals row uses bolded fields.
+        assert "**Total**" in out
+        assert "**$1.23**" in out
+
+    def test_parent_origin_sorts_first(self) -> None:
+        out = render_token_metrics(_data())
+        parent_idx = out.index("parent")
+        subagent_idx = out.index("subagent")
+        assert parent_idx < subagent_idx
+
+    def test_empty_by_model_emits_no_usage_note(self) -> None:
+        d = _data()
+        d["token_metrics"]["by_model"] = []
+        out = render_token_metrics(d)
+        assert "No token usage recorded." in out
+        assert "| Model" not in out
+
+
+# ---- render_agent_metrics -------------------------------------------------
+
+
+class TestRenderAgentMetrics:
+    def test_renders_per_type_rows_with_builtin_annotation(self) -> None:
+        out = render_agent_metrics(_data())
+        assert "## Agent Metrics" in out
+        assert "pm" in out
+        assert "Explore (builtin)" in out
+        assert "12,000" in out
+        assert "60.0s" in out
+        # Footer line with agent token share.
+        assert "42.5%" in out
+
+    def test_zero_invocations_emits_fallback(self) -> None:
+        out = render_agent_metrics(
+            _data(agent_metrics={"by_agent_type": {}, "total_invocations": 0}),
+        )
+        assert "No agent invocations." in out
+        assert "| Agent Type" not in out
+
+
+# ---- render_diagnostics ---------------------------------------------------
+
+
+def _agg(
+    *,
+    severity: str = "warning",
+    target: str = "model",
+    agent: str | None = "pm",
+    count: int = 1,
+    axis: str = "cost",
+    msg: str = "Use a cheaper model for this pattern.",
+    priority: float = 10.0,
+) -> dict[str, Any]:
+    return {
+        "agent_type": agent,
+        "target": target,
+        "severity": severity,
+        "signal_types": [],
+        "count": count,
+        "representative_message": msg,
+        "primary_axis": axis,
+        "priority_score": priority,
+        "axis_scores": {"cost": 0.0, "speed": 0.0, "quality": 0.0},
+        "contributing_recommendations": [],
+    }
+
+
+class TestRenderDiagnostics:
+    def test_empty_recommendations_emits_no_findings(self) -> None:
+        out = render_diagnostics(_data(diagnostics={"aggregated_recommendations": []}))
+        assert "## Diagnostics" in out
+        assert "No findings." in out
+
+    def test_diagnostics_none_treated_as_no_findings(self) -> None:
+        # ``analyze --no-diagnostics`` leaves ``diagnostics`` as ``None``;
+        # the renderer must not crash on the missing key.
+        out = render_diagnostics(_data(diagnostics=None))
+        assert "No findings." in out
+
+    def test_severity_groups_in_critical_warning_info_order(self) -> None:
+        out = render_diagnostics(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [
+                        _agg(severity="info", priority=1.0, target="prompt"),
+                        _agg(severity="critical", priority=99.0, target="model"),
+                        _agg(severity="warning", priority=50.0, target="tools"),
+                    ],
+                },
+            ),
+        )
+        idx_crit = out.index("### Critical")
+        idx_warn = out.index("### Warning")
+        idx_info = out.index("### Info")
+        assert idx_crit < idx_warn < idx_info
+
+    def test_axis_labels_present_on_every_row(self) -> None:
+        out = render_diagnostics(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [
+                        _agg(axis="cost", target="t1"),
+                        _agg(axis="speed", target="t2"),
+                        _agg(axis="quality", target="t3"),
+                    ],
+                },
+            ),
+        )
+        assert r"\[cost]" in out
+        assert r"\[speed]" in out
+        assert r"\[quality]" in out
+
+    def test_top_n_summary_caps_at_five(self) -> None:
+        recs = [
+            _agg(target=f"t{i}", priority=100.0 - i, severity="warning")
+            for i in range(7)
+        ]
+        out = render_diagnostics(
+            _data(diagnostics={"aggregated_recommendations": recs}),
+        )
+        assert "Top 5 priority fixes" in out
+
+    def test_global_agent_label_for_null_agent(self) -> None:
+        out = render_diagnostics(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [
+                        _agg(agent=None, target="mcp_servers"),
+                    ],
+                },
+            ),
+        )
+        assert "(global)" in out
+
+
+# ---- render_offload ------------------------------------------------------
+
+
+def _offload(
+    *,
+    name: str = "ts-bulk-edits",
+    savings: float = 1.50,
+    confidence: str = "high",
+    cluster_size: int = 12,
+    tools: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": "...",
+        "confidence": confidence,
+        "cluster_size": cluster_size,
+        "cohesion_score": 0.85,
+        "top_terms": [],
+        "tool_sequence_summary": [],
+        "tools": tools or ["Edit", "Read"],
+        "tools_note": "",
+        "estimated_parent_tokens": 50_000,
+        "estimated_parent_cost_usd": 5.0,
+        "estimated_savings_usd": savings,
+        "parent_model": "claude-opus-4-7",
+        "alternative_model": "claude-sonnet-4-6",
+        "cost_note": "",
+        "target_kind": "subagent",
+        "subagent_draft": None,
+        "skill_draft": None,
+        "matched_agent": "",
+        "dedup_note": "",
+        "yaml_draft": "",
+    }
+
+
+class TestRenderOffload:
+    def test_renders_positive_savings_only(self) -> None:
+        out = render_offload(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [],
+                    "offload_candidates": [
+                        _offload(name="keep", savings=2.0),
+                        _offload(name="drop", savings=-1.5),
+                    ],
+                },
+            ),
+        )
+        assert "## Offload Candidates" in out
+        assert "keep" in out
+        assert "drop" not in out
+
+    def test_section_absent_when_all_savings_nonpositive(self) -> None:
+        out = render_offload(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [],
+                    "offload_candidates": [
+                        _offload(name="zero", savings=0.0),
+                        _offload(name="negative", savings=-1.0),
+                    ],
+                },
+            ),
+        )
+        assert out == ""
+
+    def test_no_offload_key_returns_empty(self) -> None:
+        out = render_offload(_data(diagnostics={"aggregated_recommendations": []}))
+        assert out == ""
+
+    def test_diagnostics_none_returns_empty(self) -> None:
+        assert render_offload(_data(diagnostics=None)) == ""
+
+    def test_sorted_by_savings_descending(self) -> None:
+        out = render_offload(
+            _data(
+                diagnostics={
+                    "aggregated_recommendations": [],
+                    "offload_candidates": [
+                        _offload(name="small", savings=0.10),
+                        _offload(name="big", savings=5.00),
+                        _offload(name="mid", savings=1.00),
+                    ],
+                },
+            ),
+        )
+        idx_big = out.index("big")
+        idx_mid = out.index("mid")
+        idx_small = out.index("small")
+        assert idx_big < idx_mid < idx_small
+
+
+# ---- render_footer -------------------------------------------------------
+
+
+class TestRenderFooter:
+    def test_reproduction_command_includes_project_and_json_flag(self) -> None:
+        out = render_footer(_data())
+        assert "## Reproduction" in out
+        assert "agentfluent analyze --project demo-project --json" in out
+        assert "```bash" in out
+        assert "*Generated:" in out
+
+    def test_window_flags_appear_when_present(self) -> None:
+        out = render_footer(
+            _data(
+                window={
+                    "since": "2026-05-01T00:00:00Z",
+                    "until": "2026-05-08T00:00:00Z",
+                    "session_count_before_filter": 10,
+                    "session_count_after_filter": 3,
+                },
+            ),
+        )
+        assert "--since 2026-05-01T00:00:00Z" in out
+        assert "--until 2026-05-08T00:00:00Z" in out
+
+    def test_no_window_omits_since_until(self) -> None:
+        out = render_footer(_data(window=None))
+        assert "--since" not in out
+        assert "--until" not in out
+
+    def test_missing_project_name_uses_unknown_placeholder(self) -> None:
+        d = _data()
+        d.pop("project_name")
+        out = render_footer(d)
+        # The unknown-project sentinel contains parens/space, so it
+        # should be quoted so the command is copy-paste-runnable.
+        assert UNKNOWN_PROJECT in out
+        assert '"(unknown project)"' in out
+
+    def test_project_with_spaces_is_quoted(self) -> None:
+        out = render_footer(_data(project_name="my project"))
+        assert '"my project"' in out


### PR DESCRIPTION
## Summary
- Implements all six Markdown section bodies for `agentfluent report` (Closes #354): summary, token metrics, agent metrics, diagnostics (severity-grouped + Top-5), offload candidates (positive-savings only), and the reproduction footer.
- Renderers live in a new `cli/commands/report_renderers.py`; dispatch wiring in `report.py` is unchanged. Section order follows D030.
- Adds `AnalysisResult.project_name: str | None` (additive on schema v2) so the report is readable as a standalone document — populated by `analyze.py`, falls back to `"(unknown project)"` on legacy envelopes per architect review.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1319 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (26 new renderer tests; D030 order assertion updated to use footer as tail since offload is now correctly omitted on empty)
- [x] Manual smoke test: `uv run agentfluent analyze --project classifier --json | report` renders cleanly, all sections present, severity groups in order, axis labels visible, reproduction command correct

## Security review
- [x] **Skip review** — no security-sensitive surface. New code is pure rendering (JSON dict in, Markdown string out); no path resolution, no subprocess, no user-controlled string rendering beyond what `analyze` already produces. The added `project_name` field is a display string only.

## Breaking changes
None. `project_name` is an additive field on `AnalysisResult` — older readers ignore it (Pydantic default `extra="ignore"` posture matches `WindowMetadata` / `ToolResultMetadata`). Schema version stays at `"2"`. Renderers degrade gracefully on v0.6 snapshots that lack the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)