### PR TITLE
test(cli): golden fixture + pipeline + v0.6 backward-compat for report (#355)

### DIFF
--- a/src/agentfluent/cli/commands/report.py
+++ b/src/agentfluent/cli/commands/report.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Callable
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -116,23 +117,37 @@ def _load_envelope(path: Path) -> tuple[str, dict[str, Any]]:
 # v0.8) stays a one-line change in ``_RENDERERS`` and doesn't pull
 # rendering helpers into this module.
 
-ANALYZE_SECTIONS: tuple[Callable[[dict[str, Any]], str], ...] = (
+# Body renderers share the ``(data) -> str`` signature; ``render_footer``
+# additionally accepts an injected ``now`` so snapshot tests get
+# deterministic output. Keeping it out of this tuple lets the
+# ``_render_analyze_report`` loop stay uniform.
+ANALYZE_BODY_SECTIONS: tuple[Callable[[dict[str, Any]], str], ...] = (
     render_summary,
     render_token_metrics,
     render_agent_metrics,
     render_diagnostics,
     render_offload,
-    render_footer,
 )
 
 
-def _render_analyze_report(data: dict[str, Any]) -> str:
-    """Assemble an analyze report from the section renderers in D030 order."""
+def _render_analyze_report(
+    data: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Assemble an analyze report from the section renderers in D030 order.
+
+    ``now`` is forwarded only to :func:`render_footer` so snapshot tests
+    can pin the reproduction timestamp.
+    """
     parts = ["# AgentFluent Report\n"]
-    for renderer in ANALYZE_SECTIONS:
+    for renderer in ANALYZE_BODY_SECTIONS:
         section = renderer(data)
         if section:
             parts.append(section)
+    footer = render_footer(data, now=now)
+    if footer:
+        parts.append(footer)
     return "\n".join(parts)
 
 

--- a/src/agentfluent/cli/commands/report.py
+++ b/src/agentfluent/cli/commands/report.py
@@ -137,8 +137,10 @@ def _render_analyze_report(
 ) -> str:
     """Assemble an analyze report from the section renderers in D030 order.
 
-    ``now`` is forwarded only to :func:`render_footer` so snapshot tests
-    can pin the reproduction timestamp.
+    Always returns a newline-terminated string so callers (CLI, snapshot
+    test, regenerator) don't each repeat the normalization. ``now`` is
+    forwarded only to :func:`render_footer` so snapshot tests can pin
+    the reproduction timestamp.
     """
     parts = ["# AgentFluent Report\n"]
     for renderer in ANALYZE_BODY_SECTIONS:
@@ -148,7 +150,10 @@ def _render_analyze_report(
     footer = render_footer(data, now=now)
     if footer:
         parts.append(footer)
-    return "\n".join(parts)
+    text = "\n".join(parts)
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
 
 
 _RENDERERS: dict[str, Callable[[dict[str, Any]], str]] = {
@@ -187,8 +192,6 @@ def report(
         raise typer.Exit(code=EXIT_USER_ERROR)
 
     text = renderer(data)
-    if not text.endswith("\n"):
-        text += "\n"
 
     if output is None:
         sys.stdout.write(text)

--- a/src/agentfluent/cli/commands/report_renderers.py
+++ b/src/agentfluent/cli/commands/report_renderers.py
@@ -335,9 +335,16 @@ def _reproduction_command(data: dict[str, Any]) -> str:
     return " ".join(parts)
 
 
-def render_footer(data: dict[str, Any]) -> str:
+def render_footer(data: dict[str, Any], *, now: datetime | None = None) -> str:
+    """Render the reproduction footer.
+
+    ``now`` is an injection seam for snapshot tests so the rendered output
+    is deterministic. Production callers omit it and accept
+    ``datetime.now(UTC)``.
+    """
     cmd = _reproduction_command(data)
-    generated = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    moment = now if now is not None else datetime.now(UTC)
+    generated = moment.strftime("%Y-%m-%dT%H:%M:%SZ")
     return (
         "## Reproduction\n\n"
         "```bash\n"

--- a/tests/fixtures/report/analyze_snapshot.json
+++ b/tests/fixtures/report/analyze_snapshot.json
@@ -1,0 +1,173 @@
+{
+  "version": "2",
+  "command": "analyze",
+  "data": {
+    "project_name": "demo-agent-shop",
+    "session_count": 5,
+    "diagnostics_version": "0.7.0",
+    "window": {
+      "since": "2026-05-01T00:00:00+00:00",
+      "until": "2026-05-08T00:00:00+00:00",
+      "session_count_before_filter": 12,
+      "session_count_after_filter": 5
+    },
+    "token_metrics": {
+      "input_tokens": 24500,
+      "output_tokens": 8200,
+      "cache_creation_input_tokens": 18300,
+      "cache_read_input_tokens": 412000,
+      "total_cost": 7.84,
+      "cache_efficiency": 0.94,
+      "by_model": [
+        {
+          "model": "claude-opus-4-7",
+          "origin": "parent",
+          "input_tokens": 14200,
+          "output_tokens": 5100,
+          "cache_creation_input_tokens": 12500,
+          "cache_read_input_tokens": 280000,
+          "cost": 5.4
+        },
+        {
+          "model": "claude-opus-4-7",
+          "origin": "subagent",
+          "input_tokens": 6300,
+          "output_tokens": 2100,
+          "cache_creation_input_tokens": 4100,
+          "cache_read_input_tokens": 92000,
+          "cost": 1.62
+        },
+        {
+          "model": "claude-haiku-4-5",
+          "origin": "subagent",
+          "input_tokens": 4000,
+          "output_tokens": 1000,
+          "cache_creation_input_tokens": 1700,
+          "cache_read_input_tokens": 40000,
+          "cost": 0.82
+        }
+      ]
+    },
+    "agent_metrics": {
+      "total_invocations": 17,
+      "agent_token_percentage": 38.5,
+      "by_agent_type": {
+        "Explore": {
+          "agent_type": "Explore",
+          "is_builtin": true,
+          "invocation_count": 8,
+          "total_tokens": 42000,
+          "total_tool_uses": 56,
+          "total_duration_ms": 320000
+        },
+        "pm": {
+          "agent_type": "pm",
+          "is_builtin": false,
+          "invocation_count": 6,
+          "total_tokens": 78000,
+          "total_tool_uses": 42,
+          "total_duration_ms": 510000
+        },
+        "tester": {
+          "agent_type": "tester",
+          "is_builtin": false,
+          "invocation_count": 3,
+          "total_tokens": 24000,
+          "total_tool_uses": 18,
+          "total_duration_ms": 145000
+        }
+      }
+    },
+    "diagnostics": {
+      "aggregated_recommendations": [
+        {
+          "agent_type": "pm",
+          "target": "model",
+          "severity": "critical",
+          "signal_types": [
+            "model_mismatch"
+          ],
+          "count": 4,
+          "representative_message": "Agent 'pm' runs Opus on tasks Sonnet handles cleanly; swap the model field to claude-sonnet-4-6.",
+          "primary_axis": "cost",
+          "priority_score": 87.0,
+          "axis_scores": {
+            "cost": 85.0,
+            "speed": 0.0,
+            "quality": 12.0
+          },
+          "contributing_recommendations": []
+        },
+        {
+          "agent_type": "tester",
+          "target": "tools",
+          "severity": "warning",
+          "signal_types": [
+            "tool_error_sequence"
+          ],
+          "count": 3,
+          "representative_message": "Tester retries Bash 4-5 times before giving up; tighten the description so it routes failing builds back to the parent.",
+          "primary_axis": "speed",
+          "priority_score": 52.5,
+          "axis_scores": {
+            "cost": 8.0,
+            "speed": 50.0,
+            "quality": 4.0
+          },
+          "contributing_recommendations": []
+        },
+        {
+          "agent_type": null,
+          "target": "mcp_servers",
+          "severity": "info",
+          "signal_types": [
+            "mcp_unused"
+          ],
+          "count": 1,
+          "representative_message": "MCP server 'github' is configured but no agent invoked it during the analyzed window.",
+          "primary_axis": "cost",
+          "priority_score": 12.0,
+          "axis_scores": {
+            "cost": 10.0,
+            "speed": 0.0,
+            "quality": 0.0
+          },
+          "contributing_recommendations": []
+        }
+      ],
+      "offload_candidates": [
+        {
+          "name": "ts-bulk-edits",
+          "description": "Bulk TypeScript file edits with Read+Edit pattern.",
+          "confidence": "high",
+          "cluster_size": 14,
+          "cohesion_score": 0.88,
+          "top_terms": [
+            "edit",
+            "typescript",
+            "rename"
+          ],
+          "tool_sequence_summary": [],
+          "tools": [
+            "Read",
+            "Edit",
+            "Grep"
+          ],
+          "tools_note": "",
+          "estimated_parent_tokens": 95000,
+          "estimated_parent_cost_usd": 4.2,
+          "estimated_savings_usd": 2.85,
+          "parent_model": "claude-opus-4-7",
+          "alternative_model": "claude-sonnet-4-6",
+          "cost_note": "",
+          "target_kind": "subagent",
+          "subagent_draft": null,
+          "skill_draft": null,
+          "matched_agent": "",
+          "dedup_note": "",
+          "yaml_draft": ""
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/report/expected_report.md
+++ b/tests/fixtures/report/expected_report.md
@@ -1,0 +1,65 @@
+# AgentFluent Report
+
+## Summary
+
+- **Project:** demo-agent-shop
+- **Sessions analyzed:** 5
+- **Window:** 2026-05-01T00:00:00+00:00 → 2026-05-08T00:00:00+00:00 (5 of 12 sessions)
+- **Total cost (API rate):** $7.84
+- **Total tokens:** 463,000 (input 24,500, output 8,200, cache creation 18,300, cache read 412,000)
+- **AgentFluent version:** 0.7.0
+
+## Token Metrics
+
+| Model | Origin | Input | Output | Cache | Cost |
+| :--- | :--- | ---: | ---: | ---: | ---: |
+| claude-haiku-4-5 | subagent | 4,000 | 1,000 | 41,700 | $0.82 |
+| claude-opus-4-7 | parent | 14,200 | 5,100 | 292,500 | $5.40 |
+| claude-opus-4-7 | subagent | 6,300 | 2,100 | 96,100 | $1.62 |
+| **Total** |  | **24,500** | **8,200** | **430,300** | **$7.84** |
+
+## Agent Metrics
+
+| Agent Type | Count | Tokens | Avg Tokens/Call | Duration |
+| :--- | ---: | ---: | ---: | ---: |
+| Explore (builtin) | 8 | 42,000 | 5,250 | 320.0s |
+| pm | 6 | 78,000 | 13,000 | 510.0s |
+| tester | 3 | 24,000 | 8,000 | 145.0s |
+| **Total** | **17** |  |  |  |
+
+Agent token share of session total: **38.5%**
+
+## Diagnostics
+
+**Top 3 priority fixes:**
+
+1. **critical** · agent: `pm` · 4× · target: `model` · axis: \[cost]
+2. **warning** · agent: `tester` · 3× · target: `tools` · axis: \[speed]
+3. **info** · agent: `(global)` · 1× · target: `mcp_servers` · axis: \[cost]
+
+
+### Critical (1)
+
+- \[cost] (target: `model`, agent: `pm`, count: 4×) — Agent 'pm' runs Opus on tasks Sonnet handles cleanly; swap the model field to claude-sonnet-4-6.
+
+### Warning (1)
+
+- \[speed] (target: `tools`, agent: `tester`, count: 3×) — Tester retries Bash 4-5 times before giving up; tighten the description so it routes failing builds back to the parent.
+
+### Info (1)
+
+- \[cost] (target: `mcp_servers`, agent: `(global)`, count: 1×) — MCP server 'github' is configured but no agent invoked it during the analyzed window.
+
+## Offload Candidates
+
+| Name | Confidence | Cluster size | Tools | Est. savings |
+| :--- | :--- | ---: | :--- | ---: |
+| ts-bulk-edits | high | 14 | Read, Edit, Grep | $2.85 |
+
+## Reproduction
+
+```bash
+agentfluent analyze --project demo-agent-shop --since 2026-05-01T00:00:00+00:00 --until 2026-05-08T00:00:00+00:00 --json
+```
+
+*Generated: 2026-05-15T14:30:00Z*

--- a/tests/unit/cli/test_report_golden.py
+++ b/tests/unit/cli/test_report_golden.py
@@ -1,0 +1,323 @@
+"""Golden-fixture snapshot test for ``agentfluent report`` (#355).
+
+The fixture pair lives in ``tests/fixtures/report/``:
+
+* ``analyze_snapshot.json`` -- a representative ``analyze --json`` envelope
+  built from :func:`_analyze_envelope_data`.
+* ``expected_report.md`` -- the rendered Markdown produced by
+  :func:`agentfluent.cli.commands.report._render_analyze_report` against
+  that data with ``now`` pinned to :data:`_FIXED_NOW`.
+
+The snapshot test loads both files and asserts byte-for-byte equality.
+The fixture pair doubles as a documentation example -- the rendered
+Markdown is exactly what a developer sees when running ``report`` on a
+real project.
+
+To regenerate after an intentional format change:
+
+    python -m tests.unit.cli.test_report_golden
+
+The same data builder produces both files, so they cannot drift apart.
+
+A separate test (:class:`TestV06EnvelopeBackwardCompat`) constructs an
+analyze envelope shaped like a v0.6 snapshot -- no ``window``, no
+``diagnostics_version``, no per-row ``origin`` on ``by_model`` -- to
+prove ``report`` still produces a sensible document when fed an older
+snapshot a user kept around.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.cli.commands.report import _render_analyze_report
+from agentfluent.cli.formatters.json_output import format_json_output
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "report"
+ANALYZE_SNAPSHOT_PATH = FIXTURE_DIR / "analyze_snapshot.json"
+EXPECTED_REPORT_PATH = FIXTURE_DIR / "expected_report.md"
+
+_FIXED_NOW = datetime(2026, 5, 15, 14, 30, 0, tzinfo=UTC)
+
+
+def _analyze_envelope_data() -> dict[str, Any]:
+    """Representative analyze ``data`` payload exercising every renderer.
+
+    Hand-built rather than captured from a real run so every renderer
+    branch has coverage: parent + subagent rows on the same model, a
+    builtin and a custom agent, one finding per severity, and a
+    positive-savings offload candidate.
+    """
+    return {
+        "project_name": "demo-agent-shop",
+        "session_count": 5,
+        "diagnostics_version": "0.7.0",
+        "window": {
+            "since": "2026-05-01T00:00:00+00:00",
+            "until": "2026-05-08T00:00:00+00:00",
+            "session_count_before_filter": 12,
+            "session_count_after_filter": 5,
+        },
+        "token_metrics": {
+            "input_tokens": 24_500,
+            "output_tokens": 8_200,
+            "cache_creation_input_tokens": 18_300,
+            "cache_read_input_tokens": 412_000,
+            "total_cost": 7.84,
+            "cache_efficiency": 0.94,
+            "by_model": [
+                {
+                    "model": "claude-opus-4-7",
+                    "origin": "parent",
+                    "input_tokens": 14_200,
+                    "output_tokens": 5_100,
+                    "cache_creation_input_tokens": 12_500,
+                    "cache_read_input_tokens": 280_000,
+                    "cost": 5.40,
+                },
+                {
+                    "model": "claude-opus-4-7",
+                    "origin": "subagent",
+                    "input_tokens": 6_300,
+                    "output_tokens": 2_100,
+                    "cache_creation_input_tokens": 4_100,
+                    "cache_read_input_tokens": 92_000,
+                    "cost": 1.62,
+                },
+                {
+                    "model": "claude-haiku-4-5",
+                    "origin": "subagent",
+                    "input_tokens": 4_000,
+                    "output_tokens": 1_000,
+                    "cache_creation_input_tokens": 1_700,
+                    "cache_read_input_tokens": 40_000,
+                    "cost": 0.82,
+                },
+            ],
+        },
+        "agent_metrics": {
+            "total_invocations": 17,
+            "agent_token_percentage": 38.5,
+            "by_agent_type": {
+                "Explore": {
+                    "agent_type": "Explore",
+                    "is_builtin": True,
+                    "invocation_count": 8,
+                    "total_tokens": 42_000,
+                    "total_tool_uses": 56,
+                    "total_duration_ms": 320_000,
+                },
+                "pm": {
+                    "agent_type": "pm",
+                    "is_builtin": False,
+                    "invocation_count": 6,
+                    "total_tokens": 78_000,
+                    "total_tool_uses": 42,
+                    "total_duration_ms": 510_000,
+                },
+                "tester": {
+                    "agent_type": "tester",
+                    "is_builtin": False,
+                    "invocation_count": 3,
+                    "total_tokens": 24_000,
+                    "total_tool_uses": 18,
+                    "total_duration_ms": 145_000,
+                },
+            },
+        },
+        "diagnostics": {
+            "aggregated_recommendations": [
+                {
+                    "agent_type": "pm",
+                    "target": "model",
+                    "severity": "critical",
+                    "signal_types": ["model_mismatch"],
+                    "count": 4,
+                    "representative_message": (
+                        "Agent 'pm' runs Opus on tasks Sonnet handles cleanly; "
+                        "swap the model field to claude-sonnet-4-6."
+                    ),
+                    "primary_axis": "cost",
+                    "priority_score": 87.0,
+                    "axis_scores": {"cost": 85.0, "speed": 0.0, "quality": 12.0},
+                    "contributing_recommendations": [],
+                },
+                {
+                    "agent_type": "tester",
+                    "target": "tools",
+                    "severity": "warning",
+                    "signal_types": ["tool_error_sequence"],
+                    "count": 3,
+                    "representative_message": (
+                        "Tester retries Bash 4-5 times before giving up; "
+                        "tighten the description so it routes failing builds "
+                        "back to the parent."
+                    ),
+                    "primary_axis": "speed",
+                    "priority_score": 52.5,
+                    "axis_scores": {"cost": 8.0, "speed": 50.0, "quality": 4.0},
+                    "contributing_recommendations": [],
+                },
+                {
+                    "agent_type": None,
+                    "target": "mcp_servers",
+                    "severity": "info",
+                    "signal_types": ["mcp_unused"],
+                    "count": 1,
+                    "representative_message": (
+                        "MCP server 'github' is configured but no agent "
+                        "invoked it during the analyzed window."
+                    ),
+                    "primary_axis": "cost",
+                    "priority_score": 12.0,
+                    "axis_scores": {"cost": 10.0, "speed": 0.0, "quality": 0.0},
+                    "contributing_recommendations": [],
+                },
+            ],
+            "offload_candidates": [
+                {
+                    "name": "ts-bulk-edits",
+                    "description": "Bulk TypeScript file edits with Read+Edit pattern.",
+                    "confidence": "high",
+                    "cluster_size": 14,
+                    "cohesion_score": 0.88,
+                    "top_terms": ["edit", "typescript", "rename"],
+                    "tool_sequence_summary": [],
+                    "tools": ["Read", "Edit", "Grep"],
+                    "tools_note": "",
+                    "estimated_parent_tokens": 95_000,
+                    "estimated_parent_cost_usd": 4.20,
+                    "estimated_savings_usd": 2.85,
+                    "parent_model": "claude-opus-4-7",
+                    "alternative_model": "claude-sonnet-4-6",
+                    "cost_note": "",
+                    "target_kind": "subagent",
+                    "subagent_draft": None,
+                    "skill_draft": None,
+                    "matched_agent": "",
+                    "dedup_note": "",
+                    "yaml_draft": "",
+                },
+            ],
+        },
+    }
+
+
+class TestSnapshot:
+    def test_rendered_report_matches_golden_fixture(self) -> None:
+        envelope_text = ANALYZE_SNAPSHOT_PATH.read_text(encoding="utf-8")
+        envelope = json.loads(envelope_text)
+        rendered = _render_analyze_report(envelope["data"], now=_FIXED_NOW)
+        if not rendered.endswith("\n"):
+            rendered += "\n"
+
+        expected = EXPECTED_REPORT_PATH.read_text(encoding="utf-8")
+        assert rendered == expected, (
+            "Rendered report drifted from the golden fixture. If this is "
+            "intentional, regenerate via: "
+            "python -m tests.unit.cli.test_report_golden"
+        )
+
+    def test_committed_envelope_matches_data_builder(self) -> None:
+        """Guard against the JSON fixture diverging from the builder."""
+        on_disk = json.loads(ANALYZE_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        rebuilt = json.loads(format_json_output("analyze", _analyze_envelope_data()))
+        assert on_disk == rebuilt, (
+            "analyze_snapshot.json drifted from _analyze_envelope_data(); "
+            "regenerate via: python -m tests.unit.cli.test_report_golden"
+        )
+
+
+class TestV06EnvelopeBackwardCompat:
+    """Older snapshots predate v0.7's ``window``, ``diagnostics_version``,
+    and per-row ``origin`` columns. ``report`` must degrade gracefully
+    rather than KeyError on missing fields."""
+
+    @pytest.fixture()
+    def v06_data(self) -> dict[str, Any]:
+        return {
+            "project_name": "legacy-project",
+            "session_count": 3,
+            "token_metrics": {
+                "input_tokens": 5000,
+                "output_tokens": 1500,
+                "cache_creation_input_tokens": 2000,
+                "cache_read_input_tokens": 18000,
+                "total_cost": 0.42,
+                "cache_efficiency": 0.78,
+                "by_model": [
+                    {
+                        "model": "claude-opus-4-6",
+                        "input_tokens": 5000,
+                        "output_tokens": 1500,
+                        "cache_creation_input_tokens": 2000,
+                        "cache_read_input_tokens": 18000,
+                        "cost": 0.42,
+                    },
+                ],
+            },
+            "agent_metrics": {
+                "by_agent_type": {},
+                "total_invocations": 0,
+                "agent_token_percentage": 0.0,
+            },
+        }
+
+    def test_renders_without_window_metadata(self, v06_data: dict[str, Any]) -> None:
+        out = _render_analyze_report(v06_data, now=_FIXED_NOW)
+        assert "## Summary" in out
+        assert "Window:** all sessions" in out
+
+    def test_omits_version_line_when_unstamped(self, v06_data: dict[str, Any]) -> None:
+        out = _render_analyze_report(v06_data, now=_FIXED_NOW)
+        assert "AgentFluent version" not in out
+
+    def test_token_table_renders_with_blank_origin(
+        self, v06_data: dict[str, Any],
+    ) -> None:
+        out = _render_analyze_report(v06_data, now=_FIXED_NOW)
+        assert "## Token Metrics" in out
+        assert "claude-opus-4-6" in out
+
+    def test_no_agent_invocations_emits_fallback(
+        self, v06_data: dict[str, Any],
+    ) -> None:
+        out = _render_analyze_report(v06_data, now=_FIXED_NOW)
+        assert "No agent invocations." in out
+
+    def test_no_diagnostics_emits_no_findings(
+        self, v06_data: dict[str, Any],
+    ) -> None:
+        out = _render_analyze_report(v06_data, now=_FIXED_NOW)
+        assert "No findings." in out
+
+
+def _regenerate_golden() -> None:
+    """Write both fixture files from the canonical data builder.
+
+    Invoke directly when the report format changes intentionally:
+
+        python -m tests.unit.cli.test_report_golden
+    """
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    data = _analyze_envelope_data()
+    envelope_text = format_json_output("analyze", data)
+    if not envelope_text.endswith("\n"):
+        envelope_text += "\n"
+    ANALYZE_SNAPSHOT_PATH.write_text(envelope_text, encoding="utf-8")
+
+    rendered = _render_analyze_report(data, now=_FIXED_NOW)
+    if not rendered.endswith("\n"):
+        rendered += "\n"
+    EXPECTED_REPORT_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {ANALYZE_SNAPSHOT_PATH}")
+    print(f"Wrote {EXPECTED_REPORT_PATH}")
+
+
+if __name__ == "__main__":
+    _regenerate_golden()

--- a/tests/unit/cli/test_report_golden.py
+++ b/tests/unit/cli/test_report_golden.py
@@ -1,4 +1,4 @@
-"""Golden-fixture snapshot test for ``agentfluent report`` (#355).
+"""Golden-fixture snapshot test for ``agentfluent report``.
 
 The fixture pair lives in ``tests/fixtures/report/``:
 
@@ -213,8 +213,6 @@ class TestSnapshot:
         envelope_text = ANALYZE_SNAPSHOT_PATH.read_text(encoding="utf-8")
         envelope = json.loads(envelope_text)
         rendered = _render_analyze_report(envelope["data"], now=_FIXED_NOW)
-        if not rendered.endswith("\n"):
-            rendered += "\n"
 
         expected = EXPECTED_REPORT_PATH.read_text(encoding="utf-8")
         assert rendered == expected, (
@@ -312,8 +310,6 @@ def _regenerate_golden() -> None:
     ANALYZE_SNAPSHOT_PATH.write_text(envelope_text, encoding="utf-8")
 
     rendered = _render_analyze_report(data, now=_FIXED_NOW)
-    if not rendered.endswith("\n"):
-        rendered += "\n"
     EXPECTED_REPORT_PATH.write_text(rendered, encoding="utf-8")
     print(f"Wrote {ANALYZE_SNAPSHOT_PATH}")
     print(f"Wrote {EXPECTED_REPORT_PATH}")

--- a/tests/unit/cli/test_report_pipeline.py
+++ b/tests/unit/cli/test_report_pipeline.py
@@ -1,0 +1,82 @@
+"""End-to-end pipeline test: ``analyze --json`` -> ``report`` (#355).
+
+Covers the composition contract: a snapshot produced by ``analyze --json``
+on the same machine round-trips through ``report`` without losing fields
+the renderers expect. Uses the existing ``populated_home`` /
+``populated_home_with_traces`` fixtures (anonymized, deterministic) so
+the test runs in CI rather than depending on real session data.
+
+Per the project's CI policy (`tests/integration/` is reserved for tests
+that need real ``~/.claude/projects/`` data), this lives under
+``tests/unit/cli/`` and is not marked ``integration``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+
+class TestAnalyzeReportPipeline:
+    def test_analyze_json_roundtrips_through_report(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home: Path,  # noqa: ARG002 — patches discovery paths
+        tmp_path: Path,
+    ) -> None:
+        analyze_result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--no-diagnostics", "--json"],
+        )
+        assert analyze_result.exit_code == 0, analyze_result.output
+
+        snap_file = tmp_path / "snap.json"
+        snap_file.write_text(analyze_result.stdout)
+
+        report_result = runner.invoke(cli_app, ["report", str(snap_file)])
+        assert report_result.exit_code == 0, report_result.output
+
+        out = report_result.stdout
+        # Every always-emitted section header is present, in the D030 order.
+        assert "# AgentFluent Report" in out
+        idx_summary = out.index("## Summary")
+        idx_tokens = out.index("## Token Metrics")
+        idx_agents = out.index("## Agent Metrics")
+        idx_diag = out.index("## Diagnostics")
+        idx_footer = out.index("## Reproduction")
+        assert idx_summary < idx_tokens < idx_agents < idx_diag < idx_footer
+
+        # The reproduction footer should echo a runnable analyze command.
+        assert "agentfluent analyze --project" in out
+
+    def test_diagnostics_path_renders_through_pipeline(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        """The diagnostics-on path produces a populated Diagnostics section.
+
+        Uses the trace-carrying fixture so the diagnostics pipeline has
+        signal evidence to aggregate. Asserts only that the section
+        renders without crashing -- the exact recommendations depend on
+        upstream rule weights, which would make this test brittle.
+        """
+        analyze_result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--json"],
+        )
+        assert analyze_result.exit_code == 0, analyze_result.output
+
+        snap_file = tmp_path / "snap.json"
+        snap_file.write_text(analyze_result.stdout)
+
+        report_result = runner.invoke(cli_app, ["report", str(snap_file)])
+        assert report_result.exit_code == 0, report_result.output
+
+        out = report_result.stdout
+        assert "## Diagnostics" in out
+        assert "Traceback" not in out

--- a/tests/unit/cli/test_report_pipeline.py
+++ b/tests/unit/cli/test_report_pipeline.py
@@ -1,4 +1,4 @@
-"""End-to-end pipeline test: ``analyze --json`` -> ``report`` (#355).
+"""End-to-end pipeline test: ``analyze --json`` -> ``report``.
 
 Covers the composition contract: a snapshot produced by ``analyze --json``
 on the same machine round-trips through ``report`` without losing fields
@@ -15,16 +15,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
 
 class TestAnalyzeReportPipeline:
+    @pytest.mark.usefixtures("populated_home")
     def test_analyze_json_roundtrips_through_report(
         self,
         runner: CliRunner,
         cli_app: typer.Typer,
-        populated_home: Path,  # noqa: ARG002 — patches discovery paths
         tmp_path: Path,
     ) -> None:
         analyze_result = runner.invoke(
@@ -40,7 +41,6 @@ class TestAnalyzeReportPipeline:
         assert report_result.exit_code == 0, report_result.output
 
         out = report_result.stdout
-        # Every always-emitted section header is present, in the D030 order.
         assert "# AgentFluent Report" in out
         idx_summary = out.index("## Summary")
         idx_tokens = out.index("## Token Metrics")
@@ -48,23 +48,20 @@ class TestAnalyzeReportPipeline:
         idx_diag = out.index("## Diagnostics")
         idx_footer = out.index("## Reproduction")
         assert idx_summary < idx_tokens < idx_agents < idx_diag < idx_footer
-
-        # The reproduction footer should echo a runnable analyze command.
         assert "agentfluent analyze --project" in out
 
+    @pytest.mark.usefixtures("populated_home_with_traces")
     def test_diagnostics_path_renders_through_pipeline(
         self,
         runner: CliRunner,
         cli_app: typer.Typer,
-        populated_home_with_traces: Path,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
-        """The diagnostics-on path produces a populated Diagnostics section.
+        """The diagnostics-on path runs without crashing.
 
-        Uses the trace-carrying fixture so the diagnostics pipeline has
-        signal evidence to aggregate. Asserts only that the section
-        renders without crashing -- the exact recommendations depend on
-        upstream rule weights, which would make this test brittle.
+        Asserts only that the Diagnostics section is present -- the
+        exact recommendations depend on upstream rule weights, which
+        would make a deeper assertion brittle.
         """
         analyze_result = runner.invoke(
             cli_app, ["analyze", "--project", "project", "--json"],


### PR DESCRIPTION
## Summary
- Snapshot test against a hand-crafted golden fixture (`tests/fixtures/report/analyze_snapshot.json` + `expected_report.md`) that exercises every renderer path.
- v0.6 backward-compat tests prove `report` degrades gracefully on snapshots that predate `window`, `diagnostics_version`, and per-row `origin`.
- End-to-end pipeline test runs `analyze --json` against the populated-home fixtures and feeds the result through `report`. Lives in `tests/unit/cli/` (not `tests/integration/`) because it doesn't need real `~/.claude/projects/` data.
- `render_footer` gains an optional `now: datetime | None = None` injection point so the snapshot test pins the reproduction-footer timestamp without monkeypatching `datetime`. Threaded through `_render_analyze_report` so production callers omit it.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1340 passed, +9 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (43 report-related tests; coverage 95% on `report_renderers.py`, 86% on `report.py` — both above the 80% target in the issue)
- [x] Manual smoke test via `python -m tests.unit.cli.test_report_golden` regenerates fixtures cleanly

## Security review
- [x] **Skip review** — test-only changes plus an internal-only optional kwarg (`now`) on a renderer function. No new CLI surface, no path resolution, no user-controlled string rendering.
- [ ] **Needs review**

## Breaking changes
None. `render_footer`'s new `now` kwarg is keyword-only with a backward-compatible default.

Closes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)