### PR TITLE
chore: sync uv.lock to v0.6.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Updates the lock-file copy of agentfluent's own version (`[[package]] name = "agentfluent"`) from `0.5.1` to `0.6.0` so it matches `pyproject.toml`, which release-please bumped at the v0.6.0 release (PR #304).
- One-line diff. `uv lock --check` is clean — no transitive dependency changes.
- Mirrors prior precedents: PR #128 (`chore: sync uv.lock to 0.2.0`) and commit `642a562` (`chore: sync uv.lock to v0.5.1`). The release-please `extra-files` list updates `pyproject.toml` but not `uv.lock`, so this drift accrues every release until a manual sync PR catches it up.

## Test plan
- [x] `uv lock --check` clean
- [x] No code paths touched — nothing to test
- [x] Unit / lint / type CI gates will run on this PR as usual

## Security review
- [x] **Skip review** — lock-file self-version metadata change only. No dependency added, removed, or version-bumped. No code touched.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)