### PR TITLE
chore: gitignore social/ marketing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ htmlcov/
 
 # Playwright MCP screenshots
 .playwright-mcp/
+
+# Marketing artifacts (social posts, case studies, baselines)
+# Case studies are committed; blog drafts are published via the github_pages
+# repo, and baseline JSONs contain local file paths and tool args (security).
+social/*
+!social/case-study-agentfluent.md


### PR DESCRIPTION
## Summary
- Adds `social/*` (with `!social/case-study-agentfluent.md` as the kept-public exception) to `.gitignore`, mirroring the classifier repo's marketing-artifacts pattern.
- Creates the `social/` directory locally so the new `marketer` user-level subagent has somewhere to drop drafts when invoked against this repo.
- Rationale: case studies are the committed public artifact; blog drafts ship via the `github_pages` repo; baseline JSONs contain absolute local paths and tool arguments that shouldn't land in a public diff.

## Test plan
- [x] `.gitignore` changes only — no code touched, nothing to test
- [x] `git check-ignore -v social/baselines/anything.json` (after the dir exists) returns the new rule; `git check-ignore -v social/case-study-agentfluent.md` returns no match (exception works)
- [x] CI gates will run on this PR as usual

## Security review
- [x] **Skip review** — gitignore-only change with explicit intent of *preventing* sensitive content (local file paths, tool arguments) from being committed. No code, no permissions, no parsing surface.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)