### PR TITLE
fix(diff): add Origin column to Token Metrics by Model table (#343)

### DIFF
--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -276,8 +276,13 @@ def _render_token_metrics(console: Console, result: DiffResult) -> None:
 
 
 def _render_by_model(console: Console, rows: list[ModelTokenDelta]) -> None:
+    # Origin column disambiguates parent vs subagent rows for the same
+    # model — otherwise two ``claude-opus-4-7`` rows look like a
+    # rendering bug instead of the legitimate ``(model, origin)`` split
+    # the aggregator emits (#343).
     table = Table(title="Token Metrics by Model")
     table.add_column("Model", style="cyan")
+    table.add_column("Origin")
     table.add_column("Baseline cost", justify="right")
     table.add_column("Current cost", justify="right")
     table.add_column("Cost Δ", justify="right")
@@ -286,6 +291,7 @@ def _render_by_model(console: Console, rows: list[ModelTokenDelta]) -> None:
     for row in rows:
         table.add_row(
             row.model,
+            row.origin,
             format_cost(row.baseline_cost),
             format_cost(row.current_cost),
             _signed_cost(row.cost_delta),

--- a/tests/unit/cli/test_diff_by_model_table.py
+++ b/tests/unit/cli/test_diff_by_model_table.py
@@ -1,0 +1,74 @@
+"""Rendering tests for the ``Token Metrics by Model`` table in
+``agentfluent diff`` output (#343).
+
+Same model can appear twice in the ``by_model`` list when ``(model,
+origin)`` differs (e.g., ``claude-opus-4-7`` for both ``parent`` and
+``subagent``). The renderer must surface ``origin`` as a column so the
+two rows look distinct instead of like a duplicate-row bug.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from agentfluent.cli.formatters.diff_table import _render_by_model
+from agentfluent.diff.models import ModelTokenDelta
+
+
+def _render(rows: list[ModelTokenDelta]) -> str:
+    buf = io.StringIO()
+    console = Console(
+        file=buf,
+        width=200,
+        force_terminal=False,
+        color_system=None,
+        legacy_windows=False,
+    )
+    _render_by_model(console, rows)
+    return buf.getvalue()
+
+
+def test_table_includes_origin_column() -> None:
+    rows = [
+        ModelTokenDelta(
+            model="claude-opus-4-7",
+            origin="parent",
+            baseline_cost=10.0,
+            current_cost=12.0,
+            cost_delta=2.0,
+        ),
+    ]
+    out = _render(rows)
+    assert "Origin" in out
+    assert "parent" in out
+
+
+def test_parent_and_subagent_rows_render_distinctly() -> None:
+    rows = [
+        ModelTokenDelta(
+            model="claude-opus-4-7",
+            origin="parent",
+            baseline_cost=346.22,
+            current_cost=319.88,
+            cost_delta=-26.34,
+            total_tokens_delta=-28_019_807,
+        ),
+        ModelTokenDelta(
+            model="claude-opus-4-7",
+            origin="subagent",
+            baseline_cost=24.38,
+            current_cost=29.24,
+            cost_delta=4.86,
+            total_tokens_delta=6_446_681,
+        ),
+    ]
+    out = _render(rows)
+    # Both rows present with the same model name but different origins.
+    assert out.count("claude-opus-4-7") == 2
+    assert "parent" in out
+    assert "subagent" in out
+    # The two distinct cost figures appear, so the rows aren't merged.
+    assert "$346.22" in out
+    assert "$24.38" in out


### PR DESCRIPTION
## Summary
- Adds an `Origin` column to the diff `Token Metrics by Model` table so `(model, origin)` rows (e.g., `claude-opus-4-7` for parent vs subagent) read as distinct instead of like a duplicate-row rendering bug. Closes #343.
- Pure renderer change. The aggregator (`diff/compute.py:_diff_by_model`) already keys on `(model, origin)` and `ModelTokenDelta.origin` is already in the JSON envelope — no schema change, no JSON output change.
- Matches the recommended approach (option 1) in the issue body.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1321 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New `tests/unit/cli/test_diff_by_model_table.py` covers (a) Origin column present, (b) parent + subagent rows for the same model render distinctly with the right cost figures
- [x] Manual smoke test: `agentfluent analyze --since 14d --until 7d --json > b.json && analyze --since 7d --json > c.json && diff b.json c.json` — table now shows `parent` ($240.83 baseline) and `subagent` ($17.43 baseline) for `claude-opus-4-7` instead of two same-named rows

## Security review
- [x] **Skip review** — single-column add to a Rich table renderer; no path resolution, subprocess, network, or user-controlled string rendering beyond what `analyze` already produces.

## Breaking changes
None. JSON output unchanged (`origin` was already serialized on `ModelTokenDelta` since #227). CLI table gains a column — visual change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)