### PR TITLE
feat(github): #399 — Tier 3 infrastructure (gh detection, cache, --github flag, consent UX)

### DIFF
--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -26,6 +27,16 @@ from agentfluent.diagnostics.delegation import (
     DEFAULT_MIN_CLUSTER_SIZE,
     DEFAULT_MIN_SIMILARITY,
     SKLEARN_AVAILABLE,
+)
+from agentfluent.github import (
+    GhNotAuthenticatedError,
+    GhNotInstalledError,
+    GitHubRepo,
+    RepoInferenceError,
+    detect_gh,
+    infer_repo,
+    parse_repo_override,
+    prompt_and_record_if_needed,
 )
 
 
@@ -69,6 +80,54 @@ def _apply_time_window(
             f"{window.session_count_before_filter} sessions)[/dim]",
         )
     return filtered, window
+
+
+def _resolve_github_repo(
+    *,
+    repo_override: str | None,
+    project_disk_path: Path | None,
+    err_console: Console,
+) -> GitHubRepo | None:
+    """Resolve the Tier 3 repo, performing detection + consent in order.
+
+    Returns the :class:`GitHubRepo` on success, or raises ``typer.Exit``
+    with ``EXIT_USER_ERROR`` on any setup failure (gh missing, gh not
+    authenticated, declined consent, repo inference failure). The
+    explicit-exit-on-failure shape is deliberate: when a user passes
+    ``--github`` they are opting into Tier 3, so silent fallback to a
+    Tier 1+2-only run would mask the problem.
+    """
+    try:
+        detect_gh()
+    except GhNotInstalledError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=EXIT_USER_ERROR) from e
+    except GhNotAuthenticatedError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=EXIT_USER_ERROR) from e
+
+    if not prompt_and_record_if_needed(is_tty=sys.stdin.isatty()):
+        err_console.print(
+            "[yellow]Tier 3 GitHub enrichment declined; "
+            "re-run without --github or accept the prompt to proceed.[/yellow]",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
+
+    if repo_override is not None:
+        try:
+            return parse_repo_override(repo_override)
+        except ValueError as e:
+            err_console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=EXIT_USER_ERROR) from e
+
+    try:
+        return infer_repo(project_disk_path)
+    except RepoInferenceError as e:
+        err_console.print(
+            f"[red]Error:[/red] Could not infer GitHub repository: {e}\n"
+            "Use [bold]--repo OWNER/NAME[/bold] to specify it explicitly.",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR) from e
 
 
 def _apply_min_severity(result: AnalysisResult, min_severity: Severity) -> None:
@@ -285,6 +344,38 @@ def analyze(
             "must be a git repo; non-repo dirs silently skip."
         ),
     ),
+    github: bool = typer.Option(
+        False,
+        "--github",
+        help=(
+            "Enable Tier 3 GitHub-API quality signals. Off by default "
+            "— AgentFluent does not call GitHub unless explicitly "
+            "opted in. Requires --diagnostics. Implies --git. "
+            "Requires the `gh` CLI to be installed and authenticated; "
+            "a first-run prompt records consent under "
+            "~/.config/agentfluent/."
+        ),
+    ),
+    repo: str | None = typer.Option(
+        None,
+        "--repo",
+        help=(
+            "Explicit GitHub repository override for Tier 3 (OWNER/NAME). "
+            "Used when the project's git remote does not point at GitHub "
+            "or when --github is run against a directory that is not "
+            "itself a git working tree."
+        ),
+    ),
+    github_no_cache: bool = typer.Option(
+        False,
+        "--github-no-cache",
+        help=(
+            "Bypass the Tier 3 response cache for this run. Fresh data "
+            "is fetched from GitHub and written back to the cache "
+            "(next run sees the updated entries). No effect without "
+            "--github."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output."),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Show summary only."),
 ) -> None:
@@ -305,6 +396,18 @@ def analyze(
             "(which already selects a single session).",
         )
         raise typer.Exit(code=EXIT_USER_ERROR)
+
+    # --github is a diagnostics-only opt-in (Tier 3 signals feed the
+    # diagnostics pipeline) and implies --git (Tier 2 supplies the
+    # session→commit mapping that Tier 3 builds on top of).
+    if github and not diagnostics:
+        err_console.print(
+            "[red]Error:[/red] --github requires --diagnostics "
+            "(Tier 3 signals feed the diagnostics pipeline).",
+        )
+        raise typer.Exit(code=EXIT_USER_ERROR)
+    if github:
+        git = True
 
     parsed_since, parsed_until = parse_time_window(
         since, until, err_console=err_console,
@@ -370,6 +473,17 @@ def analyze(
         project_disk_path = resolve_project_disk_path(
             project_info.slug, claude_config_dir=config_dir,
         )
+        # Tier 3 setup runs only when the user passed --github (already
+        # checked to require --diagnostics above). On any failure the
+        # CLI exits — we do not silently fall through to a Tier 1+2-only
+        # run after the user explicitly asked for Tier 3.
+        github_repo: GitHubRepo | None = None
+        if github:
+            github_repo = _resolve_github_repo(
+                repo_override=repo,
+                project_disk_path=project_disk_path,
+                err_console=err_console,
+            )
         # When --git is set, the project's source directory becomes
         # the git_repo we hand to diagnostics. project_disk_path is
         # the ~/.claude/projects mapping resolution; it may or may not
@@ -391,6 +505,7 @@ def analyze(
             session_count=result.session_count,
             sessions=result.sessions if git else None,
             git_repo=project_disk_path if git else None,
+            github_repo=github_repo,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         err_console.print(

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -91,12 +91,32 @@ def _resolve_github_repo(
     """Resolve the Tier 3 repo, performing detection + consent in order.
 
     Returns the :class:`GitHubRepo` on success, or raises ``typer.Exit``
-    with ``EXIT_USER_ERROR`` on any setup failure (gh missing, gh not
-    authenticated, declined consent, repo inference failure). The
-    explicit-exit-on-failure shape is deliberate: when a user passes
-    ``--github`` they are opting into Tier 3, so silent fallback to a
-    Tier 1+2-only run would mask the problem.
+    with ``EXIT_USER_ERROR`` on any setup failure (malformed ``--repo``
+    override, gh missing, gh not authenticated, declined consent, repo
+    inference failure). The explicit-exit-on-failure shape is
+    deliberate: when a user passes ``--github`` they are opting into
+    Tier 3, so silent fallback to a Tier 1+2-only run would mask the
+    problem.
+
+    Order matters: the ``--repo`` override is validated *before* the
+    consent prompt fires, so a malformed override in CI (where
+    non-TTY auto-consent would persist a consent record) does not
+    leave a half-opted-in state on disk for a run that's about to
+    exit with USER_ERROR.
     """
+    # 1. Validate the override first — purely local, no side effects.
+    #    Reject malformed inputs before any consent persistence.
+    parsed_override: GitHubRepo | None = None
+    if repo_override is not None:
+        try:
+            parsed_override = parse_repo_override(repo_override)
+        except ValueError as e:
+            err_console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=EXIT_USER_ERROR) from e
+
+    # 2. Detect gh + auth. detect_gh() is lru_cached at module level,
+    #    so calling it here is the right precondition site even
+    #    though gh_api() will also call it on every request.
     try:
         detect_gh()
     except GhNotInstalledError as e:
@@ -106,6 +126,8 @@ def _resolve_github_repo(
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(code=EXIT_USER_ERROR) from e
 
+    # 3. Consent. In non-TTY this records silently — only reached if
+    #    detection succeeded AND the override (if any) parsed.
     if not prompt_and_record_if_needed(is_tty=sys.stdin.isatty()):
         err_console.print(
             "[yellow]Tier 3 GitHub enrichment declined; "
@@ -113,18 +135,15 @@ def _resolve_github_repo(
         )
         raise typer.Exit(code=EXIT_USER_ERROR)
 
-    if repo_override is not None:
-        try:
-            return parse_repo_override(repo_override)
-        except ValueError as e:
-            err_console.print(f"[red]Error:[/red] {e}")
-            raise typer.Exit(code=EXIT_USER_ERROR) from e
+    # 4. Use the validated override if present; otherwise infer.
+    if parsed_override is not None:
+        return parsed_override
 
     try:
         return infer_repo(project_disk_path)
     except RepoInferenceError as e:
         err_console.print(
-            f"[red]Error:[/red] Could not infer GitHub repository: {e}\n"
+            f"[red]Error:[/red] could not infer GitHub repository: {e}.\n"
             "Use [bold]--repo OWNER/NAME[/bold] to specify it explicitly.",
         )
         raise typer.Exit(code=EXIT_USER_ERROR) from e
@@ -465,25 +484,31 @@ def analyze(
     all_mcp_calls = [c for s in result.sessions for c in s.mcp_tool_calls]
     all_messages = [m for s in result.sessions for m in s.messages]
 
-    if all_invocations and diagnostics:
-        # `project_info.path` is the ~/.claude/projects/<slug>/ dir, not
-        # the original project source path. MCP discovery needs the
-        # real path (for .mcp.json and ~/.claude.json:projects[<abs>]
-        # lookups); resolve it via the slug.
-        project_disk_path = resolve_project_disk_path(
-            project_info.slug, claude_config_dir=config_dir,
+    # `project_info.path` is the ~/.claude/projects/<slug>/ dir, not the
+    # original project source path. MCP discovery needs the real path
+    # (for .mcp.json and ~/.claude.json:projects[<abs>] lookups); resolve
+    # it via the slug. Resolved up-front because both diagnostics and
+    # Tier 3 setup consume it.
+    project_disk_path = resolve_project_disk_path(
+        project_info.slug, claude_config_dir=config_dir,
+    )
+
+    # Tier 3 setup runs whenever the user passed --github (which requires
+    # --diagnostics, enforced earlier). Lifted out of the
+    # `if all_invocations` gate so a zero-invocations project still
+    # reports a clear error rather than silently skipping detection /
+    # consent / repo inference. On any failure the CLI exits — we do not
+    # silently fall through to a Tier 1+2-only run after the user
+    # explicitly asked for Tier 3.
+    github_repo: GitHubRepo | None = None
+    if github:
+        github_repo = _resolve_github_repo(
+            repo_override=repo,
+            project_disk_path=project_disk_path,
+            err_console=err_console,
         )
-        # Tier 3 setup runs only when the user passed --github (already
-        # checked to require --diagnostics above). On any failure the
-        # CLI exits — we do not silently fall through to a Tier 1+2-only
-        # run after the user explicitly asked for Tier 3.
-        github_repo: GitHubRepo | None = None
-        if github:
-            github_repo = _resolve_github_repo(
-                repo_override=repo,
-                project_disk_path=project_disk_path,
-                err_console=err_console,
-            )
+
+    if all_invocations and diagnostics:
         # When --git is set, the project's source directory becomes
         # the git_repo we hand to diagnostics. project_disk_path is
         # the ~/.claude/projects mapping resolution; it may or may not
@@ -506,6 +531,7 @@ def analyze(
             sessions=result.sessions if git else None,
             git_repo=project_disk_path if git else None,
             github_repo=github_repo,
+            github_no_cache=github_no_cache,
         )
     elif result.agent_metrics.total_invocations == 0 and diagnostics:
         err_console.print(

--- a/src/agentfluent/core/paths.py
+++ b/src/agentfluent/core/paths.py
@@ -8,6 +8,7 @@ so an override replaces the root once and every subdirectory follows.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 DEFAULT_CLAUDE_CONFIG_DIR = Path.home() / ".claude"
@@ -19,6 +20,10 @@ AGENTS_SUBDIR = "agents"
 SUBAGENTS_SUBDIR = "subagents"
 """The per-session directory that holds subagent trace JSONL files:
 ``<project>/<session-uuid>/subagents/agent-<agentId>.jsonl``."""
+
+AGENTFLUENT_SUBDIR = "agentfluent"
+XDG_CONFIG_HOME_ENV_VAR = "XDG_CONFIG_HOME"
+XDG_CACHE_HOME_ENV_VAR = "XDG_CACHE_HOME"
 
 
 def projects_dir_for(config_root: Path | None) -> Path | None:
@@ -88,3 +93,33 @@ def validate_claude_config_dir(override: Path | None) -> Path | None:
         raise NotADirectoryError(msg)
 
     return override.resolve()
+
+
+def agentfluent_config_dir() -> Path:
+    """Canonical AgentFluent config root.
+
+    Honors ``$XDG_CONFIG_HOME`` when set, else falls back to
+    ``~/.config/agentfluent``. This is AgentFluent's own config tree —
+    distinct from Claude Code's ``~/.claude/`` — and is where persistent
+    user state (consent records, future tool config) lives. Established
+    as the canonical config root in v0.8 with the Tier 3 consent file;
+    additional consent surfaces and future config files (if any) live
+    here.
+    """
+    xdg = os.environ.get(XDG_CONFIG_HOME_ENV_VAR)
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / AGENTFLUENT_SUBDIR
+
+
+def agentfluent_cache_dir() -> Path:
+    """Canonical AgentFluent cache root.
+
+    Honors ``$XDG_CACHE_HOME`` when set, else falls back to
+    ``~/.cache/agentfluent``. Used for the Tier 3 GitHub response cache
+    (``<root>/github/<sha256>.json``); other ephemeral state can live
+    in sibling subdirectories. Distinct from ``agentfluent_config_dir``
+    because XDG separates ephemeral (cache) from persistent (config).
+    """
+    xdg = os.environ.get(XDG_CACHE_HOME_ENV_VAR)
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / AGENTFLUENT_SUBDIR

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -586,15 +586,18 @@ class DiagnosticsResult(BaseModel):
     pipeline (#189). Empty list when sklearn isn't installed or no
     cluster met ``min_cluster_size``."""
 
-    # v0.8: added tier3_degraded (#399). Set to True by Tier 3 signal
-    # extractors when at least one `gh api` call returned a 403/429
-    # rate-limit response. False when Tier 3 ran cleanly OR Tier 3 was
-    # not requested (`--github` not passed). Per-extractor degradation;
-    # partial Tier 3 output is preferred over hard failure, so the run
-    # still exits 0 — this field exists so JSON consumers can see that
-    # the analysis was incomplete and surface it appropriately.
+    # v0.8: added tier3_degraded (#399 infrastructure). Reserved for
+    # Tier 3 signal extractors (#400, #401) to flip when a `gh api`
+    # call returns 403/429 with a rate-limit signature. The
+    # infrastructure story (#399) ships the field, the
+    # ``RateLimitedError`` exception in :mod:`agentfluent.github`, and
+    # the wiring through :func:`run_diagnostics`; the actual
+    # producer/consumer pairing lands with the signal extractors.
+    # Additive default keeps pre-v0.8 envelopes loadable.
     tier3_degraded: bool = False
-    """True when at least one Tier 3 extractor was skipped due to a
-    GitHub API rate-limit response. False when Tier 3 ran cleanly OR
-    Tier 3 was not requested. The field is additive — pre-v0.8 envelopes
-    load as False via the default."""
+    """``True`` when at least one Tier 3 extractor was skipped due to
+    a GitHub API rate-limit response. ``False`` when Tier 3 ran cleanly
+    OR Tier 3 was not requested. Producer lands with #400/#401 signal
+    extractors; the infrastructure PR (#399) ships only the field and
+    the typed exception ``agentfluent.github.RateLimitedError`` that
+    extractors will catch to flip the flag."""

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -585,3 +585,16 @@ class DiagnosticsResult(BaseModel):
     """Parent-thread offload candidates surfaced by the burst-clustering
     pipeline (#189). Empty list when sklearn isn't installed or no
     cluster met ``min_cluster_size``."""
+
+    # v0.8: added tier3_degraded (#399). Set to True by Tier 3 signal
+    # extractors when at least one `gh api` call returned a 403/429
+    # rate-limit response. False when Tier 3 ran cleanly OR Tier 3 was
+    # not requested (`--github` not passed). Per-extractor degradation;
+    # partial Tier 3 output is preferred over hard failure, so the run
+    # still exits 0 — this field exists so JSON consumers can see that
+    # the analysis was incomplete and surface it appropriately.
+    tier3_degraded: bool = False
+    """True when at least one Tier 3 extractor was skipped due to a
+    GitHub API rate-limit response. False when Tier 3 ran cleanly OR
+    Tier 3 was not requested. The field is additive — pre-v0.8 envelopes
+    load as False via the default."""

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -185,6 +185,7 @@ def run_diagnostics(
     sessions: list[SessionAnalysis] | None = None,
     git_repo: Path | None = None,
     github_repo: GitHubRepo | None = None,
+    github_no_cache: bool = False,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
@@ -309,11 +310,14 @@ def run_diagnostics(
     # signal extractors). When `github_repo` is None the caller did not
     # pass `--github` (or repo inference failed and the CLI exited
     # before reaching here). Signal extraction itself lands in #400/#401;
-    # the infrastructure story just threads the parameter through.
+    # the infrastructure story just threads the parameters through.
+    # `github_no_cache` is forwarded so extractors can pass it to
+    # :func:`agentfluent.github.gh_api` per request.
     if github_repo is not None:
         logger.debug(
-            "tier 3 github_repo received: %s/%s — extractors land in #400, #401",
-            github_repo.owner, github_repo.repo,
+            "tier 3 github_repo received: %s/%s (no_cache=%s) — "
+            "extractors land in #400, #401",
+            github_repo.owner, github_repo.repo, github_no_cache,
         )
 
     correlated_pairs = correlate(signals, configs_by_name)

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -23,6 +23,7 @@ from agentfluent.agents.models import AgentInvocation
 
 if TYPE_CHECKING:
     from agentfluent.analytics.pipeline import SessionAnalysis
+    from agentfluent.github.models import GitHubRepo
 from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
@@ -183,6 +184,7 @@ def run_diagnostics(
     session_count: int | None = None,
     sessions: list[SessionAnalysis] | None = None,
     git_repo: Path | None = None,
+    github_repo: GitHubRepo | None = None,
 ) -> DiagnosticsResult:
     """Run the full diagnostics pipeline on agent invocations.
 
@@ -301,6 +303,17 @@ def run_diagnostics(
         logger.debug(
             "git signals skipped: git_repo=%s sessions=%s",
             git_repo is not None, sessions is not None,
+        )
+
+    # Tier 3 GitHub-API quality signals (#399 infrastructure; #400, #401
+    # signal extractors). When `github_repo` is None the caller did not
+    # pass `--github` (or repo inference failed and the CLI exited
+    # before reaching here). Signal extraction itself lands in #400/#401;
+    # the infrastructure story just threads the parameter through.
+    if github_repo is not None:
+        logger.debug(
+            "tier 3 github_repo received: %s/%s — extractors land in #400, #401",
+            github_repo.owner, github_repo.repo,
         )
 
     correlated_pairs = correlate(signals, configs_by_name)

--- a/src/agentfluent/github/__init__.py
+++ b/src/agentfluent/github/__init__.py
@@ -1,0 +1,54 @@
+"""Tier 3 GitHub enrichment infrastructure (#399).
+
+Public surface for downstream signal extractors (#400, #401). All
+imports go through this module so signal code does not need to know
+the internal file layout — it consumes a curated set of names.
+"""
+
+from __future__ import annotations
+
+from agentfluent.github.cache import (
+    TTL_CLOSED_PR,
+    TTL_OPEN_PR_OR_CI,
+    TTL_REPO_METADATA,
+)
+from agentfluent.github.client import gh_api
+from agentfluent.github.consent import (
+    has_consent,
+    is_stdin_tty,
+    prompt_and_record_if_needed,
+    record_consent,
+)
+from agentfluent.github.detection import (
+    detect_gh,
+    gh_auth_login,
+    infer_repo,
+    parse_repo_override,
+)
+from agentfluent.github.models import (
+    GhNotAuthenticatedError,
+    GhNotInstalledError,
+    GitHubRepo,
+    RateLimitedError,
+    RepoInferenceError,
+)
+
+__all__ = [
+    "TTL_CLOSED_PR",
+    "TTL_OPEN_PR_OR_CI",
+    "TTL_REPO_METADATA",
+    "GhNotAuthenticatedError",
+    "GhNotInstalledError",
+    "GitHubRepo",
+    "RateLimitedError",
+    "RepoInferenceError",
+    "detect_gh",
+    "gh_api",
+    "gh_auth_login",
+    "has_consent",
+    "infer_repo",
+    "is_stdin_tty",
+    "parse_repo_override",
+    "prompt_and_record_if_needed",
+    "record_consent",
+]

--- a/src/agentfluent/github/cache.py
+++ b/src/agentfluent/github/cache.py
@@ -41,6 +41,15 @@ TTL_REPO_METADATA = 24 * 3600  # 24 hours
 _CACHE_SUBDIR = "github"
 _TIMESTAMP_KEY = "_cached_at"
 
+# Sentinel returned by :func:`get` to distinguish "no cached entry / miss /
+# expired / corrupt" from a legitimate hit whose payload happens to be
+# ``None``. The wrapper layer (``client.gh_api``) must check
+# ``cached is not MISS`` rather than ``cached is not None`` — otherwise a
+# cached null payload (empty stdout from ``gh api``, or a ``--jq`` filter
+# that legitimately yields nothing) would be repeatedly re-fetched
+# instead of served from cache, defeating the rate-limit defense.
+MISS: object = object()
+
 
 def cache_key(
     *,
@@ -84,40 +93,57 @@ def get(
     cache_dir: Path | None = None,
     now: datetime | None = None,
 ) -> Any:
-    """Read a cache entry. Returns the cached payload or ``None``.
+    """Read a cache entry. Returns the cached payload, or :data:`MISS`.
 
-    Returns ``None`` on cache miss, expiry, or any read/parse error.
-    A corrupted entry is treated as a miss (logged at DEBUG) rather
-    than raising — Tier 3 should never crash because of a stale cache
-    file on disk.
+    Returns the sentinel :data:`MISS` on cache miss, expiry, or any
+    read/parse error. A corrupted entry is treated as a miss (logged
+    at DEBUG) rather than raising — Tier 3 should never crash because
+    of a stale cache file on disk.
+
+    The sentinel return (rather than ``None``) is load-bearing:
+    legitimately-cached ``None`` payloads (empty ``gh api`` stdout,
+    null ``--jq`` projection) must serve from cache, not trigger
+    re-fetch. Callers check ``result is MISS`` to distinguish.
 
     ``now`` defaults to ``datetime.now(UTC)``; tests pass an explicit
     value to exercise the expiry boundary deterministically.
     """
     path = _entry_path(key, cache_dir=cache_dir)
     if not path.exists():
-        return None
+        return MISS
     try:
         with path.open("r", encoding="utf-8") as f:
             payload = json.load(f)
     except (OSError, json.JSONDecodeError):
         logger.debug("cache entry unreadable: %s", path, exc_info=True)
-        return None
+        return MISS
 
     cached_at_raw = payload.get(_TIMESTAMP_KEY)
     if not isinstance(cached_at_raw, str):
-        return None
+        return MISS
     try:
         cached_at = datetime.fromisoformat(cached_at_raw)
     except ValueError:
-        return None
+        return MISS
+    # Naive timestamps (no tzinfo) would crash the subtraction below
+    # ("can't subtract offset-naive and offset-aware datetimes") and
+    # break the documented "returns MISS on any read/parse error"
+    # contract. Treat as corrupt and miss; the entry will be
+    # overwritten by the next successful fetch.
+    if cached_at.tzinfo is None:
+        return MISS
 
     current = now if now is not None else datetime.now(UTC)
     age_sec = (current - cached_at).total_seconds()
     if age_sec >= ttl:
-        return None
+        return MISS
 
-    return payload.get("data")
+    # The payload object must carry a "data" key (set() always writes
+    # one). Use the sentinel to distinguish "explicit null data" from
+    # "key absent (malformed file)".
+    if "data" not in payload:
+        return MISS
+    return payload["data"]
 
 
 def set(  # noqa: A001 — name parallels `get`

--- a/src/agentfluent/github/cache.py
+++ b/src/agentfluent/github/cache.py
@@ -1,0 +1,175 @@
+"""File-backed TTL cache for Tier 3 GitHub responses.
+
+One JSON file per cache entry, named by SHA-256 over the request
+inputs. The key deliberately includes the ``--jq`` filter so two
+callers hitting the same endpoint with different projections do not
+collide on disk — a cached response filtered to ``mergeable_state``
+must never be served to a caller that needs ``additions + deletions``.
+
+TTLs are caller-chosen (passed in per :func:`get` call) rather than
+encoded inside the cache, so the three constants in this module
+(:data:`TTL_CLOSED_PR`, :data:`TTL_OPEN_PR_OR_CI`,
+:data:`TTL_REPO_METADATA`) are just shared defaults that signal
+extractors import; the cache itself is tier-agnostic.
+
+Cache location: ``agentfluent_cache_dir() / "github" / "<sha256>.json"``.
+The directory is created on first write; tests pass a ``cache_dir``
+override to keep their state isolated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from agentfluent.core.paths import agentfluent_cache_dir
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL tiers (seconds). Three tiers per architect note 3 in #399
+# review. Closed PRs are immutable; open PRs / CI status are mutable;
+# repo metadata changes slowly. Callers pick the right one per
+# endpoint — the cache itself just respects whatever TTL it is handed.
+TTL_CLOSED_PR = 7 * 86400  # 7 days
+TTL_OPEN_PR_OR_CI = 15 * 60  # 15 minutes
+TTL_REPO_METADATA = 24 * 3600  # 24 hours
+
+_CACHE_SUBDIR = "github"
+_TIMESTAMP_KEY = "_cached_at"
+
+
+def cache_key(
+    *,
+    endpoint: str,
+    query_params: dict[str, str] | None,
+    jq_filter: str | None,
+    auth_user_login: str,
+) -> str:
+    """Build a SHA-256 cache key from request inputs.
+
+    The key includes ``jq_filter`` so that two callers hitting the same
+    endpoint with different field projections get different cache
+    entries (architect note 1 in #399 review). ``auth_user_login`` is
+    included so a shared machine doesn't leak cache state between
+    accounts. ``query_params`` is serialized with ``sort_keys=True`` so
+    equivalent dicts hash to the same key regardless of insertion
+    order.
+    """
+    parts = [
+        endpoint,
+        json.dumps(query_params or {}, sort_keys=True, separators=(",", ":")),
+        jq_filter or "",
+        auth_user_login,
+    ]
+    payload = "\n".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _cache_root(cache_dir: Path | None) -> Path:
+    return (cache_dir if cache_dir is not None else agentfluent_cache_dir()) / _CACHE_SUBDIR
+
+
+def _entry_path(key: str, *, cache_dir: Path | None) -> Path:
+    return _cache_root(cache_dir) / f"{key}.json"
+
+
+def get(
+    key: str,
+    *,
+    ttl: int,
+    cache_dir: Path | None = None,
+    now: datetime | None = None,
+) -> Any:
+    """Read a cache entry. Returns the cached payload or ``None``.
+
+    Returns ``None`` on cache miss, expiry, or any read/parse error.
+    A corrupted entry is treated as a miss (logged at DEBUG) rather
+    than raising — Tier 3 should never crash because of a stale cache
+    file on disk.
+
+    ``now`` defaults to ``datetime.now(UTC)``; tests pass an explicit
+    value to exercise the expiry boundary deterministically.
+    """
+    path = _entry_path(key, cache_dir=cache_dir)
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.debug("cache entry unreadable: %s", path, exc_info=True)
+        return None
+
+    cached_at_raw = payload.get(_TIMESTAMP_KEY)
+    if not isinstance(cached_at_raw, str):
+        return None
+    try:
+        cached_at = datetime.fromisoformat(cached_at_raw)
+    except ValueError:
+        return None
+
+    current = now if now is not None else datetime.now(UTC)
+    age_sec = (current - cached_at).total_seconds()
+    if age_sec >= ttl:
+        return None
+
+    return payload.get("data")
+
+
+def set(  # noqa: A001 — name parallels `get`
+    key: str,
+    value: Any,
+    *,
+    endpoint: str,
+    jq_filter: str | None,
+    cache_dir: Path | None = None,
+    now: datetime | None = None,
+) -> None:
+    """Write a cache entry. Silently swallows write errors.
+
+    A failed cache write must never block the actual API response from
+    being returned to the caller, so OS errors are logged at DEBUG and
+    swallowed. ``endpoint`` and ``jq_filter`` are persisted alongside
+    the payload for human debuggability — a user inspecting the cache
+    dir can see which endpoint a hash corresponds to.
+    """
+    root = _cache_root(cache_dir)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.debug("could not create cache dir %s", root, exc_info=True)
+        return
+
+    current = now if now is not None else datetime.now(UTC)
+    payload = {
+        _TIMESTAMP_KEY: current.isoformat(),
+        "endpoint": endpoint,
+        "jq_filter": jq_filter,
+        "data": value,
+    }
+    path = _entry_path(key, cache_dir=cache_dir)
+    try:
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    except OSError:
+        logger.debug("could not write cache entry %s", path, exc_info=True)
+
+
+def clear_all(*, cache_dir: Path | None = None) -> None:
+    """Remove every entry under the github cache root.
+
+    Intended for tests and an eventual ``agentfluent github wipe-cache``
+    CLI command. Silently no-ops when the directory does not exist.
+    """
+    root = _cache_root(cache_dir)
+    if not root.exists():
+        return
+    for entry in root.glob("*.json"):
+        try:
+            entry.unlink()
+        except OSError:
+            logger.debug("could not remove cache entry %s", entry, exc_info=True)

--- a/src/agentfluent/github/client.py
+++ b/src/agentfluent/github/client.py
@@ -1,0 +1,190 @@
+"""Tier 3 GitHub API wrapper.
+
+Single public entry point — :func:`gh_api` — that signal extractors
+call to fetch a GitHub resource. Responsibilities:
+
+- Subprocess invocation of ``gh api`` (with optional ``--jq`` filter
+  and ``-f`` query params).
+- Cache lookup / write keyed on the request inputs (see
+  :mod:`agentfluent.github.cache`).
+- Rate-limit detection (HTTP 403 / 429 with a parseable reset time)
+  raising :class:`RateLimitedError`, which downstream extractors
+  catch to set ``DiagnosticsResult.tier3_degraded = True`` and skip.
+
+The wrapper is intentionally small. Per-endpoint logic (which jq
+filter, which TTL, how to interpret the response) lives in the
+signal modules — this file knows nothing about CI status,
+PR reviews, or any specific endpoint.
+
+# TODO(#400, #401): when concrete signal extractors land, define
+# shared jq projection constants here for endpoints that both
+# signals fetch (e.g. pulls/{n}) so cache entries can be reused.
+# Deferred per architect review of #399 — no extractors exist yet
+# to share them with.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from agentfluent.github import cache
+from agentfluent.github.detection import gh_auth_login
+from agentfluent.github.models import RateLimitedError
+
+logger = logging.getLogger(__name__)
+
+_GH_API_TIMEOUT_SEC = 60
+
+# `gh api` surfaces rate-limit responses as "HTTP 403:" or
+# "HTTP 429:" on stderr. The reset epoch lands in
+# "X-RateLimit-Reset: <unix-seconds>" when `gh api -i` would have
+# returned headers — but `gh api` without `-i` swallows headers, so
+# we extract the reset time from the body when present (the API
+# returns a human-readable message that includes the reset time on
+# secondary limits) and fall back to "now + 60 seconds" otherwise.
+_RATE_LIMIT_RE = re.compile(r"HTTP\s+(?P<code>403|429)\b")
+_RATE_LIMIT_RESET_HEADER = re.compile(r"X-RateLimit-Reset:\s*(?P<epoch>\d+)", re.IGNORECASE)
+_RATE_LIMIT_KEYWORDS = ("rate limit", "secondary rate limit", "abuse detection")
+
+
+def gh_api(
+    endpoint: str,
+    *,
+    jq_filter: str | None = None,
+    cache_ttl: int,
+    query_params: dict[str, str] | None = None,
+    no_cache: bool = False,
+    cache_dir: Path | None = None,
+) -> Any:
+    """Fetch a GitHub API resource via the ``gh`` CLI, with caching.
+
+    Args:
+        endpoint: ``gh api`` endpoint path, e.g. ``repos/{owner}/{repo}/pulls/{n}``.
+        jq_filter: Optional ``--jq`` expression passed to ``gh`` for
+            server-side field selection. Part of the cache key — two
+            callers with different projections do not share entries.
+        cache_ttl: Per-call TTL (seconds). Pick from the three tier
+            constants in :mod:`agentfluent.github.cache`.
+        query_params: Mapping of query parameters; each becomes
+            ``-f key=value`` on the ``gh`` command line.
+        no_cache: If True, skip the cache *read* but still *write*
+            the fresh response (next run sees cached data).
+        cache_dir: Cache root override (tests only; production uses
+            :func:`agentfluent_cache_dir`).
+
+    Returns:
+        Parsed JSON response (dict or list, depending on the endpoint
+        and any ``--jq`` projection).
+
+    Raises:
+        RateLimitedError: ``gh`` returned 403/429 with a rate-limit
+            signature. Signal extractors catch this to flag Tier 3 as
+            degraded and skip cleanly.
+        RuntimeError: ``gh api`` returned a non-rate-limit error.
+            Bubbles up so misconfiguration is loud, not silent.
+        ValueError: Response was not valid JSON.
+    """
+    user_login = gh_auth_login()
+    key = cache.cache_key(
+        endpoint=endpoint,
+        query_params=query_params,
+        jq_filter=jq_filter,
+        auth_user_login=user_login,
+    )
+    if not no_cache:
+        cached = cache.get(key, ttl=cache_ttl, cache_dir=cache_dir)
+        if cached is not None:
+            return cached
+
+    cmd = ["gh", "api", endpoint]
+    if jq_filter is not None:
+        cmd.extend(["--jq", jq_filter])
+    for k, v in (query_params or {}).items():
+        cmd.extend(["-f", f"{k}={v}"])
+
+    try:
+        result = subprocess.run(  # noqa: S603 — args constructed from typed inputs
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GH_API_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "`gh` binary disappeared mid-run; was it removed from PATH?",
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"`gh api {endpoint}` timed out after {_GH_API_TIMEOUT_SEC}s.",
+        ) from e
+
+    if result.returncode != 0:
+        _maybe_raise_rate_limit(endpoint, result.stderr)
+        raise RuntimeError(
+            f"`gh api {endpoint}` failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}",
+        )
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        parsed: Any = None
+    else:
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"`gh api {endpoint}` returned non-JSON output: {stdout[:200]!r}",
+            ) from e
+
+    cache.set(
+        key,
+        parsed,
+        endpoint=endpoint,
+        jq_filter=jq_filter,
+        cache_dir=cache_dir,
+    )
+    return parsed
+
+
+def _maybe_raise_rate_limit(endpoint: str, stderr: str) -> None:
+    """Inspect stderr for a rate-limit signature; raise if found.
+
+    `gh api` does not surface response headers by default, so the
+    signature detection is heuristic: an HTTP 403/429 line plus any
+    of the rate-limit keywords GitHub uses in error bodies. Other
+    403s (e.g. permission denied on a private repo) fall through to
+    the generic RuntimeError path so misconfiguration stays loud.
+    """
+    code_match = _RATE_LIMIT_RE.search(stderr)
+    if code_match is None:
+        return
+    lowered = stderr.lower()
+    if not any(kw in lowered for kw in _RATE_LIMIT_KEYWORDS):
+        # 403 without rate-limit keywords is likely a permissions error
+        # (private repo, missing scope) — propagate as generic failure.
+        return
+    reset_at = _parse_reset_time(stderr)
+    raise RateLimitedError(reset_at=reset_at, endpoint=endpoint)
+
+
+def _parse_reset_time(stderr: str) -> datetime:
+    """Best-effort extraction of the rate-limit reset epoch.
+
+    Falls back to ``now + 60s`` when no header is parseable — better
+    a slightly-wrong reset time than crashing on header absence.
+    """
+    header_match = _RATE_LIMIT_RESET_HEADER.search(stderr)
+    if header_match is not None:
+        try:
+            return datetime.fromtimestamp(int(header_match["epoch"]), tz=UTC)
+        except (ValueError, OverflowError):
+            pass
+    from datetime import timedelta
+    return datetime.now(UTC) + timedelta(seconds=60)

--- a/src/agentfluent/github/client.py
+++ b/src/agentfluent/github/client.py
@@ -7,9 +7,9 @@ call to fetch a GitHub resource. Responsibilities:
   and ``-f`` query params).
 - Cache lookup / write keyed on the request inputs (see
   :mod:`agentfluent.github.cache`).
-- Rate-limit detection (HTTP 403 / 429 with a parseable reset time)
-  raising :class:`RateLimitedError`, which downstream extractors
-  catch to set ``DiagnosticsResult.tier3_degraded = True`` and skip.
+- Rate-limit detection (HTTP 403 / 429) raising
+  :class:`RateLimitedError`, which downstream extractors catch to set
+  ``DiagnosticsResult.tier3_degraded = True`` and skip.
 
 The wrapper is intentionally small. Per-endpoint logic (which jq
 filter, which TTL, how to interpret the response) lives in the
@@ -29,28 +29,34 @@ import json
 import logging
 import re
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from agentfluent.github import cache
-from agentfluent.github.detection import gh_auth_login
+from agentfluent.github.detection import detect_gh, gh_auth_login
 from agentfluent.github.models import RateLimitedError
 
 logger = logging.getLogger(__name__)
 
 _GH_API_TIMEOUT_SEC = 60
 
-# `gh api` surfaces rate-limit responses as "HTTP 403:" or
-# "HTTP 429:" on stderr. The reset epoch lands in
-# "X-RateLimit-Reset: <unix-seconds>" when `gh api -i` would have
-# returned headers — but `gh api` without `-i` swallows headers, so
-# we extract the reset time from the body when present (the API
-# returns a human-readable message that includes the reset time on
-# secondary limits) and fall back to "now + 60 seconds" otherwise.
-_RATE_LIMIT_RE = re.compile(r"HTTP\s+(?P<code>403|429)\b")
-_RATE_LIMIT_RESET_HEADER = re.compile(r"X-RateLimit-Reset:\s*(?P<epoch>\d+)", re.IGNORECASE)
+# `gh api` surfaces rate-limit responses as "HTTP 403:" or "HTTP 429:" on
+# stderr. Case-insensitive because ``gh``'s formatting isn't a
+# contractual API — a future release that writes lowercase "http 429"
+# must still trigger the soft-failure path. Without the IGNORECASE
+# the keyword check below (which lower-cases) would accept the body
+# while the code check would reject the prefix, and the rate-limit
+# response would crash the analyze run.
+_RATE_LIMIT_RE = re.compile(r"HTTP\s+(?P<code>403|429)\b", re.IGNORECASE)
 _RATE_LIMIT_KEYWORDS = ("rate limit", "secondary rate limit", "abuse detection")
+
+# ``gh api`` without ``-i`` does not surface response headers, so the
+# precise reset time isn't available to us. The fallback used by
+# :func:`_rate_limit_reset_fallback` is a 60-second skew — enough for
+# extractors to log a meaningful WARNING; the value is informational
+# rather than load-bearing for any current control-flow decision.
+_RATE_LIMIT_FALLBACK_SEC = 60
 
 
 def gh_api(
@@ -79,10 +85,12 @@ def gh_api(
             :func:`agentfluent_cache_dir`).
 
     Returns:
-        Parsed JSON response (dict or list, depending on the endpoint
-        and any ``--jq`` projection).
+        Parsed JSON response (dict, list, or ``None`` for empty / null
+        projections — cached the same way, served from cache on hit).
 
     Raises:
+        GhNotInstalledError: ``gh`` binary not on PATH.
+        GhNotAuthenticatedError: ``gh auth status`` non-zero.
         RateLimitedError: ``gh`` returned 403/429 with a rate-limit
             signature. Signal extractors catch this to flag Tier 3 as
             degraded and skip cleanly.
@@ -90,6 +98,14 @@ def gh_api(
             Bubbles up so misconfiguration is loud, not silent.
         ValueError: Response was not valid JSON.
     """
+    # Precondition: gh installed and authenticated. detect_gh is
+    # lru_cached, so this is a no-op subprocess-cost after the first
+    # successful call in a process — but it ensures programmatic
+    # callers that skipped CLI-side detection get the right typed
+    # exception (GhNotInstalledError) rather than a FileNotFoundError
+    # mis-classified as auth failure inside gh_auth_login.
+    detect_gh()
+
     user_login = gh_auth_login()
     key = cache.cache_key(
         endpoint=endpoint,
@@ -99,7 +115,11 @@ def gh_api(
     )
     if not no_cache:
         cached = cache.get(key, ttl=cache_ttl, cache_dir=cache_dir)
-        if cached is not None:
+        # Sentinel comparison — NOT ``is not None`` — so a legitimately
+        # cached ``None`` payload (empty stdout from gh, null --jq
+        # projection) serves from cache instead of triggering a refetch
+        # on every call.
+        if cached is not cache.MISS:
             return cached
 
     cmd = ["gh", "api", endpoint]
@@ -162,29 +182,12 @@ def _maybe_raise_rate_limit(endpoint: str, stderr: str) -> None:
     403s (e.g. permission denied on a private repo) fall through to
     the generic RuntimeError path so misconfiguration stays loud.
     """
-    code_match = _RATE_LIMIT_RE.search(stderr)
-    if code_match is None:
+    if _RATE_LIMIT_RE.search(stderr) is None:
         return
     lowered = stderr.lower()
     if not any(kw in lowered for kw in _RATE_LIMIT_KEYWORDS):
         # 403 without rate-limit keywords is likely a permissions error
         # (private repo, missing scope) — propagate as generic failure.
         return
-    reset_at = _parse_reset_time(stderr)
+    reset_at = datetime.now(UTC) + timedelta(seconds=_RATE_LIMIT_FALLBACK_SEC)
     raise RateLimitedError(reset_at=reset_at, endpoint=endpoint)
-
-
-def _parse_reset_time(stderr: str) -> datetime:
-    """Best-effort extraction of the rate-limit reset epoch.
-
-    Falls back to ``now + 60s`` when no header is parseable — better
-    a slightly-wrong reset time than crashing on header absence.
-    """
-    header_match = _RATE_LIMIT_RESET_HEADER.search(stderr)
-    if header_match is not None:
-        try:
-            return datetime.fromtimestamp(int(header_match["epoch"]), tz=UTC)
-        except (ValueError, OverflowError):
-            pass
-    from datetime import timedelta
-    return datetime.now(UTC) + timedelta(seconds=60)

--- a/src/agentfluent/github/consent.py
+++ b/src/agentfluent/github/consent.py
@@ -1,0 +1,178 @@
+"""First-run consent flow for Tier 3 GitHub enrichment.
+
+Stores a small JSON record at
+``agentfluent_config_dir() / "github-consent.json"`` so the
+interactive prompt only fires the first time a user passes
+``--github``. Non-TTY contexts (CI, pipes) treat the explicit flag
+itself as consent and silently record it.
+
+The schema is intentionally extensible from day one (architect note
+3 in #399 review). Future consent surfaces (PAT auth, telemetry,
+anything else that talks to a third party) drop into the
+``consents`` object as new keys without breaking existing entries::
+
+    {
+      "version": 1,
+      "consents": {
+        "github_api": {"granted_at": "...", "version": 1},
+        "telemetry":  {"granted_at": "...", "version": 1}   # future
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from agentfluent.core.paths import agentfluent_config_dir
+
+logger = logging.getLogger(__name__)
+
+CONSENT_FILENAME = "github-consent.json"
+GITHUB_API_SURFACE = "github_api"
+_SCHEMA_VERSION = 1
+
+_DISCLOSURE = """\
+AgentFluent's --github flag enables Tier 3 quality signals, which call
+GitHub's API via the `gh` CLI.
+
+  Sent to api.github.com (via `gh`):
+    • Repository owner / name (inferred from your git remote)
+    • PR numbers and commit SHAs touched in the analyzed time window
+    • Your GitHub username (carried in the `gh` auth headers)
+
+  Cached locally (response bodies, hashed filenames):
+    {cache_dir}
+
+  Not sent:
+    • JSONL session contents, prompts, or tool outputs
+    • File contents or agent definitions
+
+You can wipe the cache at any time with: rm -rf {cache_dir}
+"""
+
+
+def consent_path(*, config_dir: Path | None = None) -> Path:
+    """Filesystem location of the consent file. ``config_dir`` overrides
+    for tests; production always uses :func:`agentfluent_config_dir`."""
+    base = config_dir if config_dir is not None else agentfluent_config_dir()
+    return base / CONSENT_FILENAME
+
+
+def _load(config_dir: Path | None) -> dict[str, Any]:
+    path = consent_path(config_dir=config_dir)
+    if not path.exists():
+        return {"version": _SCHEMA_VERSION, "consents": {}}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.debug("consent file unreadable: %s", path, exc_info=True)
+        return {"version": _SCHEMA_VERSION, "consents": {}}
+    if not isinstance(data, dict):
+        return {"version": _SCHEMA_VERSION, "consents": {}}
+    # Defensive normalization: a hand-edited file might miss the consents
+    # object; ensure it exists so callers can index without a guard.
+    if not isinstance(data.get("consents"), dict):
+        data["consents"] = {}
+    return data
+
+
+def has_consent(
+    surface: str = GITHUB_API_SURFACE,
+    *,
+    config_dir: Path | None = None,
+) -> bool:
+    """``True`` when ``surface`` already has a granted consent record."""
+    data = _load(config_dir)
+    entry = data["consents"].get(surface)
+    return isinstance(entry, dict) and "granted_at" in entry
+
+
+def record_consent(
+    surface: str = GITHUB_API_SURFACE,
+    *,
+    version: int = 1,
+    config_dir: Path | None = None,
+    now: datetime | None = None,
+) -> None:
+    """Persist consent for ``surface`` without altering other entries.
+
+    The on-disk file is read first, the new entry is merged in, and
+    the whole document is rewritten — so writing a second consent key
+    never destroys an earlier one (the extensibility invariant
+    asserted by ``test_github_consent.py``).
+    """
+    data = _load(config_dir)
+    current = now if now is not None else datetime.now(UTC)
+    data["consents"][surface] = {
+        "granted_at": current.isoformat(),
+        "version": version,
+    }
+    path = consent_path(config_dir=config_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError:
+        logger.warning("could not persist consent record to %s", path, exc_info=True)
+
+
+def prompt_and_record_if_needed(
+    *,
+    is_tty: bool,
+    config_dir: Path | None = None,
+    cache_dir_display: Path | None = None,
+    input_fn: Any = input,
+    output_fn: Any = None,
+) -> bool:
+    """Resolve consent for the GitHub API surface for this run.
+
+    Returns ``True`` when consent is in place after this call (already
+    granted, freshly accepted, or non-TTY auto-consented), ``False``
+    when the user declined the interactive prompt.
+
+    - **TTY, no prior consent:** print the disclosure, ask ``[y/N]``;
+      record consent on Y, return False on N or empty.
+    - **TTY, prior consent:** return ``True`` immediately, no prompt.
+    - **Non-TTY:** treat ``--github`` itself as consent; record
+      silently and return ``True``. This matches the spike's privacy
+      model — the CLI flag is explicit per-invocation opt-in.
+
+    ``cache_dir_display`` is the path shown in the disclosure (defaults
+    to the github subdir under :func:`agentfluent_cache_dir`); tests
+    inject this to keep output stable.
+
+    ``input_fn`` and ``output_fn`` are injected for test isolation;
+    production uses ``input`` and ``print``.
+    """
+    if has_consent(config_dir=config_dir):
+        return True
+
+    if not is_tty:
+        record_consent(config_dir=config_dir)
+        return True
+
+    out = output_fn if output_fn is not None else print
+    if cache_dir_display is None:
+        from agentfluent.core.paths import agentfluent_cache_dir
+        cache_dir_display = agentfluent_cache_dir() / "github"
+    out(_DISCLOSURE.format(cache_dir=cache_dir_display))
+    try:
+        answer = input_fn("Enable Tier 3 GitHub enrichment for this and future runs? [y/N]: ")
+    except EOFError:
+        return False
+    if answer.strip().lower() in {"y", "yes"}:
+        record_consent(config_dir=config_dir)
+        return True
+    return False
+
+
+def is_stdin_tty() -> bool:
+    """Helper for callers that don't already have a stream handle."""
+    return sys.stdin.isatty()

--- a/src/agentfluent/github/consent.py
+++ b/src/agentfluent/github/consent.py
@@ -123,6 +123,22 @@ def record_consent(
         logger.warning("could not persist consent record to %s", path, exc_info=True)
 
 
+def _default_disclosure_output(message: str) -> None:
+    """Write the disclosure to stderr, not stdout.
+
+    Default ``output_fn`` for :func:`prompt_and_record_if_needed`.
+    Writing to stderr keeps the disclosure out of any JSON or
+    machine-readable payload the user is piping from stdout (e.g.
+    ``agentfluent analyze --github --json | jq .``) — a TTY prompt
+    can still fire because ``sys.stdin.isatty()`` is unaffected by
+    stdout redirection.
+    """
+    sys.stderr.write(message)
+    if not message.endswith("\n"):
+        sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
 def prompt_and_record_if_needed(
     *,
     is_tty: bool,
@@ -137,9 +153,11 @@ def prompt_and_record_if_needed(
     granted, freshly accepted, or non-TTY auto-consented), ``False``
     when the user declined the interactive prompt.
 
-    - **TTY, no prior consent:** print the disclosure, ask ``[y/N]``;
-      record consent on Y, return False on N or empty.
-    - **TTY, prior consent:** return ``True`` immediately, no prompt.
+    - **TTY, no prior consent:** write the disclosure to stderr, ask
+      ``[y/N]`` on stdin; record consent on Y, return False on N or
+      empty.
+    - **TTY, prior consent:** return ``True`` immediately — disclosure
+      is *not* re-shown, prompt is *not* re-issued.
     - **Non-TTY:** treat ``--github`` itself as consent; record
       silently and return ``True``. This matches the spike's privacy
       model — the CLI flag is explicit per-invocation opt-in.
@@ -149,7 +167,8 @@ def prompt_and_record_if_needed(
     inject this to keep output stable.
 
     ``input_fn`` and ``output_fn`` are injected for test isolation;
-    production uses ``input`` and ``print``.
+    production uses ``input`` for the prompt and a stderr writer for
+    the disclosure (so JSON piped from stdout stays clean).
     """
     if has_consent(config_dir=config_dir):
         return True
@@ -158,7 +177,7 @@ def prompt_and_record_if_needed(
         record_consent(config_dir=config_dir)
         return True
 
-    out = output_fn if output_fn is not None else print
+    out = output_fn if output_fn is not None else _default_disclosure_output
     if cache_dir_display is None:
         from agentfluent.core.paths import agentfluent_cache_dir
         cache_dir_display = agentfluent_cache_dir() / "github"

--- a/src/agentfluent/github/detection.py
+++ b/src/agentfluent/github/detection.py
@@ -1,0 +1,187 @@
+"""Detection and identity for the Tier 3 GitHub auth path.
+
+Three concerns:
+
+1. **Binary + auth detection.** Confirm ``gh`` is installed and the
+   user has run ``gh auth login`` before any API call. Failures here
+   surface as friendly, typed exceptions the CLI converts to install
+   / login hints.
+2. **Auth user identity.** A cached ``gh api user --jq .login`` lookup
+   feeds the cache key (so a shared machine can't leak entries across
+   accounts). Memoized via :func:`functools.lru_cache` for testability
+   — tests call ``gh_auth_login.cache_clear()`` between runs.
+3. **Repo inference.** Map a project's on-disk directory to a
+   :class:`GitHubRepo` by parsing the ``origin`` remote URL. The
+   ``--repo OWNER/NAME`` CLI override goes through
+   :func:`parse_repo_override` instead.
+
+All subprocess invocations mirror ``diagnostics/git_signals.py``:
+stdlib :mod:`subprocess`, bounded timeout, ``shell=False``, graceful
+handling of ``FileNotFoundError`` / ``TimeoutExpired``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+from agentfluent.github.models import (
+    GhNotAuthenticatedError,
+    GhNotInstalledError,
+    GitHubRepo,
+    RepoInferenceError,
+)
+
+logger = logging.getLogger(__name__)
+
+_GH_TIMEOUT_SEC = 30
+_GIT_TIMEOUT_SEC = 10
+
+# Match the two URL forms `git remote get-url origin` can produce:
+#   git@github.com:owner/repo(.git)?
+#   https://github.com/owner/repo(.git)?
+# The trailing `.git` and any trailing slash are optional. Owner/repo
+# may contain letters, digits, hyphens, underscores, and dots (GitHub's
+# real character set).
+_SSH_REMOTE = re.compile(r"^git@github\.com:(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$")
+_HTTPS_REMOTE = re.compile(
+    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$",
+)
+_OWNER_REPO = re.compile(r"^(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)$")
+
+
+def detect_gh() -> None:
+    """Raise if ``gh`` is unavailable or unauthenticated.
+
+    Two checks, fail-fast: binary present, then ``gh auth status``
+    exits 0. The CLI catches ``GhNotInstalledError`` /
+    ``GhNotAuthenticatedError`` and prints the install / login hint;
+    programmatic callers do whatever they like.
+    """
+    if shutil.which("gh") is None:
+        raise GhNotInstalledError(
+            "Tier 3 signals require the GitHub CLI (`gh`). "
+            "Install: https://cli.github.com/",
+        )
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        raise GhNotAuthenticatedError(
+            "Could not verify `gh` authentication. Run `gh auth login`.",
+        ) from e
+    if result.returncode != 0:
+        raise GhNotAuthenticatedError(
+            "GitHub CLI is not authenticated. Run `gh auth login`.",
+        )
+
+
+@lru_cache(maxsize=1)
+def gh_auth_login() -> str:
+    """Return the authenticated user's GitHub login.
+
+    Memoized for the process lifetime so we make a single
+    ``gh api user`` subprocess call per CLI run (one cache write
+    amortized over every Tier 3 API call). Tests call
+    :func:`gh_auth_login.cache_clear` to reset between runs.
+
+    Raises :class:`GhNotAuthenticatedError` on any failure — by the
+    time this is called, :func:`detect_gh` has already validated
+    auth, so a non-zero exit here means transient gh / network state
+    rather than configuration. Treating it as an auth failure is the
+    right user-facing classification.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        raise GhNotAuthenticatedError(
+            "Could not resolve `gh` auth user. Run `gh auth status` to debug.",
+        ) from e
+    if result.returncode != 0:
+        raise GhNotAuthenticatedError(
+            f"`gh api user` failed: {result.stderr.strip()}",
+        )
+    login = result.stdout.strip()
+    if not login:
+        raise GhNotAuthenticatedError("`gh api user` returned an empty login.")
+    return login
+
+
+def infer_repo(project_disk_path: Path | None) -> GitHubRepo:
+    """Map a project directory to a :class:`GitHubRepo`.
+
+    Reads ``git -C <path> remote get-url origin`` and parses the SSH
+    or HTTPS form. Raises :class:`RepoInferenceError` when:
+
+    - ``project_disk_path`` is ``None`` (slug-to-path resolution
+      failed upstream),
+    - the directory is not a git repo,
+    - ``origin`` is absent,
+    - the remote URL is not on github.com.
+
+    The CLI catches the exception and points users at the
+    ``--repo OWNER/NAME`` override.
+    """
+    if project_disk_path is None:
+        raise RepoInferenceError(
+            "Could not resolve the project's on-disk path.",
+        )
+    if not project_disk_path.exists():
+        raise RepoInferenceError(
+            f"Project directory does not exist: {project_disk_path}",
+        )
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants, project_disk_path is path-typed
+            ["git", "-C", str(project_disk_path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise RepoInferenceError("`git` binary not found on PATH.") from e
+    except subprocess.TimeoutExpired as e:
+        raise RepoInferenceError("`git remote get-url origin` timed out.") from e
+
+    if result.returncode != 0:
+        raise RepoInferenceError(
+            f"No `origin` remote in {project_disk_path}: {result.stderr.strip()}",
+        )
+
+    url = result.stdout.strip()
+    match = _SSH_REMOTE.match(url) or _HTTPS_REMOTE.match(url)
+    if match is None:
+        raise RepoInferenceError(
+            f"`origin` remote is not on github.com: {url}",
+        )
+    return GitHubRepo(owner=match["owner"], repo=match["repo"])
+
+
+def parse_repo_override(value: str) -> GitHubRepo:
+    """Parse an explicit ``OWNER/NAME`` override into a :class:`GitHubRepo`.
+
+    Raises :class:`ValueError` on malformed input — the CLI converts
+    this into a ``typer.BadParameter`` so the user sees a flag-name
+    error rather than a stack trace.
+    """
+    match = _OWNER_REPO.match(value.strip())
+    if match is None:
+        raise ValueError(
+            f"--repo must be of the form OWNER/NAME, got: {value!r}",
+        )
+    return GitHubRepo(owner=match["owner"], repo=match["repo"])

--- a/src/agentfluent/github/detection.py
+++ b/src/agentfluent/github/detection.py
@@ -5,11 +5,13 @@ Three concerns:
 1. **Binary + auth detection.** Confirm ``gh`` is installed and the
    user has run ``gh auth login`` before any API call. Failures here
    surface as friendly, typed exceptions the CLI converts to install
-   / login hints.
+   / login hints. Memoized via :func:`functools.lru_cache` for the
+   process lifetime so :func:`gh_api` can call :func:`detect_gh` as a
+   precondition without paying repeated subprocess cost; tests call
+   ``detect_gh.cache_clear()`` between cases.
 2. **Auth user identity.** A cached ``gh api user --jq .login`` lookup
    feeds the cache key (so a shared machine can't leak entries across
-   accounts). Memoized via :func:`functools.lru_cache` for testability
-   — tests call ``gh_auth_login.cache_clear()`` between runs.
+   accounts). Also lru-cached for testability.
 3. **Repo inference.** Map a project's on-disk directory to a
    :class:`GitHubRepo` by parsing the ``origin`` remote URL. The
    ``--repo OWNER/NAME`` CLI override goes through
@@ -41,19 +43,38 @@ logger = logging.getLogger(__name__)
 _GH_TIMEOUT_SEC = 30
 _GIT_TIMEOUT_SEC = 10
 
+# Owner: GitHub username / organization. Per GitHub's rules, alphanumeric
+# plus hyphens, no leading/trailing hyphen, no consecutive hyphens. The
+# regex is slightly looser (single-hyphen runs disallowed only at the
+# boundaries) — strict-enough to reject ``.``, ``..``, ``-evil``, and
+# similar non-name segments that could leak into endpoint construction.
+#
+# Repo: looser than owner. May contain underscores and dots, but must
+# start with an alphanumeric (rejects ``.``, ``..``, leading-dot names).
+_OWNER = r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
+_REPO = r"[A-Za-z0-9][\w.-]*?"
+
 # Match the two URL forms `git remote get-url origin` can produce:
 #   git@github.com:owner/repo(.git)?
 #   https://github.com/owner/repo(.git)?
-# The trailing `.git` and any trailing slash are optional. Owner/repo
-# may contain letters, digits, hyphens, underscores, and dots (GitHub's
-# real character set).
-_SSH_REMOTE = re.compile(r"^git@github\.com:(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$")
-_HTTPS_REMOTE = re.compile(
-    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$",
+# The trailing `.git` and any trailing slash are optional and consumed
+# at the suffix; the ``_REPO`` non-greedy match lets the suffix bind.
+_SSH_REMOTE = re.compile(
+    rf"^git@github\.com:(?P<owner>{_OWNER})/(?P<repo>{_REPO})(?:\.git)?/?$",
 )
-_OWNER_REPO = re.compile(r"^(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)$")
+_HTTPS_REMOTE = re.compile(
+    rf"^https?://github\.com/(?P<owner>{_OWNER})/(?P<repo>{_REPO})(?:\.git)?/?$",
+)
+# The override accepts a trailing ``.git`` for parity with what users
+# copy-paste from a clone URL, but strips it so the resulting
+# ``GitHubRepo.repo`` matches what :func:`infer_repo` would produce
+# for the same logical repository.
+_OWNER_REPO = re.compile(
+    rf"^(?P<owner>{_OWNER})/(?P<repo>{_REPO})(?:\.git)?/?$",
+)
 
 
+@lru_cache(maxsize=1)
 def detect_gh() -> None:
     """Raise if ``gh`` is unavailable or unauthenticated.
 
@@ -61,6 +82,13 @@ def detect_gh() -> None:
     exits 0. The CLI catches ``GhNotInstalledError`` /
     ``GhNotAuthenticatedError`` and prints the install / login hint;
     programmatic callers do whatever they like.
+
+    Memoized so :func:`gh_api` can call ``detect_gh()`` as a
+    precondition on every request without paying subprocess cost; the
+    successful-path return value (``None``) is cached. Raised
+    exceptions are *not* cached, so a failed detection on the first
+    call does not poison subsequent retries after the user installs
+    or authenticates ``gh``.
     """
     if shutil.which("gh") is None:
         raise GhNotInstalledError(
@@ -75,9 +103,18 @@ def detect_gh() -> None:
             timeout=_GH_TIMEOUT_SEC,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+    except FileNotFoundError as e:
+        # gh disappeared between shutil.which() and subprocess.run() —
+        # rare but possible (PATH change, uninstall). Classify as
+        # not-installed so the user sees the install hint, not the
+        # login hint.
+        raise GhNotInstalledError(
+            "`gh` binary disappeared between PATH check and invocation. "
+            "Reinstall: https://cli.github.com/",
+        ) from e
+    except subprocess.TimeoutExpired as e:
         raise GhNotAuthenticatedError(
-            "Could not verify `gh` authentication. Run `gh auth login`.",
+            "`gh auth status` timed out; check `gh` configuration.",
         ) from e
     if result.returncode != 0:
         raise GhNotAuthenticatedError(
@@ -94,6 +131,11 @@ def gh_auth_login() -> str:
     amortized over every Tier 3 API call). Tests call
     :func:`gh_auth_login.cache_clear` to reset between runs.
 
+    Note: long-running embeddings that span a ``gh auth switch`` need
+    to call ``cache_clear()`` manually after the switch — the memo
+    intentionally pins identity for the process lifetime to keep cache
+    keys stable across an analyze run.
+
     Raises :class:`GhNotAuthenticatedError` on any failure — by the
     time this is called, :func:`detect_gh` has already validated
     auth, so a non-zero exit here means transient gh / network state
@@ -108,9 +150,16 @@ def gh_auth_login() -> str:
             timeout=_GH_TIMEOUT_SEC,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+    except FileNotFoundError as e:
+        # As in detect_gh: a missing-binary race is install state,
+        # not auth state. detect_gh() should have caught this first,
+        # but raise the correct typed error if it didn't.
+        raise GhNotInstalledError(
+            "`gh` binary not found. Install: https://cli.github.com/",
+        ) from e
+    except subprocess.TimeoutExpired as e:
         raise GhNotAuthenticatedError(
-            "Could not resolve `gh` auth user. Run `gh auth status` to debug.",
+            "Could not resolve `gh` auth user (timeout). Run `gh auth status`.",
         ) from e
     if result.returncode != 0:
         raise GhNotAuthenticatedError(
@@ -139,11 +188,12 @@ def infer_repo(project_disk_path: Path | None) -> GitHubRepo:
     """
     if project_disk_path is None:
         raise RepoInferenceError(
-            "Could not resolve the project's on-disk path.",
+            "could not resolve the project's on-disk path "
+            "(missing or stale ~/.claude.json entry)",
         )
     if not project_disk_path.exists():
         raise RepoInferenceError(
-            f"Project directory does not exist: {project_disk_path}",
+            f"project directory does not exist: {project_disk_path}",
         )
     try:
         result = subprocess.run(  # noqa: S603 — args are constants, project_disk_path is path-typed
@@ -159,8 +209,18 @@ def infer_repo(project_disk_path: Path | None) -> GitHubRepo:
         raise RepoInferenceError("`git remote get-url origin` timed out.") from e
 
     if result.returncode != 0:
+        stderr_lower = result.stderr.lower()
+        if "not a git repository" in stderr_lower:
+            raise RepoInferenceError(
+                f"{project_disk_path} is not a git working tree",
+            )
+        if "no such remote" in stderr_lower:
+            raise RepoInferenceError(
+                f"no `origin` remote in {project_disk_path}",
+            )
         raise RepoInferenceError(
-            f"No `origin` remote in {project_disk_path}: {result.stderr.strip()}",
+            f"`git remote get-url origin` failed in {project_disk_path}: "
+            f"{result.stderr.strip()}",
         )
 
     url = result.stdout.strip()
@@ -175,13 +235,22 @@ def infer_repo(project_disk_path: Path | None) -> GitHubRepo:
 def parse_repo_override(value: str) -> GitHubRepo:
     """Parse an explicit ``OWNER/NAME`` override into a :class:`GitHubRepo`.
 
+    Trailing ``.git`` and trailing slashes are stripped so the result
+    matches what :func:`infer_repo` would produce for the same
+    logical repository — preventing cache-key fragmentation and 404s
+    against ``repos/<owner>/<repo>.git/...`` endpoints.
+
     Raises :class:`ValueError` on malformed input — the CLI converts
     this into a ``typer.BadParameter`` so the user sees a flag-name
-    error rather than a stack trace.
+    error rather than a stack trace. Inputs containing ``..``,
+    leading dots, or leading dashes are rejected by the underlying
+    regex.
     """
     match = _OWNER_REPO.match(value.strip())
     if match is None:
         raise ValueError(
-            f"--repo must be of the form OWNER/NAME, got: {value!r}",
+            f"--repo must be of the form OWNER/NAME (alphanumeric, "
+            f"hyphen, underscore, dot — no leading dots or `..`), "
+            f"got: {value!r}",
         )
     return GitHubRepo(owner=match["owner"], repo=match["repo"])

--- a/src/agentfluent/github/models.py
+++ b/src/agentfluent/github/models.py
@@ -1,0 +1,73 @@
+"""Public types for the Tier 3 GitHub enrichment subpackage.
+
+Re-exported through ``agentfluent.github`` so downstream signal
+extractors (``#400``, ``#401``) consume them via the package root
+rather than reaching into individual modules.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GitHubRepo(BaseModel):
+    """A GitHub repository identified by owner and repo name.
+
+    Produced by the infrastructure layer (either inferred from the
+    project's git remote or parsed from an explicit ``--repo`` override)
+    and consumed by per-signal Tier 3 extractors. Owning this model in
+    the infrastructure layer means signal modules never re-parse a git
+    remote — they receive an already-validated ``GitHubRepo`` from the
+    pipeline.
+    """
+
+    owner: str
+    repo: str
+
+
+class GhNotInstalledError(Exception):
+    """``gh`` binary is not on PATH.
+
+    Raised by :func:`agentfluent.github.detection.detect_gh` when the
+    GitHub CLI cannot be invoked. The CLI catches this and prints a
+    friendly install hint; programmatic callers handle it however they
+    like.
+    """
+
+
+class GhNotAuthenticatedError(Exception):
+    """``gh`` is installed but ``gh auth status`` returned non-zero.
+
+    Raised by :func:`agentfluent.github.detection.detect_gh` when the
+    user has the binary but has not run ``gh auth login``. The CLI
+    surfaces this with the appropriate ``gh auth login`` hint.
+    """
+
+
+class RepoInferenceError(Exception):
+    """The project's git remote does not map to a GitHub repository.
+
+    Raised by :func:`agentfluent.github.detection.infer_repo` when the
+    project directory is not a git repo, has no ``origin`` remote, or
+    the remote URL is not a GitHub host. The CLI prints a hint pointing
+    at the ``--repo OWNER/NAME`` override.
+    """
+
+
+class RateLimitedError(Exception):
+    """``gh api`` returned 403 or 429 with rate-limit headers.
+
+    Carries the reset time and endpoint so per-signal extractors can
+    log a useful WARNING and skip cleanly. Tier 3 sets
+    ``DiagnosticsResult.tier3_degraded = True`` when at least one
+    extractor hits this path; the run still exits 0.
+    """
+
+    def __init__(self, *, reset_at: datetime, endpoint: str) -> None:
+        super().__init__(
+            f"GitHub API rate limit hit for {endpoint!r}; resets at {reset_at.isoformat()}",
+        )
+        self.reset_at = reset_at
+        self.endpoint = endpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,34 @@ import pytest
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_agentfluent_xdg_dirs(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redirect ``XDG_CONFIG_HOME`` and ``XDG_CACHE_HOME`` per test.
+
+    Both :func:`agentfluent.core.paths.agentfluent_config_dir` and
+    :func:`agentfluent.core.paths.agentfluent_cache_dir` honor these
+    env vars; CliRunner's mocked stdin reports ``isatty() == False``,
+    which triggers the consent module's non-TTY auto-record branch.
+    Without this fixture, any CLI test that exercises ``--github`` —
+    or any test that calls ``record_consent`` / ``cache.set`` without
+    a ``config_dir`` / ``cache_dir`` override — would silently write
+    to the contributor's real ``~/.config/agentfluent/`` and
+    ``~/.cache/agentfluent/``.
+
+    Autouse + function-scoped so the redirect applies to every test
+    automatically. Tests that explicitly ``monkeypatch.delenv`` or
+    ``setenv`` these vars to assert default-path behavior (e.g.
+    ``tests/unit/test_paths.py``) override this fixture's setenv
+    naturally — monkeypatch unwinds LIFO at test teardown.
+    """
+    base = tmp_path_factory.mktemp("agentfluent-xdg")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(base / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(base / "cache"))
+
+
 @pytest.fixture()
 def write_jsonl(tmp_path: Path) -> Callable[[str, list[dict[str, Any]]], Path]:
     """Return a helper that writes a list of dicts as a JSONL file under tmp_path.

--- a/tests/unit/cli/test_analyze_github_flag.py
+++ b/tests/unit/cli/test_analyze_github_flag.py
@@ -1,0 +1,123 @@
+"""End-to-end CLI checks for the ``--github`` flag plumbing.
+
+Verifies the flag's *contract* in ``analyze``: it requires
+``--diagnostics``, surfaces friendly errors when ``gh`` is missing
+or unauthenticated, and produces a clear hint when repo inference
+fails. The actual API call path is not exercised here — that lands
+once the signal extractors (#400, #401) ship.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.github import detection
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_memo() -> None:
+    detection.gh_auth_login.cache_clear()
+
+
+class TestRequiresDiagnostics:
+    def test_github_without_diagnostics_errors(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--no-diagnostics", "--github"],
+        )
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.stdout + (result.stderr or ""))
+        assert "--github requires --diagnostics" in combined
+
+
+class TestDetectionFailures:
+    def test_gh_missing_emits_install_hint(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: None,
+        )
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--github"],
+        )
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.stdout + (result.stderr or ""))
+        assert "GitHub CLI" in combined
+
+    def test_gh_unauthenticated_emits_login_hint(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=_args, returncode=1, stdout="", stderr="not logged in",
+            )
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run", fake_run,
+        )
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--github"],
+        )
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.stdout + (result.stderr or ""))
+        assert "gh auth login" in combined
+
+
+class TestRepoOverrideValidation:
+    def test_malformed_override_emits_friendly_error(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # Bypass real detection and consent so the test focuses on the
+        # --repo parse failure path.
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.detect_gh", lambda: None,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.prompt_and_record_if_needed",
+            lambda **_kwargs: True,
+        )
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--github", "--repo", "not-a-valid-repo",
+            ],
+        )
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.stdout + (result.stderr or ""))
+        assert "OWNER/NAME" in combined

--- a/tests/unit/cli/test_analyze_github_flag.py
+++ b/tests/unit/cli/test_analyze_github_flag.py
@@ -2,9 +2,12 @@
 
 Verifies the flag's *contract* in ``analyze``: it requires
 ``--diagnostics``, surfaces friendly errors when ``gh`` is missing
-or unauthenticated, and produces a clear hint when repo inference
-fails. The actual API call path is not exercised here — that lands
-once the signal extractors (#400, #401) ship.
+or unauthenticated, produces a clear hint when repo inference fails,
+runs Tier 3 setup regardless of invocation count, propagates
+``--github-no-cache`` through ``run_diagnostics``, and validates
+``--repo`` before persisting any consent state. The actual API call
+path is not exercised here — that lands once the signal extractors
+(#400, #401) ship.
 """
 
 from __future__ import annotations
@@ -28,8 +31,9 @@ def _strip_ansi(text: str) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _clear_auth_memo() -> None:
+def _clear_detection_memos() -> None:
     detection.gh_auth_login.cache_clear()
+    detection.detect_gh.cache_clear()
 
 
 class TestRequiresDiagnostics:
@@ -94,23 +98,38 @@ class TestDetectionFailures:
 
 
 class TestRepoOverrideValidation:
-    def test_malformed_override_emits_friendly_error(
+    def test_malformed_override_emits_friendly_error_before_detection(
         self,
         runner: CliRunner,
         cli_app: typer.Typer,
         populated_home_with_traces: Path,
         monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
     ) -> None:
-        # Bypass real detection and consent so the test focuses on the
-        # --repo parse failure path.
+        # --repo is now validated BEFORE detect_gh and the consent
+        # prompt fire, so a malformed override never persists a consent
+        # record on disk for a run that exits with USER_ERROR. We don't
+        # monkeypatch detect_gh / prompt — if the order regressed, the
+        # test would either fail with a different error or auto-record
+        # consent (which the XDG-isolated tmp_path fixture would catch).
+        detect_called = {"count": 0}
+
+        def fake_detect() -> None:
+            detect_called["count"] += 1
+
+        prompt_called = {"count": 0}
+
+        def fake_prompt(**_kwargs: Any) -> bool:
+            prompt_called["count"] += 1
+            return True
+
         monkeypatch.setattr(
-            "agentfluent.cli.commands.analyze.detect_gh", lambda: None,
+            "agentfluent.cli.commands.analyze.detect_gh", fake_detect,
         )
         monkeypatch.setattr(
             "agentfluent.cli.commands.analyze.prompt_and_record_if_needed",
-            lambda **_kwargs: True,
+            fake_prompt,
         )
+
         result = runner.invoke(
             cli_app,
             [
@@ -121,3 +140,133 @@ class TestRepoOverrideValidation:
         assert result.exit_code != 0
         combined = _strip_ansi(result.stdout + (result.stderr or ""))
         assert "OWNER/NAME" in combined
+        # Neither detection nor consent should have run — the order
+        # check is what this test exists for.
+        assert detect_called["count"] == 0
+        assert prompt_called["count"] == 0
+
+
+class TestNoCacheFlag:
+    def test_no_cache_threads_through_run_diagnostics(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The --github-no-cache flag must reach run_diagnostics so that
+        # signal extractors (#400/#401) can forward it to gh_api. The
+        # Pylance "unused variable" warning that originally exposed
+        # this regression now has a regression test.
+        from agentfluent.github.models import GitHubRepo
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_diagnostics(*_args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            from agentfluent.diagnostics.models import DiagnosticsResult
+            return DiagnosticsResult()
+
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.run_diagnostics",
+            fake_run_diagnostics,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.detect_gh", lambda: None,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.prompt_and_record_if_needed",
+            lambda **_kw: True,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.infer_repo",
+            lambda _p: GitHubRepo(owner="o", repo="r"),
+        )
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "analyze", "--project", "project",
+                "--github", "--github-no-cache",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        assert captured.get("github_no_cache") is True
+        assert captured.get("github_repo") == GitHubRepo(owner="o", repo="r")
+
+    def test_default_is_false(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from agentfluent.github.models import GitHubRepo
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_diagnostics(*_args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            from agentfluent.diagnostics.models import DiagnosticsResult
+            return DiagnosticsResult()
+
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.run_diagnostics",
+            fake_run_diagnostics,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.detect_gh", lambda: None,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.prompt_and_record_if_needed",
+            lambda **_kw: True,
+        )
+        monkeypatch.setattr(
+            "agentfluent.cli.commands.analyze.infer_repo",
+            lambda _p: GitHubRepo(owner="o", repo="r"),
+        )
+
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--github"],
+        )
+        assert result.exit_code == 0
+        assert captured.get("github_no_cache") is False
+
+
+class TestTier3SetupNotGatedByInvocations:
+    def test_zero_invocations_still_runs_detection(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        isolated_home: Path,
+        fixtures_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A project with zero agent invocations + --github used to
+        # silently skip detection/consent and exit 0. Now Tier 3 setup
+        # runs unconditionally when --github is passed, so the user
+        # sees the gh-not-installed (or detection) error and can
+        # correct it instead of believing Tier 3 ran successfully.
+        import shutil
+        project_dir = isolated_home / "projects" / "-home-user-test-project"
+        project_dir.mkdir()
+        # Use a fixture with no Agent invocations so all_invocations=[].
+        shutil.copy(
+            fixtures_dir / "session_basic.jsonl",
+            project_dir / "session-1.jsonl",
+        )
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: None,
+        )
+
+        result = runner.invoke(
+            cli_app,
+            ["analyze", "--project", "project", "--github"],
+        )
+        # Detection ran (and failed), so the user gets the install hint
+        # instead of a silent success that they'd discover later.
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.stdout + (result.stderr or ""))
+        assert "GitHub CLI" in combined

--- a/tests/unit/test_github_cache.py
+++ b/tests/unit/test_github_cache.py
@@ -1,6 +1,6 @@
 """Tests for the Tier 3 file-backed TTL cache.
 
-Verifies the four cache invariants:
+Verifies the cache invariants:
 
 1. **Key uniqueness** — endpoint, query params, jq filter, and auth
    user login each contribute to the SHA-256, so distinct projections
@@ -9,8 +9,11 @@ Verifies the four cache invariants:
    the window miss.
 3. **Schema** — files store ``_cached_at`` + ``endpoint`` + ``jq_filter``
    + ``data`` so the cache directory is human-debuggable.
-4. **Soft failure** — corrupted or unreadable entries return ``None``
-   instead of raising.
+4. **Soft failure** — corrupted, unreadable, or naive-timestamp
+   entries return the :data:`MISS` sentinel instead of raising.
+5. **Sentinel return** — :func:`get` returns :data:`MISS` on miss
+   and the cached value (which may be ``None``) on hit, so a
+   legitimately-cached ``None`` payload doesn't trigger a refetch.
 """
 
 from __future__ import annotations
@@ -92,17 +95,31 @@ class TestGetSet:
         result = cache.get(_key(), ttl=60, cache_dir=tmp_path)
         assert result == {"hello": "world"}
 
-    def test_missing_entry_returns_none(self, tmp_path: Path) -> None:
-        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+    def test_missing_entry_returns_miss(self, tmp_path: Path) -> None:
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is cache.MISS
 
-    def test_expired_entry_returns_none(self, tmp_path: Path) -> None:
+    def test_expired_entry_returns_miss(self, tmp_path: Path) -> None:
         past = datetime.now(UTC) - timedelta(seconds=120)
         cache.set(
             _key(), {"v": 1},
             endpoint="x", jq_filter=None,
             cache_dir=tmp_path, now=past,
         )
-        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is cache.MISS
+
+    def test_cached_null_is_hit_not_miss(self, tmp_path: Path) -> None:
+        # The whole point of the MISS sentinel: a legitimately cached
+        # ``None`` (empty stdout from gh, or a --jq filter that yields
+        # null) must serve from the cache, not trigger re-fetch every
+        # call. cache.get must distinguish "cached None" from "no entry".
+        cache.set(
+            _key(), None,
+            endpoint="x", jq_filter=".missing_field",
+            cache_dir=tmp_path,
+        )
+        result = cache.get(_key(), ttl=60, cache_dir=tmp_path)
+        assert result is None
+        assert result is not cache.MISS
 
     def test_unexpired_entry_returns_value(self, tmp_path: Path) -> None:
         recent = datetime.now(UTC) - timedelta(seconds=10)
@@ -153,11 +170,43 @@ class TestSchema:
 
 
 class TestSoftFailure:
-    def test_corrupted_entry_returns_none(self, tmp_path: Path) -> None:
+    def test_corrupted_entry_returns_miss(self, tmp_path: Path) -> None:
         github_dir = tmp_path / "github"
         github_dir.mkdir()
         (github_dir / f"{_key()}.json").write_text("not-json")
-        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is cache.MISS
+
+    def test_naive_timestamp_returns_miss(self, tmp_path: Path) -> None:
+        # A hand-edited or downgrade-corrupted file with a naive ISO
+        # timestamp would crash the cached-at - now subtraction
+        # ("can't subtract offset-naive and offset-aware datetimes").
+        # The wrapper must treat it as MISS, not raise.
+        github_dir = tmp_path / "github"
+        github_dir.mkdir()
+        (github_dir / f"{_key()}.json").write_text(
+            json.dumps({
+                "_cached_at": "2026-01-01T00:00:00",  # naive — no tz
+                "endpoint": "x",
+                "jq_filter": None,
+                "data": {"v": 1},
+            }),
+        )
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is cache.MISS
+
+    def test_missing_data_key_returns_miss(self, tmp_path: Path) -> None:
+        # A file with everything but the "data" key (malformed write)
+        # should fall through to MISS rather than return None implicitly.
+        github_dir = tmp_path / "github"
+        github_dir.mkdir()
+        (github_dir / f"{_key()}.json").write_text(
+            json.dumps({
+                "_cached_at": datetime.now(UTC).isoformat(),
+                "endpoint": "x",
+                "jq_filter": None,
+                # no "data" key
+            }),
+        )
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is cache.MISS
 
     def test_clear_all_removes_entries(self, tmp_path: Path) -> None:
         cache.set(

--- a/tests/unit/test_github_cache.py
+++ b/tests/unit/test_github_cache.py
@@ -1,0 +1,173 @@
+"""Tests for the Tier 3 file-backed TTL cache.
+
+Verifies the four cache invariants:
+
+1. **Key uniqueness** — endpoint, query params, jq filter, and auth
+   user login each contribute to the SHA-256, so distinct projections
+   of the same endpoint do not collide.
+2. **TTL respected** — entries within the window read, entries past
+   the window miss.
+3. **Schema** — files store ``_cached_at`` + ``endpoint`` + ``jq_filter``
+   + ``data`` so the cache directory is human-debuggable.
+4. **Soft failure** — corrupted or unreadable entries return ``None``
+   instead of raising.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from agentfluent.github import cache
+
+
+def _key() -> str:
+    return cache.cache_key(
+        endpoint="repos/owner/r/pulls/1",
+        query_params=None,
+        jq_filter=None,
+        auth_user_login="alice",
+    )
+
+
+class TestCacheKey:
+    def test_endpoint_changes_key(self) -> None:
+        k1 = cache.cache_key(
+            endpoint="a", query_params=None, jq_filter=None, auth_user_login="u",
+        )
+        k2 = cache.cache_key(
+            endpoint="b", query_params=None, jq_filter=None, auth_user_login="u",
+        )
+        assert k1 != k2
+
+    def test_jq_filter_changes_key(self) -> None:
+        k1 = cache.cache_key(
+            endpoint="a", query_params=None, jq_filter=".x", auth_user_login="u",
+        )
+        k2 = cache.cache_key(
+            endpoint="a", query_params=None, jq_filter=".y", auth_user_login="u",
+        )
+        assert k1 != k2
+
+    def test_auth_user_changes_key(self) -> None:
+        k1 = cache.cache_key(
+            endpoint="a", query_params=None, jq_filter=None, auth_user_login="alice",
+        )
+        k2 = cache.cache_key(
+            endpoint="a", query_params=None, jq_filter=None, auth_user_login="bob",
+        )
+        assert k1 != k2
+
+    def test_query_params_order_invariant(self) -> None:
+        k1 = cache.cache_key(
+            endpoint="a", query_params={"x": "1", "y": "2"},
+            jq_filter=None, auth_user_login="u",
+        )
+        k2 = cache.cache_key(
+            endpoint="a", query_params={"y": "2", "x": "1"},
+            jq_filter=None, auth_user_login="u",
+        )
+        assert k1 == k2
+
+    def test_none_query_params_equals_empty(self) -> None:
+        k1 = cache.cache_key(
+            endpoint="a", query_params=None,
+            jq_filter=None, auth_user_login="u",
+        )
+        k2 = cache.cache_key(
+            endpoint="a", query_params={},
+            jq_filter=None, auth_user_login="u",
+        )
+        assert k1 == k2
+
+
+class TestGetSet:
+    def test_set_then_get_round_trip(self, tmp_path: Path) -> None:
+        cache.set(  # noqa: SLF001 — function is the public API
+            _key(), {"hello": "world"},
+            endpoint="repos/owner/r/pulls/1", jq_filter=None,
+            cache_dir=tmp_path,
+        )
+        result = cache.get(_key(), ttl=60, cache_dir=tmp_path)
+        assert result == {"hello": "world"}
+
+    def test_missing_entry_returns_none(self, tmp_path: Path) -> None:
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+
+    def test_expired_entry_returns_none(self, tmp_path: Path) -> None:
+        past = datetime.now(UTC) - timedelta(seconds=120)
+        cache.set(
+            _key(), {"v": 1},
+            endpoint="x", jq_filter=None,
+            cache_dir=tmp_path, now=past,
+        )
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+
+    def test_unexpired_entry_returns_value(self, tmp_path: Path) -> None:
+        recent = datetime.now(UTC) - timedelta(seconds=10)
+        cache.set(
+            _key(), {"v": 1},
+            endpoint="x", jq_filter=None,
+            cache_dir=tmp_path, now=recent,
+        )
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) == {"v": 1}
+
+    def test_distinct_jq_filters_isolated(self, tmp_path: Path) -> None:
+        k_a = cache.cache_key(
+            endpoint="repos/o/r/pulls/1", query_params=None,
+            jq_filter=".additions", auth_user_login="alice",
+        )
+        k_b = cache.cache_key(
+            endpoint="repos/o/r/pulls/1", query_params=None,
+            jq_filter=".mergeable_state", auth_user_login="alice",
+        )
+        cache.set(
+            k_a, 100,
+            endpoint="repos/o/r/pulls/1", jq_filter=".additions",
+            cache_dir=tmp_path,
+        )
+        cache.set(
+            k_b, "clean",
+            endpoint="repos/o/r/pulls/1", jq_filter=".mergeable_state",
+            cache_dir=tmp_path,
+        )
+        assert cache.get(k_a, ttl=60, cache_dir=tmp_path) == 100
+        assert cache.get(k_b, ttl=60, cache_dir=tmp_path) == "clean"
+
+
+class TestSchema:
+    def test_file_contains_required_keys(self, tmp_path: Path) -> None:
+        cache.set(
+            _key(), {"foo": 1},
+            endpoint="repos/o/r", jq_filter=".x",
+            cache_dir=tmp_path,
+        )
+        files = list((tmp_path / "github").glob("*.json"))
+        assert len(files) == 1
+        payload = json.loads(files[0].read_text())
+        assert "_cached_at" in payload
+        assert payload["endpoint"] == "repos/o/r"
+        assert payload["jq_filter"] == ".x"
+        assert payload["data"] == {"foo": 1}
+
+
+class TestSoftFailure:
+    def test_corrupted_entry_returns_none(self, tmp_path: Path) -> None:
+        github_dir = tmp_path / "github"
+        github_dir.mkdir()
+        (github_dir / f"{_key()}.json").write_text("not-json")
+        assert cache.get(_key(), ttl=60, cache_dir=tmp_path) is None
+
+    def test_clear_all_removes_entries(self, tmp_path: Path) -> None:
+        cache.set(
+            _key(), {"a": 1},
+            endpoint="x", jq_filter=None,
+            cache_dir=tmp_path,
+        )
+        assert list((tmp_path / "github").glob("*.json"))
+        cache.clear_all(cache_dir=tmp_path)
+        assert not list((tmp_path / "github").glob("*.json"))
+
+    def test_clear_all_on_missing_dir_is_noop(self, tmp_path: Path) -> None:
+        cache.clear_all(cache_dir=tmp_path)  # no raise

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,0 +1,173 @@
+"""Tests for the ``gh_api`` wrapper.
+
+The wrapper layers cache + subprocess + rate-limit detection over
+``gh api``. Each test patches ``subprocess.run`` and the auth-user
+memo to keep behavior deterministic without `gh` on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.github import client, detection
+from agentfluent.github.models import RateLimitedError
+
+
+@pytest.fixture(autouse=True)
+def _stub_auth_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid the real ``gh api user`` lookup for every test in this file."""
+    detection.gh_auth_login.cache_clear()
+    monkeypatch.setattr(
+        "agentfluent.github.client.gh_auth_login", lambda: "alice",
+    )
+
+
+def _fake_run(
+    *, stdout: str = "", stderr: str = "", returncode: int = 0,
+) -> Any:
+    def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=_args, returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+    return runner
+
+
+class TestSuccess:
+    def test_parses_json_response(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(stdout='{"number": 42}'),
+        )
+        out = client.gh_api(
+            "repos/owner/r/pulls/42",
+            cache_ttl=60,
+            cache_dir=tmp_path,
+        )
+        assert out == {"number": 42}
+
+    def test_writes_cache_entry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(stdout='{"v": 1}'),
+        )
+        client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+        cached_files = list((tmp_path / "github").glob("*.json"))
+        assert len(cached_files) == 1
+
+    def test_cache_hit_skips_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        calls = {"count": 0}
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls["count"] += 1
+            return subprocess.CompletedProcess(
+                args=_args, returncode=0, stdout='{"v": 1}', stderr="",
+            )
+
+        monkeypatch.setattr("agentfluent.github.client.subprocess.run", runner)
+        client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+        client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+        assert calls["count"] == 1
+
+    def test_no_cache_bypasses_read_but_writes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # Seed the cache with stale data, then run with no_cache=True.
+        # The fresh response must come back, AND the stale entry must
+        # be overwritten so the next no_cache=False run sees the new value.
+        from agentfluent.github import cache as cache_mod
+        key = cache_mod.cache_key(
+            endpoint="x", query_params=None, jq_filter=None,
+            auth_user_login="alice",
+        )
+        cache_mod.set(
+            key, {"stale": True},
+            endpoint="x", jq_filter=None, cache_dir=tmp_path,
+        )
+
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(stdout='{"fresh": true}'),
+        )
+        out = client.gh_api(
+            "x", cache_ttl=60, cache_dir=tmp_path, no_cache=True,
+        )
+        assert out == {"fresh": True}
+        # Subsequent cached read sees the freshly written entry.
+        assert cache_mod.get(key, ttl=60, cache_dir=tmp_path) == {"fresh": True}
+
+
+class TestErrors:
+    def test_rate_limit_403_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(
+                returncode=1,
+                stderr=(
+                    "gh: HTTP 403: API rate limit exceeded for user alice "
+                    "(see https://docs.github.com/...)"
+                ),
+            ),
+        )
+        with pytest.raises(RateLimitedError):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+
+    def test_rate_limit_429_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(
+                returncode=1,
+                stderr=(
+                    "gh: HTTP 429: You have exceeded a secondary rate limit "
+                    "and have been temporarily blocked"
+                ),
+            ),
+        )
+        with pytest.raises(RateLimitedError):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+
+    def test_permission_403_propagates_as_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(
+                returncode=1,
+                stderr="gh: HTTP 403: Resource not accessible by integration",
+            ),
+        )
+        with pytest.raises(RuntimeError, match="failed"):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+
+    def test_other_failure_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(returncode=1, stderr="gh: HTTP 500"),
+        )
+        with pytest.raises(RuntimeError, match="failed"):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
+
+    def test_invalid_json_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(stdout="not-json"),
+        )
+        with pytest.raises(ValueError, match="non-JSON"):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,8 +1,9 @@
 """Tests for the ``gh_api`` wrapper.
 
 The wrapper layers cache + subprocess + rate-limit detection over
-``gh api``. Each test patches ``subprocess.run`` and the auth-user
-memo to keep behavior deterministic without `gh` on PATH.
+``gh api``. Each test patches ``subprocess.run``, the detection
+precondition, and the auth-user memo to keep behavior deterministic
+without `gh` on PATH.
 """
 
 from __future__ import annotations
@@ -13,14 +14,24 @@ from typing import Any
 
 import pytest
 
-from agentfluent.github import client, detection
+from agentfluent.github import cache, client, detection
 from agentfluent.github.models import RateLimitedError
 
 
 @pytest.fixture(autouse=True)
-def _stub_auth_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Avoid the real ``gh api user`` lookup for every test in this file."""
+def _stub_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass `gh` detection + auth lookup for every test in this file.
+
+    ``gh_api`` calls :func:`detect_gh` (precondition) and
+    :func:`gh_auth_login` (cache-key input) before any subprocess. We
+    patch both at the ``client`` module's bound names so the wrapper
+    sees a clean, authenticated state without ever shelling out.
+    """
     detection.gh_auth_login.cache_clear()
+    detection.detect_gh.cache_clear()
+    monkeypatch.setattr(
+        "agentfluent.github.client.detect_gh", lambda: None,
+    )
     monkeypatch.setattr(
         "agentfluent.github.client.gh_auth_login", lambda: "alice",
     )
@@ -84,12 +95,11 @@ class TestSuccess:
         # Seed the cache with stale data, then run with no_cache=True.
         # The fresh response must come back, AND the stale entry must
         # be overwritten so the next no_cache=False run sees the new value.
-        from agentfluent.github import cache as cache_mod
-        key = cache_mod.cache_key(
+        key = cache.cache_key(
             endpoint="x", query_params=None, jq_filter=None,
             auth_user_login="alice",
         )
-        cache_mod.set(
+        cache.set(
             key, {"stale": True},
             endpoint="x", jq_filter=None, cache_dir=tmp_path,
         )
@@ -103,7 +113,46 @@ class TestSuccess:
         )
         assert out == {"fresh": True}
         # Subsequent cached read sees the freshly written entry.
-        assert cache_mod.get(key, ttl=60, cache_dir=tmp_path) == {"fresh": True}
+        assert cache.get(key, ttl=60, cache_dir=tmp_path) == {"fresh": True}
+
+    def test_cached_null_served_from_cache(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # The MISS-sentinel fix: an endpoint with empty stdout (or a
+        # --jq projection that yields null) gets cached as None. Next
+        # call must serve from cache, not re-shell out.
+        calls = {"count": 0}
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls["count"] += 1
+            return subprocess.CompletedProcess(
+                args=_args, returncode=0, stdout="", stderr="",
+            )
+
+        monkeypatch.setattr("agentfluent.github.client.subprocess.run", runner)
+        assert client.gh_api("x", cache_ttl=60, cache_dir=tmp_path) is None
+        # Second call must hit the cache despite the first response
+        # being None — pre-fix this would re-shell every call.
+        assert client.gh_api("x", cache_ttl=60, cache_dir=tmp_path) is None
+        assert calls["count"] == 1
+
+    def test_rate_limit_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # If gh ever emits lowercase 'http 429', we still want
+        # RateLimitedError (so extractors set tier3_degraded and skip),
+        # not a generic RuntimeError that crashes the whole run.
+        monkeypatch.setattr(
+            "agentfluent.github.client.subprocess.run",
+            _fake_run(
+                returncode=1,
+                stderr=(
+                    "gh: http 429: You have exceeded a secondary rate limit"
+                ),
+            ),
+        )
+        with pytest.raises(RateLimitedError):
+            client.gh_api("x", cache_ttl=60, cache_dir=tmp_path)
 
 
 class TestErrors:

--- a/tests/unit/test_github_consent.py
+++ b/tests/unit/test_github_consent.py
@@ -1,0 +1,128 @@
+"""Tests for the Tier 3 consent flow.
+
+Covers the three invariants the consent surface promises:
+
+1. **TTY path** prompts once, records on accept, returns False on
+   decline, does not re-prompt on subsequent calls.
+2. **Non-TTY path** records silently and returns True — the
+   ``--github`` CLI flag itself is per-invocation consent.
+3. **Schema extensibility** — writing a second consent key under
+   ``consents`` does not destroy an earlier entry, satisfying the
+   architect-mandated forward-compat invariant for v0.8.x and beyond.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentfluent.github import consent
+
+
+class TestPrompt:
+    def test_tty_accept_records_and_returns_true(self, tmp_path: Path) -> None:
+        result = consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=lambda _prompt: "y",
+            output_fn=lambda _msg: None,
+        )
+        assert result is True
+        assert consent.has_consent(config_dir=tmp_path)
+
+    def test_tty_decline_returns_false_and_no_record(self, tmp_path: Path) -> None:
+        result = consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=lambda _prompt: "n",
+            output_fn=lambda _msg: None,
+        )
+        assert result is False
+        assert not consent.has_consent(config_dir=tmp_path)
+
+    def test_tty_empty_answer_treated_as_decline(self, tmp_path: Path) -> None:
+        result = consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=lambda _prompt: "",
+            output_fn=lambda _msg: None,
+        )
+        assert result is False
+
+    def test_tty_eof_treated_as_decline(self, tmp_path: Path) -> None:
+        def raise_eof(_prompt: str) -> str:
+            raise EOFError
+
+        result = consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=raise_eof,
+            output_fn=lambda _msg: None,
+        )
+        assert result is False
+
+    def test_repeat_call_skips_prompt(self, tmp_path: Path) -> None:
+        consent.record_consent(config_dir=tmp_path)
+        called = {"count": 0}
+
+        def fake_input(_prompt: str) -> str:
+            called["count"] += 1
+            return "y"
+
+        result = consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=fake_input,
+            output_fn=lambda _msg: None,
+        )
+        assert result is True
+        assert called["count"] == 0
+
+
+class TestNonTty:
+    def test_non_tty_auto_consents(self, tmp_path: Path) -> None:
+        result = consent.prompt_and_record_if_needed(
+            is_tty=False,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+        )
+        assert result is True
+        assert consent.has_consent(config_dir=tmp_path)
+
+
+class TestSchema:
+    def test_record_then_load_round_trip(self, tmp_path: Path) -> None:
+        consent.record_consent(config_dir=tmp_path)
+        path = consent.consent_path(config_dir=tmp_path)
+        data = json.loads(path.read_text())
+        assert data["version"] == 1
+        assert "github_api" in data["consents"]
+        assert "granted_at" in data["consents"]["github_api"]
+        assert data["consents"]["github_api"]["version"] == 1
+
+    def test_second_consent_key_preserves_first(self, tmp_path: Path) -> None:
+        # Pretend a future AgentFluent release records a second consent
+        # surface (e.g., telemetry). The earlier github_api entry must
+        # survive — that is the schema's whole reason to exist.
+        consent.record_consent(config_dir=tmp_path)
+        original = json.loads(consent.consent_path(config_dir=tmp_path).read_text())
+        original_granted_at = original["consents"]["github_api"]["granted_at"]
+
+        consent.record_consent(surface="telemetry", config_dir=tmp_path)
+        merged = json.loads(consent.consent_path(config_dir=tmp_path).read_text())
+
+        assert "github_api" in merged["consents"]
+        assert "telemetry" in merged["consents"]
+        assert (
+            merged["consents"]["github_api"]["granted_at"]
+            == original_granted_at
+        )
+
+    def test_has_consent_false_for_unrelated_surface(self, tmp_path: Path) -> None:
+        consent.record_consent(config_dir=tmp_path)
+        assert consent.has_consent(surface="telemetry", config_dir=tmp_path) is False

--- a/tests/unit/test_github_consent.py
+++ b/tests/unit/test_github_consent.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from agentfluent.github import consent
 
 
@@ -66,22 +68,32 @@ class TestPrompt:
         assert result is False
 
     def test_repeat_call_skips_prompt(self, tmp_path: Path) -> None:
+        # A user with prior consent must NOT see the disclosure or
+        # the prompt again — check both input_fn and output_fn are
+        # untouched, not just one. (Prior version of this test only
+        # asserted input_fn was untouched, so a regression that
+        # re-printed the disclosure on every run would have passed.)
         consent.record_consent(config_dir=tmp_path)
-        called = {"count": 0}
+        input_calls = {"count": 0}
+        output_calls = {"count": 0}
 
         def fake_input(_prompt: str) -> str:
-            called["count"] += 1
+            input_calls["count"] += 1
             return "y"
+
+        def fake_output(_msg: str) -> None:
+            output_calls["count"] += 1
 
         result = consent.prompt_and_record_if_needed(
             is_tty=True,
             config_dir=tmp_path,
             cache_dir_display=tmp_path / "fake-cache",
             input_fn=fake_input,
-            output_fn=lambda _msg: None,
+            output_fn=fake_output,
         )
         assert result is True
-        assert called["count"] == 0
+        assert input_calls["count"] == 0
+        assert output_calls["count"] == 0
 
 
 class TestNonTty:
@@ -93,6 +105,27 @@ class TestNonTty:
         )
         assert result is True
         assert consent.has_consent(config_dir=tmp_path)
+
+
+class TestDisclosureOutput:
+    def test_default_disclosure_writes_to_stderr_not_stdout(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The default output target is stderr so JSON piped from
+        # stdout (e.g. `agentfluent analyze --github --json | jq`)
+        # is not corrupted by the disclosure text.
+        consent.prompt_and_record_if_needed(
+            is_tty=True,
+            config_dir=tmp_path,
+            cache_dir_display=tmp_path / "fake-cache",
+            input_fn=lambda _prompt: "y",
+            # output_fn not supplied → default = stderr writer
+        )
+        captured = capsys.readouterr()
+        assert "AgentFluent's --github" in captured.err
+        assert "AgentFluent's --github" not in captured.out
 
 
 class TestSchema:

--- a/tests/unit/test_github_detection.py
+++ b/tests/unit/test_github_detection.py
@@ -21,6 +21,13 @@ from agentfluent.github.models import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_detection_memos() -> None:
+    """Clear lru_caches between tests so memoization doesn't leak."""
+    detection.detect_gh.cache_clear()
+    detection.gh_auth_login.cache_clear()
+
+
 def _fake_run(*, stdout: str = "", stderr: str = "", returncode: int = 0) -> Any:
     def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
@@ -35,6 +42,25 @@ class TestDetectGh:
     ) -> None:
         monkeypatch.setattr("agentfluent.github.detection.shutil.which", lambda _: None)
         with pytest.raises(GhNotInstalledError, match="GitHub CLI"):
+            detection.detect_gh()
+
+    def test_binary_disappeared_classifies_as_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # shutil.which sees gh, but subprocess.run can't find it
+        # (race: PATH change / uninstall between the two calls). The
+        # taxonomy should give an install hint, not a login hint.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+
+        def raises_fnf(*_args: Any, **_kwargs: Any) -> Any:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run", raises_fnf,
+        )
+        with pytest.raises(GhNotInstalledError, match="Reinstall"):
             detection.detect_gh()
 
     def test_unauthenticated_raises(
@@ -62,15 +88,54 @@ class TestDetectGh:
         )
         detection.detect_gh()
 
+    def test_success_is_memoized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # detect_gh is wrapped in @lru_cache so callers (gh_api) can
+        # invoke it as a per-request precondition without paying
+        # subprocess cost on every call.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+        calls = {"count": 0}
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls["count"] += 1
+            return subprocess.CompletedProcess(
+                args=_args, returncode=0, stdout="", stderr="",
+            )
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run", runner,
+        )
+        detection.detect_gh()
+        detection.detect_gh()
+        assert calls["count"] == 1
+
+    def test_failure_is_not_memoized(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Raised exceptions must NOT be cached — otherwise a failed
+        # detection in a long-lived process would poison subsequent
+        # retries after the user installs / authenticates gh.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: None,
+        )
+        with pytest.raises(GhNotInstalledError):
+            detection.detect_gh()
+        # Now flip the bypass so detection should succeed.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(returncode=0),
+        )
+        detection.detect_gh()
+
 
 class TestGhAuthLogin:
-    def teardown_method(self) -> None:
-        detection.gh_auth_login.cache_clear()
-
     def test_returns_login_on_success(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        detection.gh_auth_login.cache_clear()
         monkeypatch.setattr(
             "agentfluent.github.detection.subprocess.run",
             _fake_run(stdout="alice\n", returncode=0),
@@ -80,7 +145,6 @@ class TestGhAuthLogin:
     def test_empty_login_raises(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        detection.gh_auth_login.cache_clear()
         monkeypatch.setattr(
             "agentfluent.github.detection.subprocess.run",
             _fake_run(stdout="", returncode=0),
@@ -89,7 +153,6 @@ class TestGhAuthLogin:
             detection.gh_auth_login()
 
     def test_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        detection.gh_auth_login.cache_clear()
         monkeypatch.setattr(
             "agentfluent.github.detection.subprocess.run",
             _fake_run(returncode=1, stderr="oops"),
@@ -97,8 +160,23 @@ class TestGhAuthLogin:
         with pytest.raises(GhNotAuthenticatedError, match="oops"):
             detection.gh_auth_login()
 
+    def test_missing_binary_classifies_as_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # If detect_gh was bypassed and gh isn't actually installed,
+        # gh_auth_login should raise GhNotInstalledError, not the
+        # generic GhNotAuthenticatedError — the taxonomy guides the
+        # user's recovery action (install vs login).
+        def raises_fnf(*_args: Any, **_kwargs: Any) -> Any:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run", raises_fnf,
+        )
+        with pytest.raises(GhNotInstalledError):
+            detection.gh_auth_login()
+
     def test_result_is_memoized(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        detection.gh_auth_login.cache_clear()
         calls = {"count": 0}
 
         def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -126,6 +204,16 @@ class TestInferRepo:
         repo = detection.infer_repo(tmp_path)
         assert (repo.owner, repo.repo) == ("owner", "some-repo")
 
+    def test_https_remote_without_git_suffix(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="https://github.com/owner/some-repo\n"),
+        )
+        repo = detection.infer_repo(tmp_path)
+        assert (repo.owner, repo.repo) == ("owner", "some-repo")
+
     def test_ssh_remote_parses(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
@@ -135,6 +223,19 @@ class TestInferRepo:
         )
         repo = detection.infer_repo(tmp_path)
         assert (repo.owner, repo.repo) == ("owner", "some-repo")
+
+    def test_repo_name_with_dots_is_preserved(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # GitHub allows dots in repo names (e.g., "claude.md", "foo.bar").
+        # The non-greedy match + .git suffix consumption must leave
+        # internal dots alone.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="git@github.com:owner/my.repo.name.git\n"),
+        )
+        repo = detection.infer_repo(tmp_path)
+        assert (repo.owner, repo.repo) == ("owner", "my.repo.name")
 
     def test_non_github_remote_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -146,14 +247,50 @@ class TestInferRepo:
         with pytest.raises(RepoInferenceError, match="not on github"):
             detection.infer_repo(tmp_path)
 
-    def test_no_origin_raises(
+    def test_not_a_git_repo_emits_specific_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # The common case for a project_disk_path that exists but
+        # isn't a working tree must get a distinct, accurate error
+        # message — not "No origin remote" (which is wrong) or the
+        # generic git-failed shell output (which is confusing).
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(
+                returncode=128,
+                stderr=(
+                    "fatal: not a git repository "
+                    "(or any of the parent directories): .git"
+                ),
+            ),
+        )
+        with pytest.raises(RepoInferenceError, match="not a git working tree"):
+            detection.infer_repo(tmp_path)
+
+    def test_no_origin_emits_specific_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # Real git stderr for the missing-origin case starts with
+        # "error: No such remote 'origin'". We branch on the lowered
+        # substring so the user sees the intended hint.
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(
+                returncode=128,
+                stderr="error: No such remote 'origin'",
+            ),
+        )
+        with pytest.raises(RepoInferenceError, match="no `origin` remote"):
+            detection.infer_repo(tmp_path)
+
+    def test_other_git_failure_emits_generic_error(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
         monkeypatch.setattr(
             "agentfluent.github.detection.subprocess.run",
-            _fake_run(returncode=128, stderr="error: No such remote 'origin'"),
+            _fake_run(returncode=128, stderr="fatal: bad config file"),
         )
-        with pytest.raises(RepoInferenceError, match="No `origin` remote"):
+        with pytest.raises(RepoInferenceError, match="failed"):
             detection.infer_repo(tmp_path)
 
     def test_none_path_raises(self) -> None:
@@ -174,7 +311,28 @@ class TestParseRepoOverride:
         r = detection.parse_repo_override("  owner/repo  ")
         assert (r.owner, r.repo) == ("owner", "repo")
 
-    @pytest.mark.parametrize("bad", ["owner", "owner/", "/repo", "owner/repo/extra", ""])
+    def test_strips_git_suffix(self) -> None:
+        # parse_repo_override must produce the same normalized form
+        # that infer_repo does; otherwise cache keys partition and
+        # `repos/owner/repo.git/...` requests 404.
+        r = detection.parse_repo_override("owner/repo.git")
+        assert (r.owner, r.repo) == ("owner", "repo")
+
+    def test_strips_trailing_slash(self) -> None:
+        r = detection.parse_repo_override("owner/repo/")
+        assert (r.owner, r.repo) == ("owner", "repo")
+
+    @pytest.mark.parametrize("bad", [
+        "owner", "owner/", "/repo", "owner/repo/extra", "",
+        "owner/.",        # bare dot repo
+        "owner/..",       # bare double-dot — would path-traverse
+        "../foo/bar",     # leading .. — same risk
+        ".owner/repo",    # leading dot in owner
+        "-owner/repo",    # leading dash in owner (could be parsed as flag)
+        "owner-/repo",    # trailing dash in owner
+        "owner/-repo",    # leading dash in repo
+        "owner/.repo",    # leading dot in repo
+    ])
     def test_invalid_raises(self, bad: str) -> None:
         with pytest.raises(ValueError, match="OWNER/NAME"):
             detection.parse_repo_override(bad)

--- a/tests/unit/test_github_detection.py
+++ b/tests/unit/test_github_detection.py
@@ -1,0 +1,180 @@
+"""Tests for Tier 3 detection helpers.
+
+Subprocess calls are mocked end-to-end. The integration tests
+(``tests/integration/``) — outside CI — cover the actual ``gh`` and
+``git`` invocations against the user's real environment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.github import detection
+from agentfluent.github.models import (
+    GhNotAuthenticatedError,
+    GhNotInstalledError,
+    RepoInferenceError,
+)
+
+
+def _fake_run(*, stdout: str = "", stderr: str = "", returncode: int = 0) -> Any:
+    def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=_args, returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+    return runner
+
+
+class TestDetectGh:
+    def test_missing_binary_raises(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("agentfluent.github.detection.shutil.which", lambda _: None)
+        with pytest.raises(GhNotInstalledError, match="GitHub CLI"):
+            detection.detect_gh()
+
+    def test_unauthenticated_raises(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(returncode=1, stderr="not logged in"),
+        )
+        with pytest.raises(GhNotAuthenticatedError, match="gh auth login"):
+            detection.detect_gh()
+
+    def test_authenticated_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.shutil.which", lambda _: "/usr/bin/gh",
+        )
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="Logged in to github.com", returncode=0),
+        )
+        detection.detect_gh()
+
+
+class TestGhAuthLogin:
+    def teardown_method(self) -> None:
+        detection.gh_auth_login.cache_clear()
+
+    def test_returns_login_on_success(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        detection.gh_auth_login.cache_clear()
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="alice\n", returncode=0),
+        )
+        assert detection.gh_auth_login() == "alice"
+
+    def test_empty_login_raises(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        detection.gh_auth_login.cache_clear()
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="", returncode=0),
+        )
+        with pytest.raises(GhNotAuthenticatedError, match="empty login"):
+            detection.gh_auth_login()
+
+    def test_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        detection.gh_auth_login.cache_clear()
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(returncode=1, stderr="oops"),
+        )
+        with pytest.raises(GhNotAuthenticatedError, match="oops"):
+            detection.gh_auth_login()
+
+    def test_result_is_memoized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        detection.gh_auth_login.cache_clear()
+        calls = {"count": 0}
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls["count"] += 1
+            return subprocess.CompletedProcess(
+                args=_args, returncode=0, stdout="alice\n", stderr="",
+            )
+
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run", runner,
+        )
+        detection.gh_auth_login()
+        detection.gh_auth_login()
+        assert calls["count"] == 1
+
+
+class TestInferRepo:
+    def test_https_remote_parses(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="https://github.com/owner/some-repo.git\n"),
+        )
+        repo = detection.infer_repo(tmp_path)
+        assert (repo.owner, repo.repo) == ("owner", "some-repo")
+
+    def test_ssh_remote_parses(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="git@github.com:owner/some-repo.git\n"),
+        )
+        repo = detection.infer_repo(tmp_path)
+        assert (repo.owner, repo.repo) == ("owner", "some-repo")
+
+    def test_non_github_remote_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(stdout="git@gitlab.com:owner/repo.git\n"),
+        )
+        with pytest.raises(RepoInferenceError, match="not on github"):
+            detection.infer_repo(tmp_path)
+
+    def test_no_origin_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            "agentfluent.github.detection.subprocess.run",
+            _fake_run(returncode=128, stderr="error: No such remote 'origin'"),
+        )
+        with pytest.raises(RepoInferenceError, match="No `origin` remote"):
+            detection.infer_repo(tmp_path)
+
+    def test_none_path_raises(self) -> None:
+        with pytest.raises(RepoInferenceError, match="on-disk path"):
+            detection.infer_repo(None)
+
+    def test_missing_path_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(RepoInferenceError, match="does not exist"):
+            detection.infer_repo(tmp_path / "ghost")
+
+
+class TestParseRepoOverride:
+    def test_valid_input(self) -> None:
+        r = detection.parse_repo_override("owner/repo-name")
+        assert (r.owner, r.repo) == ("owner", "repo-name")
+
+    def test_strips_whitespace(self) -> None:
+        r = detection.parse_repo_override("  owner/repo  ")
+        assert (r.owner, r.repo) == ("owner", "repo")
+
+    @pytest.mark.parametrize("bad", ["owner", "owner/", "/repo", "owner/repo/extra", ""])
+    def test_invalid_raises(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="OWNER/NAME"):
+            detection.parse_repo_override(bad)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -9,6 +9,10 @@ import pytest
 from agentfluent.core.paths import (
     CLAUDE_CONFIG_DIR_ENV_VAR,
     DEFAULT_CLAUDE_CONFIG_DIR,
+    XDG_CACHE_HOME_ENV_VAR,
+    XDG_CONFIG_HOME_ENV_VAR,
+    agentfluent_cache_dir,
+    agentfluent_config_dir,
     validate_claude_config_dir,
 )
 
@@ -39,3 +43,31 @@ class TestValidateClaudeConfigDir:
         f.write_text("")
         with pytest.raises(NotADirectoryError, match="not a directory"):
             validate_claude_config_dir(f)
+
+
+class TestAgentfluentConfigDir:
+    def test_default_under_home_config(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(XDG_CONFIG_HOME_ENV_VAR, raising=False)
+        assert agentfluent_config_dir() == Path.home() / ".config" / "agentfluent"
+
+    def test_honors_xdg_config_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv(XDG_CONFIG_HOME_ENV_VAR, str(tmp_path))
+        assert agentfluent_config_dir() == tmp_path / "agentfluent"
+
+
+class TestAgentfluentCacheDir:
+    def test_default_under_home_cache(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(XDG_CACHE_HOME_ENV_VAR, raising=False)
+        assert agentfluent_cache_dir() == Path.home() / ".cache" / "agentfluent"
+
+    def test_honors_xdg_cache_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv(XDG_CACHE_HOME_ENV_VAR, str(tmp_path))
+        assert agentfluent_cache_dir() == tmp_path / "agentfluent"


### PR DESCRIPTION
## Summary

- New `github/` subpackage: detection (gh binary + auth + repo inference), file-backed TTL cache, three TTL tier constants, extensible consent flow, and the `gh_api(endpoint, *, jq_filter, cache_ttl)` wrapper that downstream signal extractors (#400, #401) will call.
- New CLI surface on `analyze`: `--github` (Tier 3 opt-in, requires `--diagnostics`, implies `--git`), `--repo OWNER/NAME` override, `--github-no-cache` bypass.
- `tier3_degraded: bool` field added to `DiagnosticsResult` so future rate-limit-degraded runs are visible in JSON envelopes; `agentfluent_config_dir()` / `agentfluent_cache_dir()` helpers honor XDG and consciously establish AgentFluent's own config-root precedent (architect note 4).

Resolves the four pre-implementation refinements from the [architect review of #399](https://github.com/frederick-douglas-pearce/agentfluent/issues/399#issuecomment-4481626997) and the two non-blocking suggestions from the [implementation-plan review](https://github.com/frederick-douglas-pearce/agentfluent/issues/399#issuecomment-4547621832): cache key includes `jq_filter`; `tier3_degraded` on `DiagnosticsResult` not `AnalysisResult`; three explicit TTL tiers; extensible consent schema; `@lru_cache` on `gh_auth_login` for testability; `# TODO(#400, #401)` marker in `client.py` for the deferred jq projection constants.

No signal extraction lands here — `github_repo` is threaded through `run_diagnostics` and consumed by #400/#401.

Closes #399.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m "not integration"\` (1438 passed)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage (66 new unit tests across cache, consent, detection, client, CLI flag plumbing, paths)
- [ ] Manual smoke test via \`uv run agentfluent analyze --github\` against this repo once #400/#401 have something to fetch

## Security review
Pick one. (If "Needs review", apply the \`needs-security-review\` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: \`.claude/hooks/\`, secret handling, \`pyproject.toml\`, \`.github/workflows/\`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

CLI argument parsing (new flags), path resolution (XDG helpers + consent + cache paths), subprocess invocation (gh + git), and rendering of user-controlled strings (gh stderr surfaces in error messages). Label is intentionally NOT applied yet per repo policy — will apply when dev-complete and CI is green.

## Breaking changes

None. All additions are additive: `tier3_degraded` defaults to `False` (so legacy envelopes load cleanly via Pydantic defaults), `github_repo` kwarg to `run_diagnostics` defaults to `None`, and the new CLI flags are off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)