### PR TITLE
chore(skills): #441 — architect-first-init mode for promote-candidates

### DIFF
--- a/.claude/skills/promote-candidates/SKILL.md
+++ b/.claude/skills/promote-candidates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: promote-candidates
-description: Dispatch decision-annotated candidates from .claude/specs/research/anthropic-feature-watch.md per route. Files blocked-on-evidence stubs, comments on overlapping issues for duplicates, or invokes the pm subagent for pm-first candidates. Runs as a parent-thread skill (not a subagent) because subagents cannot invoke other subagents in Claude Code, and the pm-first route requires Agent-tool access.
-argument-hint: "[dry-run|live] [ALL|C-NNN,C-NNN,...]"
+description: Dispatch decision-annotated candidates from .claude/specs/research/anthropic-feature-watch.md per route. In default mode, files blocked-on-evidence stubs, comments on overlapping issues for duplicates, or invokes the pm subagent for pm-first candidates. In architect-first-init mode, files an architect-review stub and invokes the architect subagent. Runs as a parent-thread skill (not a subagent) because subagents cannot invoke other subagents in Claude Code, and pm/architect dispatch requires Agent-tool access.
+argument-hint: "[architect-first-init] [dry-run|live] [ALL|C-NNN,C-NNN,...]"
 allowed-tools:
   - Read
   - Edit
@@ -57,31 +57,45 @@ the run summary instead of working around it.
 
 ## Arguments
 
-Parse $ARGUMENTS for two positional values:
+Parse $ARGUMENTS for an optional mode prefix and two positional values:
 
-1. **Mode** — `dry-run` (default) or `live`
+1. **Mode prefix** (optional, first positional if present) — one of:
+   - (none) — **default mode:** processes `pm-first`, `dismiss-as-duplicate`, `needs-evidence` routes; skips `architect-first` candidates
+   - `architect-first-init` — processes ONLY `architect-first` candidates; files stub + invokes architect, then stops for human review (see "Architect-first init mode" section below)
+   - `architect-first-pm` — completes architect-first dispatch by invoking pm (Phase 3 PR #442 — not yet implemented; the skill should refuse this mode with a "not yet implemented" error in the run summary)
+
+   Detection: if the first arg matches `architect-first-*`, it is the mode prefix. Otherwise the first arg is the `dry-run`/`live` mode below.
+
+2. **Mode** — `dry-run` (default) or `live`
    - `dry-run`: describe planned actions per candidate, do NOT call
-     any GitHub MCP tool, do NOT invoke pm, do NOT edit the queue
+     any GitHub MCP tool, do NOT invoke pm or architect, do NOT edit the queue
    - `live`: execute the plan
-2. **Scope** — `ALL` (default) or a comma-separated list of candidate
+3. **Scope** — `ALL` (default) or a comma-separated list of candidate
    IDs like `C-002,C-005`. Candidates outside the scope are left
    untouched (not deferred — they remain valid for a later run).
 
-If $ARGUMENTS is empty, default to `dry-run ALL`. If $ARGUMENTS
+If $ARGUMENTS is empty, default to `dry-run ALL` (default mode). If $ARGUMENTS
 contains context but no explicit mode/scope, infer from the user's
 chat message, state your assumption at the top of the run, and
 proceed.
 
 ## Inputs to read first
 
-- `.claude/specs/research/anthropic-feature-watch.md` — the queue.
-  Process every candidate that has a `**Decision (YYYY-MM-DD):**`
+- `.claude/specs/research/anthropic-feature-watch.md` — the queue. Eligibility differs by mode:
+
+  **Default mode** — process every candidate that has a `**Decision (YYYY-MM-DD):**`
   line AND whose `**Status:**` is `verified`, `needs-evidence`, or
-  `duplicate`. Skip:
+  `duplicate`, AND whose effective route is one of `pm-first`,
+  `dismiss-as-duplicate`, `needs-evidence`. Skip:
   - `queued` (verifier hasn't run yet)
+  - `architect-reviewed` (in-flight architect-first dispatch; needs `architect-first-pm` mode)
   - `promoted` / `dismissed` (already handled)
   - anything without a Decision line (human gate not closed)
-- `CLAUDE.md` — only to pass full context to pm when delegating.
+  - candidates whose effective route is `architect-first` (route-mismatch; use `architect-first-init` mode)
+
+  **`architect-first-init` mode** — process candidates with Status `verified`, a Decision line, AND effective route `architect-first`. See "Architect-first init mode" section below for the per-candidate flow.
+
+- `CLAUDE.md` — only to pass full context to pm when delegating (default mode pm-first route only).
 
 ## Process per candidate
 
@@ -153,8 +167,7 @@ on re-runs. If none exist, use `mcp__github__create_issue`:
 - **labels:** `blocked-on-evidence` (must already exist in the repo;
   if it doesn't, surface that as a setup error and skip the candidate)
 
-**`architect-first`** — See `architect-first-init` and
-`architect-first-pm` mode handling below.
+**`architect-first`** — In default mode, SKIP and add the candidate to the run summary's `skipped — architect-first (use init mode)` list. To dispatch this route, re-invoke the skill in `architect-first-init` mode (see "Architect-first init mode" section below). The pm-after-architect step (`architect-first-pm` mode) is tracked as #442 and not yet implemented.
 
 ### 3. Annotate the queue
 
@@ -176,21 +189,144 @@ Outcome format examples:
 
 Use today's date in the Promotion block header.
 
+## Architect-first init mode
+
+When invoked with `architect-first-init` as the mode prefix, the skill runs a different per-candidate flow than the default dispatch. This mode files a stub epic and invokes the `architect` subagent for design review, then stops. The human reviews the architect's comment and explicitly re-invokes the skill in `architect-first-pm` mode (#442) to complete the dispatch.
+
+This split is intentional — see PRD `.claude/specs/prd-research-pipeline-phase-3.md` decisions D2 and D4. Auto-continuing to pm would be silently wrong when architect recommends a structural change (e.g., split the candidate into two epics, as happened with C-006 → #431 + #433).
+
+### 1. Eligibility
+
+Process candidates that meet ALL of these conditions:
+- `**Status:**` is `verified`
+- A `**Decision (YYYY-MM-DD):**` line exists
+- The effective route (from Decision per the table above, or Verification's Suggested route when Decision is `approve`) is `architect-first`
+
+Skip with a clear note in the run summary:
+- Candidates with Status `architect-reviewed` — they need `architect-first-pm` (#442)
+- Candidates whose effective route is not `architect-first` — "wrong mode for this route"
+- Candidates without a Decision line — "human gate not closed"
+
+### 2. Idempotency check (PRD Q1)
+
+Before filing a stub, scan the candidate's existing Promotion block (if any) for text matching `stub #\d+`. If a stub has already been filed:
+- Stop processing that candidate
+- Emit `already in progress — stub #NNN exists` in the run summary
+- Do NOT re-invoke architect, do NOT re-file a stub, do NOT edit Status
+
+Filing is idempotent; architect invocation is NOT. If the architect's first comment was inadequate, the human handles it manually (edit the stub body, invoke architect interactively) rather than re-running the skill.
+
+### 3. File the stub epic
+
+Use `mcp__github__create_issue` to file the stub. **No labels applied** (PRD D5).
+
+**Title format:** the candidate's `### C-NNN: <Title>` heading text with the `C-NNN:` prefix stripped. Example: candidate `### C-001: Hook input duration_ms — per-tool timing config check` becomes stub title `Hook input duration_ms — per-tool timing config check`.
+
+**Body template** (parameterize from candidate fields):
+
+```markdown
+**Status:** stub — awaiting architect design review.
+
+**Source candidate:** C-NNN in `.claude/specs/research/anthropic-feature-watch.md`
+
+**Upstream signal:** <candidate's Source URL>
+
+## Summary
+
+<candidate's Summary field>
+
+## AgentFluent relevance
+
+<candidate's AgentFluent relevance field>
+
+## Verification status
+
+<full Verification block from the queue, verbatim>
+
+## What architect review needs to decide
+
+<design questions derived from the Verification block's Notes and Suggested route rationale. If the Dedup check references in-flight overlapping issues (e.g., "overlaps with #163 (open)"), include "Scope boundary vs. #163" as one of the questions.>
+
+## Decision
+
+Approved for dispatch from the research queue.
+
+**Decision line:** <candidate's Decision line, verbatim>
+```
+
+Capture the returned issue number from `mcp__github__create_issue`. If filing fails, record the failure in the run summary and do NOT proceed to architect invocation for that candidate.
+
+### 4. Invoke the architect subagent
+
+Invoke `architect` via the `Agent` tool. The prompt must include:
+
+- **Stub epic pointer:** "Read GitHub issue #NNN in `frederick-douglas-pearce/agentfluent` for context."
+- **Code touchpoints:** extracted from the Verification block's Premise check. Look for `file:line` references (e.g., `src/agentfluent/diagnostics/signals.py:218-232`) and pass them as "Code to read."
+- **In-flight context:** if the Verification block's Dedup check references existing issues (e.g., `overlaps with #163 (open)`), include those issue numbers and instruct architect to read them via `mcp__github__get_issue` or `gh issue view <n>` for scope-boundary context.
+- **Required comment format:** "Post a single comment on issue #NNN via `mcp__github__add_issue_comment`. Start with `## Architect design review (YYYY-MM-DD)` using today's date."
+- **Required sections** (must appear as section headings in the architect's comment — PRD D6 + Q2):
+  1. **Location** — where the new capability lives in the codebase
+  2. **Mechanism** — how the work is implemented (regex vs. AST, helper vs. inline, etc.)
+  3. **Scope** — the vertical slice for v1 + what's deferred
+  4. **Output** — data model, function shape, downstream wiring
+  5. **Test fixtures** — what fixture data the implementation needs
+  6. **Risks** — known false positives, edge cases, performance concerns
+  7. **Forward compatibility** — what fields/capabilities to design for so this doesn't need a rewrite when an adjacent feature lands soon
+  8. **Open questions for verifier** — premise claims that need empirical confirmation before story implementation ships; **this heading is required even if architect has no questions** (leave the section body empty in that case)
+- **What architect must NOT do:** modify files, file additional issues, fold scope decisions silently, invoke other subagents.
+
+If the architect Agent invocation returns without confirming the comment was posted, record the failure in the run summary and do NOT flip Status or edit the queue.
+
+### 5. Annotate the queue (partial Promotion block)
+
+Edit `.claude/specs/research/anthropic-feature-watch.md`:
+
+1. Insert a **partial Promotion block** AFTER the Decision line and BEFORE the `**Status:**` line:
+
+   ```
+   **Promotion (YYYY-MM-DD):** architect-first → stub epic #NNN; architect design comment on #NNN — awaiting human review before pm dispatch.
+   ```
+
+2. Flip `**Status:**` from `verified` to `architect-reviewed`.
+
+Use today's date in the Promotion block header. The `architect-first-pm` mode (#442) will edit this partial Promotion line **in-place** to the complete form once pm dispatch finishes — do NOT use a format that's hard to find-and-replace later (keep the literal prefix `**Promotion (YYYY-MM-DD):** architect-first →` parseable).
+
+### 6. Stop
+
+The skill does NOT continue to pm dispatch in `architect-first-init` mode. The human reads the architect comment and explicitly re-invokes the skill in `architect-first-pm` mode (#442) to complete the dispatch. This pause is intentional (PRD D2/D4) — it catches architect's structural recommendations (split/fold/defer) that auto-continue would silently miss.
+
 ## Output
 
-Return a structured run summary (under 300 words):
+Return a structured run summary (under 300 words). The summary fields differ by mode.
+
+### Default mode
 
 1. **Mode:** dry-run | live
 2. **Scope:** ALL | comma-separated IDs
 3. **Candidates processed:** N of M (in scope, eligible)
 4. **Per-candidate table:** ID, decision, effective route, action taken
    (or "would take" in dry-run), outcome
-5. **Skipped — architect-first:** list of IDs
-6. **Skipped — out of scope this run:** list of IDs (only when scope
+5. **Skipped — architect-first (use init mode):** list of IDs
+6. **Skipped — architect-reviewed (use pm mode):** list of IDs
+7. **Skipped — out of scope this run:** list of IDs (only when scope
    is not ALL)
-7. **Skipped — no Decision line:** list of IDs (human gate not closed)
-8. **Errors / partial failures:** anything that didn't complete cleanly
-9. **Budget consumption:** Edit / Bash / MCP / Agent counts
+8. **Skipped — no Decision line:** list of IDs (human gate not closed)
+9. **Errors / partial failures:** anything that didn't complete cleanly
+10. **Budget consumption:** Edit / Bash / MCP / Agent counts
+
+### `architect-first-init` mode
+
+1. **Mode:** architect-first-init (dry-run | live)
+2. **Scope:** ALL | comma-separated IDs
+3. **Candidates processed:** N of M (in scope, eligible)
+4. **Per-candidate table:** ID, decision, route, action taken
+   (or "would take" in dry-run), stub epic #, architect comment status (posted | failed | not-attempted)
+5. **Skipped — wrong route:** list of IDs (effective route is not `architect-first`)
+6. **Skipped — already in progress:** list of IDs (stub already exists)
+7. **Skipped — out of scope this run:** list of IDs (only when scope is not ALL)
+8. **Skipped — no Decision line:** list of IDs
+9. **Errors / partial failures:** anything that didn't complete cleanly (filing failure, architect-invocation failure, queue-annotation failure)
+10. **Budget consumption:** Edit / Bash / MCP / Agent counts
 
 ## What you must NOT do
 


### PR DESCRIPTION
## Summary
- Adds `architect-first-init` mode prefix to the `promote-candidates` skill, implementing Phase 3.A from PRD #439.
- Init mode files an architect-review stub (no labels, body templated from candidate), invokes architect via the Agent tool with a hard-coded prompt template requiring 8 section headings, writes a partial Promotion block, and flips Status to `architect-reviewed` — then stops for human review.
- Backward compatible: mode arg detected via `architect-first-*` prefix match; default mode behavior unchanged for the 3 existing routes (pm-first, dismiss-as-duplicate, needs-evidence).

Closes #441. Epic #439. Builds on #440 (merged).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — no test changes needed (markdown-only)
- [x] Lint clean: `uv run ruff check src/ tests/` — no Python touched
- [x] Type check clean: `uv run mypy src/agentfluent/` — no Python touched
- [x] New/changed behavior has test coverage — N/A, skill body is a prompt (no automated tests for skill markdown today)
- [ ] **Manual smoke test deferred to #443** — end-to-end validation of architect-first-init + architect-first-pm across both modes is the dedicated #443 story. This PR ships the init-mode skill body without exercising it on a real candidate (the queue currently has no architect-first candidates awaiting init dispatch — all 3 prior architect-first cases were dispatched manually before this skill existed).

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Default mode (no mode prefix) preserves exact existing behavior. The detection rule "if first arg matches `architect-first-*`, it's the mode prefix; otherwise it's dry-run|live" is backward compatible — no existing invocation pattern conflicts with the prefix namespace.

## Resolved decisions referenced
From [PRD #439](https://github.com/frederick-douglas-pearce/agentfluent/issues/439):
- D1 (extend existing skill with new mode), D2 (stop after architect), D5 (no labels), D6 (hard-coded architect prompt template with required sections), Q1 (stop-if-already-in-progress idempotency), Q2 (Open questions for verifier required heading), Gap 1/2 (no new MCP tools added), Gap 4 (relies on #440's SKILL.md line 219 update)