### PR TITLE
docs: #446 — document Conventional Commits scope for `.claude/` paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,8 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 
 **Breaking changes:** Add `!` after the type (e.g., `feat!: remove legacy API`) or include `BREAKING CHANGE:` in the commit body. Triggers a major version bump.
 
+**Scope for `.claude/` paths:** Changes that only touch `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, `.claude/specs/`, or `.claude/commands/` are maintainer-only Claude Code tooling — they don't ship in the PyPI package. Use `chore:` or `docs:` for these (e.g., `chore(skills): ...`, `docs(specs): ...`, `chore(agents): ...`), NOT `feat:`/`fix:`. Reserve `feat:`/`fix:` for changes to `src/agentfluent/`, `pyproject.toml` runtime deps, or CLI entry points — anything a `pip install agentfluent` user would see. This prevents the release-please changelog from advertising internal-tooling commits as user-facing features (and prevents spurious version bumps driven by maintainer-only work). See [#446](https://github.com/frederick-douglas-pearce/agentfluent/issues/446) for the convention's history and [#447](https://github.com/frederick-douglas-pearce/agentfluent/issues/447) for the mechanical enforcement work.
+
 ## Production Standards
 
 - **All new features must have tests.** No merging without test coverage for the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ All three must pass before merge. CI runs them on every PR (`.github/workflows/c
 
 - Branch from `main` using `feature/<issue-number>-short-description` or `fix/<issue-number>-...`
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `refactor:`. These drive automated version bumps via release-please.
+- **Scope for internal-tooling changes:** Use `chore:` or `docs:` (NOT `feat:`/`fix:`) when a change only touches `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, `.claude/specs/`, or `.claude/commands/`. Those paths are maintainer-only Claude Code tooling and don't ship in the PyPI package, so they shouldn't appear in the user-facing changelog. Examples: `chore(skills): update prompt template`, `docs(specs): clarify PRD wording`, `chore(agents): add new subagent definition`. Reserve `feat:`/`fix:` for changes to `src/agentfluent/` (the shipped Python code) or top-level config affecting installation (`pyproject.toml`, CLI entry points).
 - Breaking changes: add `!` (`feat!: remove legacy API`) or include `BREAKING CHANGE:` in the body.
 - Keep PRs focused — one issue per PR whenever possible.
 


### PR DESCRIPTION
## Summary
- Adds a paragraph to `CLAUDE.md` (under "Commit Messages") clarifying that `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, `.claude/specs/`, and `.claude/commands/` are maintainer-only — use `chore:`/`docs:`, not `feat:`/`fix:`.
- Adds the equivalent bullet to `CONTRIBUTING.md` (under "Branch + commit conventions") for external contributors.
- Both writeups include example prefixes per directory.

**Addresses #446** (the doc half — CLAUDE.md + CONTRIBUTING.md writeup). Sub-issue #447 tracks the mechanical-enforcement work (release-please config) separately. When both this PR and #447 land, #446 can be closed manually.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — N/A, markdown-only
- [x] Lint clean: `uv run ruff check src/ tests/` — N/A, no Python touched
- [x] Type check clean: `uv run mypy src/agentfluent/` — N/A, no Python touched
- [x] New/changed behavior has test coverage — N/A, documentation only
- [x] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI behavior changes

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Documentation-only addition; no contract change. The convention itself has been enforced at PR-review time for two prior PRs (#444 used `docs(skills):`; #445 was renamed from `feat(skills):` to `chore(skills):` before merge). This PR codifies that enforcement so future contributors and maintainers don't have to relearn the rule each time.

## Notes
- Commit prefix on this PR itself: `docs:` (no scope) — touches both `CLAUDE.md` and `CONTRIBUTING.md`, no single subdirectory scope applies. Consistent with the rule being documented.
- The CLAUDE.md and CONTRIBUTING.md writeups are intentionally different phrasings of the same rule, tailored to each audience: maintainers + Claude vs. external contributors.
- Sub-issue #447 covers the mechanical enforcement that will eventually clean up PR #409. Until #447 lands, the convention is enforced at PR-review time.