### PR TITLE
fix(diagnostics): #453 — tag no-trace invocations as duration-unreliable

### DIFF
--- a/.claude/specs/backlog-v0.8.md
+++ b/.claude/specs/backlog-v0.8.md
@@ -12,31 +12,54 @@ Ordered backlog for v0.8 (Sharpen the Signal). Issues are sequenced by dependenc
 
 | Disposition | Count | Issues |
 |-------------|-------|--------|
-| In scope (open) | 9 | #394, #395, #396, #402, #399, #400, #401, #392, #390 |
-| Stretch | 1 | #333 |
-| Total in milestone | 10 | (including parent epic #398) |
+| In scope (open) | 11 | #453, #454, #395, #396, #402, #399, #400, #401, #392, #390, #333 |
+| Closed (superseded) | 1 | #394 (replaced by #453 + #454, see D038) |
+| Total in milestone | 12 | (including parent epic #398) |
 
 ---
 
 ## Stream A: Diagnostics Signal Quality (dogfood fixes)
 
-Three independent stories addressing the dominant misleading signals from the v0.7 dogfood analysis (2026-05-17). All three can be implemented in parallel.
+Four independent stories addressing the dominant misleading signals from the v0.7 dogfood analysis (2026-05-17). All four can be implemented in parallel (though #454 has a soft dependency on #453 for its dogfood validation AC).
 
-### A1. #394 -- Extend `active_duration_ms` to non-trace agents (AskUserQuestion-anchored wait detection)
+### A1a. #453 -- Tag no-trace agent invocations as duration-unreliable
 
 **Priority:** high
 **Labels:** `bug`, `enhancement`, `priority:high`
-**Sizing:** M (2-3 days)
+**Sizing:** XS-S (~1 day)
 **Dependencies:** None
 **Status:** IN SCOPE
+**Replaces:** #394 (Cause A -- see D038)
 
-**Summary:** pm's `active_duration_ms` returns `None` when no subagent trace exists, causing the CLI table to fall back to wall-clock duration (33 min avg in dogfood). The original #230 spec called out the AskUserQuestion-anchored detection path but it was never implemented. Extend the computation to subtract AskUserQuestion wait gaps from wall-clock duration for parent-thread agents.
+**Summary:** 6 of 31 pm invocations (~20%) have no subagent trace file on disk (all from one session). Without trace data, `active_duration_ms` returns `None` and the table silently falls back to wall-clock duration. Add a `duration_reliable` flag to `AgentInvocation` so consumers can distinguish real active durations from wall-clock fallbacks. Table formatter annotates unreliable durations. `duration_outlier` signal skips unreliable invocations.
 
 **Key considerations:**
-- Option A (recommended by issue author): compute from parent-thread messages by detecting AskUserQuestion tool_result blocks between invocation start/end, summing gaps, subtracting from wall-clock
-- Option B (pragmatic fallback): tag invocations as "may include user-wait time" without computing active duration
-- Requires plumbing parent_messages into the AgentInvocation computation path
-- `duration_outlier` signal must use active duration for AskUserQuestion-using agents
+- `duration_reliable: bool` property on `AgentInvocation` -- True when trace exists, False otherwise
+- Table formatter annotates (e.g., `~33m*` with footnote)
+- `duration_outlier` gated: skip or down-weight to INFO for unreliable invocations
+- JSON output includes `duration_reliable` per invocation
+- No heuristic changes, no calibration risk
+
+**Blocks:** Nothing (but #454's dogfood validation AC uses this flag)
+
+---
+
+### A1b. #454 -- Re-tune idle-gap thresholds for moderate user-coupled waits
+
+**Priority:** medium
+**Labels:** `enhancement`, `priority:medium`
+**Sizing:** M (2-3 days)
+**Dependencies:** Soft dependency on #453 (for dogfood validation AC only)
+**Status:** IN SCOPE
+**Replaces:** #394 (Cause B -- see D038)
+
+**Summary:** The idle-gap heuristic (`IDLE_GAP_K=10`, `IDLE_GAP_FLOOR_MS=300_000`) catches dramatic gaps but misses moderate 1-4 minute user-coupled waits. Re-run the calibration notebook against the v0.7+ corpus to find new constants that catch moderate gaps while maintaining 100% `stuck_session` recall. May require splitting idle-gap vs stuck-session thresholds.
+
+**Key considerations:**
+- Constants are shared with `stuck_session` signal -- calibrated to 100% recall on 12 stuck traces in `scripts/calibration/threshold_validation.ipynb` section 11
+- Sweep `IDLE_GAP_K` (5, 7, 8, 10) and `IDLE_GAP_FLOOR_MS` (60k, 120k, 180k, 300k)
+- If constants can't serve both signals, consider splitting into separate threshold pairs
+- Dogfood target: pm avg duration < 10 min (reliable invocations only, per #453)
 
 **Blocks:** Nothing
 
@@ -193,25 +216,23 @@ New external data source. Sequential dependency chain: infrastructure -> signal 
 **Dependencies:** All feature work complete (docs reflect what shipped)
 **Status:** IN SCOPE
 
-**Summary:** Auto-created when v0.8.0 milestone was opened. Update README (feature list, CLI flags, JSON example for `--github`), GLOSSARY (new terms: `ci_failure_first_push`, `pr_review_comment_density`, `tier3_degraded`, updated `reviewer_caught`), CHANGELOG (prose expansion).
+**Summary:** Auto-created when v0.8.0 milestone was opened. Update README (feature list, CLI flags, JSON example for `--github`), GLOSSARY (new terms: `ci_failure_first_push`, `pr_review_comment_density`, `tier3_degraded`, `duration_reliable`, updated `reviewer_caught`), CHANGELOG (prose expansion).
 
 **Blocks:** Nothing
 
 ---
 
-## Stretch Scope
+## Stream E: Additional Signal-Quality Fix
 
-### S1. #333 -- ERROR_PATTERN FP reduction on prose-heavy outputs
+### E1. #333 -- ERROR_PATTERN FP reduction on prose-heavy outputs
 
-**Priority:** low (within stretch)
+**Priority:** low
 **Labels:** `bug`, `priority:low`
 **Sizing:** M (2-3 days)
 **Dependencies:** None
-**Status:** STRETCH
+**Status:** IN SCOPE
 
-**Summary:** Residual ERROR_PATTERN false-positive rate post-#281. ~10 of 11 leading-200 matches on the dogfood corpus are false positives (issue titles, code identifiers, schema field mentions). Five hypotheses in the issue; hypothesis 5 (suppress metadata fallback for trace-linked invocations) is the simplest scope-cut. Fits the "sharpen the signal" theme but lower priority than the three anchor fixes.
-
-**Why stretch:** The anchors (#394/#395/#396) address the three highest-volume misleading signals. #333 addresses a lower-volume FP class. Pull in if time allows after must-include scope completes.
+**Summary:** Residual ERROR_PATTERN false-positive rate post-#281. ~10 of 11 leading-200 matches on the dogfood corpus are false positives (issue titles, code identifiers, schema field mentions). Five hypotheses in the issue; hypothesis 5 (suppress metadata fallback for trace-linked invocations) is the simplest scope-cut. Fits the "sharpen the signal" theme alongside the Stream A anchor fixes.
 
 ---
 
@@ -219,29 +240,30 @@ New external data source. Sequential dependency chain: infrastructure -> signal 
 
 ### Wave 1 -- Dogfood fixes + Tier 3 infrastructure (start immediately, parallel)
 
-All four are independent. Start them in parallel or interleave.
+All five are independent. Start them in parallel or interleave.
 
-1. **#394** -- active_duration_ms for non-trace agents (M, no deps, highest-impact dogfood fix)
-2. **#395** -- retry_loop built-in-tool down-weight (S, no deps)
-3. **#396** -- reviewer_caught healthy-band (S-M, no deps)
-4. **#399** -- Tier 3 infrastructure (M-L, no deps, blocks Stream B)
+1. **#453** -- tag no-trace invocations as duration-unreliable (XS-S, no deps, quick win)
+2. **#454** -- idle-gap threshold re-tuning (M, soft dep on #453 for validation)
+3. **#395** -- retry_loop built-in-tool down-weight (S, no deps)
+4. **#396** -- reviewer_caught healthy-band (S-M, no deps)
+5. **#399** -- Tier 3 infrastructure (M-L, no deps, blocks Stream B)
 
 ### Wave 2 -- Tier 3 signals + calibration (days 5-12)
 
-5. **#400** -- CI_FAILURE_FIRST_PUSH signal (M, depends on #399)
-6. **#401** -- PR_REVIEW_COMMENT_DENSITY signal (M, depends on #399, parallel with #400)
-7. **#402** -- feat_fix_proximity calibration (S-M, independent)
-8. **#392** -- CHANGELOG tidy (XS, independent early win)
+6. **#400** -- CI_FAILURE_FIRST_PUSH signal (M, depends on #399)
+7. **#401** -- PR_REVIEW_COMMENT_DENSITY signal (M, depends on #399, parallel with #400)
+8. **#402** -- feat_fix_proximity calibration (S-M, independent)
+9. **#392** -- CHANGELOG tidy (XS, independent early win)
 
-### Wave 3 -- Stretch (if time allows)
+### Wave 3 -- Additional signal-quality fix
 
-9. **#333** -- ERROR_PATTERN FP reduction (M, independent)
+10. **#333** -- ERROR_PATTERN FP reduction (M, independent)
 
 ### Wave 4 -- Release prep (days 16-22)
 
-10. **#390** -- Docs catch-up (M, depends on all features)
-11. Dogfood validation runs (Tier 3 signals, duration fix, retry ranking)
-12. Release prep (changelog, version bump, CI green)
+11. **#390** -- Docs catch-up (M, depends on all features)
+12. Dogfood validation runs (Tier 3 signals, duration fix, retry ranking)
+13. Release prep (changelog, version bump, CI green)
 
 ---
 
@@ -249,22 +271,32 @@ All four are independent. Start them in parallel or interleave.
 
 | Order | # | Title | In/Out | Priority | Deps | Stream |
 |-------|---|-------|--------|----------|------|--------|
-| 1 | #394 | active_duration_ms non-trace agents | IN | high | none | A |
-| 2 | #395 | retry_loop built-in down-weight | IN | medium | none | A |
-| 3 | #396 | reviewer_caught healthy band | IN | medium | none | A |
-| 4 | #399 | Tier 3 infrastructure | IN | high | none | B |
-| 5 | #400 | CI_FAILURE_FIRST_PUSH signal | IN | high | #399 | B |
-| 6 | #401 | PR_REVIEW_COMMENT_DENSITY signal | IN | high | #399 | B |
-| 7 | #402 | feat_fix_proximity calibration | IN | medium | none | C |
-| 8 | #392 | CHANGELOG tidy | IN | low | none | D |
-| 9 | #333 | ERROR_PATTERN FP reduction | STRETCH | low | none | -- |
-| 10 | #390 | Docs catch-up | IN | required | all features | D |
+| 1 | #453 | Tag no-trace as duration-unreliable | IN | high | none | A |
+| 2 | #454 | Idle-gap threshold re-tuning | IN | medium | soft #453 | A |
+| 3 | #395 | retry_loop built-in down-weight | IN | medium | none | A |
+| 4 | #396 | reviewer_caught healthy band | IN | medium | none | A |
+| 5 | #399 | Tier 3 infrastructure | IN | high | none | B |
+| 6 | #400 | CI_FAILURE_FIRST_PUSH signal | IN | high | #399 | B |
+| 7 | #401 | PR_REVIEW_COMMENT_DENSITY signal | IN | high | #399 | B |
+| 8 | #402 | feat_fix_proximity calibration | IN | medium | none | C |
+| 9 | #392 | CHANGELOG tidy | IN | low | none | D |
+| 10 | #333 | ERROR_PATTERN FP reduction | IN | low | none | E |
+| 11 | #390 | Docs catch-up | IN | required | all features | D |
+
+---
+
+## Closed / Superseded
+
+| # | Title | Disposition | Replaced by |
+|---|-------|-------------|-------------|
+| #394 | active_duration_ms non-trace agents (AskUserQuestion-anchored) | Closed -- premise disproved (D038) | #453 + #454 |
 
 ---
 
 ## Estimated Total
 
-**Must-include: 9 open issues, ~18-26 dev days (3-4 weeks)**
-**With stretch: +1 issue, ~2-3 additional dev days**
+**11 open issues, ~20-29 dev days (3-4+ weeks)**
 
-Streams A, B, and C are fully independent. Within Stream B, the infrastructure story (#399) blocks the two signal stories (#400, #401) which are independent of each other. A solo developer can start with Wave 1 (interleaving #394 with #399), then shift to Wave 2 (Tier 3 signals + calibration) once infrastructure lands.
+Net effect of the #394 split: one M issue replaced by one XS-S + one M. Total effort is similar but risk is better distributed -- the quick win (#453) ships independently of the calibration work (#454). If #454 threatens the timeline, it can slip to v0.8.1 without leaving users with silently misleading durations (because #453 tags them).
+
+Streams A, B, C, and E are fully independent. Within Stream B, the infrastructure story (#399) blocks the two signal stories (#400, #401) which are independent of each other. A solo developer can start with Wave 1 (interleaving #453 with #399), then shift to Wave 2 (Tier 3 signals + calibration) once infrastructure lands.

--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -767,3 +767,32 @@ primary_axis = max(AXIS_TIEBREAKER, key=lambda a: axis_scores[a])
 **Reference:** Issue #451 (cron deployment); `.claude/agents/anthropic-research.md`; `.claude/specs/research/anthropic-feature-watch.md` Reviewed Sources section (2026-05-20 scout pass data).
 
 ---
+## D038: #394 re-scope -- split into #453 (tag no-trace) + #454 (threshold re-tuning)
+
+**Date:** 2026-05-25
+**Context:** #394 ("extend active_duration_ms to non-trace agents via AskUserQuestion-anchored wait detection") was the highest-priority story in v0.8 Stream A. Before implementation, an empirical investigation ran the existing extractor + trace parser against the agentfluent project corpus (25 sessions, 31 pm invocations). The investigation disproved the issue's premise and identified two distinct root causes for the inflated 33-min pm average.
+
+**Findings:**
+1. **AskUserQuestion does not appear in pm traces** -- zero occurrences across 31 invocations. The upstream gap (anthropics/claude-code#55240) is real. The "AskUserQuestion-anchored detection path" proposed in #394 and #230 cannot be built.
+2. **The existing idle-gap heuristic works** for dramatic gaps (8h, 1.5h) but misses moderate 1-4 min user-coupled waits.
+3. **Two distinct causes inflate the average:**
+   - **Cause A:** 6/31 pm invocations (~20%) have no subagent trace file; `active_duration_ms` returns `None`; table silently falls back to wall-clock.
+   - **Cause B:** Moderate idle gaps (1-4 min) fall below the `IDLE_GAP_K=10` / `IDLE_GAP_FLOOR_MS=300_000` threshold, which is shared with the `stuck_session` signal and calibrated to 100% recall on 12 stuck traces.
+
+**Options considered:**
+- A) Edit #394 in place with new title/body/ACs -- rejected because the original title, ACs, and comment thread all reference AskUserQuestion anchoring; overwriting creates a confusing audit trail.
+- B) Close #394, open two replacement issues -- chosen. Preserves the diagnostic trail (original framing + empirical rebuttal + re-scope rationale all readable in one thread). Splits scope by risk profile.
+- C) Close #394, open one combined replacement -- rejected because Cause A (XS-S, zero calibration risk) and Cause B (M, notebook re-run, calibration risk) have fundamentally different risk profiles and should not block each other.
+
+**Decision:** Option B. Close #394 as superseded. Open:
+- **#453** -- Tag no-trace invocations as duration-unreliable (Cause A). `priority:high`, XS-S, v0.8.0.
+- **#454** -- Re-tune idle-gap thresholds for moderate user-coupled waits (Cause B). `priority:medium`, M, v0.8.0 (slippable to v0.8.1 if calibration threatens timeline).
+
+**Rationale:**
+- **Risk separation.** #453 has zero calibration risk and can ship immediately. #454 requires notebook re-validation and risks degrading `stuck_session` recall. Bundling them means the quick win waits for the risky work.
+- **Audit trail.** Closing #394 with a pointer to replacements preserves the diagnostic journey. Future readers see: original hypothesis, empirical rebuttal, re-scope decision, and the two replacement issues -- all linked.
+- **Milestone stability.** Both replacements stay in v0.8.0. #454 has an explicit deferral path to v0.8.1 if needed, documented in its ACs. #453 alone ensures users are never silently misled by wall-clock fallback durations.
+- **Dogfood goal.** The pm avg < 10 min success criterion requires both issues. #453 prevents no-trace invocations from inflating the average. #454 catches moderate idle gaps in trace-attached invocations. Spec files updated to reflect that this goal depends on both.
+- **AskUserQuestion explicitly moved to Non-Goals** in `prd-v0.8.md` -- it cannot be built until the upstream gap is resolved.
+
+**Reference:** Issue #394 (closed); #453; #454. Empirical re-diagnosis: #394 comment (2026-05-25). `backlog-v0.8.md` and `prd-v0.8.md` updated to reflect the split.

--- a/.claude/specs/prd-v0.8.md
+++ b/.claude/specs/prd-v0.8.md
@@ -1,7 +1,7 @@
 # PRD: AgentFluent v0.8 -- Sharpen the Signal
 
 **Status:** Draft
-**Date:** 2026-05-18
+**Date:** 2026-05-18 (updated 2026-05-25 -- #394 re-scope, see D038)
 **Author:** PM Agent
 **Decision log:** See `decisions.md` for key decisions referenced below.
 **Backlog:** See `backlog-v0.8.md` for the full sequenced backlog.
@@ -16,7 +16,7 @@ v0.7 completed the output layer: `agentfluent report` for shareable Markdown, `-
 
 The v0.7 dogfood run (2026-05-17, `.claude/specs/analysis/2026-05-17-v07-dogfood-analysis.md`) confirmed the signals are firing -- and exposed where they mislead. Three concrete problems surfaced:
 
-1. **Duration metrics lie for human-coupled agents.** pm's reported 33-min average duration includes user-wait time that `active_duration_ms` was supposed to exclude. The AskUserQuestion-anchored path was never implemented (#394).
+1. **Duration metrics lie for human-coupled agents.** pm's reported 33-min average duration includes user-wait time that `active_duration_ms` was supposed to exclude. Empirical investigation (2026-05-25) revealed two distinct causes: (a) ~20% of pm invocations have no subagent trace file on disk, causing silent fallback to wall-clock duration, and (b) moderate 1-4 min idle gaps fall below the detection threshold for trace-attached invocations. The originally hypothesized AskUserQuestion-anchored detection path cannot be built -- zero AskUserQuestion occurrences exist in the pm corpus. See D038 for the re-scope from #394 to #453 + #454.
 2. **Retry noise drowns actionable signals.** Read retries account for 68% of all `retry_loop` signals (104 of 152), but Read retries are built-in-tool behavior with no agent-config fix. They crowd out the actionable Bash/MCP retries in the priority list (#395).
 3. **Reviewer effectiveness is mislabeled.** A 31% `parent_acted` rate on architect's `reviewer_caught` signal looks like a problem, but ~50% of "not acted on" findings are deliberate rejections. The recommendation copy treats rejection as failure (#396).
 
@@ -36,11 +36,11 @@ The alternative was to broaden detection (tool-inventory diagnostics #371, new d
 
 2. **Tier 3 is the natural follow-through on the quality axis.** v0.6 shipped Tier 1 (JSONL-only quality signals). v0.7 shipped Tier 2 (local git). Tier 3 (GitHub enrichment) is the next step in the planned progression (D015), and the spike deliverable (#352) resolved all design-blocking questions. Deferring Tier 3 to v0.9 would break the momentum of the quality-axis story.
 
-3. **The dogfood fixes and Tier 3 reinforce each other.** #394/#395/#396 make existing signals trustworthy. Tier 3 adds new signals that are inherently high-confidence (CI pass/fail is binary; review comments are human-generated). Together they raise the floor and the ceiling of diagnostics quality in one release.
+3. **The dogfood fixes and Tier 3 reinforce each other.** #453/#454/#395/#396 make existing signals trustworthy. Tier 3 adds new signals that are inherently high-confidence (CI pass/fail is binary; review comments are human-generated). Together they raise the floor and the ceiling of diagnostics quality in one release.
 
 ## 2. Goals
 
-1. **Fix duration measurement for human-coupled agents** by implementing AskUserQuestion-anchored wait detection (#394)
+1. **Fix duration measurement for human-coupled agents** by tagging no-trace invocations as unreliable (#453) and re-tuning idle-gap thresholds for moderate waits (#454)
 2. **Reduce retry noise in priority rankings** by down-weighting built-in-tool retries (#395)
 3. **Calibrate reviewer effectiveness interpretation** by introducing a healthy parent_acted band (#396)
 4. **Validate feat_fix_proximity precision** with a ground-truth calibration check (#402)
@@ -62,18 +62,22 @@ The alternative was to broaden detection (tool-inventory diagnostics #371, new d
 - ERROR_PATTERN FP reduction (#333) -- fits theme but lower priority than anchors; v0.8.1 candidate
 - Negative recommendations ("remove this subagent") -- deferred per D020
 - `agentfluent report` for `diff` output -- deferred from v0.7 OQ3, still deferred
+- AskUserQuestion-anchored wait detection -- upstream gap (anthropics/claude-code#55240) means zero AskUserQuestion events in JSONL; cannot be built (D038)
 
-## 4. In Scope -- 10 issues
+## 4. In Scope -- 11 issues
 
 ### Stream A: Diagnostics Signal Quality (dogfood fixes)
 
-Three independent stories addressing the three dominant misleading signals from the v0.7 dogfood.
+Four independent stories addressing the dominant misleading signals from the v0.7 dogfood.
 
 | # | Title | Effort | Priority | Deps |
 |---|-------|--------|----------|------|
-| #394 | Extend `active_duration_ms` to non-trace agents (AskUserQuestion-anchored wait detection) | M (2-3 days) | high | None |
+| #453 | Tag no-trace invocations as duration-unreliable | XS-S (~1 day) | high | None |
+| #454 | Re-tune idle-gap thresholds for moderate user-coupled waits | M (2-3 days) | medium | Soft #453 |
 | #395 | Down-weight `retry_loop` on built-in tools (Read dominates noise) | S (1-2 days) | medium | None |
 | #396 | `reviewer_caught` parent_acted interpretation -- healthy-band gating | S-M (1-2 days) | medium | None |
+
+Note: #394 (original AskUserQuestion-anchored approach) was closed and replaced by #453 + #454 after empirical investigation disproved its premise. See D038.
 
 ### Stream B: Tier 3 GitHub Enrichment
 
@@ -104,35 +108,36 @@ New external data source. Epic #398 with three child stories in a dependency cha
 |---|-------|--------|----------|------|
 | #333 | ERROR_PATTERN FP reduction on prose-heavy outputs | M (2-3 days) | low | None |
 
-**Total in-scope: 10 issues (9 must-include + 1 stretch), ~18-26 dev days**
+**Total in-scope: 11 issues (10 must-include + 1 stretch), ~19-27 dev days**
 
 ## 5. Open Questions / Decisions Needed
 
-All four open questions resolved by user on 2026-05-18 — recommendations accepted as written.
+All four open questions resolved by user on 2026-05-18 -- recommendations accepted as written.
 
-### OQ1: Should `--github` imply `--git`? — **RESOLVED: (a) imply silently**
+### OQ1: Should `--github` imply `--git`? -- **RESOLVED: (a) imply silently**
 
 The Tier 3 infrastructure story (#399) proposes that `--github` implies `--git` because session-to-PR mapping relies on git commit data from Tier 2. This creates a coupling: a user who wants only GitHub signals also gets local git signals in their output. **Alternatives:** (a) `--github` implies `--git` silently -- simplest; (b) `--github` requires `--git` explicitly -- user knows what they're opting into; (c) `--github` runs Tier 3 independently, using timestamp heuristics for session-to-PR mapping instead of git data.
 
 **Decision:** (a) imply silently. The coupling is real (session-to-PR needs git data), and forcing `--git --github` is ergonomically worse than a single flag. Document the implication in `--help`.
 
-### OQ2: Does `--github` in CI/non-TTY require explicit consent? — **RESOLVED: no, `--github` is consent**
+### OQ2: Does `--github` in CI/non-TTY require explicit consent? -- **RESOLVED: no, `--github` is consent**
 
 The spike (Section 5) proposes that `--github` in non-TTY contexts is self-consenting. An alternative is requiring `--accept-github-tos` in non-TTY contexts. **Decision:** `--github` is consent in non-TTY. TTY still prompts on first run. Adding a second flag for CI adds friction for the primary early adopter (the project owner running in their own CI).
 
-### OQ3: Should v0.8 include the CHANGELOG breaking-changes section restructuring (#392)? — **RESOLVED: yes**
+### OQ3: Should v0.8 include the CHANGELOG breaking-changes section restructuring (#392)? -- **RESOLVED: yes**
 
 This is a docs chore from v0.7.0's release. It touches `release-please-config.json` which has CI implications. **Decision:** Include as a low-priority early win -- it's XS effort and prevents the pattern from compounding into v0.8.
 
-### OQ4: Tier 3 dogfood scope -- agentfluent or CodeFluent? — **RESOLVED: agentfluent**
+### OQ4: Tier 3 dogfood scope -- agentfluent or CodeFluent? -- **RESOLVED: agentfluent**
 
-Tier 3 needs a GitHub-hosted repo with PRs, CI, and review comments. AgentFluent qualifies. CodeFluent also qualifies and has a longer PR history. **Decision:** Dogfood against agentfluent first — both for consistency with prior dogfood runs and because the user has been more active here recently. CodeFluent validation can follow if breadth is needed.
+Tier 3 needs a GitHub-hosted repo with PRs, CI, and review comments. AgentFluent qualifies. CodeFluent also qualifies and has a longer PR history. **Decision:** Dogfood against agentfluent first -- both for consistency with prior dogfood runs and because the user has been more active here recently. CodeFluent validation can follow if breadth is needed.
 
 ## 6. Dependencies
 
 ```
-STREAM A (Diagnostics Signal Quality) -- all independent
-[#394 active_duration_ms] -- independent
+STREAM A (Diagnostics Signal Quality) -- mostly independent
+[#453 tag no-trace] -- independent
+[#454 threshold re-tuning] -- soft dep on #453 (dogfood validation only)
 [#395 retry_loop down-weight] -- independent
 [#396 reviewer_caught band] -- independent
 
@@ -161,7 +166,7 @@ Streams A, B, and C have zero cross-dependencies. They can be implemented in any
 |------|--------|------------|
 | `gh` CLI subprocess is flaky on some platforms (Windows, Docker) | Tier 3 doesn't work for a subset of users on day one | `gh` is the most common case; clear error messages guide users. PAT fallback in v0.8.1 covers CI/headless. |
 | Session-to-PR mapping is imprecise (timestamp heuristics) | Tier 3 signals fire on wrong PRs | Use git commit SHAs + `gh api commits/{sha}/pulls` for precise mapping. Fall back to timestamp only when commit data is unavailable. |
-| `active_duration_ms` AskUserQuestion-anchored detection requires parent-message plumbing | #394 is larger than estimated | The issue already proposes Option B (tag-only) as a pragmatic fallback. If Option A (full computation) is too complex, ship B and iterate. |
+| Idle-gap threshold re-tuning (#454) degrades `stuck_session` recall | Calibrated signal regresses | Hard constraint in #454 ACs: `stuck_session` recall must remain >= 100% on the original 12 stuck traces. If shared constants can't serve both signals, split into separate threshold pairs. If re-tuning proves too risky, #454 can slip to v0.8.1 -- #453 alone prevents silently misleading durations. |
 | Tier 3 rate-limit degradation makes signals unreliable | Users don't trust partial output | `tier3_degraded: true` field in JSON envelope; visible warning in CLI output. Partial > nothing. |
 | `feat_fix_proximity` precision check (#402) reveals poor precision | Signal needs rework | The story explicitly gates on precision results: if <70%, tune thresholds rather than ship uncalibrated. |
 
@@ -169,7 +174,7 @@ Streams A, B, and C have zero cross-dependencies. They can be implemented in any
 
 v0.8 is successful when:
 
-1. **pm's duration metric is honest.** `agentfluent analyze --project agentfluent` shows pm's average duration < 10 minutes (was 33 minutes in v0.7 dogfood). `active_duration_ms` is populated for AskUserQuestion-using agents.
+1. **pm's duration metric is honest.** `agentfluent analyze --project agentfluent` shows pm's average duration < 10 minutes (was 33 minutes in v0.7 dogfood). No-trace invocations are visually annotated as unreliable (#453). Reliable invocations have tighter idle-gap subtraction (#454). Combined effect: the table tells the truth.
 2. **Retry noise is suppressed.** Read retries fall out of the top 5 priority fixes in the agentfluent dogfood corpus. Bash/MCP retries rank higher despite lower absolute counts.
 3. **Reviewer effectiveness reads correctly.** architect's 31% parent_acted rate falls in the "healthy collaboration" band. The recommendation is INFO with "no action needed," not WARNING with "investigate."
 4. **`feat_fix_proximity` precision is documented.** Calibration check completes with >=20 samples classified. If precision < 70%, one round of threshold tuning ships.
@@ -180,7 +185,8 @@ v0.8 is successful when:
 
 ## 9. Release Checklist
 
-- [ ] #394 merged: `active_duration_ms` for non-trace agents
+- [ ] #453 merged: tag no-trace invocations as duration-unreliable
+- [ ] #454 merged: idle-gap threshold re-tuning (or explicitly deferred to v0.8.1 with documented rationale)
 - [ ] #395 merged: retry_loop built-in-tool down-weight
 - [ ] #396 merged: reviewer_caught healthy-band interpretation
 - [ ] #402 merged: feat_fix_proximity precision validation
@@ -190,7 +196,8 @@ v0.8 is successful when:
 - [ ] #392 merged: CHANGELOG tidy
 - [ ] #390 merged: docs catch-up
 - [ ] Dogfood run: `agentfluent analyze --project agentfluent --diagnostics --git --github --json` produces clean output with Tier 3 signals
-- [ ] Dogfood run: pm duration metric is honest (< 10 min avg)
+- [ ] Dogfood run: pm duration metric is honest (< 10 min avg on reliable invocations)
+- [ ] Dogfood run: no-trace invocations visually annotated
 - [ ] Dogfood run: Read retries no longer dominate priority fixes
 - [ ] `uv run pytest --cov=agentfluent` passes with >80% coverage
 - [ ] `uv run ruff check src/` clean

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from agentfluent.traces.models import SubagentTrace
 
@@ -124,6 +124,21 @@ class AgentInvocation(BaseModel):
         if self.trace is None:
             return None
         return self.trace.active_duration_ms
+
+    # mypy + pydantic ``@computed_field`` interaction (pydantic/pydantic#6709).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def duration_reliable(self) -> bool:
+        """Whether ``duration_ms`` represents active work rather than
+        wall-clock-including-wait. ``True`` only when a subagent trace is
+        linked: with a trace, the idle-gap heuristic can subtract user-
+        wait time. Without a trace, the only available duration is the
+        parent-side wall-clock, which silently includes any time the user
+        spent away from the keyboard between tool calls. Consumers
+        (formatter, ``duration_outlier`` signal, aggregate stats) should
+        treat unreliable durations as wall-clock estimates, not active
+        work, and either annotate or filter them out."""
+        return self.trace is not None
 
     @property
     def active_duration_per_tool_use(self) -> float | None:

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -245,6 +245,7 @@ def format_analysis_table(
         inv_table.add_column("Tokens", justify="right")
         inv_table.add_column("Tool uses", justify="right")
         inv_table.add_column("Duration", justify="right")
+        any_unreliable = False
         for s in result.sessions:
             for inv in s.invocations:
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
@@ -255,6 +256,9 @@ def format_analysis_table(
                 # no idle was detected.
                 if inv.duration_ms is None:
                     duration = "-"
+                elif not inv.duration_reliable:
+                    any_unreliable = True
+                    duration = f"~{inv.duration_ms / 1000:.1f}s*"
                 elif inv.idle_gap_ms and inv.active_duration_ms is not None:
                     duration = (
                         f"{inv.active_duration_ms / 1000:.1f}s "
@@ -271,6 +275,12 @@ def format_analysis_table(
                     duration,
                 )
         console.print(inv_table)
+        if any_unreliable:
+            console.print(
+                "* Duration estimated from wall-clock; no subagent trace available "
+                "(may include user-wait time).",
+                style="dim",
+            )
 
     console.print(API_RATE_FOOTNOTE, style="dim")
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -219,10 +219,14 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
     """Detect invocations with unusually high active duration per tool call.
 
     Uses ``active_duration_per_tool_use`` so user-approval wait time
-    isn't attributed to the agent.
+    isn't attributed to the agent. Filters to ``duration_reliable``
+    invocations only: no-trace invocations fall back to wall-clock,
+    which silently includes user-wait time and would produce false
+    "this agent is slow" outliers (see #453).
     """
+    reliable = [inv for inv in invocations if inv.duration_reliable]
     return _detect_outliers(
-        invocations,
+        reliable,
         accessor=lambda i: i.active_duration_per_tool_use,
         signal_type=SignalType.DURATION_OUTLIER,
         format_message=lambda inv, val, q3, iqr: (

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -137,3 +137,47 @@ class TestActiveDuration:
         )
         inv.trace = self._trace(idle_gap_ms=3000)  # type: ignore[assignment]
         assert inv.active_duration_per_tool_use is None
+
+
+class TestDurationReliable:
+    """`duration_reliable` indicates whether duration_ms represents
+    active work or wall-clock-including-wait. True only when a trace
+    is linked (#453)."""
+
+    @staticmethod
+    def _trace(*, idle_gap_ms: int | None) -> object:
+        from agentfluent.traces.models import SubagentTrace
+
+        return SubagentTrace(
+            agent_id="abc",
+            agent_type="pm",
+            delegation_prompt="x",
+            duration_ms=120_000,
+            idle_gap_ms=idle_gap_ms,
+        )
+
+    def test_no_trace_is_unreliable(self) -> None:
+        inv = _full_invocation()
+        assert inv.trace is None
+        assert inv.duration_reliable is False
+
+    def test_trace_attached_is_reliable(self) -> None:
+        inv = _full_invocation()
+        inv.trace = self._trace(idle_gap_ms=60_000)  # type: ignore[assignment]
+        assert inv.duration_reliable is True
+
+    def test_trace_without_idle_gap_still_reliable(self) -> None:
+        # Trace exists but couldn't compute idle_gap (too few paired
+        # calls). Duration is still derived from trace timestamps, so
+        # the flag tracks trace presence, not idle_gap computability.
+        inv = _full_invocation()
+        inv.trace = self._trace(idle_gap_ms=None)  # type: ignore[assignment]
+        assert inv.duration_reliable is True
+
+    def test_serialized_in_json(self) -> None:
+        inv = _full_invocation()
+        payload = inv.model_dump(mode="json")
+        assert payload["duration_reliable"] is False
+        inv.trace = self._trace(idle_gap_ms=60_000)  # type: ignore[assignment]
+        payload = inv.model_dump(mode="json")
+        assert payload["duration_reliable"] is True

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -14,8 +14,9 @@ def _inv(
     duration_ms: int | None = None,
     tool_use_id: str = "toolu_01",
     agent_id: str | None = None,
+    with_trace: bool = False,
 ) -> AgentInvocation:
-    return AgentInvocation(
+    inv = AgentInvocation(
         agent_type=agent_type,
         description="test",
         prompt="do something",
@@ -26,6 +27,17 @@ def _inv(
         output_text=output_text,
         agent_id=agent_id,
     )
+    if with_trace:
+        from agentfluent.traces.models import SubagentTrace
+
+        inv.trace = SubagentTrace(
+            agent_id=agent_id or "test-trace",
+            agent_type=agent_type,
+            delegation_prompt="x",
+            duration_ms=duration_ms,
+            idle_gap_ms=None,
+        )
+    return inv
 
 
 class TestErrorPatternDetection:
@@ -185,17 +197,30 @@ class TestDurationOutlierDetection:
     def test_detects_outlier(self) -> None:
         # Spread of 1000–1800 ms/use + one outlier at 50000.
         invocations = [
-            _inv(duration_ms=10_000 + 1000 * i, tool_uses=10) for i in range(9)
-        ] + [_inv(duration_ms=500_000, tool_uses=10)]
+            _inv(duration_ms=10_000 + 1000 * i, tool_uses=10, with_trace=True)
+            for i in range(9)
+        ] + [_inv(duration_ms=500_000, tool_uses=10, with_trace=True)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
         assert len(outliers) == 1
 
     def test_single_invocation_skipped(self) -> None:
-        invocations = [_inv(duration_ms=50000, tool_uses=10)]
+        invocations = [_inv(duration_ms=50000, tool_uses=10, with_trace=True)]
         signals = extract_signals(invocations)
         outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
         assert len(outliers) == 0
+
+    def test_no_trace_invocations_excluded(self) -> None:
+        # #453: no-trace invocations have duration_reliable=False and
+        # must not produce duration_outlier signals (would false-positive
+        # because wall-clock duration silently includes user-wait time).
+        invocations = [
+            _inv(duration_ms=10_000 + 1000 * i, tool_uses=10, with_trace=True)
+            for i in range(9)
+        ] + [_inv(duration_ms=500_000, tool_uses=10, with_trace=False)]
+        signals = extract_signals(invocations)
+        outliers = [s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER]
+        assert outliers == []
 
     def test_uses_active_duration_when_trace_present(self) -> None:
         # #230: outlier detection compares active_duration_per_tool_use.
@@ -277,10 +302,16 @@ class TestInvocationIdPropagation:
 
     def test_duration_outlier_signal_carries_invocation_id(self) -> None:
         peers = [
-            _inv(duration_ms=1000 + 100 * i, tool_uses=10, agent_id=f"ag-{i}")
+            _inv(
+                duration_ms=1000 + 100 * i, tool_uses=10,
+                agent_id=f"ag-{i}", with_trace=True,
+            )
             for i in range(9)
         ]
-        slow = _inv(duration_ms=100_000, tool_uses=10, agent_id="ag-slow")
+        slow = _inv(
+            duration_ms=100_000, tool_uses=10,
+            agent_id="ag-slow", with_trace=True,
+        )
         signals = extract_signals([*peers, slow])
         outlier = next(s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER)
         assert outlier.invocation_id == "ag-slow"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Adds `AgentInvocation.duration_reliable` computed field — `True` when a subagent trace is linked, `False` when only parent-side wall-clock metadata is available. Surfaces in JSON output.
- Table formatter annotates unreliable durations as `~Ns*` with a footnote ("Duration estimated from wall-clock; no subagent trace available — may include user-wait time").
- `duration_outlier` signal now filters out no-trace invocations so the "this agent is slow, swap model" false-positives on no-trace pm calls (the 33-min avg from v0.7 dogfood) no longer fire.
- Companion docs: closes #394 (superseded), splits into #453 (this PR) + #454 (threshold re-tune). D038 logged in `decisions.md`. Backlog + PRD updated.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1368 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — added `TestDurationReliable` (4 tests) in `test_agent_models.py`, added `test_no_trace_invocations_excluded` + `with_trace=` plumbing in `test_signals.py`
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent -v` — confirms `~586.3s*`, `~331.4s*`, etc. with footnote on real no-trace pm/architect invocations; JSON output carries `duration_reliable` per invocation (24 reliable / 13 unreliable in last 7d)

## Security review
- [x] **Skip review** — no security-sensitive surface. Internal-only computed field on a Pydantic model; table formatter is display-only; signal change is a filter on the existing pipeline. No new I/O, no parsing of untrusted input, no path/subprocess/network changes.

## Breaking changes
None.

- **JSON envelope:** adds `duration_reliable: bool` to each invocation; additive, no schema version bump needed.
- **Table output:** introduces a new annotation suffix (`~Ns*` + footnote) on the verbose per-invocation table. No flag or default change; existing reliable durations render unchanged.
- **`duration_outlier` signal:** now skips no-trace invocations. This is a behavior change in the sense that some signals that *did* fire (false-positively) on wall-clock-only invocations will no longer fire. That's the intended fix; consumers relying on those false positives would be relying on a known bug.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)