### PR TITLE
feat(diagnostics): local-git feat-then-fix proximity signal (#275)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -629,6 +629,47 @@ per-(session, agent_type) substantive rate >= MIN_REVIEWER_CAUGHT_RATE
 
 **Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`primary_axis`](#primary_axis)
 
+### `feat_fix_proximity`
+
+**Short:** A `feat:` commit followed within a short window by `fix:` commits
+touching the same files -- evidence that the feature shipped with
+quality issues an independent reviewer might have caught.
+
+**Detail:** Local-git quality-axis signal (v0.7). Off by default; runs only
+when the CLI passes `--git`. Scans the last 90 days of `git log`
+in the project's source directory for `feat:` commits, then for
+each one looks 7 days forward for any `fix:` commits that share
+at least one file. Each matched pair becomes one signal.
+
+Cross-cutting (`agent_type=None`). Severity branches on whether
+the originating session used a review-style subagent (architect,
+code-reviewer, tester, security-review): WARNING when no reviewer
+ran (strong "add review" signal), INFO when one ran (weaker --
+the reviewer was present but the issue slipped, so the
+recommendation pivots from "add a reviewer" to "audit the
+reviewer's coverage").
+
+Session correlation: AgentFluent picks the session whose last
+message timestamp most closely precedes the feat commit, then
+inspects its invocations. Commits made outside any analyzed
+session window yield `session_used_reviewer: null`.
+
+Subprocess invocation is bounded (30s timeout); missing git
+binary, non-repo dir, or empty window all silently skip the
+pipeline rather than raising.
+
+**Example:**
+
+```
+feat a1b2c3d followed by 2 fixes on shared file(s) within 3d
+```
+
+**Severity:** info -> warning
+
+**Recommendation target:** `subagent`
+
+**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`primary_axis`](#primary_axis)
+
 
 ---
 

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -275,6 +275,16 @@ def analyze(
             "actionable. JSON output always carries the full list."
         ),
     ),
+    git: bool = typer.Option(
+        False,
+        "--git",
+        help=(
+            "Enable local-git quality signals (FEAT_FIX_PROXIMITY). "
+            "Off by default — AgentFluent does not shell out to git "
+            "unless explicitly opted in. The project's source directory "
+            "must be a git repo; non-repo dirs silently skip."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
@@ -360,6 +370,10 @@ def analyze(
         project_disk_path = resolve_project_disk_path(
             project_info.slug, claude_config_dir=config_dir,
         )
+        # When --git is set, the project's source directory becomes
+        # the git_repo we hand to diagnostics. project_disk_path is
+        # the ~/.claude/projects mapping resolution; it may or may not
+        # be a git repo, and git_signals silently skips when it isn't.
         result.diagnostics = run_diagnostics(
             all_invocations,
             min_cluster_size=(
@@ -375,6 +389,8 @@ def analyze(
             project_dir=project_disk_path,
             parent_messages=all_messages,
             session_count=result.session_count,
+            sessions=result.sessions if git else None,
+            git_repo=project_disk_path if git else None,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         err_console.print(

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -78,6 +78,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.USER_CORRECTION: Axis.QUALITY,
     SignalType.FILE_REWORK: Axis.QUALITY,
     SignalType.REVIEWER_CAUGHT: Axis.QUALITY,
+    SignalType.FEAT_FIX_PROXIMITY: Axis.QUALITY,
 }
 
 # Signal types that carry comparable scalar metrics in ``detail``. Only

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -825,6 +825,47 @@ class ReviewerCaughtRule(_QualityRule):
         return observation, reason, action
 
 
+class FeatFixProximityRule(_QualityRule):
+    """FEAT_FIX_PROXIMITY -> recommend a review-style subagent (or
+    revisit reviewer effectiveness when one was already used).
+
+    Cross-cutting (``agent_type=None``). Recommendation copy branches
+    on ``session_used_reviewer``: a fix-storm right after a feature
+    shipped *without* a reviewer is a strong "add review" signal;
+    the same pattern *with* a reviewer in the loop instead asks whether
+    the reviewer's coverage matched the feature's risk surface.
+    """
+
+    SIGNAL_TYPE = SignalType.FEAT_FIX_PROXIMITY
+
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        used_reviewer = signal.detail.get("session_used_reviewer")
+        observation = signal.message
+        if used_reviewer is True:
+            reason = (
+                "A review-style subagent ran on the originating session, "
+                "yet a fix landed quickly. The reviewer's coverage may not "
+                "have matched the feature's risk surface."
+            )
+            action = (
+                "Audit the reviewer's prompt and tool access against the "
+                "kinds of issues the fix commits addressed."
+            )
+        else:
+            reason = (
+                "Fixes landing within days of a feature on the same files "
+                "indicate a quality miss an independent reviewer could "
+                "have caught before merge."
+            )
+            action = (
+                "Consider routing similar feature work through an "
+                "architect or code-reviewer subagent before commit."
+            )
+        return observation, reason, action
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -840,6 +881,7 @@ RULES: list[CorrelationRule] = [
     UserCorrectionRule(),
     FileReworkRule(),
     ReviewerCaughtRule(),
+    FeatFixProximityRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/git_signals.py
+++ b/src/agentfluent/diagnostics/git_signals.py
@@ -1,0 +1,321 @@
+"""Local-git quality signal extraction (Tier 2 / opt-in).
+
+Sibling to ``quality_signals.py`` (parent-message-driven) and
+``trace_signals.py`` (subagent-trace-driven). This module mines the
+local git history for ``feat:`` commits followed within a window by
+``fix:`` commits touching the same files, then correlates each pair
+back to the session that produced the ``feat:`` commit to check
+whether a review-style subagent was used.
+
+The signal is "this feature shipped with quality issues that a
+reviewer might have caught" — strong evidence when the session did
+*not* use a review subagent.
+
+**Off by default.** Runs only when the CLI passes ``--git`` (which
+in turn passes ``git_repo`` to :func:`run_diagnostics`). AgentFluent
+should not silently shell out to git on every analyze run.
+
+All git invocations use stdlib :mod:`subprocess` with bounded timeout
+and graceful degradation: a missing git binary, a non-repo dir, an
+empty window, or a timeout all return ``[]`` rather than raising.
+The diagnostics pipeline never crashes because the user opted into
+``--git`` from a non-repo working dir.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+from agentfluent.diagnostics.quality_signals import REVIEW_AGENT_TYPES
+
+if TYPE_CHECKING:
+    from agentfluent.analytics.pipeline import SessionAnalysis
+
+logger = logging.getLogger(__name__)
+
+# Default lookback window for `git log --since`. A pair only counts as
+# "proximity" when feat and fix are within this many days of each other,
+# but we also need to cap how far back the initial scan reaches — pulling
+# the entire repo history on every run is wasteful and the signal value
+# decays fast with age.
+DEFAULT_PROXIMITY_DAYS = 7
+DEFAULT_LOOKBACK_DAYS = 90
+
+# Match the ``feat:`` / ``fix:`` Conventional Commits prefix on the
+# commit subject. ``feat(scope):`` and ``feat!:`` both count. Other
+# prefixes (``docs:``, ``chore:``, ``test:``) are deliberately ignored
+# — they are not "shipped features" and don't tell us anything about
+# quality misses.
+_FEAT_PATTERN = re.compile(r"^feat(\([^)]*\))?!?:", re.IGNORECASE)
+_FIX_PATTERN = re.compile(r"^fix(\([^)]*\))?!?:", re.IGNORECASE)
+
+# ASCII record separators chosen because they don't appear in commit
+# subjects, paths, or ISO timestamps. The same format is parsed inline
+# by :func:`_parse_commits`. ``%x1e`` separates fields within a commit;
+# ``%x1f`` separates commits.
+_GIT_LOG_FORMAT = "%H%x1e%cI%x1e%s"
+_GIT_LOG_COMMIT_SEPARATOR = "\x1f"
+_GIT_LOG_FIELD_SEPARATOR = "\x1e"
+
+# Subprocess timeout. A real `git log --name-only` over 90 days finishes
+# in well under a second on healthy repos; 30s is generous headroom for
+# slow filesystems / huge repos without making an honest hang invisible.
+_GIT_TIMEOUT_SEC = 30
+
+
+@dataclass(frozen=True)
+class _GitCommit:
+    """One parsed entry from ``git log --format=...``."""
+
+    sha: str
+    timestamp: datetime
+    subject: str
+    files: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class _FeatFixPair:
+    """A `feat:` commit followed by one or more `fix:` commits within
+    the proximity window that share at least one file with the feat."""
+
+    feat: _GitCommit
+    fixes: tuple[_GitCommit, ...]
+    shared_files: frozenset[str]
+
+    @property
+    def days_between(self) -> int:
+        latest_fix = max(f.timestamp for f in self.fixes)
+        return (latest_fix - self.feat.timestamp).days
+
+
+def extract_git_quality_signals(
+    sessions: list[SessionAnalysis],
+    *,
+    repo_dir: Path,
+    proximity_days: int = DEFAULT_PROXIMITY_DAYS,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+) -> list[DiagnosticSignal]:
+    """Find feat-then-fix proximity pairs in ``repo_dir`` and emit signals.
+
+    Each ``feat:`` commit in the last ``lookback_days`` is paired with
+    any ``fix:`` commit within ``proximity_days`` that shares at least
+    one file. Each pair correlates back to the session whose last
+    message precedes the feat commit, and the signal carries a
+    ``session_used_reviewer`` boolean (or ``None`` if no session
+    matches) so downstream consumers can distinguish "no reviewer was
+    used" (strong signal, WARNING) from "reviewer was used but issue
+    slipped" (weaker signal, INFO).
+
+    Returns ``[]`` on any non-fatal git error (no binary, not a repo,
+    empty window, timeout). The caller does not need a try/except.
+    """
+    since = datetime.now().astimezone() - timedelta(days=lookback_days)
+    commits = _run_git_log(repo_dir, since=since)
+    if not commits:
+        return []
+
+    pairs = _find_feat_fix_pairs(commits, proximity_days=proximity_days)
+    if not pairs:
+        return []
+
+    return [_signal_for_pair(pair, sessions) for pair in pairs]
+
+
+def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
+    """Run ``git log`` and parse the output. Returns ``[]`` on any error.
+
+    The subprocess invocation is bounded by :data:`_GIT_TIMEOUT_SEC`
+    and uses a fixed-shape ``--format`` that pairs cleanly with
+    ``--name-only`` so file paths land below each commit header.
+    """
+    cmd = [
+        "git", "-C", str(repo_dir),
+        "log",
+        f"--since={since.isoformat()}",
+        f"--format={_GIT_LOG_COMMIT_SEPARATOR}{_GIT_LOG_FORMAT}",
+        "--name-only",
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants, not user input
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.debug("git binary not found on PATH; skipping git signals")
+        return []
+    except subprocess.TimeoutExpired:
+        logger.warning("git log timed out after %ds; skipping git signals", _GIT_TIMEOUT_SEC)
+        return []
+
+    if result.returncode != 0:
+        # Not a repo, or another git error. Stderr is human-readable
+        # but we don't want to surface it on every run — DEBUG only.
+        logger.debug(
+            "git log returned %d: %s",
+            result.returncode, result.stderr.strip(),
+        )
+        return []
+
+    return _parse_commits(result.stdout)
+
+
+def _parse_commits(stdout: str) -> list[_GitCommit]:
+    """Parse the structured ``git log`` output into ``_GitCommit`` records.
+
+    Output shape (with our separators):
+
+        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
+        <file1>
+        <file2>
+        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
+        <file1>
+        ...
+
+    The leading ``\\x1f`` makes ``split`` cleanly produce one entry per
+    commit (the first entry is empty and gets filtered).
+    """
+    commits: list[_GitCommit] = []
+    for entry in stdout.split(_GIT_LOG_COMMIT_SEPARATOR):
+        entry = entry.strip()
+        if not entry:
+            continue
+        # First line is the header; subsequent lines are file paths.
+        header, _, file_block = entry.partition("\n")
+        parts = header.split(_GIT_LOG_FIELD_SEPARATOR)
+        if len(parts) != 3:
+            continue
+        sha, timestamp_str, subject = parts
+        try:
+            timestamp = datetime.fromisoformat(timestamp_str)
+        except ValueError:
+            continue
+        files = frozenset(
+            line.strip() for line in file_block.splitlines() if line.strip()
+        )
+        commits.append(_GitCommit(
+            sha=sha, timestamp=timestamp, subject=subject, files=files,
+        ))
+    return commits
+
+
+def _find_feat_fix_pairs(
+    commits: list[_GitCommit], *, proximity_days: int,
+) -> list[_FeatFixPair]:
+    """Pair each ``feat:`` commit with subsequent in-window ``fix:`` commits
+    that share at least one file. Commits are sorted chronologically."""
+    sorted_commits = sorted(commits, key=lambda c: c.timestamp)
+    feats = [c for c in sorted_commits if _FEAT_PATTERN.match(c.subject)]
+    fixes = [c for c in sorted_commits if _FIX_PATTERN.match(c.subject)]
+
+    pairs: list[_FeatFixPair] = []
+    for feat in feats:
+        window_end = feat.timestamp + timedelta(days=proximity_days)
+        matching_fixes: list[_GitCommit] = []
+        shared: set[str] = set()
+        for fix in fixes:
+            if fix.timestamp <= feat.timestamp:
+                continue
+            if fix.timestamp > window_end:
+                continue
+            overlap = feat.files & fix.files
+            if not overlap:
+                continue
+            matching_fixes.append(fix)
+            shared.update(overlap)
+        if matching_fixes:
+            pairs.append(_FeatFixPair(
+                feat=feat,
+                fixes=tuple(matching_fixes),
+                shared_files=frozenset(shared),
+            ))
+    return pairs
+
+
+def _signal_for_pair(
+    pair: _FeatFixPair, sessions: list[SessionAnalysis],
+) -> DiagnosticSignal:
+    """Build the ``FEAT_FIX_PROXIMITY`` signal for one pair."""
+    used_reviewer = _session_used_reviewer(pair.feat.timestamp, sessions)
+
+    severity = (
+        Severity.INFO if used_reviewer is True else Severity.WARNING
+    )
+
+    fix_count = len(pair.fixes)
+    fix_word = "fix" if fix_count == 1 else "fixes"
+    message = (
+        f"feat {pair.feat.sha[:7]} followed by {fix_count} {fix_word} "
+        f"on shared file(s) within {pair.days_between}d"
+    )
+
+    return DiagnosticSignal(
+        signal_type=SignalType.FEAT_FIX_PROXIMITY,
+        severity=severity,
+        agent_type=None,
+        invocation_id=None,
+        message=message,
+        detail={
+            "feat_commit": {
+                "sha": pair.feat.sha,
+                "subject": pair.feat.subject,
+                "timestamp": pair.feat.timestamp.isoformat(),
+                "files": sorted(pair.feat.files),
+            },
+            "fix_commits": [
+                {
+                    "sha": fix.sha,
+                    "subject": fix.subject,
+                    "timestamp": fix.timestamp.isoformat(),
+                    "files": sorted(fix.files),
+                }
+                for fix in pair.fixes
+            ],
+            "days_between": pair.days_between,
+            "shared_files": sorted(pair.shared_files),
+            "session_used_reviewer": used_reviewer,
+        },
+    )
+
+
+def _session_used_reviewer(
+    feat_timestamp: datetime, sessions: list[SessionAnalysis],
+) -> bool | None:
+    """Find the session whose last message precedes ``feat_timestamp``
+    most closely; return whether any of its invocations used a
+    review-style subagent.
+
+    Returns ``None`` when no session matches — the typical case for
+    commits made outside any AgentFluent-analyzed session window.
+    """
+    best_session: SessionAnalysis | None = None
+    best_end: datetime | None = None
+    for session in sessions:
+        end = _session_end(session)
+        if end is None or end > feat_timestamp:
+            continue
+        if best_end is None or end > best_end:
+            best_end = end
+            best_session = session
+    if best_session is None:
+        return None
+    return any(
+        inv.agent_type.lower() in REVIEW_AGENT_TYPES
+        for inv in best_session.invocations
+    )
+
+
+def _session_end(session: SessionAnalysis) -> datetime | None:
+    """Latest message timestamp in the session, or ``None`` if none has one."""
+    timestamps = [m.timestamp for m in session.messages if m.timestamp is not None]
+    return max(timestamps) if timestamps else None

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -65,6 +65,10 @@ class SignalType(StrEnum):
 
     Quality signals (extracted from parent-thread message patterns):
     - `USER_CORRECTION`, `FILE_REWORK`, `REVIEWER_CAUGHT`
+
+    Local-git quality signals (extracted from `git log` history,
+    opt-in via `--git`):
+    - `FEAT_FIX_PROXIMITY`
     """
 
     ERROR_PATTERN = "error_pattern"
@@ -81,6 +85,7 @@ class SignalType(StrEnum):
     USER_CORRECTION = "user_correction"
     FILE_REWORK = "file_rework"
     REVIEWER_CAUGHT = "reviewer_caught"
+    FEAT_FIX_PROXIMITY = "feat_fix_proximity"
 
 
 # Signal types emitted by the trace-level extractor. Used by the dedup

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agentfluent.agents.models import AgentInvocation
+
+if TYPE_CHECKING:
+    from agentfluent.analytics.pipeline import SessionAnalysis
 from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
@@ -33,6 +37,7 @@ from agentfluent.diagnostics.delegation import (
     _count_clusterable_invocations,
     suggest_delegations,
 )
+from agentfluent.diagnostics.git_signals import extract_git_quality_signals
 from agentfluent.diagnostics.mcp_assessment import (
     McpToolCall,
     audit_mcp_servers,
@@ -176,6 +181,8 @@ def run_diagnostics(
     project_dir: Path | None = None,
     parent_messages: list[SessionMessage] | None = None,
     session_count: int | None = None,
+    sessions: list[SessionAnalysis] | None = None,
+    git_repo: Path | None = None,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
@@ -283,6 +290,18 @@ def run_diagnostics(
         signals.extend(extract_quality_signals(parent_messages, invocations))
     else:
         logger.debug("quality signals skipped: parent_messages=None")
+
+    # Local-git quality signals (#275). Off unless the caller passes
+    # both ``sessions`` (for feat-commit → session correlation) and
+    # ``git_repo`` (the working tree to inspect). The CLI gates this
+    # behind ``--git`` so programmatic callers never silently shell out.
+    if git_repo is not None and sessions is not None:
+        signals.extend(extract_git_quality_signals(sessions, repo_dir=git_repo))
+    else:
+        logger.debug(
+            "git signals skipped: git_repo=%s sessions=%s",
+            git_repo is not None, sessions is not None,
+        )
 
     correlated_pairs = correlate(signals, configs_by_name)
     recommendations = [rec for _, rec in correlated_pairs]

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -468,6 +468,40 @@
   recommendation_target: subagent
   related: [user_correction, file_rework, primary_axis]
 
+- name: feat_fix_proximity
+  category: signal_type
+  short: |
+    A `feat:` commit followed within a short window by `fix:` commits
+    touching the same files -- evidence that the feature shipped with
+    quality issues an independent reviewer might have caught.
+  long: |
+    Local-git quality-axis signal (v0.7). Off by default; runs only
+    when the CLI passes `--git`. Scans the last 90 days of `git log`
+    in the project's source directory for `feat:` commits, then for
+    each one looks 7 days forward for any `fix:` commits that share
+    at least one file. Each matched pair becomes one signal.
+
+    Cross-cutting (`agent_type=None`). Severity branches on whether
+    the originating session used a review-style subagent (architect,
+    code-reviewer, tester, security-review): WARNING when no reviewer
+    ran (strong "add review" signal), INFO when one ran (weaker --
+    the reviewer was present but the issue slipped, so the
+    recommendation pivots from "add a reviewer" to "audit the
+    reviewer's coverage").
+
+    Session correlation: AgentFluent picks the session whose last
+    message timestamp most closely precedes the feat commit, then
+    inspects its invocations. Commits made outside any analyzed
+    session window yield `session_used_reviewer: null`.
+
+    Subprocess invocation is bounded (30s timeout); missing git
+    binary, non-repo dir, or empty window all silently skip the
+    pipeline rather than raising.
+  example: "feat a1b2c3d followed by 2 fixes on shared file(s) within 3d"
+  severity_range: info -> warning
+  recommendation_target: subagent
+  related: [user_correction, file_rework, reviewer_caught, primary_axis]
+
 # =============================================================================
 # Severity
 # =============================================================================

--- a/tests/integration/test_git_signals_real.py
+++ b/tests/integration/test_git_signals_real.py
@@ -1,0 +1,62 @@
+"""End-to-end smoke test for ``extract_git_quality_signals`` against
+this repo's real git history.
+
+Skipped in CI (no git repo in the actions-checkout that runs unit
+tests; also marked ``integration``). Locally, this catches issues
+where the synthetic stdout the unit tests mock diverges from real
+``git log`` output shape — e.g., commit subjects with embedded
+newlines, file paths with unusual characters, timezone handling.
+
+The test runs against the agentfluent repo itself, so it requires a
+clone with at least one ``feat:`` commit in the last 90 days. The
+repo's CHANGELOG demonstrates ample such commits exist.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentfluent.diagnostics.git_signals import extract_git_quality_signals
+from agentfluent.diagnostics.models import SignalType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Skip if git isn't installed or the path isn't a repo. The
+# ``check=True`` would raise on a non-repo dir, so we explicitly
+# inspect returncode.
+_probe = subprocess.run(  # noqa: S603,S607 — fixed args, repo root only
+    ["git", "-C", str(REPO_ROOT), "rev-parse", "--git-dir"],
+    capture_output=True, text=True, check=False,
+)
+has_git_repo = _probe.returncode == 0
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not has_git_repo,
+        reason="No git repo at repo root (or git binary missing)",
+    ),
+]
+
+
+class TestGitSignalsAgainstRealRepo:
+    def test_runs_without_error_against_repo(self) -> None:
+        signals = extract_git_quality_signals(
+            sessions=[],
+            repo_dir=REPO_ROOT,
+            proximity_days=7,
+            lookback_days=90,
+        )
+        # Don't assert signal count — depends on real commit timing.
+        # Just assert the list is well-formed.
+        for sig in signals:
+            assert sig.signal_type == SignalType.FEAT_FIX_PROXIMITY
+            assert sig.agent_type is None
+            assert "feat_commit" in sig.detail
+            assert "fix_commits" in sig.detail
+            assert isinstance(sig.detail["days_between"], int)
+            assert sig.detail["days_between"] >= 0
+            assert sig.detail["session_used_reviewer"] is None  # sessions=[]

--- a/tests/unit/test_git_signals.py
+++ b/tests/unit/test_git_signals.py
@@ -1,0 +1,259 @@
+"""Unit tests for ``diagnostics/git_signals.py``.
+
+Subprocess invocations are mocked so the tests run without git on PATH
+and without a real git repo. The integration test
+(``tests/integration/test_git_signals_real.py``) covers the actual
+``git log`` shape against this repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.pipeline import SessionAnalysis
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.config.models import Severity
+from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics.git_signals import (
+    _GIT_LOG_COMMIT_SEPARATOR,
+    _GIT_LOG_FIELD_SEPARATOR,
+    _find_feat_fix_pairs,
+    _GitCommit,
+    extract_git_quality_signals,
+)
+from agentfluent.diagnostics.models import SignalType
+
+
+def _commit(
+    sha: str, ts: datetime, subject: str, files: list[str],
+) -> _GitCommit:
+    return _GitCommit(
+        sha=sha, timestamp=ts, subject=subject, files=frozenset(files),
+    )
+
+
+def _format_git_log(commits: list[_GitCommit]) -> str:
+    """Build the exact stdout shape :func:`_parse_commits` consumes."""
+    parts: list[str] = []
+    for c in commits:
+        header = _GIT_LOG_FIELD_SEPARATOR.join(
+            [c.sha, c.timestamp.isoformat(), c.subject],
+        )
+        files = "\n".join(sorted(c.files))
+        parts.append(f"{_GIT_LOG_COMMIT_SEPARATOR}{header}\n{files}")
+    return "\n".join(parts) + "\n"
+
+
+def _fake_run(stdout: str = "", returncode: int = 0):
+    """Build a ``subprocess.run`` patch target returning the given output."""
+    def _runner(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=returncode, stdout=stdout, stderr="",
+        )
+    return _runner
+
+
+def _session(end: datetime, agent_types: list[str]) -> SessionAnalysis:
+    """Minimal SessionAnalysis: one message with the end timestamp,
+    plus one synthetic invocation per supplied agent_type."""
+    from agentfluent.agents.models import AgentInvocation
+    msg = SessionMessage(type="user", timestamp=end)
+    invs = [
+        AgentInvocation(
+            invocation_id=f"inv-{i}",
+            agent_type=at,
+            description=f"{at} call",
+            prompt="do work",
+            tool_use_id=f"toolu_{i}",
+            session_id="s",
+            session_path=Path("/x"),
+        )
+        for i, at in enumerate(agent_types)
+    ]
+    return SessionAnalysis(
+        session_path=Path("/tmp/x.jsonl"),
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=AgentMetrics(),
+        messages=[msg],
+        invocations=invs,
+    )
+
+
+class TestFeatFixPairing:
+    def test_pair_within_window_with_shared_files_emitted(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "feat: add foo", ["src/foo.py"]),
+            _commit("b", t0 + timedelta(days=2), "fix: foo edge case", ["src/foo.py"]),
+        ]
+        pairs = _find_feat_fix_pairs(commits, proximity_days=7)
+        assert len(pairs) == 1
+        assert pairs[0].days_between == 2
+        assert pairs[0].shared_files == frozenset({"src/foo.py"})
+
+    def test_pair_outside_window_skipped(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "feat: add foo", ["src/foo.py"]),
+            _commit("b", t0 + timedelta(days=30), "fix: foo regression", ["src/foo.py"]),
+        ]
+        assert _find_feat_fix_pairs(commits, proximity_days=7) == []
+
+    def test_pair_with_no_file_overlap_skipped(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "feat: add foo", ["src/foo.py"]),
+            _commit("b", t0 + timedelta(days=1), "fix: bar bug", ["src/bar.py"]),
+        ]
+        assert _find_feat_fix_pairs(commits, proximity_days=7) == []
+
+    def test_feat_with_scope_and_breaking_marker_matches(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "feat(cli)!: redo flag parsing", ["cli.py"]),
+            _commit("b", t0 + timedelta(days=1), "fix(cli): off-by-one", ["cli.py"]),
+        ]
+        pairs = _find_feat_fix_pairs(commits, proximity_days=7)
+        assert len(pairs) == 1
+
+    def test_non_conventional_commits_ignored(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "added foo", ["src/foo.py"]),
+            _commit("b", t0 + timedelta(days=1), "fixed foo", ["src/foo.py"]),
+        ]
+        assert _find_feat_fix_pairs(commits, proximity_days=7) == []
+
+    def test_multiple_fixes_collapsed_into_one_pair(self) -> None:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a", t0, "feat: add foo", ["src/foo.py", "src/bar.py"]),
+            _commit("b", t0 + timedelta(days=1), "fix: foo regression", ["src/foo.py"]),
+            _commit("c", t0 + timedelta(days=3), "fix: bar regression", ["src/bar.py"]),
+        ]
+        pairs = _find_feat_fix_pairs(commits, proximity_days=7)
+        assert len(pairs) == 1
+        assert len(pairs[0].fixes) == 2
+        assert pairs[0].shared_files == frozenset({"src/foo.py", "src/bar.py"})
+
+
+class TestSubprocessErrorHandling:
+    def test_missing_git_binary_returns_empty(self, tmp_path: Path) -> None:
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            side_effect=FileNotFoundError("git not found"),
+        ):
+            assert extract_git_quality_signals([], repo_dir=tmp_path) == []
+
+    def test_non_zero_exit_returns_empty(self, tmp_path: Path) -> None:
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout="", returncode=128),
+        ):
+            assert extract_git_quality_signals([], repo_dir=tmp_path) == []
+
+    def test_timeout_returns_empty(self, tmp_path: Path) -> None:
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["git"], timeout=30),
+        ):
+            assert extract_git_quality_signals([], repo_dir=tmp_path) == []
+
+    def test_empty_log_returns_empty(self, tmp_path: Path) -> None:
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout="", returncode=0),
+        ):
+            assert extract_git_quality_signals([], repo_dir=tmp_path) == []
+
+
+class TestSessionCorrelation:
+    """When a session's last-message timestamp precedes the feat commit
+    most closely, the signal reports whether that session used a
+    review-style subagent."""
+
+    @pytest.fixture()
+    def feat_fix_stdout(self) -> str:
+        t0 = datetime(2026, 5, 1, tzinfo=UTC)
+        commits = [
+            _commit("a1b2c3d", t0, "feat: add widget", ["src/widget.py"]),
+            _commit(
+                "deadbee", t0 + timedelta(days=2),
+                "fix: widget off-by-one", ["src/widget.py"],
+            ),
+        ]
+        return _format_git_log(commits)
+
+    def test_session_with_reviewer_yields_info_severity(
+        self, tmp_path: Path, feat_fix_stdout: str,
+    ) -> None:
+        feat_time = datetime(2026, 5, 1, tzinfo=UTC)
+        # Session ends 1 minute before the feat commit -> matched.
+        sessions = [
+            _session(feat_time - timedelta(minutes=1), ["architect", "general-purpose"]),
+        ]
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout=feat_fix_stdout),
+        ):
+            signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
+        assert len(signals) == 1
+        assert signals[0].signal_type == SignalType.FEAT_FIX_PROXIMITY
+        assert signals[0].severity == Severity.INFO
+        assert signals[0].detail["session_used_reviewer"] is True
+
+    def test_session_without_reviewer_yields_warning(
+        self, tmp_path: Path, feat_fix_stdout: str,
+    ) -> None:
+        feat_time = datetime(2026, 5, 1, tzinfo=UTC)
+        sessions = [
+            _session(feat_time - timedelta(minutes=1), ["pm", "general-purpose"]),
+        ]
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout=feat_fix_stdout),
+        ):
+            signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
+        assert len(signals) == 1
+        assert signals[0].severity == Severity.WARNING
+        assert signals[0].detail["session_used_reviewer"] is False
+
+    def test_no_matching_session_yields_none_reviewer(
+        self, tmp_path: Path, feat_fix_stdout: str,
+    ) -> None:
+        feat_time = datetime(2026, 5, 1, tzinfo=UTC)
+        # All sessions end AFTER the feat commit -> no match.
+        sessions = [_session(feat_time + timedelta(days=1), ["pm"])]
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout=feat_fix_stdout),
+        ):
+            signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
+        assert len(signals) == 1
+        # No session match -> WARNING (no proof a reviewer was used).
+        assert signals[0].severity == Severity.WARNING
+        assert signals[0].detail["session_used_reviewer"] is None
+
+    def test_signal_detail_carries_full_pair_metadata(
+        self, tmp_path: Path, feat_fix_stdout: str,
+    ) -> None:
+        sessions: list[SessionAnalysis] = []
+        with patch(
+            "agentfluent.diagnostics.git_signals.subprocess.run",
+            new=_fake_run(stdout=feat_fix_stdout),
+        ):
+            signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
+        detail = signals[0].detail
+        assert detail["feat_commit"]["sha"] == "a1b2c3d"
+        assert detail["fix_commits"][0]["sha"] == "deadbee"
+        assert detail["days_between"] == 2
+        assert detail["shared_files"] == ["src/widget.py"]


### PR DESCRIPTION
Closes #275.

## Summary
- New Tier 2 quality signal: \`FEAT_FIX_PROXIMITY\`. Detects \`feat:\` commits followed within 7 days by \`fix:\` commits touching the same files; correlates each pair back to the originating session to flag whether a review-style subagent ran.
- Off by default. Runs only when the CLI passes \`--git\` (which in turn passes \`git_repo\` to \`run_diagnostics\`). Per the AC: AgentFluent does not silently shell out to git on every analyze run.
- Severity branches on \`session_used_reviewer\`: WARNING when no reviewer was in the loop (strong \"add review\" signal); INFO when one was used (weaker — the reviewer was present but the issue slipped, so the recommendation pivots to \"audit the reviewer's coverage\").

## What's added
- \`SignalType.FEAT_FIX_PROXIMITY\` + \`Axis.QUALITY\` mapping. Drift-prevention test (\`test_map_covers_every_signal_type\`) passes.
- \`diagnostics/git_signals.py\` — subprocess to \`git log\` with 30s timeout, record-separator stdout format, graceful degradation on missing binary / non-repo / timeout / empty window (returns \`[]\` in every error case; never raises).
- \`FeatFixProximityRule\` in \`correlator.py\` — recommendation copy branches on \`session_used_reviewer\` so the action matches the evidence.
- \`pipeline.run_diagnostics\` gains \`sessions\` + \`git_repo\` kwargs; both required to enable extraction.
- CLI: new \`--git\` flag on \`analyze\`. When set, CLI passes \`project_disk_path\` as \`git_repo\` and \`result.sessions\` as \`sessions\`.
- GLOSSARY entry under \`signal_type\`.

## Architect review
[Posted on issue #275](https://github.com/frederick-douglas-pearce/agentfluent/issues/275). Two adjustments from the original plan:
- Signature uses \`sessions: list[SessionAnalysis]\` (not \`invocations: list[AgentInvocation]\`) because timestamps live on messages, not invocations.
- Confirmed: cross-cutting signal (\`agent_type=None\`); \`--git\` flag bundled here (not split); subprocess approach over a Python git library.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m \"not integration\"\` (1363 passed; +14 from this PR)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage — 14 unit tests in \`tests/unit/test_git_signals.py\` + 1 integration test in \`tests/integration/test_git_signals_real.py\`
- [x] Manual smoke test — \`uv run agentfluent analyze --help\` shows \`--git\` with full help text

## Security review
- [ ] **Skip review** _(initial)_
- [x] **Needs review** ← **flagging for review at merge time**: this PR adds a new subprocess call to \`git\` with arguments derived from a user-supplied repo path. The arg list is constructed from constants + the resolved project disk path (no user-string interpolation), \`shell=False\`, and bounded by \`timeout=30\`. Worth a second look at the subprocess invocation in \`git_signals.py:_run_git_log\` before merge. (Per the project's \`needs-security-review\` label timing memory: applying the label now would burn the single review on the current SHA — leaving as a flag here and adding the label when dev-complete.)

## Breaking changes
None. \`--git\` is opt-in. The \`sessions\` and \`git_repo\` kwargs on \`run_diagnostics\` default to \`None\`, preserving the existing programmatic-caller contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)