### PR TITLE
docs(changelog): document --session diagnostics auto-scope breaking change (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v0.7.0 — Breaking changes
+
+> Manual prose; release-please will add its auto-generated `## [0.7.0]` block (Features / Bug Fixes / etc.) above the v0.6.0 header when v0.7.0 is cut. Keep this section as-is across release-please regenerations.
+
+### `analyze --session` auto-scopes diagnostics
+
+In v0.6.0, `agentfluent analyze --project P --session <uuid> --diagnostics` scoped token/cost metrics to the named session but **rolled diagnostics up across all sessions in the project** — recommendations, offload candidates, and quality signals reflected the full window even though the metrics did not.
+
+In v0.7.0, `--session` auto-scopes the diagnostics pipeline too. Every metric and finding in the output now reflects only the named session. The same flag means the same scope across the whole envelope.
+
+**Before (v0.6.0):**
+
+```
+$ agentfluent analyze --project P --session abc123.jsonl --diagnostics --json
+# token_metrics: scoped to session abc123
+# diagnostics.recommendations: aggregated across ALL project sessions
+```
+
+**After (v0.7.0):**
+
+```
+$ agentfluent analyze --project P --session abc123.jsonl --diagnostics --json
+# token_metrics: scoped to session abc123
+# diagnostics.recommendations: scoped to session abc123
+# scope_session: "abc123.jsonl"   (new metadata field, lets consumers verify scope)
+```
+
+Two related changes shipped alongside:
+
+- The JSON envelope now carries a top-level `scope_session: str | None` so consumers can confirm scope without re-counting sessions ([#357](https://github.com/frederick-douglas-pearce/agentfluent/pull/383)).
+- `--session` + `--latest` is now an error instead of silently no-op'd ([#358](https://github.com/frederick-douglas-pearce/agentfluent/pull/384)).
+
+**Rationale:** see decision [D032](.claude/specs/decisions.md) — the v0.6 behavior was a latent inconsistency, not a feature anyone depended on. Per [D029](.claude/specs/decisions.md), the change is documented as a breaking note but kept under a `0.x` minor bump rather than a major bump, because the leading-zero version already signals "expect breaking changes."
+
 ## [0.6.0](https://github.com/frederick-douglas-pearce/agentfluent/compare/v0.5.1...v0.6.0) (2026-05-09)
 
 


### PR DESCRIPTION
Closes #360.

## Summary
- Add a v0.7.0 \`### Breaking changes\` prose section to CHANGELOG.md above the v0.6.0 header, explaining the \`--session\` semantics shift with before/after JSON envelope examples.
- References D032 (the decision to auto-scope diagnostics) and D029 (keep the minor bump, document via CHANGELOG prose instead of \`feat!:\`).
- Cross-links the two related PRs that landed the implementation: #383 (\`scope_session\` field) and #384 (\`--session\` + \`--latest\` guard).

## Why a manual prose section, not a \`BREAKING CHANGE:\` commit footer
Per D029, the change keeps the 0.x minor bump. Adding \`BREAKING CHANGE:\` to a commit footer would trigger release-please to bump to 1.0.0, which D029 explicitly rejected. Manual prose is the only path that satisfies the issue's AC ("CHANGELOG entry with BREAKING CHANGE: prefix or dedicated breaking changes section") without conflicting with D029's version-bump decision.

The prose is positioned above the v0.6.0 header, where release-please will insert its auto-generated \`## [0.7.0]\` block on the next release-PR refresh. The two sections sit side-by-side: human-authored breaking-changes notice, then auto-generated Features / Bug Fixes list.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` — N/A (docs-only)
- [x] Lint clean: \`uv run ruff check src/ tests/\` — N/A (docs-only)
- [x] Type check clean: \`uv run mypy src/agentfluent/\` — N/A (docs-only)
- [x] New/changed behavior has test coverage — N/A (docs-only)
- [x] Manual smoke test via \`uv run agentfluent ...\` — N/A (docs-only)

## Security review
- [x] **Skip review** — docs-only CHANGELOG addition. No code, no config, no security-sensitive surface.
- [ ] **Needs review**

## Breaking changes
The CHANGELOG entry documents a breaking change that already shipped (#383, #384). This PR is the documentation closeout, not the breaking change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)