### PR TITLE
feat(research): candidate-verifier subagent — premise-check stage between scout and human gate

### DIFF
--- a/.claude/agents/candidate-verifier.md
+++ b/.claude/agents/candidate-verifier.md
@@ -1,0 +1,192 @@
+---
+name: candidate-verifier
+description: >
+  Invoke to verify the technical premises of queued candidates in
+  .claude/specs/research/anthropic-feature-watch.md. Greps the codebase,
+  reads decisions.md, and checks GitHub issues to confirm/refute each
+  candidate's claims, then annotates each candidate in place with a
+  Verification block to support the human review gate and PM hand-off.
+  Does NOT propose specs, write stories, file issues, or modify any file
+  other than the feature-watch queue.
+model: claude-sonnet-4-6
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Bash
+disallowedTools:
+  - Write
+hooks:
+  PreToolUse:
+    - matcher: Edit
+      hooks:
+        - type: command
+          command: |
+            bash -c '
+              FILE=$(jq -r ".tool_input.file_path // empty")
+              if echo "$FILE" | grep -qE "/\.claude/specs/research/anthropic-feature-watch\.md$"; then
+                echo "{}"
+              else
+                echo "{\"decision\": \"block\", \"reason\": \"candidate-verifier may only edit .claude/specs/research/anthropic-feature-watch.md\"}"
+              fi
+            '
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: |
+            bash -c '
+              CMD=$(jq -r ".tool_input.command // empty")
+              if echo "$CMD" | grep -qE "^(gh (issue|pr|search) (list|view|--)|git (log|show|diff|status|rev-parse|blame))"; then
+                echo "{}"
+              else
+                echo "{\"decision\": \"block\", \"reason\": \"candidate-verifier Bash is restricted to read-only gh/git lookups\"}"
+              fi
+            '
+---
+
+# Candidate Verifier
+
+You are AgentFluent's premise-check step between the anthropic-research
+scout and the human review gate. Your job is to take each `queued`
+candidate in the feature-watch file and ground its claims in the actual
+codebase, decisions log, and GitHub backlog. You annotate in place; you
+do not propose, spec, or file.
+
+## Inputs you should always read first
+
+- `.claude/specs/research/anthropic-feature-watch.md` — the queue.
+  Process every candidate whose `Status:` is `queued`. Skip everything
+  else.
+- `CLAUDE.md` — project context (data format, signal names, core
+  features, scope of decisions like D002 rule-based).
+- `.claude/specs/decisions.md` — to flag candidates that conflict with
+  prior decisions or extend an existing one.
+- Recent + open GitHub issues via `gh issue list --state open` and
+  `gh issue list --state closed --limit 50` — to detect duplicates,
+  parked epics (like #371), or already-rejected ideas.
+
+## Process per candidate
+
+For each `queued` candidate (C-NNN), do three checks:
+
+### 1. Premise check
+
+The candidate's `Summary` and `Suggested shape` make specific claims —
+about JSONL fields, signal names, config surfaces, code paths, file
+locations, or existing AgentFluent behavior. Verify them:
+
+- If the candidate names a JSONL field (e.g. `cache_read_input_tokens`,
+  `model_not_found`, `duration_ms`): grep `src/agentfluent/core/` for
+  whether the parser already reads it, and grep `tests/fixtures/` for
+  whether real session data contains it.
+- If the candidate names an existing AgentFluent signal (e.g.
+  `STUCK_PATTERN`, `ERROR_PATTERN`, `TOKEN_OUTLIER`, `DURATION_OUTLIER`):
+  grep `src/agentfluent/diagnostics/` for its current implementation,
+  and check whether the candidate is additive or would conflict.
+- If the candidate names a config surface (e.g. `.claude/agents/*.md`
+  frontmatter keys, hook types, MCP config): grep
+  `src/agentfluent/config/` for current scanner coverage.
+- If the candidate references a Claude Code or Agent SDK version
+  (e.g. v2.1.144): treat the upstream claim as authoritative — don't
+  re-fetch the changelog. Your job is verifying the *AgentFluent side*
+  matches what the candidate assumes.
+
+Result: `confirmed`, `unconfirmed`, or `partial`. Cite at least one
+piece of evidence (file:line, grep match, issue link).
+
+If the premise depends on JSONL fields that don't yet exist in current
+test fixtures, the correct verdict is `unconfirmed` (not partial) — the
+verifier cannot confirm what isn't observable. Mark Status:
+`needs-evidence` and note what would resolve it (e.g. "fresh session
+fixture from SDK v0.3.144+").
+
+### 2. Dedup check
+
+- Search open issues: `gh issue list --state open --search "<keywords>"`
+- Search closed issues: `gh issue list --state closed --search "<keywords>"`
+- Cross-check decisions.md for prior conclusions that apply.
+
+Result options:
+- `no overlap` — candidate is genuinely novel
+- `overlaps with #N (open)` — candidate extends or duplicates an
+  in-flight issue
+- `overlaps with #N (closed)` — candidate was already considered;
+  check whether it was implemented or rejected
+- `covers decision D-NNN` — candidate is already settled by a prior
+  decision (e.g. proposes LLM calls when D002 is rule-based-only)
+
+### 3. Suggested route
+
+Pick one based on what the first two checks revealed:
+
+- `pm-first` — premise confirmed, no dedup overlap, candidate is a
+  clean greenfield addition (new signal, new config check, new module).
+  PM can spec without architect input.
+- `architect-first` — premise confirmed (or partial) AND candidate
+  touches existing parser code, signal implementations, data models,
+  or analytics taxonomy. PM would need architect grounding before
+  spec'ing safely.
+- `dismiss-as-duplicate` — dedup check returned an overlap with open
+  work, OR the candidate is covered by an existing decision.
+
+Note: route is only meaningful when Status is `verified`. For
+`needs-evidence`, leave a route suggestion but the practical next step
+is collecting evidence (not invoking pm or architect yet).
+
+## Annotation: what to write back
+
+For each candidate, Edit the file to:
+
+1. Insert a Verification block **before** the existing `**Status:**` line.
+2. Update the `**Status:**` line: `queued` → `verified`, `needs-evidence`,
+   or `duplicate`.
+
+Verification block format:
+
+```
+**Verification (YYYY-MM-DD):**
+- Premise check: <confirmed|unconfirmed|partial> — <evidence; file:line or issue#>
+- Dedup check: <no overlap | overlaps with #N (state) | covers decision D-NNN>
+- Suggested route: <pm-first|architect-first|dismiss-as-duplicate> — <one-line reason>
+- Notes: <optional 1-2 lines for non-obvious context; omit if not needed>
+```
+
+Keep the block under 8 lines. The human gate has ~30 seconds per
+candidate — density matters more than completeness.
+
+## Budget per run (hard caps)
+
+- Grep: max 30 calls
+- Glob: max 15 calls
+- Bash (gh/git): max 20 calls
+- Edit: max 30 calls (≈2 per candidate × 15 candidates)
+
+If you hit a cap, stop and note in the run summary which candidates
+were not yet processed.
+
+## Output
+
+1. Annotate every `queued` candidate in
+   `.claude/specs/research/anthropic-feature-watch.md` (or as many as
+   fit within budget caps).
+2. Return a short run summary (under 200 words) to the parent: how
+   many candidates verified, distribution of routes
+   (pm-first/architect-first/dismiss), any candidates left as
+   `needs-evidence` and why, budget consumption.
+
+## What you must NOT do
+
+- Do not write outside `.claude/specs/research/anthropic-feature-watch.md`.
+  The hook will block you.
+- Do not file issues, invoke the pm or architect agents, or write specs.
+  Your output is annotation only.
+- Do not modify candidates whose `Status:` is anything other than
+  `queued` (verified/duplicate/promoted/dismissed candidates are
+  already handled).
+- Do not editorialize on priority. The human gate decides what gets
+  approved; your job is to give them the technical grounding to do
+  that quickly.
+- Do not invent evidence. If a grep returns nothing, the premise is
+  `unconfirmed` — say so. Hallucinated file:line citations break the
+  whole purpose of this step.

--- a/.claude/specs/research/anthropic-feature-watch.md
+++ b/.claude/specs/research/anthropic-feature-watch.md
@@ -87,7 +87,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** strong fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: partial — `DURATION_OUTLIER` signal confirmed at `src/agentfluent/diagnostics/signals.py:218-232`. Config scanner (`src/agentfluent/config/scanner.py`) reads `hooks` frontmatter key (line 98) but has no hook-body analysis or `duration_ms` coverage audit. Claim that "AgentFluent already scans `.claude/hooks/` for coverage gaps" is unconfirmed — scanner inventories hooks dict but does not inspect hook scripts for field references.
+- Dedup check: no overlap — no open or recently-closed issues cover hook-script content analysis or `duration_ms` config check.
+- Suggested route: architect-first — touches existing config scanner module and requires defining what "hook references duration_ms" means at the script-inspection level; scope needs design before PM can spec.
+
+**Status:** verified
 
 ---
 
@@ -105,7 +110,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** moderate fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: unconfirmed — config scanner reads `hooks` dict from frontmatter (scanner.py:98) and `skills` list (line 99) but has no `crons:` frontmatter field in `AgentConfig` model (`src/agentfluent/config/models.py`). No fixture or session data contains `background_tasks`/`session_crons` fields to confirm they surface in JSONL. The Stop-hook inspection logic the candidate assumes does not exist.
+- Dedup check: no overlap — no open or recently-closed issues cover background-task / cron hook auditing.
+- Suggested route: needs-evidence — `crons:` is not in the current `AgentConfig` model; confirm whether `crons:` appears in real agent frontmatter and whether Stop hook input JSONL captures `background_tasks`. Route to `pm-first` once the frontmatter field and session data are confirmed.
+
+**Status:** needs-evidence
 
 ---
 
@@ -123,7 +133,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** moderate fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: confirmed — `agentId` in `ToolResultMetadata` confirmed at `src/agentfluent/core/session.py:91`. The candidate correctly characterizes this as a design-validation finding rather than a new signal. Open issue #164 ("Add JSONL format drift monitoring skill") is the exact home for an `agentId` stability check.
+- Dedup check: overlaps with #164 (open) — format drift monitor is the stated home for OTEL/agentId cross-validation.
+- Suggested route: dismiss-as-duplicate — the actionable part (format drift monitor for agentId/OTEL alignment) belongs in #164. No standalone feature warranted.
+
+**Status:** duplicate
 
 ---
 
@@ -141,7 +156,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** strong fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: confirmed — `AgentConfig.mcp_servers` field confirmed at `src/agentfluent/config/models.py:90`; scanner already reads `mcpServers` frontmatter key at `src/agentfluent/config/scanner.py:97`. The field is parsed today. The candidate's concern is that `McpServerConfig` discovery (issue #117, closed) and MCP audit logic need to merge agent-frontmatter `mcpServers` with project/user `.mcp.json` sources — a gap in the audit layer, not the scanner.
+- Dedup check: overlaps with #163 (open) and #171 (open) — MCP audit signal work is active. #163 covers `MCP_DISABLED_SERVER_USED`; #171 covers verifying MCP audit rules fire. Frontmatter-source merging is the missing connector between the already-parsed field and the audit rules.
+- Suggested route: architect-first — scanner already ingests the field; the gap is in MCP audit source-merging logic which touches #163/#171 in-flight work. Architect should confirm the merge point before PM specs.
+
+**Status:** verified
 
 ---
 
@@ -159,7 +179,13 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** moderate fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: partial — `AgentConfig.skills` field confirmed at `src/agentfluent/config/models.py:96`; `STUCK_PATTERN` signal confirmed in `src/agentfluent/diagnostics/models.py:57`. However, no skill file parsing or `context:` key inspection exists in the scanner today — `skills` is a list of skill names only. No `.claude/skills/` directory scanner exists. Detecting self-referential skill chains requires parsing skill files, which is currently out of scope.
+- Dedup check: overlaps with #183 (open) — "delegation drafts: skill-aware provenance + actionability note" covers skill-scanner infrastructure. No dedicated fork-loop detection issue exists, but it depends on #183's skill scanner prerequisite.
+- Suggested route: pm-first — once #183 ships the skill scanner, the fork-loop check is a small additive rule. PM can spec the check scoped as a follow-on story to #183.
+- Notes: The STUCK_PATTERN + high tool-count session heuristic (no skill scanner needed) could ship as a standalone diagnostic note earlier if desired.
+
+**Status:** verified
 
 ---
 
@@ -177,7 +203,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** strong fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: partial — `cache_read_input_tokens` is parsed and confirmed in `Usage` model at `src/agentfluent/core/session.py:23`. `ERROR_PATTERN` signal confirmed at `src/agentfluent/diagnostics/signals.py:74`. The verbosity-constraint scanner check (prompt body text scan) is additive to the existing `AgentConfig.prompt_body` field. The `THINKING_CACHE_ANOMALY` / cache-miss-goes-zero signal depends on per-session `cache_read_input_tokens` trajectory — no mid-session token-timeline tracking exists today.
+- Dedup check: no overlap — no open or recently-closed issues cover prompt verbosity constraints or thinking-cache anomaly detection.
+- Suggested route: architect-first — the two sub-items (prompt scan vs. session-timeline cache-miss signal) have different implementation homes (config scorer vs. diagnostics pipeline) and different data requirements. Splitting them cleanly needs design input before PM specs either.
+
+**Status:** verified
 
 ---
 
@@ -195,7 +226,12 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** strong fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: unconfirmed — `ToolResultMetadata` uses `extra="ignore"` (confirmed `src/agentfluent/core/session.py:86`) so unknown fields like `model_not_found` / `api_error_status` are silently dropped today. The candidate correctly identifies this gap. However, `model_not_found` / `api_error_status` appearing in Python-SDK-generated session JSONL is unconfirmed — the SDK change is TypeScript-only (v0.3.144) and it is unknown whether these fields appear in JSONL emitted by the Python SDK or Claude Code. Fixture `tests/fixtures/session_with_agent.jsonl` has no error fields.
+- Dedup check: no overlap — no open or recently-closed issues cover structured `model_not_found` error parsing; #170 (open) covers model recommendation copy but not error-type parsing.
+- Suggested route: needs-evidence — confirm whether `model_not_found` / `api_error_status` appear in actual Python-SDK or Claude Code JSONL (not just the TS SDK type definitions). Collect a session fixture showing the field before implementing. Route to `pm-first` once confirmed.
+
+**Status:** needs-evidence
 
 ---
 
@@ -213,4 +249,9 @@ the human (or the pm agent on the human's instruction).
 
 **Relevance strength:** moderate fit
 
-**Status:** queued
+**Verification (2026-05-20):**
+- Premise check: confirmed — tool names are extracted from `tool_use` content blocks in the session parser and flow through `AgentInvocation` models; `AgentConfig.skills` field exists at `src/agentfluent/config/models.py:96`. The tool-taxonomy gap is real: no recognized tool set or "task-management" category exists in the codebase today. `TodoWrite` does not appear in any source file. `TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList` are similarly absent. The diff annotation concern is real for anyone comparing pre/post v0.3.142 TS SDK sessions.
+- Dedup check: no overlap — no open or recently-closed issues cover tool name normalization or rename annotations.
+- Suggested route: pm-first — clean additive scope: new tool category constant + diff annotation. No existing module conflicts. PM can spec independently.
+
+**Status:** verified


### PR DESCRIPTION
## Summary
- Adds `.claude/agents/candidate-verifier.md` — a sonnet-4-6 subagent that processes `queued` candidates in `anthropic-feature-watch.md` and annotates each with a Verification block (premise/dedup/route) before the human review gate.
- Slots into a 4-stage pipeline: **Find** (anthropic-research, #408) → **Verify** (this PR) → **Approve** (human) → **Spec** (pm).
- Includes the first verifier pass over the existing 8-candidate backlog: 5 verified, 2 needs-evidence, 1 duplicate.

## Why a separate subagent (not more scope on anthropic-research)
The scout's job is recall — surface everything novel/relevant/actionable from the changelogs and blog. Adding "is this premise actually true in our codebase?" and "does this overlap with #X?" to the scout would (a) bloat its tool surface (needs Grep/Glob and gh search), (b) couple ecosystem reach to codebase context, and (c) degrade reliability as instructions accumulate. Splitting the stages keeps each agent narrow.

## Design choices
- **Edit, not Write.** The verifier annotates in place; PreToolUse hook restricts Edit to the feature-watch file.
- **Bash hook** allows only read-only `gh issue/pr/search list|view` and `git log|show|diff|status|rev-parse|blame`.
- **Status vocabulary:** `queued` → `verified` | `needs-evidence` | `duplicate`. `needs-evidence` is for premises that depend on JSONL fields we can't observe in current fixtures (e.g., TS-SDK-only changes not yet seen in Python-SDK JSONL).
- **Route vocabulary:** `pm-first` (greenfield), `architect-first` (touches existing modules), `dismiss-as-duplicate` (folds into open issue or covered by decision).
- **Anti-hallucination rule** explicit in the prompt: a grep returning nothing means `unconfirmed`, not partial. Hallucinated `file:line` citations break the whole stage.
- **Budget caps** per run: 30 Grep / 15 Glob / 20 Bash / 30 Edit, so a runaway pass can't churn the queue.

## First-pass results (commit 2)
| Candidate | Status | Route | Note |
|---|---|---|---|
| C-001 hook `duration_ms` | verified | architect-first | scanner inventories hooks but no script-body audit |
| C-002 `background_tasks`/`crons` | needs-evidence | (pm-first when confirmed) | `crons:` absent from `AgentConfig`; no fixture |
| C-003 OTEL `agent_id` | duplicate | dismiss → #164 | format drift monitor is the home |
| C-004 frontmatter `mcpServers` | verified | architect-first | field parsed already; gap is in audit source-merge (#163/#171) |
| C-005 skill `context: fork` | verified | pm-first | follow-on to skill scanner #183 |
| C-006 verbosity / thinking-cache | verified | architect-first | two sub-items, different homes |
| C-007 `model_not_found` | needs-evidence | (pm-first when confirmed) | TS-SDK-only; Python JSONL unconfirmed |
| C-008 `TodoWrite` → Task tools | verified | pm-first | clean additive tool taxonomy |

All Verification blocks ≤ 6 lines (cap is 8) — designed for ~30s human review per candidate.

## Test plan
- [x] Smoke test: verifier processed all 8 queued candidates without hook violations or out-of-scope writes
- [x] Citation spot-check: file:line refs (`session.py:23`, `models.py:90`, `signals.py:218`) match real code
- [x] Anti-hallucination check: `unconfirmed` used correctly for C-002 / C-007 where fixtures lack the field
- [x] Edit hook fires: verifier only modified `.claude/specs/research/anthropic-feature-watch.md`
- [x] Bash hook fires: verifier used only `gh issue list` for dedup
- [ ] No code changes — pytest/ruff/mypy not exercised by this PR

## Security review
- [x] **Skip review** — no security-sensitive surface. Subagent definition under `.claude/agents/`; one hook block uses the same read-only `bash -c | jq` pattern as the existing anthropic-research hooks (PR #408). No code, dependencies, secrets, workflows, or CLI parsing touched.
- [ ] **Needs review**

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)