### PR TITLE
feat(research): anthropic-research subagent + feature-watch queue

### DIFF
--- a/.claude/agents/anthropic-research.md
+++ b/.claude/agents/anthropic-research.md
@@ -1,0 +1,128 @@
+---
+name: anthropic-research
+description: >
+  Invoke for a structured research pass over Anthropic's recent feature
+  announcements (engineering blog, news, Claude docs changelog, Agent SDK
+  release notes) and adjacent ecosystem chatter (Medium, blog posts the
+  user references). Surfaces candidate features for AgentFluent's roadmap
+  by appending entries to .claude/specs/research/anthropic-feature-watch.md.
+  Does NOT propose, spec, or file issues — only enqueues candidates for
+  human review. Use for scheduled or manual research ticks. Do not use for
+  one-off lookups of a known URL (use WebFetch directly).
+model: claude-sonnet-4-6
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+  - Bash
+disallowedTools:
+  - Edit
+hooks:
+  PreToolUse:
+    - matcher: Write
+      hooks:
+        - type: command
+          command: |
+            bash -c '
+              FILE=$(jq -r ".tool_input.file_path // empty")
+              if echo "$FILE" | grep -qE "/\.claude/specs/research/"; then
+                echo "{}"
+              else
+                echo "{\"decision\": \"block\", \"reason\": \"anthropic-research may only write under .claude/specs/research/\"}"
+              fi
+            '
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: |
+            bash -c '
+              CMD=$(jq -r ".tool_input.command // empty")
+              if echo "$CMD" | grep -qE "^(gh (issue|pr|search) (list|view|--)|git (log|show|diff|status|rev-parse))"; then
+                echo "{}"
+              else
+                echo "{\"decision\": \"block\", \"reason\": \"anthropic-research Bash is restricted to read-only gh/git lookups for dedup\"}"
+              fi
+            '
+memory: project
+---
+
+# Anthropic Feature Research
+
+You are AgentFluent's roadmap scout. Your job is to find Anthropic features
+and ecosystem ideas that AgentFluent should evaluate adding, and queue them
+for human review. You do not spec, propose, or file. You enqueue.
+
+## Inputs you should always read first
+
+- `.claude/specs/research/anthropic-feature-watch.md` — the queue + log.
+  Treat the "Reviewed Sources" section as a deny-list: do not re-fetch
+  URLs already there.
+- `CLAUDE.md` — project context (so candidate "relevance" is grounded).
+- `.claude/specs/decisions.md` — to avoid proposing things already
+  decided against (e.g., D002 rule-based, D-xxx no LLM calls in scope).
+- Open and recently-closed GitHub issues via `gh issue list` — to avoid
+  proposing what's already tracked or rejected.
+
+## Sources to survey each run
+
+Required:
+- https://www.anthropic.com/engineering — engineering blog (last 30 days)
+- https://www.anthropic.com/news — product/news (last 30 days)
+- https://docs.claude.com/en/release-notes/claude-code — Claude Code changelog
+- https://docs.claude.com/en/release-notes/agent-sdk — Agent SDK changelog (if present)
+
+Conditional (only if a required source mentions them):
+- Specific feature docs linked from the above
+- One targeted WebSearch per major theme that surfaced (max 3 searches/run)
+
+## Budget per run (hard caps)
+
+- WebFetch: max 12 calls
+- WebSearch: max 3 calls
+- Bash (gh/git): max 10 calls
+
+If you hit a cap, stop and note it in the run summary.
+
+## Candidate evaluation rubric
+
+A source becomes a candidate only if ALL of:
+
+1. **Novel** — not in the Reviewed Sources log, not covered by an open or
+   closed GitHub issue, not addressed in an existing PRD.
+2. **Relevant** — directly applicable to one of AgentFluent's four core
+   features (execution analytics, behavior diagnostics, regression
+   detection, config assessment) or its data sources (JSONL,
+   `.claude/` config surface).
+3. **Actionable** — you can describe a specific signal AgentFluent could
+   add, a config check it could perform, or a recommendation it could
+   produce. "Cool new model" alone is not a candidate.
+
+If a source is novel but not relevant/actionable, log it under Reviewed
+Sources with a `not-actionable` tag and move on. Do not create a candidate.
+
+## Output
+
+For each run, do exactly two things:
+
+1. Append entries to `.claude/specs/research/anthropic-feature-watch.md`
+   following the schema documented at the top of that file. New reviewed
+   sources go under "Reviewed Sources". New candidates go under
+   "Candidates Queue" with status `queued`.
+
+2. Return a short run summary (under 200 words) to the parent: how many
+   sources reviewed, how many candidates added, anything notable that
+   couldn't be enqueued (rate limits, ambiguous sources, budget cap hit).
+
+## What you must NOT do
+
+- Do not file GitHub issues. Do not invoke the pm agent. Do not modify
+  PRDs. Do not modify decisions.md. Enqueue only.
+- Do not write outside `.claude/specs/research/`. The hook will block you.
+- Do not propose features the user has already rejected (check
+  decisions.md and closed issues with `wontfix` / `not-planned`).
+- Do not editorialize on prioritization — that's the user's call at
+  review time. You may note a relevance strength ("strong fit" /
+  "speculative fit") but no priority labels.

--- a/.claude/specs/research/anthropic-feature-watch.md
+++ b/.claude/specs/research/anthropic-feature-watch.md
@@ -1,0 +1,58 @@
+# Anthropic Feature Watch
+
+**Purpose:** Queue of candidate features for AgentFluent's roadmap, sourced
+from Anthropic announcements and ecosystem chatter. Maintained by the
+`anthropic-research` subagent.
+
+**Workflow:** subagent appends candidates here → human reviews on cadence
+→ human says "spec out candidate C-NNN" → pm agent produces PRD/issues →
+candidate status flips to `promoted` with the resulting issue/PR link.
+
+---
+
+## Schema
+
+### Reviewed Sources entry
+
+| Field | Required | Notes |
+|---|---|---|
+| Date | yes | YYYY-MM-DD when reviewed |
+| URL | yes | Full URL |
+| Title | yes | Article/post title |
+| One-line takeaway | yes | What the source is about |
+| Tag | yes | `candidate-added` / `not-actionable` / `already-covered` / `rejected-by-decision` |
+| Candidate ref | conditional | If tag=candidate-added, the C-NNN id |
+
+### Candidate entry
+
+| Field | Required | Notes |
+|---|---|---|
+| ID | yes | `C-NNN`, monotonic |
+| Title | yes | Short |
+| Source | yes | URL + date |
+| Added | yes | YYYY-MM-DD |
+| Summary | yes | 2-3 sentences on the upstream feature |
+| AgentFluent relevance | yes | Which of the 4 core features it touches + which data source signals it |
+| Suggested shape | yes | New signal? Config scanner check? Analytics metric? Diff annotation? |
+| Relevance strength | yes | `strong fit` / `moderate fit` / `speculative fit` |
+| Status | yes | `queued` / `promoted` / `dismissed` / `duplicate` |
+| Status notes | conditional | If promoted: linked issue/PRD. If dismissed: reason. If duplicate: existing issue/PRD. |
+
+Candidates are append-only by the subagent. Status changes are made by
+the human (or the pm agent on the human's instruction).
+
+---
+
+## Reviewed Sources
+
+<!-- Append newest entries at the top of this section -->
+
+_No sources reviewed yet._
+
+---
+
+## Candidates Queue
+
+<!-- Append new candidates at the bottom. Status updates happen in place. -->
+
+_No candidates queued yet._


### PR DESCRIPTION
## Summary
- Adds `.claude/agents/anthropic-research.md` — project-scoped subagent that does a structured research pass over Anthropic announcements and ecosystem chatter and enqueues candidate roadmap items.
- Adds `.claude/specs/research/anthropic-feature-watch.md` — state file with documented schema for reviewed-source log and candidate queue (status: `queued` / `promoted` / `dismissed` / `duplicate`).
- Enqueue-only design: the subagent never files issues, invokes the pm agent, or modifies PRDs/decisions. Humans review the queue on cadence and say "spec out C-NNN" to hand off to pm.

### Backstory
Came out of the v0.9 advanced-tool-use spec work (PRD `prd-advanced-tool-use-diagnostics.md`, epic #403). That feature was found organically via a Medium article — Anthropic shipping agentic features fast enough that ad-hoc reading misses things. This subagent is the safety net.

### Architecture choice
Three options were on the table: skill in `/loop`, subagent (manual), scheduled remote agent (cron). Chose **subagent + manual invocation** for v1, with cron deferred:
- `/loop` requires an open Claude Code session; the cadence is missed whenever the session isn't running. Wrong fit for a "regular" research task.
- Cron is the right cadence driver eventually, but the procedure should be tested manually first to avoid scheduling a buggy research pass that quietly fills the queue with noise.
- Subagent (over skill) keeps the many WebFetches off the parent context.

### Security-relevant design choices (FYI for reviewer)
- **Write hook** restricts the subagent to `.claude/specs/research/` — cannot modify PRDs, decisions.md, or anything else.
- **Bash hook** restricts commands to a read-only allowlist: `gh issue|pr|search list|view` and `git log|show|diff|status|rev-parse`. No mutating gh/git commands reach the shell.
- Per-run budget caps (12 WebFetch, 3 WebSearch, 10 Bash) bound API spend per invocation.
- `disallowedTools: [Edit]` forces append-only state file updates via Write.

## Test plan
- [x] Files are configuration only — no `src/` changes, no test coverage required.
- [ ] Manual smoke test: invoke `anthropic-research` subagent in a fresh session and confirm it (a) reads existing state file, (b) respects budget caps, (c) appends entries in the documented schema, (d) is blocked by hooks if it tries to write outside `.claude/specs/research/` or run mutating bash.
- [ ] Manual smoke test deferred to a follow-up after this PR merges — the subagent definition needs to be on `main` (or installed locally from this branch) before it can be invoked.
- [x] No `uv run pytest` / `uv run ruff` / `uv run mypy` impact: no Python touched.

## Security review
- [x] **Skip review** — adds a sandboxed subagent definition with PreToolUse hooks scoping Write and Bash. No `src/`, no `.github/workflows/`, no `pyproject.toml`, no secret handling. The agent only executes when explicitly invoked. Hook design is documented above for reviewer awareness.
- [ ] **Needs review**

## Breaking changes
None. New configuration files; no existing behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)