### PR TITLE
fix(diagnostics): #395 — down-weight RETRY_LOOP priority on built-in read-only tools

### DIFF
--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -24,6 +24,17 @@ volume of WARNINGs. ``log1p(count)`` damps repeats. Trace evidence
 ``TOOL_ERROR_SEQUENCE``) gets a modest boost over metadata-only
 signals.
 
+**Built-in retry noise down-weight (#395).** Groups composed entirely
+of ``RETRY_LOOP`` signals get an additional multiplier in
+``[_BUILTIN_RETRY_DOWNWEIGHT, 1.0]`` applied to the final score,
+proportional to the share of signals on read-only built-in tools
+(``Read``, ``Grep``, ``Glob``). Retries on those tools are mostly
+inherent to the tool's nature and don't have a config-level fix, so
+noise crowds out actionable retries (Bash, Edit, custom MCP tools)
+in the Top-N without this gate. Bash stays at full weight (built-in
+but actionable). Tuning of ``_BUILTIN_RETRY_DOWNWEIGHT`` is deferred
+per the issue's "Out of scope" section — re-validate post-v0.8.
+
 The ``quality_evidence_factor`` (D021) is ``1.0`` when any
 contributing signal maps to ``Axis.QUALITY``, else ``0.0``. The
 annotations approach preserves backward compatibility: recommendations
@@ -96,6 +107,19 @@ _PRIORITY_WEIGHT_COUNT = 10.0
 _PRIORITY_WEIGHT_COST = 1.0
 _PRIORITY_WEIGHT_TRACE = 5.0
 _PRIORITY_WEIGHT_QUALITY = 5.0
+
+# Built-in read-only tools whose retries are mostly inherent to the
+# tool's nature (speculative file reads after grep misses, re-reading
+# the same file across analysis steps) and don't have a config-level
+# fix. #395: down-weight RETRY_LOOP priority in proportion to the
+# share of signals on these tools, so noise doesn't crowd out
+# actionable retries (Bash, Edit, custom MCP tools) in the Top-N.
+# Bash is built-in but actionable — kept at full weight. The 0.3
+# default is informed by v0.7 dogfood (104/152 retries were on Read)
+# but not yet calibrated against multi-contributor data; #459 tracks
+# the post-v0.8 re-validation.
+_BUILTIN_RETRY_NOISE_TOOLS: frozenset[str] = frozenset({"Read", "Grep", "Glob"})
+_BUILTIN_RETRY_DOWNWEIGHT = 0.3
 
 # D027: deterministic tiebreaker for ``primary_axis`` when two or more
 # axes carry equal ``axis_scores``. Quality wins ties so the v0.6
@@ -210,6 +234,34 @@ def _compute_priority_score(
     )
 
 
+def _retry_noise_multiplier(
+    signals: list[DiagnosticSignal], severity: Severity,
+) -> float:
+    """Return a priority multiplier in `[_BUILTIN_RETRY_DOWNWEIGHT, 1.0]`.
+
+    Returns `1.0` (no down-weight) unless every signal in the group is
+    `RETRY_LOOP` and the aggregated severity is not `CRITICAL`. For
+    qualifying groups, the multiplier linearly scales from `1.0` (no
+    signals on noise tools) to `_BUILTIN_RETRY_DOWNWEIGHT` (all signals
+    on noise tools), proportional to the noise share. This drops
+    Read/Grep/Glob-dominated retry rows below actionable retries (Bash,
+    Edit, MCP) in the Top-N priority without suppressing the signal
+    itself (#395). `CRITICAL` rows are exempt so the "severity
+    dominates" invariant in the priority model is preserved.
+    """
+    if severity == Severity.CRITICAL:
+        return 1.0
+    if not signals or not all(s.signal_type == SignalType.RETRY_LOOP for s in signals):
+        return 1.0
+    noise = sum(
+        1 for s in signals if s.detail.get("tool_name") in _BUILTIN_RETRY_NOISE_TOOLS
+    )
+    if noise == 0:
+        return 1.0
+    noise_share = noise / len(signals)
+    return 1.0 - noise_share * (1.0 - _BUILTIN_RETRY_DOWNWEIGHT)
+
+
 def _signal_axis_contribution(signal: DiagnosticSignal) -> float:
     """Per-signal contribution to its axis bucket — Tier 1 = severity rank.
 
@@ -275,6 +327,7 @@ def aggregate_recommendations(
             has_trace_evidence,
             quality_evidence_factor=quality_evidence_factor,
         )
+        priority_score *= _retry_noise_multiplier(signals, severity)
 
         aggregated.append(
             AggregatedRecommendation(

--- a/tests/unit/test_recommendation_aggregation.py
+++ b/tests/unit/test_recommendation_aggregation.py
@@ -461,6 +461,82 @@ class TestPriorityScore:
         assert aggregated[0].severity == Severity.CRITICAL
 
 
+class TestBuiltinRetryDownweight:
+    """#395: RETRY_LOOP groups composed of read-only built-in tool
+    retries (Read, Grep, Glob) get a priority multiplier so the noise
+    doesn't crowd out actionable retries (Bash, Edit, MCP) in Top-N."""
+
+    def test_all_noise_tool_retries_downweighted_below_actionable(self) -> None:
+        # 100 Read retries on one agent vs 5 Bash retries on another.
+        # Both groups end up at WARNING severity, trace evidence on,
+        # similar shape — but the noise-only row drops below the
+        # actionable singleton.
+        noise_pairs = [_retry_loop_pair("pm", "Read", 3) for _ in range(100)]
+        bash_pairs = [_retry_loop_pair("explore", "Bash", 3) for _ in range(5)]
+        aggregated = aggregate_recommendations([*noise_pairs, *bash_pairs])
+        bash_row = next(a for a in aggregated if a.agent_type == "explore")
+        read_row = next(a for a in aggregated if a.agent_type == "pm")
+        assert read_row.count == 100
+        assert bash_row.count == 5
+        # Bash row outranks Read row despite lower count.
+        assert bash_row.priority_score > read_row.priority_score
+
+    def test_mixed_tool_group_partial_downweight(self) -> None:
+        # A group that's 50% Read + 50% Edit should sit between a
+        # pure-Read group and a pure-Edit group at matching count.
+        pure_noise = [_retry_loop_pair("a", "Read", 3) for _ in range(10)]
+        mixed = [
+            *(_retry_loop_pair("b", "Read", 3) for _ in range(5)),
+            *(_retry_loop_pair("b", "Edit", 3) for _ in range(5)),
+        ]
+        pure_actionable = [_retry_loop_pair("c", "Edit", 3) for _ in range(10)]
+        aggregated = aggregate_recommendations([*pure_noise, *mixed, *pure_actionable])
+        rows = {a.agent_type: a for a in aggregated}
+        assert (
+            rows["c"].priority_score
+            > rows["b"].priority_score
+            > rows["a"].priority_score
+        )
+
+    def test_non_retry_loop_groups_unaffected(self) -> None:
+        # The downweight only applies to RETRY_LOOP-only groups. A
+        # TOKEN_OUTLIER row's tool-name irrelevant, no multiplier.
+        baseline_outlier = _token_outlier_pair("a", 2.0)
+        retry_noise = _retry_loop_pair("b", "Read", 3)
+        aggregated = aggregate_recommendations([baseline_outlier, retry_noise])
+        outlier_row = next(a for a in aggregated if a.agent_type == "a")
+        # If the multiplier accidentally applied to TOKEN_OUTLIER rows,
+        # the priority would be reduced by 30-70%. Spot-check that the
+        # baseline lands in the expected range (~211 for WARNING+count=1).
+        assert outlier_row.priority_score > 200
+
+    def test_bash_not_in_noise_set_even_though_builtin(self) -> None:
+        # Bash is built-in but actionable: a Bash-only retry group must
+        # NOT get the multiplier applied.
+        bash_pairs = [_retry_loop_pair("a", "Bash", 3) for _ in range(5)]
+        glob_pairs = [_retry_loop_pair("b", "Glob", 3) for _ in range(5)]
+        aggregated = aggregate_recommendations([*bash_pairs, *glob_pairs])
+        bash_row = next(a for a in aggregated if a.agent_type == "a")
+        glob_row = next(a for a in aggregated if a.agent_type == "b")
+        # Bash full weight, Glob downweighted — Bash wins at equal count.
+        assert bash_row.priority_score > glob_row.priority_score
+
+    def test_critical_severity_exempt_from_downweight(self) -> None:
+        # The "severity dominates" invariant must hold: a CRITICAL
+        # RETRY_LOOP on a noise tool must not be down-weighted, or it
+        # could sink below WARNING rows on actionable tools.
+        critical_noise = _retry_loop_pair(
+            "a", "Read", 7, severity=Severity.CRITICAL,
+        )
+        warning_actionable = _retry_loop_pair("b", "Bash", 3)
+        aggregated = aggregate_recommendations(
+            [critical_noise, warning_actionable],
+        )
+        # CRITICAL on Read still outranks WARNING on Bash.
+        assert aggregated[0].agent_type == "a"
+        assert aggregated[0].severity == Severity.CRITICAL
+
+
 def _quality_pair(
     signal_type: SignalType,
     agent_type: str,


### PR DESCRIPTION
## Summary
- Apply a `[0.3, 1.0]` multiplier to RETRY_LOOP-only aggregated recommendation rows, scaling linearly from `1.0` (no Read/Grep/Glob signals in the group) to `0.3` (all signals on those tools). Bash stays at full weight (built-in but actionable).
- `CRITICAL` severity rows are exempt from the multiplier so the "severity dominates" invariant is preserved (verified by a regression test).
- Tuning the 0.3 default is deferred per the issue's "Out of scope" section. Filed [#459](https://github.com/frederick-douglas-pearce/agentfluent/issues/459) to track the post-v0.8 calibration against multi-contributor data.

## Dogfood validation
30-day window on the agentfluent corpus. Read-dominated retry rows drop out of the top 5; actionable singletons rise:

| Agent | Retries | Priority (pre) | Priority (post) | Tools |
|---|---:|---:|---:|---|
| architect | 39 | 241.9 | 89.9 | ~90% Read, ~10% mcp__github__* |
| general-purpose | 33 | 240.3 | 97.6 | mostly Read |
| pm | 24 | 237.2 | 126.5 | mostly Read |
| Plan | 2 | 216.0 | 64.8 | all Read |
| Explore | 1 | 211.9 | **211.9** | Bash (actionable, no multiplier) |
| candidate-verifier | 1 | 211.9 | **211.9** | Edit |
| candidate-promoter | 1 | 211.9 | **211.9** | Edit |
| anthropic-research | 1 | 211.9 | **211.9** | WebFetch |

The post-#395 top 5 priority rows are `tool_error_sequence`, `file_rework`, `token_outlier`, and `duration_outlier` rows — no Read retry rows in sight. AC satisfied.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1374 passed (1369 + 5 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — new `TestBuiltinRetryDownweight` class with 5 tests: all-noise vs actionable ranking, mixed-tool partial down-weight, non-RETRY_LOOP unaffected, Bash exempt, CRITICAL severity exempt
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent --since 30d --json` — confirms the dogfood table above

## Security review
- [x] **Skip review** — internal priority-score arithmetic. No I/O, no parsing of untrusted input, no path/subprocess/network changes. The new constants are hard-coded tool names + a float.

## Breaking changes
None.

- **No schema change.** `priority_score` remains a `float` on `AggregatedRecommendation`. No new fields.
- **Behavior shift in `priority_score` values** for RETRY_LOOP rows on noise tools — they get smaller. This shifts ranking; consumers that hard-code expected priority values for retry_loop rows would need updates, but no such consumers exist in this repo. The signal itself isn't suppressed (still emitted at WARNING, still in `contributing_recommendations`); only its sort position changes.
- **No GLOSSARY changes** — the spec explicitly notes "No GLOSSARY or schema changes".

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)