### PR TITLE
fix: include agent frontmatter MCP servers in audit

### DIFF
--- a/src/agentfluent/config/mcp_discovery.py
+++ b/src/agentfluent/config/mcp_discovery.py
@@ -1,13 +1,14 @@
 """Discover configured MCP servers from Claude Code config files.
 
-Reads MCP server entries from three effective sources and dedups by
-server name using the precedence ``project_local > project_shared >
-user`` (matches Claude Code's ``local > project > user`` resolution
-order). This module is the config-layer counterpart to
+Reads MCP server entries from Claude Code config sources and dedups by
+server name using the precedence ``agent_frontmatter > project_local >
+project_shared > user``. The base config scopes match Claude Code's
+``local > project > user`` resolution order; agent frontmatter is the
+most specific audit source. This module is the config-layer counterpart to
 ``config/scanner.py``: it discovers what the user *configured*, not
 what the agent *did* — that lives in ``diagnostics/mcp_assessment.py``.
 
-The three sources:
+The sources:
 
 - **User** — top-level ``mcpServers`` key in ``~/.claude.json``.
 - **Project-shared** — ``mcpServers`` in ``.mcp.json`` at the project
@@ -15,6 +16,8 @@ The three sources:
   ``enabledMcpjsonServers`` / ``disabledMcpjsonServers`` lists).
 - **Project-local** — per-project ``mcpServers`` inside
   ``~/.claude.json:projects[<project_dir>]``.
+- **Agent frontmatter** — ``mcpServers`` names parsed from
+  ``.claude/agents/*.md`` by ``config/scanner.py``.
 
 The ``settings.json`` files (``~/.claude/settings.json``,
 ``.claude/settings.json``) carry hooks and other settings but no
@@ -29,7 +32,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from agentfluent.config.models import McpScope, McpServerConfig
+from agentfluent.config.models import AgentConfig, McpScope, McpServerConfig
 from agentfluent.core.paths import claude_json_for
 
 logger = logging.getLogger(__name__)
@@ -118,9 +121,35 @@ def discover_mcp_servers(
             disabled_list=disabled_list,
         )
 
-    return _dedup_by_name_with_precedence(
+    return dedup_by_name_with_precedence(
         user_servers, project_shared_servers, project_local_servers,
     )
+
+
+def mcp_servers_from_agent_configs(
+    agent_configs: list[AgentConfig],
+) -> list[McpServerConfig]:
+    """Convert scanned agent frontmatter ``mcpServers`` names into config.
+
+    Agent frontmatter carries server names only, so generated records
+    are enabled, have no configured tool allow-list, and point
+    ``source_file`` at the agent definition that declared the server.
+    """
+    servers: list[McpServerConfig] = []
+    for agent_config in agent_configs:
+        for server_name in agent_config.mcp_servers:
+            if not server_name:
+                continue
+            servers.append(
+                McpServerConfig(
+                    server_name=server_name,
+                    enabled=True,
+                    configured_tools=None,
+                    source_file=agent_config.file_path,
+                    scope="agent_frontmatter",
+                ),
+            )
+    return dedup_by_name_with_precedence(servers)
 
 
 @lru_cache(maxsize=16)
@@ -313,11 +342,16 @@ def _read_project_shared_mcp_servers(
     return servers
 
 
-_PRECEDENCE_ORDER: tuple[McpScope, ...] = ("user", "project_shared", "project_local")
+_PRECEDENCE_ORDER: tuple[McpScope, ...] = (
+    "user",
+    "project_shared",
+    "project_local",
+    "agent_frontmatter",
+)
 """Lowest → highest precedence. Later scopes overwrite earlier ones."""
 
 
-def _dedup_by_name_with_precedence(
+def dedup_by_name_with_precedence(
     *scope_buckets: list[McpServerConfig],
 ) -> list[McpServerConfig]:
     """Merge multiple scope buckets into a precedence-ordered list.

--- a/src/agentfluent/config/models.py
+++ b/src/agentfluent/config/models.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-McpScope = Literal["user", "project_shared", "project_local"]
+McpScope = Literal["user", "project_shared", "project_local", "agent_frontmatter"]
 """Where an MCP server entry was discovered.
 
 - ``user`` — top-level ``mcpServers`` in ``~/.claude.json``.
@@ -22,10 +22,14 @@ McpScope = Literal["user", "project_shared", "project_local"]
   ``enabledMcpjsonServers`` / ``disabledMcpjsonServers`` lists).
 - ``project_local`` — per-project ``mcpServers`` inside
   ``~/.claude.json:projects[<project_dir>]``.
+- ``agent_frontmatter`` — ``mcpServers`` listed in a scanned agent
+  definition's YAML frontmatter.
 
 Precedence when the same server name appears in multiple scopes:
-``project_local > project_shared > user`` (matches Claude Code's
-documented ``local > project > user`` resolution order)."""
+``agent_frontmatter > project_local > project_shared > user``. The
+base config scopes match Claude Code's documented
+``local > project > user`` resolution order; agent frontmatter is most
+specific for an agent audit context."""
 
 
 class Scope(StrEnum):

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -23,7 +23,11 @@ from agentfluent.agents.models import AgentInvocation
 
 if TYPE_CHECKING:
     from agentfluent.analytics.pipeline import SessionAnalysis
-from agentfluent.config.mcp_discovery import discover_mcp_servers
+from agentfluent.config.mcp_discovery import (
+    dedup_by_name_with_precedence,
+    discover_mcp_servers,
+    mcp_servers_from_agent_configs,
+)
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.core.session import SessionMessage
@@ -271,6 +275,10 @@ def run_diagnostics(
         mcp_usage = extract_mcp_usage(invocations, mcp_tool_calls)
         configured_mcp = discover_mcp_servers(
             claude_config_dir=claude_config_dir, project_dir=project_dir,
+        )
+        configured_mcp = dedup_by_name_with_precedence(
+            configured_mcp,
+            mcp_servers_from_agent_configs(agent_configs),
         )
         if mcp_usage or configured_mcp:
             signals.extend(

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -670,6 +670,29 @@ class TestMcpAuditWiring:
         assert len(unused) == 1
         assert unused[0].detail["server_name"] == "unused-svc"
 
+    def test_agent_frontmatter_mcp_servers_join_audit_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        def fake_scan(scope: str) -> list[AgentConfig]:
+            assert scope == "all"
+            return [
+                AgentConfig(
+                    name="pm",
+                    file_path=tmp_path / ".claude" / "agents" / "pm.md",
+                    scope=Scope.PROJECT,
+                    mcp_servers=["github"],
+                ),
+            ]
+
+        monkeypatch.setattr("agentfluent.diagnostics.pipeline.scan_agents", fake_scan)
+        calls = [McpToolCall(server_name="github", tool_name="create_issue", is_error=True)]
+
+        result = run_diagnostics([_inv()], mcp_tool_calls=calls)
+
+        assert all(
+            s.signal_type != SignalType.MCP_MISSING_SERVER for s in result.signals
+        )
+
 
 class TestQualitySignalsWiring:
     """``parent_messages`` opts the caller into quality-signal extraction.

--- a/tests/unit/test_mcp_assessment.py
+++ b/tests/unit/test_mcp_assessment.py
@@ -416,6 +416,20 @@ class TestAuditMcpServers:
         )
         assert signals == []
 
+    def test_agent_frontmatter_config_suppresses_missing_server(self) -> None:
+        signals = audit_mcp_servers(
+            usage_by_server={"github": _usage("github", total=10, errors=2)},
+            configured=[
+                _server(
+                    "github",
+                    source="/repo/.claude/agents/pm.md",
+                    scope="agent_frontmatter",
+                ),
+            ],
+            sessions_analyzed=3,
+        )
+        assert signals == []
+
     def test_mixed_scenario_emits_per_server_signals(self) -> None:
         # Four servers: github (used + configured), slack (unused +
         # configured), unknown (missing + errors), friendly (missing

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -22,11 +22,42 @@ import pytest
 
 from agentfluent.config.mcp_discovery import (
     MCP_PROJECT_FILENAME,
+    dedup_by_name_with_precedence,
     discover_mcp_servers,
+    mcp_servers_from_agent_configs,
     resolve_project_disk_path,
 )
+from agentfluent.config.models import AgentConfig, McpServerConfig, Scope
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "mcp"
+
+
+def _agent_config(
+    name: str,
+    path: Path,
+    mcp_servers: list[str],
+) -> AgentConfig:
+    return AgentConfig(
+        name=name,
+        file_path=path,
+        scope=Scope.PROJECT,
+        mcp_servers=mcp_servers,
+    )
+
+
+def _server(
+    name: str,
+    *,
+    source: Path,
+    scope: str = "project_local",
+) -> McpServerConfig:
+    return McpServerConfig(
+        server_name=name,
+        enabled=True,
+        configured_tools=None,
+        source_file=source,
+        scope=scope,  # type: ignore[arg-type]
+    )
 
 
 def _write_claude_json(
@@ -93,6 +124,68 @@ def _override_claude_json_location(
     ``claude_config_dir`` whose parent contains ``claude_json``.
     """
     monkeypatch.setattr(Path, "home", lambda: claude_json.parent)
+
+
+class TestAgentFrontmatterScope:
+    def test_agent_configs_are_converted_to_mcp_server_configs(
+        self, tmp_path: Path,
+    ) -> None:
+        agent_path = tmp_path / ".claude" / "agents" / "pm.md"
+        configs = [_agent_config("pm", agent_path, ["github", "slack"])]
+
+        servers = mcp_servers_from_agent_configs(configs)
+
+        assert [s.server_name for s in servers] == ["github", "slack"]
+        for server in servers:
+            assert server.enabled is True
+            assert server.configured_tools is None
+            assert server.source_file == agent_path
+            assert server.scope == "agent_frontmatter"
+
+    def test_empty_agent_configs_return_no_servers(self) -> None:
+        assert mcp_servers_from_agent_configs([]) == []
+
+    def test_duplicate_agent_frontmatter_servers_keep_later_agent(
+        self, tmp_path: Path,
+    ) -> None:
+        first_path = tmp_path / ".claude" / "agents" / "pm.md"
+        second_path = tmp_path / ".claude" / "agents" / "reviewer.md"
+
+        servers = mcp_servers_from_agent_configs(
+            [
+                _agent_config("pm", first_path, ["github"]),
+                _agent_config("reviewer", second_path, ["github"]),
+            ],
+        )
+
+        assert len(servers) == 1
+        assert servers[0].server_name == "github"
+        assert servers[0].source_file == second_path
+        assert servers[0].scope == "agent_frontmatter"
+
+    def test_agent_frontmatter_overrides_project_local_precedence(
+        self, tmp_path: Path,
+    ) -> None:
+        project_server = _server(
+            "github",
+            source=tmp_path / ".claude.json",
+            scope="project_local",
+        )
+        agent_server = mcp_servers_from_agent_configs(
+            [
+                _agent_config(
+                    "pm",
+                    tmp_path / ".claude" / "agents" / "pm.md",
+                    ["github"],
+                ),
+            ],
+        )[0]
+
+        servers = dedup_by_name_with_precedence([project_server], [agent_server])
+
+        assert len(servers) == 1
+        assert servers[0].source_file == agent_server.source_file
+        assert servers[0].scope == "agent_frontmatter"
 
 
 class TestReadUserScope:


### PR DESCRIPTION
## Summary

Hi, I am an AI agent helping with the MCP audit issue described in #427.

This PR wires agent frontmatter `mcpServers` into the MCP audit configuration set so servers declared in `.claude/agents/*.md` are no longer reported as missing when subagent traces use them.

Changes:
- add `agent_frontmatter` as an `McpScope` with highest precedence
- expose `dedup_by_name_with_precedence()` and add `mcp_servers_from_agent_configs()`
- merge scanned agent-frontmatter MCP servers into the diagnostics pipeline before `audit_mcp_servers()`
- add unit coverage for conversion, precedence, direct audit suppression, and pipeline wiring

Addresses #427 and covers the implementation shape requested in #428, #429, and #430.

## Verification

- `uv run --group dev pytest tests/unit/test_mcp_discovery.py tests/unit/test_mcp_assessment.py tests/unit/test_diagnostics_pipeline.py -q`
- `uv run --group dev ruff check src/agentfluent/config/mcp_discovery.py src/agentfluent/config/models.py src/agentfluent/diagnostics/pipeline.py tests/unit/test_mcp_discovery.py tests/unit/test_mcp_assessment.py tests/unit/test_diagnostics_pipeline.py`
- `git diff --check`
