### PR TITLE
feat(cli): block --session + --latest, surface scope in table footer (#358)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -185,7 +185,10 @@ def analyze(
         None,
         "--latest",
         "-n",
-        help="Analyze only the N most recent sessions.",
+        help=(
+            "Analyze only the N most recent sessions. "
+            "Mutually exclusive with --session."
+        ),
     ),
     since: Optional[str] = typer.Option(  # noqa: UP007, UP045
         None,
@@ -283,6 +286,13 @@ def analyze(
         err_console.print(
             "[red]Error:[/red] --since/--until cannot be combined with "
             "--session (which selects a specific file).",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
+
+    if session is not None and latest is not None:
+        err_console.print(
+            "[red]Error:[/red] --latest cannot be combined with --session "
+            "(which already selects a single session).",
         )
         raise typer.Exit(code=EXIT_USER_ERROR)
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -284,7 +284,10 @@ def format_analysis_table(
         else:
             _format_diagnostics_summary(console, diag)
 
-    console.print(f"\n[bold]Sessions analyzed:[/bold] {result.session_count}")
+    if result.scope_session is not None:
+        console.print(f"\n[bold]Session:[/bold] {result.scope_session}")
+    else:
+        console.print(f"\n[bold]Sessions analyzed:[/bold] {result.session_count}")
 
 
 def _verbose_signal_message(sig: DiagnosticSignal) -> str:

--- a/tests/unit/cli/test_analyze_session_scope.py
+++ b/tests/unit/cli/test_analyze_session_scope.py
@@ -181,3 +181,52 @@ class TestSessionScopesEverything:
         assert agent_keys == {"pm", "tester"}, (
             "expected both sessions' agent types when --session is omitted"
         )
+
+
+class TestSessionLatestMutualExclusion:
+    """``--session`` + ``--latest`` is silently no-op'd in v0.6 — when
+    ``--session`` is set, ``session_infos`` already has length 1, so
+    ``[:latest]`` is a noop. Make the conflict explicit so users get a
+    clear error instead of a misleading-but-accepted combination."""
+
+    @pytest.mark.usefixtures("two_session_project")
+    def test_session_with_latest_errors(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project",
+             "--session", "alpha.jsonl", "--latest", "3"],
+        )
+        assert result.exit_code != 0
+        assert "--latest cannot be combined with --session" in result.stderr
+
+
+class TestScopedFooterRendering:
+    """Table footer must read ``Session: <filename>`` (not ``Sessions
+    analyzed: 1``) when ``scope_session`` is set, so users can confirm
+    scope from the terminal output without reading JSON."""
+
+    @pytest.mark.usefixtures("two_session_project")
+    def test_scoped_footer_shows_session_filename(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--session", "alpha.jsonl",
+             "--no-diagnostics"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Session: alpha.jsonl" in result.stdout
+        assert "Sessions analyzed:" not in result.stdout
+
+    @pytest.mark.usefixtures("two_session_project")
+    def test_unscoped_footer_shows_session_count(
+        self, runner: CliRunner, cli_app: typer.Typer,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--no-diagnostics"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Sessions analyzed: 2" in result.stdout


### PR DESCRIPTION
Closes #358.

## Summary
- Reject \`--session\` + \`--latest\` at parse time. v0.6 silently no-op'd this combination (when \`--session\` is set, \`session_infos\` has length 1, so \`[:latest]\` does nothing) — users would believe \`--latest\` applied. Mirrors the existing \`--session\` + \`--since/--until\` guard at \`commands/analyze.py:277\`. Architect callout from the #357 review.
- Table footer switches to \`Session: <filename>\` when \`scope_session\` is set, instead of \`Sessions analyzed: 1\`. Lets a user confirm scope from terminal output without reading the JSON envelope.
- \`--latest\` help text now documents the mutual exclusion with \`--session\`.

## AC mapping (per updated #358 body)
- ✅ JSON envelope scope field — shipped in #357 (PR #383)
- ✅ \`--session\` + \`--since/--until\` error — already enforced (D024)
- ✅ \`--session\` + \`--latest\` error — **this PR**
- ✅ Verbose output reflects single-session context — already true by construction (per-session breakdown at \`table.py:224\` gates on \`len(result.sessions) > 1\`)
- ✅ No \"aggregated across N sessions\" language when scoped — **this PR** (footer change)
- ✅ Table header shows \"Session: <uuid>\" when scoped — reinterpreted as a footer change: the analyze table has no top-level header today, and adding one only for the scoped path would be inconsistent. The footer is the existing single line that already references session count, so changing it is the minimal coherent fix.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` (1346 passed)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage — \`tests/unit/cli/test_analyze_session_scope.py\` extended with \`TestSessionLatestMutualExclusion\` and \`TestScopedFooterRendering\` (3 new tests)
- [x] Manual smoke test — N/A (text rendering verified by assertion on stdout; error message verified by assertion on stderr)

## Security review
- [x] **Skip review** — no security-sensitive surface. Adds one CLI validation branch (rejects an invalid flag combination) and one conditional in a renderer; no I/O, parsing, subprocess, or rendering of user-controlled strings beyond the existing \`scope_session\` value already validated as a filename in the CLI.
- [ ] **Needs review**

## Breaking changes
\`--session SID --latest N\` used to be silently accepted and ignored; it now exits 1 with a clear error. Anyone scripting both flags by accident would have gotten misleading results before — strictly an improvement. No change to either flag in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)