### PR TITLE
docs(skills): #440 — architect-reviewed status + allow architect invocation

### DIFF
--- a/.claude/skills/promote-candidates/SKILL.md
+++ b/.claude/skills/promote-candidates/SKILL.md
@@ -48,8 +48,8 @@ Agent access.
 - `Read` / `Edit` — full access (use Edit only on the feature-watch
   file; see "what you must NOT do")
 - `Bash` — read-only `gh` and `git` lookups, restricted by glob patterns
-- `Agent` — for pm dispatch only (do not invoke architect or any other
-  subagent; the architect-first route is Phase 3, not implemented)
+- `Agent` — for pm and architect dispatch (do not invoke any other
+  subagent)
 - `mcp__github__*` — issue create/comment/get/list/search only
 
 If you need a tool outside the allow-list, stop and surface the gap in
@@ -153,10 +153,8 @@ on re-runs. If none exist, use `mcp__github__create_issue`:
 - **labels:** `blocked-on-evidence` (must already exist in the repo;
   if it doesn't, surface that as a setup error and skip the candidate)
 
-**`architect-first`** — SKIP. Phase 3 (architect-first choreography)
-is not yet implemented. Add the candidate to the run summary's
-`skipped — architect-first` list. Do not edit the candidate's Status
-or add a Promotion block.
+**`architect-first`** — See `architect-first-init` and
+`architect-first-pm` mode handling below.
 
 ### 3. Annotate the queue
 
@@ -216,5 +214,5 @@ Return a structured run summary (under 300 words):
   (This is a body-level rule; allowed-tools cannot path-restrict
   Edit, so the discipline is on you. Stop and surface the issue if
   you find yourself wanting to edit elsewhere.)
-- Do not invoke any subagent except `pm` via the `Agent` tool. The
-  architect-first route is Phase 3 and not implemented.
+- Do not invoke any subagent other than `pm` or `architect` via the
+  `Agent` tool.

--- a/.claude/specs/research/anthropic-feature-watch.md
+++ b/.claude/specs/research/anthropic-feature-watch.md
@@ -93,6 +93,7 @@ Examples:
 | `verified` | verifier | premise confirmed, awaiting human gate |
 | `needs-evidence` | verifier | premise depends on unobserved data; human decides whether to track |
 | `duplicate` | verifier | overlaps with existing issue or decision; awaiting human gate |
+| `architect-reviewed` | `promote-candidates` skill | architect-first stub filed + architect design comment posted; awaiting human review before pm dispatch |
 | `promoted` | `promote-candidates` skill | downstream action complete (issue filed, pm invoked, comment posted) |
 | `dismissed` | `promote-candidates` skill | human chose to drop |
 


### PR DESCRIPTION
## Summary
- Adds `architect-reviewed` status to the queue schema (D3 from Phase 3 PRD #439).
- Updates SKILL.md tool surface, architect-first dispatch section, and "what you must NOT do" rule to allow architect invocation (Gap 4 from PRD).
- No behavior change — existing modes and the 3 implemented routes (pm-first, dismiss-as-duplicate, needs-evidence) are unaffected. Pure prep for #441/#442.

Closes #440. Epic #439.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — no test changes needed (markdown-only)
- [x] Lint clean: `uv run ruff check src/ tests/` — no Python touched
- [x] Type check clean: `uv run mypy src/agentfluent/` — no Python touched
- [x] New/changed behavior has test coverage — N/A, no behavior change
- [x] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI behavior changes; markdown only

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. The skill's existing 3 routes and modes are untouched. The `architect-first` route still results in a no-op until #441/#442 land — same effective behavior as before (the "SKIP" path was never invoked because no candidate has `architect-first` decision-line routing today; in the manual flow we bypassed the skill entirely for those dispatches).