### PR TITLE
feat(diagnostics): detect custom agents defined but never delegated to (#346)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -452,6 +452,43 @@ MCP config. Add to ~/.claude.json or .mcp.json.
 
 **Related:** [`mcp_unused_server`](#mcp_unused_server), [`target_mcp`](#target_mcp)
 
+### `unused_agent`
+
+**Short:** A custom agent is defined but the parent never delegates to it in the
+analyzed window.
+
+**Detail:** Triggered when a custom `~/.claude/agents/<name>.md` (or project-scoped
+equivalent) is present in the config scanner output but `agent_type`
+has zero invocations across the analyzed sessions. Likely causes:
+
+1. `description` doesn't match how the parent thread frames the task.
+2. `description` is too narrow and only fires for an exact phrase.
+3. The triggering context (e.g., a failing test for a `tester` agent)
+   isn't present in the analyzed window.
+4. The parent has no awareness of the agent (config-discovery gap).
+
+Built-in agents (Explore, Plan, general-purpose, etc.) are silently
+excluded per D033 — their absence in a given window may be entirely
+normal. New agents added partway through the window will appear
+unused due to a partial-window confound; consider re-running on a
+fresh window after enough sessions have accumulated to fire the
+agent.
+
+**Example:**
+
+```
+Agent 'tester' is defined in /home/u/.claude/agents/tester.md but has 0
+invocations across 11 analyzed sessions.
+```
+
+**Severity:** info
+
+**Threshold:** 0 invocations across analyzed sessions
+
+**Recommendation target:** `description`
+
+**Related:** [`target_description`](#target_description), [`mcp_unused_server`](#mcp_unused_server)
+
 ### `user_correction`
 
 **Short:** The user interrupted or redirected the parent thread mid-flight ("no, do X
@@ -723,6 +760,25 @@ agent.
 **Aliases:** `mcp`
 
 **Related:** [`mcp_unused_server`](#mcp_unused_server), [`mcp_missing_server`](#mcp_missing_server)
+
+### `target_description`
+
+**Short:** Rewrite the agent's `description:` field in frontmatter -- the trigger
+logic the parent reads when deciding to delegate.
+
+**Detail:** The `description` field is the only configuration surface the parent
+thread sees when deciding whether to delegate to a subagent. A
+misaligned, too-narrow, or vague description is the most common
+reason a defined agent is never invoked. Used for `unused_agent`:
+the recommendation surfaces the current description verbatim so the
+user can compare against typical parent phrasing for the task. The
+fix is to broaden, sharpen, or rewrite the description; accepting
+that the agent is unused for the analyzed workload is also a valid
+outcome.
+
+**Aliases:** `description`
+
+**Related:** [`unused_agent`](#unused_agent)
 
 
 ---

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -458,21 +458,17 @@ MCP config. Add to ~/.claude.json or .mcp.json.
 analyzed window.
 
 **Detail:** Triggered when a custom `~/.claude/agents/<name>.md` (or project-scoped
-equivalent) is present in the config scanner output but `agent_type`
-has zero invocations across the analyzed sessions. Likely causes:
-
-1. `description` doesn't match how the parent thread frames the task.
-2. `description` is too narrow and only fires for an exact phrase.
-3. The triggering context (e.g., a failing test for a `tester` agent)
-   isn't present in the analyzed window.
-4. The parent has no awareness of the agent (config-discovery gap).
-
-Built-in agents (Explore, Plan, general-purpose, etc.) are silently
-excluded per D033 — their absence in a given window may be entirely
-normal. New agents added partway through the window will appear
-unused due to a partial-window confound; consider re-running on a
-fresh window after enough sessions have accumulated to fire the
-agent.
+equivalent) is present in the config scanner output but `agent_type` has
+zero invocations across the analyzed sessions. Likely causes: the
+`description` doesn't match how the parent frames the task, the
+description is too narrow and only fires for an exact phrase, the
+triggering context (e.g., a failing test for a `tester` agent) isn't
+present in the window, or the parent has no awareness of the agent.
+Built-in agents (Explore, Plan, general-purpose, etc.) are excluded per
+D033 — their absence in any given window may be entirely normal. New
+agents added partway through the window will appear unused due to a
+partial-window confound; consider re-running after enough sessions
+accumulate.
 
 **Example:**
 

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -359,6 +359,7 @@ def analyze(
             claude_config_dir=config_dir,
             project_dir=project_disk_path,
             parent_messages=all_messages,
+            session_count=result.session_count,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         err_console.print(

--- a/src/agentfluent/diagnostics/agent_audit.py
+++ b/src/agentfluent/diagnostics/agent_audit.py
@@ -1,21 +1,10 @@
-"""Agent-config audit: detect custom agents defined but never delegated to.
+"""Configured-vs-observed agent-definition audit (#346).
 
-Mirrors the ``mcp_assessment.audit_mcp_servers`` pattern — compares a
-configured surface (agent definitions from
-``config.scanner.scan_agents``) against an observed surface (agent
-types in the session's ``AgentInvocation`` list) and emits a signal
-for each configured-but-unused custom agent.
-
-Built-in agents (``general-purpose``, ``Explore``, ``Plan``, etc.) are
-silently excluded per D033 — their absence in a given window may be
-entirely normal and a recommendation surface would just produce
-noise.
-
-Empty-invocations early return (per architect review for #346): if
-nothing fired in the window, flagging every custom agent as unused is
-meaninglessly true and undermines the diagnostics surface's signal-
-to-noise ratio. Callers who want config-only checks have
-``agentfluent config-check``.
+Emits ``UNUSED_AGENT`` for each custom agent defined in
+``~/.claude/agents/`` (or the project-scoped equivalent) with zero
+invocations in the analyzed window. Built-ins excluded per D033;
+empty-window suppression so the surface stays useful — callers who
+want config-only checks have ``agentfluent config-check``.
 """
 
 from __future__ import annotations
@@ -40,8 +29,6 @@ def audit_unused_agents(
     default to ``len(invocations) or 1`` via ``run_diagnostics``.
     """
     if not invocations:
-        # Empty-window suppression: flagging every custom agent as
-        # unused when nothing ran is meaninglessly true.
         return []
 
     observed = {inv.agent_type.lower() for inv in invocations}

--- a/src/agentfluent/diagnostics/agent_audit.py
+++ b/src/agentfluent/diagnostics/agent_audit.py
@@ -1,0 +1,73 @@
+"""Agent-config audit: detect custom agents defined but never delegated to.
+
+Mirrors the ``mcp_assessment.audit_mcp_servers`` pattern — compares a
+configured surface (agent definitions from
+``config.scanner.scan_agents``) against an observed surface (agent
+types in the session's ``AgentInvocation`` list) and emits a signal
+for each configured-but-unused custom agent.
+
+Built-in agents (``general-purpose``, ``Explore``, ``Plan``, etc.) are
+silently excluded per D033 — their absence in a given window may be
+entirely normal and a recommendation surface would just produce
+noise.
+
+Empty-invocations early return (per architect review for #346): if
+nothing fired in the window, flagging every custom agent as unused is
+meaninglessly true and undermines the diagnostics surface's signal-
+to-noise ratio. Callers who want config-only checks have
+``agentfluent config-check``.
+"""
+
+from __future__ import annotations
+
+from agentfluent.agents.models import AgentInvocation, is_builtin_agent
+from agentfluent.config.models import AgentConfig, Severity
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+
+
+def audit_unused_agents(
+    invocations: list[AgentInvocation],
+    agent_configs: list[AgentConfig],
+    *,
+    sessions_analyzed: int,
+) -> list[DiagnosticSignal]:
+    """Emit ``UNUSED_AGENT`` signals for custom agents with zero invocations.
+
+    ``sessions_analyzed`` is surfaced in signal detail so the user can
+    judge confidence ("0 invocations across 50 sessions" is stronger
+    evidence than "0 invocations across 2 sessions"). Threaded from
+    ``AnalysisResult.session_count`` by the CLI; programmatic callers
+    default to ``len(invocations) or 1`` via ``run_diagnostics``.
+    """
+    if not invocations:
+        # Empty-window suppression: flagging every custom agent as
+        # unused when nothing ran is meaninglessly true.
+        return []
+
+    observed = {inv.agent_type.lower() for inv in invocations}
+
+    signals: list[DiagnosticSignal] = []
+    for config in agent_configs:
+        if is_builtin_agent(config.name):
+            continue
+        if config.name.lower() in observed:
+            continue
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.UNUSED_AGENT,
+                severity=Severity.INFO,
+                agent_type=config.name,
+                message=(
+                    f"Agent '{config.name}' is defined in {config.file_path} "
+                    f"but has 0 invocations across {sessions_analyzed} "
+                    "analyzed sessions."
+                ),
+                detail={
+                    "agent_name": config.name,
+                    "source_file": str(config.file_path),
+                    "description": config.description,
+                    "sessions_analyzed": sessions_analyzed,
+                },
+            ),
+        )
+    return signals

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -74,6 +74,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.ERROR_PATTERN: Axis.SPEED,
     SignalType.PERMISSION_FAILURE: Axis.SPEED,
     SignalType.MCP_MISSING_SERVER: Axis.SPEED,
+    SignalType.UNUSED_AGENT: Axis.COST,
     SignalType.USER_CORRECTION: Axis.QUALITY,
     SignalType.FILE_REWORK: Axis.QUALITY,
     SignalType.REVIEWER_CAUGHT: Axis.QUALITY,

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -619,6 +619,59 @@ class McpAuditRule:
         )
 
 
+class UnusedAgentRule:
+    """``UNUSED_AGENT`` -> recommend description rewrite or accept-as-unused.
+
+    Description is the trigger logic for delegation — when a custom
+    agent is defined but never delegated to, the most common cause is a
+    description mismatch with how the parent thread frames the task.
+    The recommendation surfaces the current description verbatim so the
+    user can compare it against parent phrasing. The partial-window
+    confound (new agents added partway through the window appearing
+    unused) lives in the glossary ``long`` field rather than every
+    recommendation row.
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.UNUSED_AGENT
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        agent_name = str(signal.detail.get("agent_name", ""))
+        description = str(signal.detail.get("description", ""))
+        source_file = str(signal.detail.get("source_file", ""))
+
+        reason = (
+            "An agent defined but never delegated to is either misaligned "
+            "with how the parent frames tasks, or the triggering context "
+            "isn't present in this analysis window."
+        )
+        description_clause = (
+            f' Current description: "{description}".' if description else ""
+        )
+        action = (
+            f"Compare the description against parent-thread phrasing.{description_clause} "
+            f"Consider broadening the description, rewriting it, or accepting "
+            f"that '{agent_name}' is unused for this workload. "
+            f"File: {source_file}."
+        )
+
+        return DiagnosticRecommendation(
+            target="description",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file=source_file,
+            signal_types=[signal.signal_type],
+        )
+
+
 class _QualityRule(ABC):
     """Shared base for cross-cutting and per-agent quality-axis rules.
 
@@ -788,6 +841,7 @@ RULES: list[CorrelationRule] = [
     ErrorSequenceRule(),
     ModelRoutingRule(),
     McpAuditRule(),
+    UnusedAgentRule(),
     UserCorrectionRule(),
     FileReworkRule(),
     ReviewerCaughtRule(),

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -622,14 +622,9 @@ class McpAuditRule:
 class UnusedAgentRule:
     """``UNUSED_AGENT`` -> recommend description rewrite or accept-as-unused.
 
-    Description is the trigger logic for delegation — when a custom
-    agent is defined but never delegated to, the most common cause is a
+    Description is the trigger logic for delegation: when a custom
+    agent is defined but never invoked, the most common cause is a
     description mismatch with how the parent thread frames the task.
-    The recommendation surfaces the current description verbatim so the
-    user can compare it against parent phrasing. The partial-window
-    confound (new agents added partway through the window appearing
-    unused) lives in the glossary ``long`` field rather than every
-    recommendation row.
     """
 
     def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
@@ -655,7 +650,7 @@ class UnusedAgentRule:
             f"Compare the description against parent-thread phrasing.{description_clause} "
             f"Consider broadening the description, rewriting it, or accepting "
             f"that '{agent_name}' is unused for this workload. "
-            f"File: {source_file}."
+            f"File: {_relpath(Path(source_file)) if source_file else 'unknown'}."
         )
 
         return DiagnosticRecommendation(

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -60,6 +60,9 @@ class SignalType(StrEnum):
     MCP audit signals (configured-vs-observed MCP server usage):
     - `MCP_UNUSED_SERVER`, `MCP_MISSING_SERVER`
 
+    Agent audit signals (configured-vs-observed agent delegation):
+    - `UNUSED_AGENT`
+
     Quality signals (extracted from parent-thread message patterns):
     - `USER_CORRECTION`, `FILE_REWORK`, `REVIEWER_CAUGHT`
     """
@@ -74,6 +77,7 @@ class SignalType(StrEnum):
     MODEL_MISMATCH = "model_mismatch"
     MCP_UNUSED_SERVER = "mcp_unused_server"
     MCP_MISSING_SERVER = "mcp_missing_server"
+    UNUSED_AGENT = "unused_agent"
     USER_CORRECTION = "user_correction"
     FILE_REWORK = "file_rework"
     REVIEWER_CAUGHT = "reviewer_caught"

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -241,9 +241,6 @@ def run_diagnostics(
     # the correlator will read from; fold them in before correlation.
     signals.extend(extract_model_routing_signals(invocations, configs_by_name))
 
-    # #346: flag custom agents that are configured but never delegated
-    # to in the analyzed window. Empty-invocation suppression lives
-    # inside the audit; built-ins (D033) are silently excluded there.
     signals.extend(
         audit_unused_agents(
             invocations, agent_configs,
@@ -273,7 +270,7 @@ def run_diagnostics(
                 audit_mcp_servers(
                     mcp_usage,
                     configured_mcp,
-                    sessions_analyzed=len(invocations) or 1,
+                    sessions_analyzed=session_count,
                 ),
             )
 

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -23,6 +23,7 @@ from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics.agent_audit import audit_unused_agents
 from agentfluent.diagnostics.aggregation import aggregate_recommendations
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.delegation import (
@@ -174,6 +175,7 @@ def run_diagnostics(
     claude_config_dir: Path | None = None,
     project_dir: Path | None = None,
     parent_messages: list[SessionMessage] | None = None,
+    session_count: int | None = None,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
@@ -199,7 +201,14 @@ def run_diagnostics(
     tool-bursts and emits ``DiagnosticsResult.offload_candidates``.
     Empty list when sklearn is missing OR ``parent_messages`` is None
     OR no cluster met the size threshold.
+
+    ``session_count`` is surfaced in #346's ``UNUSED_AGENT`` audit
+    message ("0 invocations across N sessions"). The CLI passes the
+    real session count from ``AnalysisResult``; programmatic callers
+    that don't have it fall back to ``len(invocations) or 1``.
     """
+    if session_count is None:
+        session_count = len(invocations) or 1
     signals = extract_signals(invocations)
 
     # Fold in trace-level signals for any invocation with an attached
@@ -231,6 +240,16 @@ def run_diagnostics(
     # Aggregate-level signals (model-routing) use the same config lookup
     # the correlator will read from; fold them in before correlation.
     signals.extend(extract_model_routing_signals(invocations, configs_by_name))
+
+    # #346: flag custom agents that are configured but never delegated
+    # to in the analyzed window. Empty-invocation suppression lives
+    # inside the audit; built-ins (D033) are silently excluded there.
+    signals.extend(
+        audit_unused_agents(
+            invocations, agent_configs,
+            sessions_analyzed=session_count,
+        ),
+    )
 
     # MCP audit. Runs only when the caller has provided explicit MCP
     # context — avoids silently picking up the user's real

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -325,6 +325,36 @@
   recommendation_target: mcp
   related: [mcp_unused_server, target_mcp]
 
+- name: unused_agent
+  category: signal_type
+  short: |
+    A custom agent is defined but the parent never delegates to it in the
+    analyzed window.
+  long: |
+    Triggered when a custom `~/.claude/agents/<name>.md` (or project-scoped
+    equivalent) is present in the config scanner output but `agent_type`
+    has zero invocations across the analyzed sessions. Likely causes:
+
+    1. `description` doesn't match how the parent thread frames the task.
+    2. `description` is too narrow and only fires for an exact phrase.
+    3. The triggering context (e.g., a failing test for a `tester` agent)
+       isn't present in the analyzed window.
+    4. The parent has no awareness of the agent (config-discovery gap).
+
+    Built-in agents (Explore, Plan, general-purpose, etc.) are silently
+    excluded per D033 — their absence in a given window may be entirely
+    normal. New agents added partway through the window will appear
+    unused due to a partial-window confound; consider re-running on a
+    fresh window after enough sessions have accumulated to fire the
+    agent.
+  example: |
+    Agent 'tester' is defined in /home/u/.claude/agents/tester.md but has 0
+    invocations across 11 analyzed sessions.
+  severity_range: info
+  threshold: 0 invocations across analyzed sessions
+  recommendation_target: description
+  related: [target_description, mcp_unused_server]
+
 - name: user_correction
   category: signal_type
   short: |
@@ -563,6 +593,24 @@
     agent.
   aliases: [mcp]
   related: [mcp_unused_server, mcp_missing_server]
+
+- name: target_description
+  category: recommendation_target
+  short: |
+    Rewrite the agent's `description:` field in frontmatter -- the trigger
+    logic the parent reads when deciding to delegate.
+  long: |
+    The `description` field is the only configuration surface the parent
+    thread sees when deciding whether to delegate to a subagent. A
+    misaligned, too-narrow, or vague description is the most common
+    reason a defined agent is never invoked. Used for `unused_agent`:
+    the recommendation surfaces the current description verbatim so the
+    user can compare against typical parent phrasing for the task. The
+    fix is to broaden, sharpen, or rewrite the description; accepting
+    that the agent is unused for the analyzed workload is also a valid
+    outcome.
+  aliases: [description]
+  related: [unused_agent]
 
 # =============================================================================
 # Built-in agent concern

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -332,21 +332,17 @@
     analyzed window.
   long: |
     Triggered when a custom `~/.claude/agents/<name>.md` (or project-scoped
-    equivalent) is present in the config scanner output but `agent_type`
-    has zero invocations across the analyzed sessions. Likely causes:
-
-    1. `description` doesn't match how the parent thread frames the task.
-    2. `description` is too narrow and only fires for an exact phrase.
-    3. The triggering context (e.g., a failing test for a `tester` agent)
-       isn't present in the analyzed window.
-    4. The parent has no awareness of the agent (config-discovery gap).
-
-    Built-in agents (Explore, Plan, general-purpose, etc.) are silently
-    excluded per D033 — their absence in a given window may be entirely
-    normal. New agents added partway through the window will appear
-    unused due to a partial-window confound; consider re-running on a
-    fresh window after enough sessions have accumulated to fire the
-    agent.
+    equivalent) is present in the config scanner output but `agent_type` has
+    zero invocations across the analyzed sessions. Likely causes: the
+    `description` doesn't match how the parent frames the task, the
+    description is too narrow and only fires for an exact phrase, the
+    triggering context (e.g., a failing test for a `tester` agent) isn't
+    present in the window, or the parent has no awareness of the agent.
+    Built-in agents (Explore, Plan, general-purpose, etc.) are excluded per
+    D033 — their absence in any given window may be entirely normal. New
+    agents added partway through the window will appear unused due to a
+    partial-window confound; consider re-running after enough sessions
+    accumulate.
   example: |
     Agent 'tester' is defined in /home/u/.claude/agents/tester.md but has 0
     invocations across 11 analyzed sessions.

--- a/tests/unit/test_agent_audit.py
+++ b/tests/unit/test_agent_audit.py
@@ -1,0 +1,131 @@
+"""Tests for the unused-agent audit (#346).
+
+Covers ``audit_unused_agents``: configured-vs-observed comparison,
+built-in exclusion (D033), empty-window suppression, case-insensitive
+matching, and the signal detail surface that the correlator's
+``UnusedAgentRule`` relies on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.diagnostics.agent_audit import audit_unused_agents
+from agentfluent.diagnostics.models import SignalType
+
+
+def _config(name: str, *, description: str = "do a thing") -> AgentConfig:
+    return AgentConfig(
+        name=name,
+        file_path=Path(f"/home/u/.claude/agents/{name}.md"),
+        scope=Scope.USER,
+        description=description,
+    )
+
+
+def _invocation(agent_type: str) -> AgentInvocation:
+    return AgentInvocation(
+        tool_use_id=f"toolu_{agent_type}",
+        agent_type=agent_type,
+        description="...",
+        prompt="...",
+    )
+
+
+class TestAuditUnusedAgents:
+    def test_flags_custom_agent_with_zero_invocations(self) -> None:
+        configs = [_config("tester", description="Fix pytest failures")]
+        invocations = [_invocation("pm")]
+
+        signals = audit_unused_agents(
+            invocations, configs, sessions_analyzed=10,
+        )
+
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == SignalType.UNUSED_AGENT
+        assert sig.severity == Severity.INFO
+        assert sig.agent_type == "tester"
+        assert "tester" in sig.message
+        assert "10 analyzed sessions" in sig.message
+        assert sig.detail["agent_name"] == "tester"
+        assert sig.detail["description"] == "Fix pytest failures"
+        assert sig.detail["sessions_analyzed"] == 10
+        # file_path is an absolute Path; source_file should be its string form.
+        assert sig.detail["source_file"].endswith("tester.md")
+
+    def test_invoked_agent_does_not_fire(self) -> None:
+        configs = [_config("pm"), _config("architect")]
+        invocations = [_invocation("pm"), _invocation("architect")]
+
+        assert (
+            audit_unused_agents(invocations, configs, sessions_analyzed=5)
+            == []
+        )
+
+    def test_builtin_agent_excluded_per_d033(self) -> None:
+        # `general-purpose` is in BUILTIN_AGENT_TYPES; even if a config
+        # exists and is never invoked, no signal fires.
+        configs = [_config("general-purpose"), _config("tester")]
+        invocations = [_invocation("pm")]
+
+        signals = audit_unused_agents(
+            invocations, configs, sessions_analyzed=5,
+        )
+        agent_names = {s.agent_type for s in signals}
+        assert agent_names == {"tester"}
+
+    def test_case_insensitive_matching(self) -> None:
+        # Config name casing differs from observed invocation casing —
+        # the audit must lowercase-compare so frontmatter "PM" doesn't
+        # falsely flag against an observed "pm" invocation.
+        configs = [_config("PM")]
+        invocations = [_invocation("pm")]
+
+        assert (
+            audit_unused_agents(invocations, configs, sessions_analyzed=3)
+            == []
+        )
+
+    def test_empty_invocations_returns_empty_per_architect_review(self) -> None:
+        # Empty-window suppression: flagging every custom agent as
+        # unused when nothing ran is meaninglessly true.
+        configs = [_config("tester"), _config("pm")]
+
+        assert audit_unused_agents([], configs, sessions_analyzed=0) == []
+
+    def test_empty_configs_returns_empty(self) -> None:
+        invocations = [_invocation("pm")]
+        assert (
+            audit_unused_agents(invocations, [], sessions_analyzed=5)
+            == []
+        )
+
+    def test_multiple_unused_agents_each_get_a_signal(self) -> None:
+        configs = [
+            _config("tester"),
+            _config("reviewer"),
+            _config("pm"),
+        ]
+        invocations = [_invocation("pm")]
+
+        signals = audit_unused_agents(
+            invocations, configs, sessions_analyzed=5,
+        )
+        agent_names = {s.agent_type for s in signals}
+        assert agent_names == {"tester", "reviewer"}
+
+    def test_missing_description_does_not_crash(self) -> None:
+        # AgentConfig.description defaults to ""; verify the signal
+        # still emits cleanly (the correlator handles the empty case
+        # by omitting the "Current description: ..." clause).
+        configs = [_config("tester", description="")]
+        invocations = [_invocation("pm")]
+
+        signals = audit_unused_agents(
+            invocations, configs, sessions_analyzed=1,
+        )
+        assert len(signals) == 1
+        assert signals[0].detail["description"] == ""

--- a/tests/unit/test_agent_audit.py
+++ b/tests/unit/test_agent_audit.py
@@ -89,9 +89,7 @@ class TestAuditUnusedAgents:
             == []
         )
 
-    def test_empty_invocations_returns_empty_per_architect_review(self) -> None:
-        # Empty-window suppression: flagging every custom agent as
-        # unused when nothing ran is meaninglessly true.
+    def test_empty_invocations_returns_empty(self) -> None:
         configs = [_config("tester"), _config("pm")]
 
         assert audit_unused_agents([], configs, sessions_analyzed=0) == []

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -473,6 +473,52 @@ class TestMcpAuditCorrelation:
         assert all(r.target != "mcp" for r in recs)
 
 
+class TestUnusedAgentCorrelation:
+    def _unused_signal(
+        self,
+        agent_name: str = "tester",
+        description: str = "Fix pytest failures",
+        source_file: str = "/home/u/.claude/agents/tester.md",
+    ) -> DiagnosticSignal:
+        return _signal(
+            signal_type=SignalType.UNUSED_AGENT,
+            severity=Severity.INFO,
+            agent_type=agent_name,
+            message=(
+                f"Agent '{agent_name}' is defined in {source_file} but "
+                "has 0 invocations across 11 analyzed sessions."
+            ),
+            detail={
+                "agent_name": agent_name,
+                "source_file": source_file,
+                "description": description,
+                "sessions_analyzed": 11,
+            },
+        )
+
+    def test_produces_description_target_recommendation(self) -> None:
+        recs = correlate([self._unused_signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "description"
+        assert rec.severity == Severity.INFO
+        assert rec.agent_type == "tester"
+        # Action surfaces the current description verbatim and points
+        # at the source file.
+        assert "Fix pytest failures" in rec.action
+        assert "tester.md" in rec.action
+        assert rec.signal_types == [SignalType.UNUSED_AGENT]
+
+    def test_empty_description_omits_clause_but_does_not_crash(self) -> None:
+        # `AgentConfig.description` defaults to ""; correlator should
+        # gracefully drop the `Current description: "..."` clause.
+        recs = correlate([self._unused_signal(description="")])
+        assert len(recs) == 1
+        rec = recs[0]
+        # No empty-quotes fragment in the action.
+        assert 'Current description: ""' not in rec.action
+
+
 def _builtin_signal(signal_type: SignalType, agent_type: str = "explore") -> DiagnosticSignal:
     detail: dict[str, object] = {}
     if signal_type == SignalType.ERROR_PATTERN:


### PR DESCRIPTION
## Summary
- New `unused_agent` diagnostic signal fires when a custom agent (`~/.claude/agents/<name>.md`) is in the config-scanner output but has zero invocations across the analyzed window. Closes #346.
- Detection isolated in a new `diagnostics/agent_audit.py` module that mirrors the `mcp_assessment.audit_mcp_servers` configured-vs-observed pattern. Built-in agents excluded per D033.
- Recommendation surfaces the current `description` verbatim with `target="description"` (a new recommendation-target value — `target` is a free-form string, so no enum touch). Axis is `cost` for parity with `mcp_unused_server`.
- Architect-review refinements folded in: real `session_count` threaded through `run_diagnostics`; empty-invocations early-return suppresses meaningless noise; partial-window confound note lives in glossary `long` field rather than every recommendation row.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1331 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New test coverage: 8 tests in `tests/unit/test_agent_audit.py` (mixed fixture, built-in exclusion, case-insensitive matching, empty-invocations early return, empty configs, multiple-unused, missing-description edge); 2 tests in `tests/unit/test_correlator.py::TestUnusedAgentCorrelation`
- [x] `agentfluent explain unused_agent` and `agentfluent explain target_description` both render the new glossary entries cleanly
- [x] `docs/GLOSSARY.md` regenerated and committed (drift test green)
- [x] Manual smoke test on the `agentfluent` project: `tester` surfaces as the sole `unused_agent` signal with `target=description`, `axis=cost`, exactly matching the issue's motivating example

## Security review
- [x] **Skip review** — no security-sensitive surface. New signal compares config-scanner output (already loaded by `run_diagnostics`) against observed agent types from `AgentInvocation` (already trusted internal data). No new path resolution, subprocess, network, or user-controlled string rendering.

## Breaking changes
None. `run_diagnostics` gains an optional `session_count` kwarg (defaults to `len(invocations) or 1` so existing programmatic callers behave identically). The new signal type is additive; `SIGNAL_AXIS_MAP` entry is additive; new correlator rule is appended to `RULES`. JSON envelope schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)