### PR TITLE
chore(release): #447 — last-release-sha to drop historical maintainer-tooling commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "35f5adba23134d646a330405c26164c230395e0e",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary
- Adds `last-release-sha: "35f5adba23134d646a330405c26164c230395e0e"` (current main HEAD) at the root of `release-please-config.json`.
- Tells release-please to ignore all commits at or before that SHA when calculating the next release — both for changelog rendering and version-bump decisions.
- Effect: the 5 historical commits with mismatched prefixes (`feat(research):` / `fix(research):` on `.claude/` paths only) drop from release-please's view. [PR #409](https://github.com/frederick-douglas-pearce/agentfluent/pull/409) regenerates as empty on the next push to main and effectively self-closes.

**Addresses #447** (the mechanical-enforcement attempt for #446). Sibling PR #448 ships the doc half of #446. When both this PR and #448 land, #446 can be closed manually.

## Scope reduction from #447's original proposal

Schema research (documented in the [issue comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/447#issuecomment-4527963634)) found:

1. **`bootstrap-sha` is initial-setup only.** Schema docstring: *"For the initial release of a library."* Replaced with `last-release-sha` (*"For any release, only consider as far back as this commit SHA"*) — ongoing-use friendly per docstring.
2. **`changelog-sections` doesn't support per-scope rules.** Schema sub-properties are `type` (required), `section` (required), `hidden` (boolean) — no `scope` field. The original proposal to map `feat(research):` to a hidden "Maintainer tooling" section is infeasible.

So this PR ships only the `last-release-sha` change. Future enforcement of the `.claude/` scope convention from #446 remains policy-only (CLAUDE.md + CONTRIBUTING.md writeup in PR #448) — no mechanical safety net for new wrong-prefix commits.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — N/A, single-line JSON config change
- [x] Lint clean: `uv run ruff check src/ tests/` — N/A, no Python touched
- [x] Type check clean: `uv run mypy src/agentfluent/` — N/A, no Python touched
- [x] New/changed behavior has test coverage — N/A, config-only
- [x] **JSON parses validly** — verified locally via `python3 -c "import json; json.load(open('release-please-config.json'))"`
- [ ] **Behavior verified post-merge** — once this merges, release-please's next run on main should regenerate PR #409 with the 5 historical commits dropped (or close it with no eligible commits). Verify before considering #447 done.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code). Config file used only by release-please CI workflow.
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None for end users. Internal release tooling behavior change: release-please will now treat all commits at or before `35f5adba23134d646a330405c26164c230395e0e` as already-released, even though they were never tagged. The 5 historical commits incorrectly prefixed `feat(research):`/`fix(research):` get absorbed silently. The git tag for `v0.7.0` points at an earlier SHA than `last-release-sha`, so `git log v0.7.0..HEAD` will continue to show all post-v0.7.0 commits including the absorbed ones — minor audit-trail discrepancy, acceptable for this purpose.

## Commit prefix
`chore(release):` — config-only, doesn't ship to PyPI users, no version bump. Consistent with the convention in #446's PR #448.