### PR TITLE
fix(diagnostics): #396 — reviewer_caught healthy-band gating for parent_acted rate

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -592,12 +592,14 @@ mentions at least one finding-keyword (`blocker`, `issue`,
 `fix`, `change needed`).
 
 The signal `detail` includes `finding_keywords` (the matched
-keywords, sorted), `parent_acted` (boolean), `response_length`
-(chars), `files_mentioned` (paths the review prose pointed at,
-extracted via a strict regex that excludes version strings and
-domain names), and `files_acted_on` (the subset of mentioned
-files the parent edited within the next
-`_PARENT_ACTED_WINDOW=15` assistant messages).
+keywords, sorted), `parent_acted` (boolean for this single
+review), `response_length` (chars), `files_mentioned` (paths
+the review prose pointed at, extracted via a strict regex that
+excludes version strings and domain names), `files_acted_on`
+(the subset of mentioned files the parent edited within the
+next `_PARENT_ACTED_WINDOW=15` assistant messages), and (#396)
+the per-agent rate fields `parent_acted_count`, `total_findings`,
+`parent_acted_rate`, and `parent_acted_band`.
 
 `parent_acted` semantics (#322): review prose carries relative
 or bare paths (`src/foo.py` / `quality_signals.py`); `Edit` tool
@@ -606,6 +608,19 @@ attribution uses suffix-match -- a mentioned token `m` matches
 an edited path `e` when `e == m` or `e.endswith("/" + m)` -- to
 bridge the relative-vs-absolute mismatch. Pre-fix this
 attribution was 0/51 on dogfood; post-fix 16/53 (30.2%).
+
+`parent_acted_band` semantics (#396): the per-(session,
+agent_type) `parent_acted_rate` (parent_acted_count /
+total_findings) is bucketed into a band:
+`below` (rate < `PARENT_ACTED_HEALTHY_BAND_LOW = 0.25`) --
+reviewer findings may be going unread; severity escalates to
+WARNING and the recommendation is actionable.
+`within` (0.25 <= rate <= `PARENT_ACTED_HEALTHY_BAND_HIGH = 0.75`)
+-- healthy review-and-reject collaboration; severity stays at
+INFO with no action item ("rejection of some findings is
+intentional, not a defect").
+`above` (rate > 0.75) -- high follow-through, reviewer is
+well-tuned; INFO with a "route more sessions" suggestion.
 
 A per-(session, agent_type) rate gate
 (`MIN_REVIEWER_CAUGHT_RATE = 0.5`) suppresses noisy reviewers --
@@ -619,10 +634,12 @@ signals.
 `architect` review surfaced 3 finding-keyword(s).
 ```
 
-**Severity:** info
+**Severity:** info-warning
 
 **Threshold:** Response >= 500 chars AND >= 1 finding keyword AND
-per-(session, agent_type) substantive rate >= MIN_REVIEWER_CAUGHT_RATE
+per-(session, agent_type) substantive rate >= MIN_REVIEWER_CAUGHT_RATE.
+Severity escalates from INFO to WARNING when parent_acted_rate
+falls below PARENT_ACTED_HEALTHY_BAND_LOW (0.25).
 
 
 **Recommendation target:** `subagent`

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -23,6 +23,10 @@ from agentfluent.diagnostics.models import (
     DiagnosticSignal,
     SignalType,
 )
+from agentfluent.diagnostics.quality_signals import (
+    PARENT_ACTED_HEALTHY_BAND_HIGH,
+    PARENT_ACTED_HEALTHY_BAND_LOW,
+)
 
 
 def _relpath(path: Path) -> str:
@@ -798,12 +802,52 @@ class ReviewerCaughtRule(_QualityRule):
         agent_type = signal.agent_type or "review-style subagent"
         keywords = signal.detail.get("finding_keywords", [])
         finding_count = len(keywords) if isinstance(keywords, list) else 0
-        parent_acted = signal.detail.get("parent_acted", False)
+        # #396: band derived from the per-agent parent_acted rate across
+        # the session, stashed onto every signal in the group by the
+        # emitter. Pre-#396 signals (no band key) fall back to the old
+        # per-signal parent_acted boolean.
+        band = signal.detail.get("parent_acted_band")
+        rate = signal.detail.get("parent_acted_rate")
+        acted_count = signal.detail.get("parent_acted_count")
+        total = signal.detail.get("total_findings")
         observation = (
             f"`{agent_type}` produced {finding_count} substantive "
             "review finding(s) in this session"
         )
-        if parent_acted:
+        if band == "within" and isinstance(rate, float):
+            reason = (
+                f"and the parent followed up on {acted_count} of "
+                f"{total} ({rate:.0%}) — a healthy review-and-reject "
+                "collaboration pattern."
+            )
+            action = (
+                "No action needed: this rate sits in the healthy band "
+                f"({PARENT_ACTED_HEALTHY_BAND_LOW:.0%}-"
+                f"{PARENT_ACTED_HEALTHY_BAND_HIGH:.0%}). Investigate "
+                "only if it falls below that band."
+            )
+        elif band == "above" and isinstance(rate, float):
+            reason = (
+                f"and the parent acted on {acted_count} of {total} "
+                f"({rate:.0%}) — high follow-through, reviewer is "
+                "well-tuned."
+            )
+            action = (
+                f"Consider routing more sessions through `{agent_type}` "
+                "for consistent design / quality review."
+            )
+        elif band == "below" and isinstance(rate, float):
+            reason = (
+                f"but the parent followed up on only {acted_count} of "
+                f"{total} ({rate:.0%}) — reviewer findings may be "
+                "going unread."
+            )
+            action = (
+                f"Investigate whether `{agent_type}`'s findings are "
+                "actionable, or whether the parent prompt should "
+                "require follow-through on review feedback."
+            )
+        elif signal.detail.get("parent_acted", False):
             reason = (
                 "and the parent acted on them — direct evidence the "
                 "review caught real issues."

--- a/src/agentfluent/diagnostics/quality_signals.py
+++ b/src/agentfluent/diagnostics/quality_signals.py
@@ -265,6 +265,20 @@ _SUBSTANTIVE_RESPONSE_MIN_CHARS = 500
 # scope avoids cross-session persistence (analyze-time architecture).
 MIN_REVIEWER_CAUGHT_RATE = 0.5
 
+# Healthy parent_acted band for REVIEWER_CAUGHT (#396). The signal
+# reports parent_acted per finding; the rate across an agent's findings
+# in a session falls into three buckets:
+#   - rate < LOW  → "below" band: reviewer findings may be going unread
+#     (WARNING severity, surfaces as an actionable recommendation)
+#   - LOW <= rate <= HIGH → "within" band: healthy review-and-reject
+#     collaboration pattern (INFO, no action item)
+#   - rate > HIGH → "above" band: high follow-through, reviewer is
+#     well-tuned (INFO, no action item)
+# Defaults from v0.7 dogfood (architect at 31% acted + ~50% legitimately
+# rejected by Fred's domain knowledge — see #396). Re-validate post-v0.8.
+PARENT_ACTED_HEALTHY_BAND_LOW = 0.25
+PARENT_ACTED_HEALTHY_BAND_HIGH = 0.75
+
 # Source-file extensions a review subagent is plausibly referencing.
 # The list is conservative — including version strings (``v1.0``) and
 # domain names (``github.com``) as "files" would inflate ``parent_acted``
@@ -556,8 +570,29 @@ def _extract_reviewer_caught_signals(
     signals: list[DiagnosticSignal] = []
     for agent_type, candidates in candidates_by_agent.items():
         rate = len(candidates) / invocations_by_agent[agent_type]
-        if rate >= MIN_REVIEWER_CAUGHT_RATE:
-            signals.extend(candidates)
+        if rate < MIN_REVIEWER_CAUGHT_RATE:
+            continue
+        parent_acted_count = sum(
+            1 for c in candidates if c.detail.get("parent_acted") is True
+        )
+        total_findings = len(candidates)
+        parent_acted_rate = parent_acted_count / total_findings
+        if parent_acted_rate < PARENT_ACTED_HEALTHY_BAND_LOW:
+            band = "below"
+            severity = Severity.WARNING
+        elif parent_acted_rate > PARENT_ACTED_HEALTHY_BAND_HIGH:
+            band = "above"
+            severity = Severity.INFO
+        else:
+            band = "within"
+            severity = Severity.INFO
+        for sig in candidates:
+            sig.detail["parent_acted_rate"] = parent_acted_rate
+            sig.detail["parent_acted_count"] = parent_acted_count
+            sig.detail["total_findings"] = total_findings
+            sig.detail["parent_acted_band"] = band
+            sig.severity = severity
+        signals.extend(candidates)
     return signals
 
 

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -440,12 +440,14 @@
     `fix`, `change needed`).
 
     The signal `detail` includes `finding_keywords` (the matched
-    keywords, sorted), `parent_acted` (boolean), `response_length`
-    (chars), `files_mentioned` (paths the review prose pointed at,
-    extracted via a strict regex that excludes version strings and
-    domain names), and `files_acted_on` (the subset of mentioned
-    files the parent edited within the next
-    `_PARENT_ACTED_WINDOW=15` assistant messages).
+    keywords, sorted), `parent_acted` (boolean for this single
+    review), `response_length` (chars), `files_mentioned` (paths
+    the review prose pointed at, extracted via a strict regex that
+    excludes version strings and domain names), `files_acted_on`
+    (the subset of mentioned files the parent edited within the
+    next `_PARENT_ACTED_WINDOW=15` assistant messages), and (#396)
+    the per-agent rate fields `parent_acted_count`, `total_findings`,
+    `parent_acted_rate`, and `parent_acted_band`.
 
     `parent_acted` semantics (#322): review prose carries relative
     or bare paths (`src/foo.py` / `quality_signals.py`); `Edit` tool
@@ -455,16 +457,31 @@
     bridge the relative-vs-absolute mismatch. Pre-fix this
     attribution was 0/51 on dogfood; post-fix 16/53 (30.2%).
 
+    `parent_acted_band` semantics (#396): the per-(session,
+    agent_type) `parent_acted_rate` (parent_acted_count /
+    total_findings) is bucketed into a band:
+    `below` (rate < `PARENT_ACTED_HEALTHY_BAND_LOW = 0.25`) --
+    reviewer findings may be going unread; severity escalates to
+    WARNING and the recommendation is actionable.
+    `within` (0.25 <= rate <= `PARENT_ACTED_HEALTHY_BAND_HIGH = 0.75`)
+    -- healthy review-and-reject collaboration; severity stays at
+    INFO with no action item ("rejection of some findings is
+    intentional, not a defect").
+    `above` (rate > 0.75) -- high follow-through, reviewer is
+    well-tuned; INFO with a "route more sessions" suggestion.
+
     A per-(session, agent_type) rate gate
     (`MIN_REVIEWER_CAUGHT_RATE = 0.5`) suppresses noisy reviewers --
     review agents whose substantive-finding fraction within a
     session falls below the gate don't surface their findings as
     signals.
   example: "`architect` review surfaced 3 finding-keyword(s)."
-  severity_range: info
+  severity_range: info-warning
   threshold: |
     Response >= 500 chars AND >= 1 finding keyword AND
-    per-(session, agent_type) substantive rate >= MIN_REVIEWER_CAUGHT_RATE
+    per-(session, agent_type) substantive rate >= MIN_REVIEWER_CAUGHT_RATE.
+    Severity escalates from INFO to WARNING when parent_acted_rate
+    falls below PARENT_ACTED_HEALTHY_BAND_LOW (0.25).
   recommendation_target: subagent
   related: [user_correction, file_rework, primary_axis]
 

--- a/tests/unit/test_quality_signals.py
+++ b/tests/unit/test_quality_signals.py
@@ -1108,6 +1108,126 @@ class TestReviewerCaughtRateGate:
         assert rev[0].agent_type == "architect"
 
 
+class TestReviewerCaughtParentActedBand:
+    """#396: per-agent parent_acted rate categorized into a healthy band.
+    Within band → INFO; below band → WARNING (reviewer findings going
+    unread); above band → INFO (high follow-through). Each signal
+    carries the computed rate/count/band on its detail."""
+
+    @staticmethod
+    def _multi_review_messages(
+        invocations: list[AgentInvocation], acted_count: int,
+    ) -> list[SessionMessage]:
+        """Build a message sequence where the first ``acted_count`` of
+        ``invocations`` have a follow-up Edit to src/foo.py (which is
+        mentioned in _SUBSTANTIVE_REVIEW). The rest are reviews-only.
+        """
+        messages: list[SessionMessage] = []
+        for i, inv in enumerate(invocations):
+            messages.append(_user_with_tool_result(inv.tool_use_id))
+            if i < acted_count:
+                messages.append(_assistant_with_edits("src/foo.py"))
+        return messages
+
+    def test_below_band_emits_warning_severity(self) -> None:
+        # 0 of 4 substantive reviews acted on → rate 0.0 < 0.25.
+        invocations = [
+            _review_invocation(
+                output_text=_SUBSTANTIVE_REVIEW, tool_use_id=f"toolu_r{i}",
+            )
+            for i in range(4)
+        ]
+        messages = self._multi_review_messages(invocations, acted_count=0)
+        signals = extract_quality_signals(messages, invocations)
+        rev = [s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT]
+        assert len(rev) == 4
+        for sig in rev:
+            assert sig.severity == Severity.WARNING
+            assert sig.detail["parent_acted_band"] == "below"
+            assert sig.detail["parent_acted_rate"] == 0.0
+            assert sig.detail["parent_acted_count"] == 0
+            assert sig.detail["total_findings"] == 4
+
+    def test_within_band_stays_info_severity(self) -> None:
+        # 2 of 4 acted on → rate 0.5, within [0.25, 0.75].
+        invocations = [
+            _review_invocation(
+                output_text=_SUBSTANTIVE_REVIEW, tool_use_id=f"toolu_r{i}",
+            )
+            for i in range(4)
+        ]
+        messages = self._multi_review_messages(invocations, acted_count=2)
+        signals = extract_quality_signals(messages, invocations)
+        rev = [s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT]
+        assert len(rev) == 4
+        for sig in rev:
+            assert sig.severity == Severity.INFO
+            assert sig.detail["parent_acted_band"] == "within"
+            assert sig.detail["parent_acted_rate"] == 0.5
+            assert sig.detail["parent_acted_count"] == 2
+
+    def test_above_band_stays_info_severity(self) -> None:
+        # 4 of 4 acted on → rate 1.0 > 0.75.
+        invocations = [
+            _review_invocation(
+                output_text=_SUBSTANTIVE_REVIEW, tool_use_id=f"toolu_r{i}",
+            )
+            for i in range(4)
+        ]
+        messages = self._multi_review_messages(invocations, acted_count=4)
+        signals = extract_quality_signals(messages, invocations)
+        rev = [s for s in signals if s.signal_type == SignalType.REVIEWER_CAUGHT]
+        assert len(rev) == 4
+        for sig in rev:
+            assert sig.severity == Severity.INFO
+            assert sig.detail["parent_acted_band"] == "above"
+            assert sig.detail["parent_acted_rate"] == 1.0
+            assert sig.detail["parent_acted_count"] == 4
+
+    def test_band_computed_per_agent_type(self) -> None:
+        # architect: 2 of 2 acted on → above band, INFO.
+        # tester: 0 of 2 acted on → below band, WARNING.
+        invocations = [
+            _review_invocation(
+                agent_type="architect",
+                output_text=_SUBSTANTIVE_REVIEW,
+                tool_use_id="toolu_arch1",
+            ),
+            _review_invocation(
+                agent_type="architect",
+                output_text=_SUBSTANTIVE_REVIEW,
+                tool_use_id="toolu_arch2",
+            ),
+            _review_invocation(
+                agent_type="tester",
+                output_text=_SUBSTANTIVE_REVIEW,
+                tool_use_id="toolu_test1",
+            ),
+            _review_invocation(
+                agent_type="tester",
+                output_text=_SUBSTANTIVE_REVIEW,
+                tool_use_id="toolu_test2",
+            ),
+        ]
+        messages = [
+            _user_with_tool_result(invocations[0].tool_use_id),
+            _assistant_with_edits("src/foo.py"),
+            _user_with_tool_result(invocations[1].tool_use_id),
+            _assistant_with_edits("src/foo.py"),
+            _user_with_tool_result(invocations[2].tool_use_id),
+            _user_with_tool_result(invocations[3].tool_use_id),
+        ]
+        signals = extract_quality_signals(messages, invocations)
+        arch = [s for s in signals if s.agent_type == "architect"]
+        tester = [s for s in signals if s.agent_type == "tester"]
+        assert len(arch) == 2
+        assert len(tester) == 2
+        assert all(s.severity == Severity.INFO for s in arch)
+        assert all(s.detail["parent_acted_band"] == "above" for s in arch)
+        assert all(s.severity == Severity.WARNING for s in tester)
+        assert all(s.detail["parent_acted_band"] == "below" for s in tester)
+
+
 class TestMinFindingKeywords:
     """``MIN_FINDING_KEYWORDS`` defaults to 1 — preserves existing
     behavior. Exposed as a module constant so #274 calibration can


### PR DESCRIPTION
## Summary
- Per-(session, agent_type) `parent_acted_rate` bucketed into three bands at signal-emission time. `PARENT_ACTED_HEALTHY_BAND_LOW = 0.25`, `PARENT_ACTED_HEALTHY_BAND_HIGH = 0.75` (defaults from v0.7 dogfood observation; configurable constants in `quality_signals.py`).
- Signal severity:
  - `below` band → **WARNING** ("findings may be going unread")
  - `within` band → **INFO** ("healthy collaboration, no action needed")
  - `above` band → **INFO** ("high follow-through, route more sessions")
- Each REVIEWER_CAUGHT signal carries `parent_acted_rate`, `parent_acted_count`, `total_findings`, and `parent_acted_band` on its detail. Correlator (`ReviewerCaughtRule`) branches recommendation copy on the band and includes the rate in the prose. Legacy per-signal `parent_acted: bool` fallback retained for pre-#396 signals.
- GLOSSARY entry updated to document the band semantics; `severity_range: info` → `info-warning`.

## Dogfood validation
30-day window on the agentfluent corpus, architect's reviewer_caught row:

```
agent=architect severity=info count=47 priority=143.7
sample message: `architect` produced 3 substantive review finding(s) in this session.
  and the parent followed up on 13 of 47 (28%) — a healthy review-and-reject
  collaboration pattern. No action needed: this rate sits in the healthy band
  (25%-75%). Investigate only if it falls below that band.
```

architect's 28% lands in the "within" band → INFO severity, "no action needed" copy. AC satisfied: the signal still surfaces for visibility, but is no longer flagged as a problem the user needs to fix.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1378 passed (1374 + 4 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — new `TestReviewerCaughtParentActedBand` class with 4 tests: below-band → WARNING, within-band → INFO, above-band → INFO, band computed per agent_type
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent --since 30d --json` — confirms architect lands within band with INFO severity and updated copy

## Security review
- [x] **Skip review** — internal signal severity/copy logic. No I/O, no parsing of untrusted input, no path/subprocess/network changes. The new constants are floats; no new code paths reach external systems.

## Breaking changes
None.

- **JSON envelope:** new fields added to `reviewer_caught` signal `detail` (`parent_acted_rate`, `parent_acted_count`, `total_findings`, `parent_acted_band`). Additive — no schema version bump.
- **Severity behavior:** REVIEWER_CAUGHT signals can now emit at WARNING (when band is `below`) where they previously always emitted at INFO. This is the intended fix; the signal type already permitted variable severity in principle and consumers shouldn't rely on the prior INFO-only assumption.
- **Recommendation copy:** changed for all REVIEWER_CAUGHT rows. Prior copy was prescriptive ("investigate whether findings are actionable"); new copy is band-aware. Pre-#396 signals without the band fields fall back to the old per-signal `parent_acted` branching.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)