### PR TITLE
docs: report command GLOSSARY entry + README workflow section (#356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ agentfluent diff baseline.json current.json --json | jq '.data.regression_detect
 
 Compares two `analyze --json` envelopes and surfaces new, resolved, and persisting recommendations (keyed by `(agent_type, target, signal_types)`), token / cost deltas, and per-agent invocation deltas. The `--fail-on {info|warning|critical|off}` flag gates exit code 3 on new findings at or above the chosen severity, so `agentfluent diff` slots into a PR check the same way a test runner does. Baselines are user-managed files — no internal cache — so re-running against an older snapshot at any time is just `agentfluent diff old.json new.json`.
 
+### `agentfluent report` — render an analyze snapshot as Markdown
+
+```bash
+agentfluent analyze --project codefluent --json > snap.json   # capture a snapshot
+agentfluent report snap.json                                  # Markdown to stdout
+agentfluent report snap.json --output report.md               # ...or to a file
+agentfluent analyze --project codefluent --json | agentfluent report /dev/stdin   # one-shot pipe
+```
+
+Renders an `analyze --json` snapshot envelope as a Markdown document — the same Summary / Token Metrics / Agent Metrics / Diagnostics / Offload / Reproduction sections you see in the CLI table, but in a form you can paste into a PR comment, attach as a CI artifact, or commit alongside a prompt change as a checked-in review trail. `report` is a separate subcommand rather than `analyze --format markdown` so the rendering layer stays decoupled from session ingestion: snapshots round-trip through file storage without re-running analysis. The Reproduction footer always echoes the original `agentfluent analyze` command line so a downstream reader can reproduce the run.
+
 ### `agentfluent config-check` — score agent definitions
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ agentfluent report snap.json --output report.md               # ...or to a file
 agentfluent analyze --project codefluent --json | agentfluent report /dev/stdin   # one-shot pipe
 ```
 
-Renders an `analyze --json` snapshot envelope as a Markdown document — the same Summary / Token Metrics / Agent Metrics / Diagnostics / Offload / Reproduction sections you see in the CLI table, but in a form you can paste into a PR comment, attach as a CI artifact, or commit alongside a prompt change as a checked-in review trail. `report` is a separate subcommand rather than `analyze --format markdown` so the rendering layer stays decoupled from session ingestion: snapshots round-trip through file storage without re-running analysis. The Reproduction footer always echoes the original `agentfluent analyze` command line so a downstream reader can reproduce the run.
+Renders an `analyze --json` snapshot envelope as a Markdown document — the same Summary / Token Metrics / Agent Metrics / Diagnostics / Offload / Reproduction sections that `analyze` prints to the terminal, but in a form you can paste into a PR comment, attach as a CI artifact, or commit alongside a prompt change as a checked-in review trail. `report` is a separate subcommand rather than `analyze --format markdown` so the rendering layer stays decoupled from session ingestion: snapshots round-trip through file storage without re-running analysis. The Reproduction footer always echoes the original `agentfluent analyze` command line so a downstream reader can reproduce the run.
 
 ### `agentfluent config-check` — score agent definitions
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1352,8 +1352,8 @@ agentfluent report snap.json > report.md
 Snapshots round-trip through file storage, PR comments, and CI
 artifact pipelines without re-running analysis. The Markdown
 layout follows D030 section ordering: Summary, Token Metrics,
-Agent Metrics, Diagnostics, Offload Candidates (when any
-positive-savings rows survive #344's filter), and a Reproduction
+Agent Metrics, Diagnostics, Offload Candidates (when at least one
+candidate has positive estimated savings), and a Reproduction
 footer that includes the original command line.
 
 `report` accepts only `analyze` envelopes in v0.7. A `diff`

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -31,6 +31,11 @@ organized to match them:
    sections explain why two findings on the same agent might suggest
    different fixes.
 
+4. **CLI commands** -- the subcommands that produce all of the above.
+   The **CLI commands** section at the end is a navigation index, not
+   vocabulary -- skim it if you want a one-line orientation to each
+   subcommand and the workflows that compose them.
+
 ---
 
 ## Token types
@@ -1322,6 +1327,89 @@ agent.
 with underscore. The first `__` after the `mcp__` prefix is the
 server/tool boundary. Not a closed enum -- MCP servers contribute
 additional namespaced tools at runtime.
+
+
+---
+
+## CLI commands
+
+### `report`
+
+**Short:** Renders an `analyze --json` snapshot envelope as a Markdown
+document suitable for PR comments, CI artifacts, or a checked-in
+review trail.
+
+**Detail:** Added in v0.7 (D031). `report` is a separate subcommand rather
+than `analyze --format markdown` because the two concerns --
+session ingestion and presentation -- benefit from being
+composable. The intended workflow is two steps:
+
+```bash
+agentfluent analyze --project P --json > snap.json
+agentfluent report snap.json > report.md
+```
+
+Snapshots round-trip through file storage, PR comments, and CI
+artifact pipelines without re-running analysis. The Markdown
+layout follows D030 section ordering: Summary, Token Metrics,
+Agent Metrics, Diagnostics, Offload Candidates (when any
+positive-savings rows survive #344's filter), and a Reproduction
+footer that includes the original command line.
+
+`report` accepts only `analyze` envelopes in v0.7. A `diff`
+envelope renderer is the v0.8 follow-up flagged in
+`prd-v0.7.md` OQ3 -- the dispatch table in `report.py` is
+structured so adding it is a one-line change.
+
+Stdout is the default sink; pass `--output report.md` (or `-o`)
+to write to a file instead. Exit code 1 on user errors (missing
+file, invalid JSON, unsupported envelope command).
+
+**Example:**
+
+```
+agentfluent analyze --project codefluent --json > snap.json
+agentfluent report snap.json --output report.md
+```
+
+**Related:** [`analyze`](#analyze), [`diff`](#diff)
+
+### `analyze`
+
+**Short:** Primary analysis command. Reads session JSONL for a project,
+computes token/cost/agent metrics, and (default) runs the
+diagnostics pipeline. Output is a Rich table by default or a
+versioned `{version, command, data}` JSON envelope under
+`--format json` / `--json`.
+
+### `diff`
+
+**Short:** Compares two `analyze --json` envelopes side-by-side: new,
+resolved, and persisting recommendations plus token/cost and
+per-agent invocation deltas. Pair with `--fail-on` to gate a
+CI check on regressions.
+
+### `config-check`
+
+**Short:** Scans `~/.claude/agents/*.md` and `./.claude/agents/*.md`,
+parses each agent's YAML frontmatter and body, and scores it
+against a 4-dimension rubric (description trigger quality, tool
+access, model selection, prompt completeness). Independent of
+session data.
+
+### `explain`
+
+**Short:** Terminal-native glossary lookup. `agentfluent explain
+<term>` prints the same definition that appears in this
+document; `--list` enumerates every term grouped by category.
+The source of truth is `src/agentfluent/glossary/terms.yaml`.
+
+### `list`
+
+**Short:** Enumerates the projects discovered under `~/.claude/projects/`
+(or `--claude-config-dir`) and the session JSONL files within a
+given project. The starting point when you don't yet know which
+`--project` slug to pass to `analyze`.
 
 ---
 

--- a/src/agentfluent/glossary/models.py
+++ b/src/agentfluent/glossary/models.py
@@ -24,6 +24,7 @@ GlossaryCategory = Literal[
     "diff_status",
     "builtin_agent_type",
     "builtin_tool",
+    "cli_command",
 ]
 
 # Display order + label for each category. Drives section ordering in the
@@ -41,6 +42,7 @@ GLOSSARY_CATEGORIES: tuple[tuple[GlossaryCategory, str], ...] = (
     ("diff_status", "Comparison row status"),
     ("builtin_agent_type", "Built-in agent types"),
     ("builtin_tool", "Built-in tools"),
+    ("cli_command", "CLI commands"),
 )
 
 

--- a/src/agentfluent/glossary/render.py
+++ b/src/agentfluent/glossary/render.py
@@ -54,6 +54,11 @@ organized to match them:
    surfaces. The **Recommendation target** and **Built-in agent concern**
    sections explain why two findings on the same agent might suggest
    different fixes.
+
+4. **CLI commands** -- the subcommands that produce all of the above.
+   The **CLI commands** section at the end is a navigation index, not
+   vocabulary -- skim it if you want a one-line orientation to each
+   subcommand and the workflows that compose them.
 """
 
 FOOTER = """\

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1098,3 +1098,92 @@
     that's getting worse without crossing a discrete threshold.
   example: |
     [persisting] warning pm: tool_error_sequence (count_delta=+2, priority_score_delta=+4.1)
+
+# =============================================================================
+# CLI commands
+#
+# Navigation index, not vocabulary. Sibling-command entries are
+# intentionally short-only -- the README and `--help` carry the
+# full reference. `report` gets the full treatment because the
+# command was added in v0.7 and its relationship to `analyze --json`
+# is the most common point of confusion.
+# =============================================================================
+
+- name: report
+  category: cli_command
+  short: |
+    Renders an `analyze --json` snapshot envelope as a Markdown
+    document suitable for PR comments, CI artifacts, or a checked-in
+    review trail.
+  long: |
+    Added in v0.7 (D031). `report` is a separate subcommand rather
+    than `analyze --format markdown` because the two concerns --
+    session ingestion and presentation -- benefit from being
+    composable. The intended workflow is two steps:
+
+    ```bash
+    agentfluent analyze --project P --json > snap.json
+    agentfluent report snap.json > report.md
+    ```
+
+    Snapshots round-trip through file storage, PR comments, and CI
+    artifact pipelines without re-running analysis. The Markdown
+    layout follows D030 section ordering: Summary, Token Metrics,
+    Agent Metrics, Diagnostics, Offload Candidates (when any
+    positive-savings rows survive #344's filter), and a Reproduction
+    footer that includes the original command line.
+
+    `report` accepts only `analyze` envelopes in v0.7. A `diff`
+    envelope renderer is the v0.8 follow-up flagged in
+    `prd-v0.7.md` OQ3 -- the dispatch table in `report.py` is
+    structured so adding it is a one-line change.
+
+    Stdout is the default sink; pass `--output report.md` (or `-o`)
+    to write to a file instead. Exit code 1 on user errors (missing
+    file, invalid JSON, unsupported envelope command).
+  example: |
+    agentfluent analyze --project codefluent --json > snap.json
+    agentfluent report snap.json --output report.md
+  related: [analyze, diff]
+
+- name: analyze
+  category: cli_command
+  short: |
+    Primary analysis command. Reads session JSONL for a project,
+    computes token/cost/agent metrics, and (default) runs the
+    diagnostics pipeline. Output is a Rich table by default or a
+    versioned `{version, command, data}` JSON envelope under
+    `--format json` / `--json`.
+
+- name: diff
+  category: cli_command
+  short: |
+    Compares two `analyze --json` envelopes side-by-side: new,
+    resolved, and persisting recommendations plus token/cost and
+    per-agent invocation deltas. Pair with `--fail-on` to gate a
+    CI check on regressions.
+
+- name: config-check
+  category: cli_command
+  short: |
+    Scans `~/.claude/agents/*.md` and `./.claude/agents/*.md`,
+    parses each agent's YAML frontmatter and body, and scores it
+    against a 4-dimension rubric (description trigger quality, tool
+    access, model selection, prompt completeness). Independent of
+    session data.
+
+- name: explain
+  category: cli_command
+  short: |
+    Terminal-native glossary lookup. `agentfluent explain
+    <term>` prints the same definition that appears in this
+    document; `--list` enumerates every term grouped by category.
+    The source of truth is `src/agentfluent/glossary/terms.yaml`.
+
+- name: list
+  category: cli_command
+  short: |
+    Enumerates the projects discovered under `~/.claude/projects/`
+    (or `--claude-config-dir`) and the session JSONL files within a
+    given project. The starting point when you don't yet know which
+    `--project` slug to pass to `analyze`.

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1129,8 +1129,8 @@
     Snapshots round-trip through file storage, PR comments, and CI
     artifact pipelines without re-running analysis. The Markdown
     layout follows D030 section ordering: Summary, Token Metrics,
-    Agent Metrics, Diagnostics, Offload Candidates (when any
-    positive-savings rows survive #344's filter), and a Reproduction
+    Agent Metrics, Diagnostics, Offload Candidates (when at least one
+    candidate has positive estimated savings), and a Reproduction
     footer that includes the original command line.
 
     `report` accepts only `analyze` envelopes in v0.7. A `diff`


### PR DESCRIPTION
## Summary
- New \`cli_command\` GLOSSARY category with a full \`report\` entry plus short-only stubs for \`analyze\`, \`diff\`, \`config-check\`, \`explain\`, \`list\`.
- Glossary preamble updated to acknowledge the new section (commands as navigation context, not vocabulary).
- README gains a \`### agentfluent report\` workflow section after the diff section, mirroring the surrounding command-doc style. The CLI \`--help\` epilog (added in #353) already matches the documented workflow.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m "not integration"\` (1331 passed, glossary drift test included)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage (drift test gates GLOSSARY regen)
- [x] Manual smoke test via \`uv run agentfluent explain report\` and \`agentfluent explain --list\` — both render cleanly

## Security review
- [x] **Skip review** — docs-only change, no security-sensitive surface.
- [ ] **Needs review**

## Breaking changes
None. Adds one entry to the closed \`GlossaryCategory\` Literal; no callers need to change.

Closes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)