### PR TITLE
Document the report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ Near-duplicate recommendations are aggregated per `(agent, target, signal)` shap
 
 Cost numbers reflect current per-token pricing; historical sessions are priced at today's rates until [#80](https://github.com/frederick-douglas-pearce/agentfluent/issues/80) (time-series pricing) lands.
 
+### `agentfluent report` — render a saved analysis as Markdown
+
+```bash
+agentfluent analyze --project codefluent --json > snap.json
+agentfluent report snap.json > report.md
+agentfluent report snap.json --output report.md
+```
+
+Renders an `analyze --json` snapshot as a standalone Markdown report. Use it when you want a human-readable PR comment, CI artifact, or local review document without re-running analysis. The workflow is intentionally composable: `analyze` produces the stable JSON envelope, and `report` turns that saved envelope into Markdown.
+
 ### `agentfluent diff` — compare two analyze runs
 
 ```bash

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,8 +10,8 @@ opening this file.
 
 ## Reading guide
 
-`agentfluent` reports on three layers of agent behavior, and the glossary is
-organized to match them:
+`agentfluent` reports on three layers of agent behavior, with command
+reference material alongside them:
 
 1. **Execution analytics** -- what happened: token counts, tool calls, costs.
    Mostly familiar Anthropic API vocabulary, plus a few AgentFluent-specific
@@ -30,6 +30,10 @@ organized to match them:
    surfaces. The **Recommendation target** and **Built-in agent concern**
    sections explain why two findings on the same agent might suggest
    different fixes.
+
+4. **CLI commands** -- what each `agentfluent` subcommand does and when
+   to use it. Start here if you want a quick overview of available
+   commands before diving into the vocabulary they produce.
 
 ---
 
@@ -1322,6 +1326,53 @@ agent.
 with underscore. The first `__` after the `mcp__` prefix is the
 server/tool boundary. Not a closed enum -- MCP servers contribute
 additional namespaced tools at runtime.
+
+
+---
+
+## CLI commands
+
+### `report`
+
+**Short:** Render a saved `analyze --json` snapshot as a Markdown report.
+
+**Detail:** `agentfluent report` is the composable Markdown rendering step for
+analysis snapshots. Run `agentfluent analyze --json` first, save or pipe
+that JSON envelope, then pass it to `report` to produce a human-readable
+document for PR comments, CI artifacts, or local review. Keeping the
+renderer separate means the same snapshot can be archived, diffed, and
+re-rendered without re-reading session data.
+
+**Example:**
+
+```
+agentfluent analyze --project codefluent --json > snap.json
+agentfluent report snap.json > report.md
+```
+
+**Aliases:** `markdown report`, `snapshot report`
+
+**Related:** [`analyze`](#analyze)
+
+### `analyze`
+
+**Short:** Analyze Claude Code or Agent SDK sessions for tokens, cost, behavior diagnostics, and recommendations.
+
+### `diff`
+
+**Short:** Compare two saved `analyze --json` envelopes and surface new, resolved, and persisting recommendations.
+
+### `config-check`
+
+**Short:** Score agent definitions against prompt, tool access, model, and configuration best practices.
+
+### `explain`
+
+**Short:** Look up an AgentFluent glossary term directly from the terminal.
+
+### `list`
+
+**Short:** Discover Claude Code and Agent SDK projects and sessions available for analysis.
 
 ---
 

--- a/src/agentfluent/glossary/models.py
+++ b/src/agentfluent/glossary/models.py
@@ -24,6 +24,7 @@ GlossaryCategory = Literal[
     "diff_status",
     "builtin_agent_type",
     "builtin_tool",
+    "cli_command",
 ]
 
 # Display order + label for each category. Drives section ordering in the
@@ -41,6 +42,7 @@ GLOSSARY_CATEGORIES: tuple[tuple[GlossaryCategory, str], ...] = (
     ("diff_status", "Comparison row status"),
     ("builtin_agent_type", "Built-in agent types"),
     ("builtin_tool", "Built-in tools"),
+    ("cli_command", "CLI commands"),
 )
 
 

--- a/src/agentfluent/glossary/render.py
+++ b/src/agentfluent/glossary/render.py
@@ -34,8 +34,8 @@ opening this file.
 
 ## Reading guide
 
-`agentfluent` reports on three layers of agent behavior, and the glossary is
-organized to match them:
+`agentfluent` reports on three layers of agent behavior, with command
+reference material alongside them:
 
 1. **Execution analytics** -- what happened: token counts, tool calls, costs.
    Mostly familiar Anthropic API vocabulary, plus a few AgentFluent-specific
@@ -54,6 +54,10 @@ organized to match them:
    surfaces. The **Recommendation target** and **Built-in agent concern**
    sections explain why two findings on the same agent might suggest
    different fixes.
+
+4. **CLI commands** -- what each `agentfluent` subcommand does and when
+   to use it. Start here if you want a quick overview of available
+   commands before diving into the vocabulary they produce.
 """
 
 FOOTER = """\

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1098,3 +1098,43 @@
     that's getting worse without crossing a discrete threshold.
   example: |
     [persisting] warning pm: tool_error_sequence (count_delta=+2, priority_score_delta=+4.1)
+
+# =============================================================================
+# CLI commands
+# =============================================================================
+
+- name: report
+  category: cli_command
+  short: Render a saved `analyze --json` snapshot as a Markdown report.
+  long: |
+    `agentfluent report` is the composable Markdown rendering step for
+    analysis snapshots. Run `agentfluent analyze --json` first, save or pipe
+    that JSON envelope, then pass it to `report` to produce a human-readable
+    document for PR comments, CI artifacts, or local review. Keeping the
+    renderer separate means the same snapshot can be archived, diffed, and
+    re-rendered without re-reading session data.
+  example: |
+    agentfluent analyze --project codefluent --json > snap.json
+    agentfluent report snap.json > report.md
+  aliases: [markdown report, snapshot report]
+  related: [analyze]
+
+- name: analyze
+  category: cli_command
+  short: Analyze Claude Code or Agent SDK sessions for tokens, cost, behavior diagnostics, and recommendations.
+
+- name: diff
+  category: cli_command
+  short: Compare two saved `analyze --json` envelopes and surface new, resolved, and persisting recommendations.
+
+- name: config-check
+  category: cli_command
+  short: Score agent definitions against prompt, tool access, model, and configuration best practices.
+
+- name: explain
+  category: cli_command
+  short: Look up an AgentFluent glossary term directly from the terminal.
+
+- name: list
+  category: cli_command
+  short: Discover Claude Code and Agent SDK projects and sessions available for analysis.


### PR DESCRIPTION
This adds documentation for the new report subcommand in the README and glossary. The glossary now has a CLI commands category with a full report entry and short stubs for sibling commands, and the generated glossary is refreshed so the drift test stays in sync. The README now shows the saved-snapshot workflow for turning analyze JSON into Markdown.