### PR TITLE
feat(diagnostics): #400 — CI_FAILURE_FIRST_PUSH Tier 3 signal

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -685,7 +685,7 @@ feat a1b2c3d followed by 2 fixes on shared file(s) within 3d
 
 **Recommendation target:** `subagent`
 
-**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`primary_axis`](#primary_axis)
+**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`ci_failure_first_push`](#ci_failure_first_push), [`primary_axis`](#primary_axis)
 
 ### `ci_failure_first_push`
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -687,6 +687,50 @@ feat a1b2c3d followed by 2 fixes on shared file(s) within 3d
 
 **Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`primary_axis`](#primary_axis)
 
+### `ci_failure_first_push`
+
+**Short:** A PR's first commit failed CI -- the agent shipped code that did
+not pass automated checks on first attempt, a direct quality miss.
+
+**Detail:** Tier 3 GitHub quality-axis signal (v0.8). Off by default; runs
+only when the CLI passes `--github` (which also requires
+`--diagnostics` and implies `--git`). For each commit authored
+within an analyzed session window, AgentFluent fetches the PRs
+touching that commit via `gh api`, then for each unique PR
+fetches the first commit and its combined CI status. When the
+first commit's combined status is `failure` or `error`, one
+`CI_FAILURE_FIRST_PUSH` signal fires per PR.
+
+Cross-cutting (`agent_type=None`). Severity is always `warning`:
+a first-push CI failure is a definite quality miss, but signal
+strength varies with project conventions (some teams treat CI
+as the first-class check rather than a pre-commit gate).
+
+The signal is only emitted when the PR's first commit can be
+attributed to a session in the analysis window -- a first commit
+authored outside any analyzed session has no actionable
+attribution. Force-push caveat: `pulls/{N}/commits` returns the
+CURRENT first commit, so a PR that was force-pushed loses its
+historical first-push failure. Detecting the original first push
+would require the PR events API; deferred to v0.8.1+.
+
+Rate-limit handling: if any `gh api` call returns 403/429 with a
+rate-limit signature, that PR is skipped and
+`DiagnosticsResult.tier3_degraded` is set to True. Other PRs
+still produce signals; the run still exits 0.
+
+**Example:**
+
+```
+PR #42 ('Add session window filter') first push failed CI: pytest failure
+```
+
+**Severity:** warning
+
+**Recommendation target:** `subagent`
+
+**Related:** [`feat_fix_proximity`](#feat_fix_proximity), [`primary_axis`](#primary_axis)
+
 
 ---
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -293,6 +293,17 @@ def format_analysis_table(
             )
         else:
             _format_diagnostics_summary(console, diag)
+        # Tier 3 degraded banner. Rendered for both --diagnostics and
+        # summary paths so the user always sees that GitHub data was
+        # incomplete; JSON output carries the flag too via
+        # ``diag.tier3_degraded``.
+        if diag.tier3_degraded:
+            console.print(
+                "\n[yellow]⚠ Tier 3 (GitHub) data is incomplete:[/yellow] "
+                "one or more `gh api` calls failed (rate limit, transient "
+                "error, or missing prerequisite). Re-run later — cached "
+                "responses make subsequent runs cheaper.",
+            )
 
     if result.scope_session is not None:
         console.print(f"\n[bold]Session:[/bold] {result.scope_session}")

--- a/src/agentfluent/diagnostics/_git_helpers.py
+++ b/src/agentfluent/diagnostics/_git_helpers.py
@@ -41,6 +41,15 @@ _GIT_LOG_FIELD_SEPARATOR = "\x1e"
 # hang invisible.
 _GIT_TIMEOUT_SEC = 30
 
+# Default ``git log --since`` lookback window in days. Shared by all
+# diagnostics extractors that scan local git history (Tier 2
+# ``git_signals.FEAT_FIX_PROXIMITY``, Tier 3
+# ``github_signals.CI_FAILURE_FIRST_PUSH``). Defined here so a single
+# tuning change applies to every tier; per-extractor overrides remain
+# possible via the ``lookback_days`` parameter on each public entry
+# point.
+DEFAULT_LOOKBACK_DAYS = 90
+
 
 @dataclass(frozen=True)
 class _GitCommit:

--- a/src/agentfluent/diagnostics/_git_helpers.py
+++ b/src/agentfluent/diagnostics/_git_helpers.py
@@ -1,0 +1,144 @@
+"""Shared low-level git-log helpers for diagnostics signal extractors.
+
+Used by both Tier 2 (:mod:`agentfluent.diagnostics.git_signals` —
+``FEAT_FIX_PROXIMITY``) and Tier 3
+(:mod:`agentfluent.diagnostics.github_signals` —
+``CI_FAILURE_FIRST_PUSH``, ``PR_REVIEW_COMMENT_DENSITY``). Both tiers
+need to enumerate commits in a time window from the project's git
+working tree; the parsing and subprocess shape lives here so the two
+extractors don't import each other's privates.
+
+This module is intentionally tier-agnostic: nothing in here knows
+about Conventional Commits, PR numbers, or signal types. It's pure
+"give me commits with their timestamps and touched files."
+
+All git invocations use stdlib :mod:`subprocess` with a bounded
+timeout and graceful degradation: a missing git binary, a non-repo
+dir, an empty window, or a timeout all return ``[]`` rather than
+raising. Callers do not need a try/except wrapper.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ASCII record separators chosen because they don't appear in commit
+# subjects, paths, or ISO timestamps. ``%x1e`` separates fields within
+# a commit; ``%x1f`` separates commits.
+_GIT_LOG_FORMAT = "%H%x1e%cI%x1e%s"
+_GIT_LOG_COMMIT_SEPARATOR = "\x1f"
+_GIT_LOG_FIELD_SEPARATOR = "\x1e"
+
+# Subprocess timeout. A real `git log --name-only` over 90 days
+# finishes in well under a second on healthy repos; 30s is generous
+# headroom for slow filesystems / huge repos without making an honest
+# hang invisible.
+_GIT_TIMEOUT_SEC = 30
+
+
+@dataclass(frozen=True)
+class _GitCommit:
+    """One parsed entry from ``git log --format=...``.
+
+    ``timestamp`` is the committer date (``%cI``) as an aware
+    :class:`datetime`. ``files`` is a (possibly empty) set of paths
+    touched by the commit, populated when ``--name-only`` was passed.
+    """
+
+    sha: str
+    timestamp: datetime
+    subject: str
+    files: frozenset[str] = field(default_factory=frozenset)
+
+
+def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
+    """Run ``git log --since=<since>`` and parse the output.
+
+    Returns ``[]`` on any error: missing git binary, non-repo
+    directory, empty window, timeout, or parse failure. Caller does
+    not need a try/except wrapper.
+
+    The subprocess invocation is bounded by :data:`_GIT_TIMEOUT_SEC`
+    and uses a fixed-shape ``--format`` that pairs cleanly with
+    ``--name-only`` so file paths land below each commit header.
+    """
+    cmd = [
+        "git", "-C", str(repo_dir),
+        "log",
+        f"--since={since.isoformat()}",
+        f"--format={_GIT_LOG_COMMIT_SEPARATOR}{_GIT_LOG_FORMAT}",
+        "--name-only",
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants, not user input
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.debug("git binary not found on PATH; returning empty commit list")
+        return []
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "git log timed out after %ds; returning empty commit list",
+            _GIT_TIMEOUT_SEC,
+        )
+        return []
+
+    if result.returncode != 0:
+        # Not a repo, or another git error. Stderr is human-readable
+        # but we don't want to surface it on every run — DEBUG only.
+        logger.debug(
+            "git log returned %d: %s",
+            result.returncode, result.stderr.strip(),
+        )
+        return []
+
+    return _parse_commits(result.stdout)
+
+
+def _parse_commits(stdout: str) -> list[_GitCommit]:
+    """Parse the structured ``git log`` output into :class:`_GitCommit` records.
+
+    Output shape (with our separators):
+
+        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
+        <file1>
+        <file2>
+        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
+        <file1>
+        ...
+
+    The leading ``\\x1f`` makes ``split`` cleanly produce one entry
+    per commit (the first entry is empty and gets filtered).
+    """
+    commits: list[_GitCommit] = []
+    for raw_entry in stdout.split(_GIT_LOG_COMMIT_SEPARATOR):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        # First line is the header; subsequent lines are file paths.
+        header, _, file_block = entry.partition("\n")
+        parts = header.split(_GIT_LOG_FIELD_SEPARATOR)
+        if len(parts) != 3:
+            continue
+        sha, timestamp_str, subject = parts
+        try:
+            timestamp = datetime.fromisoformat(timestamp_str)
+        except ValueError:
+            continue
+        files = frozenset(
+            line.strip() for line in file_block.splitlines() if line.strip()
+        )
+        commits.append(_GitCommit(
+            sha=sha, timestamp=timestamp, subject=subject, files=files,
+        ))
+    return commits

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -90,6 +90,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.FILE_REWORK: Axis.QUALITY,
     SignalType.REVIEWER_CAUGHT: Axis.QUALITY,
     SignalType.FEAT_FIX_PROXIMITY: Axis.QUALITY,
+    SignalType.CI_FAILURE_FIRST_PUSH: Axis.QUALITY,
 }
 
 # Signal types that carry comparable scalar metrics in ``detail``. Only

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -926,12 +926,19 @@ class CIFailureFirstPushRule(_QualityRule):
         self, signal: DiagnosticSignal,
     ) -> tuple[str, str, str]:
         d = signal.detail
+        # All four detail keys are populated by the extractor, but the
+        # correlator runs against any DiagnosticSignal carrying the
+        # CI_FAILURE_FIRST_PUSH type — including manually-constructed
+        # ones in tests and future emitters. Guard each key so a
+        # malformed signal still renders a coherent message instead of
+        # "PR #None ('(no title)') failed CI on first push (ci: failure)."
         pr_number = d.get("pr_number")
+        pr_number_disp = f"#{pr_number}" if pr_number is not None else "(unknown)"
         pr_title = d.get("pr_title") or "(no title)"
         context = d.get("primary_context") or "ci"
         state = d.get("primary_state") or "failure"
         observation = (
-            f"PR #{pr_number} ({pr_title!r}) failed CI on first push "
+            f"PR {pr_number_disp} ({pr_title!r}) failed CI on first push "
             f"({context}: {state})."
         )
         reason = (

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -910,6 +910,43 @@ class FeatFixProximityRule(_QualityRule):
         return observation, reason, action
 
 
+class CIFailureFirstPushRule(_QualityRule):
+    """CI_FAILURE_FIRST_PUSH -> recommend pre-commit validation.
+
+    Tier 3 signal (#400). Cross-cutting (``agent_type=None``) because
+    the miss is about a PR's first push, not a specific subagent.
+    The recommendation copy nudges the user toward putting validation
+    in the agent's prompt or hooks rather than relying on CI to
+    catch issues post-push.
+    """
+
+    SIGNAL_TYPE = SignalType.CI_FAILURE_FIRST_PUSH
+
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        d = signal.detail
+        pr_number = d.get("pr_number")
+        pr_title = d.get("pr_title") or "(no title)"
+        context = d.get("primary_context") or "ci"
+        state = d.get("primary_state") or "failure"
+        observation = (
+            f"PR #{pr_number} ({pr_title!r}) failed CI on first push "
+            f"({context}: {state})."
+        )
+        reason = (
+            "CI failures on first push indicate the agent did not "
+            "validate its changes against the project's test/lint "
+            "suite before committing."
+        )
+        action = (
+            "Consider adding pre-commit validation to the agent's "
+            "prompt or hooks. Review whether the agent has access "
+            "to the project's test runner."
+        )
+        return observation, reason, action
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -926,6 +963,7 @@ RULES: list[CorrelationRule] = [
     FileReworkRule(),
     ReviewerCaughtRule(),
     FeatFixProximityRule(),
+    CIFailureFirstPushRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/git_signals.py
+++ b/src/agentfluent/diagnostics/git_signals.py
@@ -26,20 +26,46 @@ from __future__ import annotations
 
 import logging
 import re
-import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentfluent.config.models import Severity
+from agentfluent.diagnostics._git_helpers import (
+    _GIT_LOG_COMMIT_SEPARATOR,
+    _GIT_LOG_FIELD_SEPARATOR,
+    _GIT_LOG_FORMAT,
+    _GIT_TIMEOUT_SEC,
+    _GitCommit,
+    _parse_commits,
+    _run_git_log,
+)
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 from agentfluent.diagnostics.quality_signals import REVIEW_AGENT_TYPES
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from agentfluent.analytics.pipeline import SessionAnalysis
 
 logger = logging.getLogger(__name__)
+
+# Re-exports for back-compat — :mod:`agentfluent.diagnostics._git_helpers`
+# is the canonical home. Tests that imported these private symbols
+# from this module continue to work; new callers should import them
+# from ``_git_helpers`` directly.
+__all__ = [
+    "DEFAULT_LOOKBACK_DAYS",
+    "DEFAULT_PROXIMITY_DAYS",
+    "_GIT_LOG_COMMIT_SEPARATOR",
+    "_GIT_LOG_FIELD_SEPARATOR",
+    "_GIT_LOG_FORMAT",
+    "_GIT_TIMEOUT_SEC",
+    "_GitCommit",
+    "_parse_commits",
+    "_run_git_log",
+    "extract_git_quality_signals",
+]
 
 # Default lookback window for `git log --since`. A pair only counts as
 # "proximity" when feat and fix are within this many days of each other,
@@ -56,29 +82,6 @@ DEFAULT_LOOKBACK_DAYS = 90
 # quality misses.
 _FEAT_PATTERN = re.compile(r"^feat(\([^)]*\))?!?:", re.IGNORECASE)
 _FIX_PATTERN = re.compile(r"^fix(\([^)]*\))?!?:", re.IGNORECASE)
-
-# ASCII record separators chosen because they don't appear in commit
-# subjects, paths, or ISO timestamps. The same format is parsed inline
-# by :func:`_parse_commits`. ``%x1e`` separates fields within a commit;
-# ``%x1f`` separates commits.
-_GIT_LOG_FORMAT = "%H%x1e%cI%x1e%s"
-_GIT_LOG_COMMIT_SEPARATOR = "\x1f"
-_GIT_LOG_FIELD_SEPARATOR = "\x1e"
-
-# Subprocess timeout. A real `git log --name-only` over 90 days finishes
-# in well under a second on healthy repos; 30s is generous headroom for
-# slow filesystems / huge repos without making an honest hang invisible.
-_GIT_TIMEOUT_SEC = 30
-
-
-@dataclass(frozen=True)
-class _GitCommit:
-    """One parsed entry from ``git log --format=...``."""
-
-    sha: str
-    timestamp: datetime
-    subject: str
-    files: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass(frozen=True)
@@ -127,86 +130,6 @@ def extract_git_quality_signals(
         return []
 
     return [_signal_for_pair(pair, sessions) for pair in pairs]
-
-
-def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
-    """Run ``git log`` and parse the output. Returns ``[]`` on any error.
-
-    The subprocess invocation is bounded by :data:`_GIT_TIMEOUT_SEC`
-    and uses a fixed-shape ``--format`` that pairs cleanly with
-    ``--name-only`` so file paths land below each commit header.
-    """
-    cmd = [
-        "git", "-C", str(repo_dir),
-        "log",
-        f"--since={since.isoformat()}",
-        f"--format={_GIT_LOG_COMMIT_SEPARATOR}{_GIT_LOG_FORMAT}",
-        "--name-only",
-    ]
-    try:
-        result = subprocess.run(  # noqa: S603 — args are constants, not user input
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT_SEC,
-            check=False,
-        )
-    except FileNotFoundError:
-        logger.debug("git binary not found on PATH; skipping git signals")
-        return []
-    except subprocess.TimeoutExpired:
-        logger.warning("git log timed out after %ds; skipping git signals", _GIT_TIMEOUT_SEC)
-        return []
-
-    if result.returncode != 0:
-        # Not a repo, or another git error. Stderr is human-readable
-        # but we don't want to surface it on every run — DEBUG only.
-        logger.debug(
-            "git log returned %d: %s",
-            result.returncode, result.stderr.strip(),
-        )
-        return []
-
-    return _parse_commits(result.stdout)
-
-
-def _parse_commits(stdout: str) -> list[_GitCommit]:
-    """Parse the structured ``git log`` output into ``_GitCommit`` records.
-
-    Output shape (with our separators):
-
-        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
-        <file1>
-        <file2>
-        \\x1f<sha>\\x1e<isoformat-cdate>\\x1e<subject>
-        <file1>
-        ...
-
-    The leading ``\\x1f`` makes ``split`` cleanly produce one entry per
-    commit (the first entry is empty and gets filtered).
-    """
-    commits: list[_GitCommit] = []
-    for entry in stdout.split(_GIT_LOG_COMMIT_SEPARATOR):
-        entry = entry.strip()
-        if not entry:
-            continue
-        # First line is the header; subsequent lines are file paths.
-        header, _, file_block = entry.partition("\n")
-        parts = header.split(_GIT_LOG_FIELD_SEPARATOR)
-        if len(parts) != 3:
-            continue
-        sha, timestamp_str, subject = parts
-        try:
-            timestamp = datetime.fromisoformat(timestamp_str)
-        except ValueError:
-            continue
-        files = frozenset(
-            line.strip() for line in file_block.splitlines() if line.strip()
-        )
-        commits.append(_GitCommit(
-            sha=sha, timestamp=timestamp, subject=subject, files=files,
-        ))
-    return commits
 
 
 def _find_feat_fix_pairs(

--- a/src/agentfluent/diagnostics/git_signals.py
+++ b/src/agentfluent/diagnostics/git_signals.py
@@ -36,6 +36,7 @@ from agentfluent.diagnostics._git_helpers import (
     _GIT_LOG_FIELD_SEPARATOR,
     _GIT_LOG_FORMAT,
     _GIT_TIMEOUT_SEC,
+    DEFAULT_LOOKBACK_DAYS,
     _GitCommit,
     _parse_commits,
     _run_git_log,
@@ -51,29 +52,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Re-exports for back-compat — :mod:`agentfluent.diagnostics._git_helpers`
-# is the canonical home. Tests that imported these private symbols
-# from this module continue to work; new callers should import them
-# from ``_git_helpers`` directly.
+# is the canonical home for the moved git-log primitives. Tests that
+# imported these private symbols from this module continue to work;
+# new callers should import them from ``_git_helpers`` directly. Also
+# includes locally-defined private symbols (``_FeatFixPair``,
+# ``_find_feat_fix_pairs``, ``_FEAT_PATTERN``, ``_FIX_PATTERN``) that
+# tests import directly from this module.
 __all__ = [
     "DEFAULT_LOOKBACK_DAYS",
     "DEFAULT_PROXIMITY_DAYS",
+    "_FEAT_PATTERN",
+    "_FIX_PATTERN",
     "_GIT_LOG_COMMIT_SEPARATOR",
     "_GIT_LOG_FIELD_SEPARATOR",
     "_GIT_LOG_FORMAT",
     "_GIT_TIMEOUT_SEC",
+    "_FeatFixPair",
     "_GitCommit",
+    "_find_feat_fix_pairs",
     "_parse_commits",
     "_run_git_log",
     "extract_git_quality_signals",
 ]
 
-# Default lookback window for `git log --since`. A pair only counts as
-# "proximity" when feat and fix are within this many days of each other,
-# but we also need to cap how far back the initial scan reaches — pulling
-# the entire repo history on every run is wasteful and the signal value
-# decays fast with age.
+# Default proximity window for feat-fix pairing. A pair only counts
+# when feat and fix are within this many days of each other. The
+# lookback window (how far back the initial scan reaches) is shared
+# with Tier 3 via :data:`agentfluent.diagnostics._git_helpers.DEFAULT_LOOKBACK_DAYS`.
 DEFAULT_PROXIMITY_DAYS = 7
-DEFAULT_LOOKBACK_DAYS = 90
 
 # Match the ``feat:`` / ``fix:`` Conventional Commits prefix on the
 # commit subject. ``feat(scope):`` and ``feat!:`` both count. Other

--- a/src/agentfluent/diagnostics/github_signals.py
+++ b/src/agentfluent/diagnostics/github_signals.py
@@ -1,0 +1,365 @@
+"""Tier 3 GitHub-API quality signals.
+
+Per-PR quality signals computed from GitHub API responses, fetched
+via the :mod:`agentfluent.github` infrastructure. Mirrors the Tier 2
+:mod:`agentfluent.diagnostics.git_signals` pattern: one public
+extractor per signal type, each returning a tuple of
+``(signals, tier3_degraded)`` so the pipeline can flip
+:attr:`DiagnosticsResult.tier3_degraded` when a ``gh api`` call hits
+a rate limit.
+
+**Off by default.** Runs only when the CLI passes ``--github``,
+which in turn passes ``github_repo`` to :func:`run_diagnostics`.
+AgentFluent should not silently call GitHub on every analyze run.
+
+API budget per session (worst case, no cache hits): one
+``commits/{sha}/pulls`` call per commit in the session window, plus
+two calls (``pulls/{N}/commits`` and ``commits/{sha}/status``) per
+unique PR. 50 sessions touching 5 PRs each at one commit per session
+is comfortably under the 5000/hour authenticated rate limit; the
+file-backed cache (:mod:`agentfluent.github.cache`) brings the
+amortized cost much lower across repeat runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics._git_helpers import _GitCommit, _run_git_log
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+from agentfluent.github import (
+    TTL_OPEN_PR_OR_CI,
+    GitHubRepo,
+    RateLimitedError,
+    gh_api,
+)
+
+if TYPE_CHECKING:
+    from agentfluent.analytics.pipeline import SessionAnalysis
+
+logger = logging.getLogger(__name__)
+
+# How far back to scan local git history when looking up commits to
+# attribute to sessions. Same default as Tier 2 (#275).
+DEFAULT_LOOKBACK_DAYS = 90
+
+# Grace period appended to ``session.end_time`` when deciding whether a
+# commit "belongs" to that session. Five minutes covers the common
+# case of a deferred ``git commit`` after the session's last message;
+# longer slack risks pulling in commits from a subsequent session.
+DEFAULT_COMMIT_SLACK_SEC = 300
+
+# GitHub's combined status endpoint reports one of: success, failure,
+# error, pending. Both ``failure`` and ``error`` indicate a CI miss
+# the agent should have caught — we treat them identically here.
+_CI_FAILURE_STATES: frozenset[str] = frozenset({"failure", "error"})
+
+
+class _PRRef(NamedTuple):
+    """Minimal PR identifier — the fields we need for attribution and
+    for the signal's ``detail`` payload. Materialized from the
+    ``commits/{sha}/pulls`` response."""
+
+    number: int
+    title: str
+    url: str
+
+
+def extract_ci_failure_first_push_signals(
+    sessions: list[SessionAnalysis],
+    *,
+    github_repo: GitHubRepo,
+    repo_dir: Path,
+    no_cache: bool = False,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    commit_slack_seconds: int = DEFAULT_COMMIT_SLACK_SEC,
+) -> tuple[list[DiagnosticSignal], bool]:
+    """Emit one ``CI_FAILURE_FIRST_PUSH`` signal per PR whose first
+    commit failed CI and was authored within an analyzed session.
+
+    Args:
+        sessions: All sessions in the analysis window. Used to map
+            commits back to the session that authored them.
+        github_repo: The GitHub repository being analyzed.
+        repo_dir: Local git working tree. Used to enumerate commits
+            in the lookback window (no API call cost).
+        no_cache: Forwarded to :func:`gh_api`. Skips cache reads but
+            still writes — next run picks up the fresh entries.
+        lookback_days: How far back to scan ``git log``. Defaults to
+            90 days; matches Tier 2.
+        commit_slack_seconds: Grace appended to each session's end
+            time when attributing commits.
+
+    Returns:
+        ``(signals, degraded)``. ``degraded`` is ``True`` when at
+        least one ``gh api`` call hit a rate limit; partial signals
+        are still returned (per-extractor degradation policy from
+        the spike spec section 3).
+
+    Force-push caveat: ``pulls/{N}/commits`` returns the CURRENT
+    first commit, so a PR that's been force-pushed loses its
+    historical first-push CI failure. This is accepted as a v0.8
+    limitation; surfacing the original first push would require the
+    PR events API and significantly more complexity.
+    """
+    since = datetime.now().astimezone() - timedelta(days=lookback_days)
+    commits = _run_git_log(repo_dir, since=since)
+    if not commits:
+        return [], False
+
+    session_windows = _build_session_windows(
+        sessions, slack=commit_slack_seconds,
+    )
+    if not session_windows:
+        return [], False
+
+    commit_to_session = _attribute_commits(commits, session_windows)
+    if not commit_to_session:
+        return [], False
+
+    degraded = False
+    pr_refs: dict[int, _PRRef] = {}
+    for sha in commit_to_session:
+        result, hit_limit = _fetch_prs_for_commit(
+            github_repo, sha, no_cache=no_cache,
+        )
+        if hit_limit:
+            degraded = True
+            continue
+        for ref in result:
+            pr_refs.setdefault(ref.number, ref)
+
+    signals: list[DiagnosticSignal] = []
+    for ref in pr_refs.values():
+        first_sha, status, hit_limit = _fetch_pr_first_status(
+            github_repo, ref.number, no_cache=no_cache,
+        )
+        if hit_limit:
+            degraded = True
+            continue
+        if first_sha is None or status is None:
+            continue
+        if status.get("state") not in _CI_FAILURE_STATES:
+            continue
+        # Only emit when the first commit is attributable to one of
+        # our sessions — the signal is about a specific agent's miss,
+        # so a first commit authored outside any analyzed session
+        # has no meaningful attribution.
+        attributed = commit_to_session.get(first_sha)
+        if attributed is None:
+            continue
+        failing = [
+            s for s in (status.get("statuses") or [])
+            if s.get("state") in _CI_FAILURE_STATES
+        ]
+        if not failing:
+            # Defensive: combined state says failure but no individual
+            # context does. Skip rather than emit a vague signal.
+            continue
+        signals.append(_build_signal(ref, first_sha, failing))
+
+    return signals, degraded
+
+
+def _build_session_windows(
+    sessions: list[SessionAnalysis], *, slack: int,
+) -> dict[int, tuple[datetime, datetime]]:
+    """Map ``id(session) → (earliest, latest + slack)`` for sessions
+    that carry at least one timestamped message.
+
+    Sessions without any timestamped messages are excluded — we have
+    no basis for attributing commits to them. ``id(session)`` is the
+    key so the windows survive being iterated alongside a parallel
+    ``commit_to_session`` map that uses identity comparisons.
+    """
+    windows: dict[int, tuple[datetime, datetime]] = {}
+    for session in sessions:
+        timestamps = [
+            m.timestamp for m in session.messages if m.timestamp is not None
+        ]
+        if not timestamps:
+            continue
+        windows[id(session)] = (
+            min(timestamps),
+            max(timestamps) + timedelta(seconds=slack),
+        )
+    return windows
+
+
+def _attribute_commits(
+    commits: list[_GitCommit],
+    session_windows: dict[int, tuple[datetime, datetime]],
+) -> dict[str, int]:
+    """Map ``commit.sha → id(session)`` for commits whose timestamp
+    falls inside a session's window. First-match wins.
+
+    Sessions rarely overlap in time, so a commit lands in exactly one
+    window in practice. When they do overlap, the iteration order of
+    ``session_windows`` is stable (Python 3.7+ dict insertion order)
+    so the earlier-built window wins.
+    """
+    attributed: dict[str, int] = {}
+    for commit in commits:
+        for sess_id, (start, end) in session_windows.items():
+            if start <= commit.timestamp <= end:
+                attributed[commit.sha] = sess_id
+                break
+    return attributed
+
+
+def _fetch_prs_for_commit(
+    github_repo: GitHubRepo, sha: str, *, no_cache: bool,
+) -> tuple[list[_PRRef], bool]:
+    """Return the PRs that include the given commit SHA.
+
+    Returns ``(refs, rate_limited)``. ``rate_limited`` short-circuits
+    further calls for this commit but doesn't poison the run — other
+    commits' fetches still proceed; the caller flags ``degraded``.
+    """
+    endpoint = f"repos/{github_repo.owner}/{github_repo.repo}/commits/{sha}/pulls"
+    # Wrap in `[...]` so a multi-PR result lands as a single JSON
+    # array we can parse with one ``json.loads`` rather than newline-
+    # delimited objects (gh's default when ``.[]`` is the top-level).
+    jq = "[.[] | {number, title, html_url}]"
+    try:
+        payload = gh_api(
+            endpoint,
+            jq_filter=jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
+        )
+    except RateLimitedError as e:
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
+            e.endpoint, e.reset_at,
+        )
+        return [], True
+    except RuntimeError:
+        logger.debug("commits/%s/pulls failed; skipping", sha, exc_info=True)
+        return [], False
+    if not isinstance(payload, list):
+        return [], False
+    refs: list[_PRRef] = []
+    for item in payload:
+        try:
+            refs.append(_PRRef(
+                number=int(item["number"]),
+                title=str(item.get("title") or ""),
+                url=str(item.get("html_url") or ""),
+            ))
+        except (KeyError, TypeError, ValueError):
+            logger.debug("malformed PR entry from %s: %r", endpoint, item)
+            continue
+    return refs, False
+
+
+def _fetch_pr_first_status(
+    github_repo: GitHubRepo, pr_number: int, *, no_cache: bool,
+) -> tuple[str | None, dict[str, Any] | None, bool]:
+    """Fetch the first commit on a PR and its combined CI status.
+
+    Returns ``(first_sha, status_dict, rate_limited)``. Either of the
+    first two will be ``None`` on a non-rate-limit failure (malformed
+    response, empty PR, etc.); the third indicates whether the
+    caller should set ``degraded=True`` for the run.
+    """
+    owner = github_repo.owner
+    repo = github_repo.repo
+    commits_endpoint = f"repos/{owner}/{repo}/pulls/{pr_number}/commits"
+    # Project to just the SHA per commit — payload stays tiny.
+    commits_jq = "[.[] | {sha}]"
+    try:
+        commits_payload = gh_api(
+            commits_endpoint,
+            jq_filter=commits_jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
+        )
+    except RateLimitedError as e:
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
+            e.endpoint, e.reset_at,
+        )
+        return None, None, True
+    except RuntimeError:
+        logger.debug(
+            "pulls/%d/commits failed; skipping", pr_number, exc_info=True,
+        )
+        return None, None, False
+    if not isinstance(commits_payload, list) or not commits_payload:
+        return None, None, False
+    try:
+        first_sha = str(commits_payload[0]["sha"])
+    except (KeyError, TypeError):
+        return None, None, False
+
+    status_endpoint = f"repos/{owner}/{repo}/commits/{first_sha}/status"
+    status_jq = "{state, statuses: [.statuses[] | {context, state}]}"
+    try:
+        status_payload = gh_api(
+            status_endpoint,
+            jq_filter=status_jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
+        )
+    except RateLimitedError as e:
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
+            e.endpoint, e.reset_at,
+        )
+        return None, None, True
+    except RuntimeError:
+        logger.debug(
+            "commits/%s/status failed; skipping", first_sha, exc_info=True,
+        )
+        return None, None, False
+    if not isinstance(status_payload, dict):
+        return None, None, False
+    return first_sha, status_payload, False
+
+
+def _build_signal(
+    pr: _PRRef,
+    first_commit_sha: str,
+    failing_contexts: list[dict[str, Any]],
+) -> DiagnosticSignal:
+    """Construct the ``CI_FAILURE_FIRST_PUSH`` signal for one PR.
+
+    ``agent_type=None`` matches the Tier 2 ``FEAT_FIX_PROXIMITY``
+    convention: the signal is cross-cutting (about a PR's first
+    push), not attributable to a single subagent type. Per-agent
+    attribution can be revisited in v0.8.1+ once we have dogfood
+    data on which attribution shape produces actionable advice.
+    """
+    primary = failing_contexts[0]
+    primary_context = str(primary.get("context") or "ci")
+    primary_state = str(primary.get("state") or "failure")
+    title_disp = pr.title if pr.title else "(no title)"
+    message = (
+        f"PR #{pr.number} ({title_disp!r}) first push failed CI: "
+        f"{primary_context} {primary_state}"
+    )
+    return DiagnosticSignal(
+        signal_type=SignalType.CI_FAILURE_FIRST_PUSH,
+        severity=Severity.WARNING,
+        agent_type=None,
+        invocation_id=None,
+        message=message,
+        detail={
+            "pr_number": pr.number,
+            "pr_title": pr.title,
+            "pr_url": pr.url,
+            "first_commit_sha": first_commit_sha,
+            "failing_contexts": [
+                {"context": str(c.get("context") or ""),
+                 "state": str(c.get("state") or "")}
+                for c in failing_contexts
+            ],
+            "primary_context": primary_context,
+            "primary_state": primary_state,
+        },
+    )

--- a/src/agentfluent/diagnostics/github_signals.py
+++ b/src/agentfluent/diagnostics/github_signals.py
@@ -29,10 +29,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from agentfluent.config.models import Severity
-from agentfluent.diagnostics._git_helpers import _GitCommit, _run_git_log
+from agentfluent.diagnostics._git_helpers import (
+    DEFAULT_LOOKBACK_DAYS,
+    _GitCommit,
+    _run_git_log,
+)
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 from agentfluent.github import (
     TTL_OPEN_PR_OR_CI,
+    GhNotAuthenticatedError,
+    GhNotInstalledError,
     GitHubRepo,
     RateLimitedError,
     gh_api,
@@ -43,10 +49,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# How far back to scan local git history when looking up commits to
-# attribute to sessions. Same default as Tier 2 (#275).
-DEFAULT_LOOKBACK_DAYS = 90
-
 # Grace period appended to ``session.end_time`` when deciding whether a
 # commit "belongs" to that session. Five minutes covers the common
 # case of a deferred ``git commit`` after the session's last message;
@@ -56,7 +58,26 @@ DEFAULT_COMMIT_SLACK_SEC = 300
 # GitHub's combined status endpoint reports one of: success, failure,
 # error, pending. Both ``failure`` and ``error`` indicate a CI miss
 # the agent should have caught — we treat them identically here.
+# Also used to filter Check Runs conclusions (``failure``,
+# ``timed_out``, ``action_required``, ``cancelled`` all surface as
+# real CI misses; the legacy state field uses the narrower set).
 _CI_FAILURE_STATES: frozenset[str] = frozenset({"failure", "error"})
+_CI_FAILURE_CONCLUSIONS: frozenset[str] = frozenset(
+    {"failure", "timed_out", "action_required", "cancelled"},
+)
+
+# Exceptions from ``agentfluent.github.gh_api`` that indicate a real
+# but recoverable problem (transient server error, malformed JSON,
+# auth lapse mid-run). The extractor flags ``tier3_degraded=True`` and
+# skips the affected PR instead of crashing the whole diagnostics run.
+# ``RateLimitedError`` is handled separately because it is the only
+# class with structured reset-time data; everything else is bucketed.
+_GH_RECOVERABLE: tuple[type[Exception], ...] = (
+    RuntimeError,
+    ValueError,
+    GhNotInstalledError,
+    GhNotAuthenticatedError,
+)
 
 
 class _PRRef(NamedTuple):
@@ -96,15 +117,23 @@ def extract_ci_failure_first_push_signals(
 
     Returns:
         ``(signals, degraded)``. ``degraded`` is ``True`` when at
-        least one ``gh api`` call hit a rate limit; partial signals
-        are still returned (per-extractor degradation policy from
-        the spike spec section 3).
+        least one ``gh api`` call hit a rate limit OR a recoverable
+        gh error (transient 5xx, malformed JSON, mid-run auth lapse);
+        partial signals are still returned (per-extractor degradation
+        policy from the spike spec section 3).
 
     Force-push caveat: ``pulls/{N}/commits`` returns the CURRENT
     first commit, so a PR that's been force-pushed loses its
     historical first-push CI failure. This is accepted as a v0.8
     limitation; surfacing the original first push would require the
     PR events API and significantly more complexity.
+
+    GitHub Actions support: the legacy ``/commits/{sha}/status``
+    endpoint only reports Statuses-API entries, NOT Check Runs (the
+    modern API GitHub Actions uses). When the legacy status returns
+    no failure but the commit was actually checked, we fall back to
+    ``/commits/{sha}/check-runs`` so Actions-only repos still produce
+    signals.
     """
     since = datetime.now().astimezone() - timedelta(days=lookback_days)
     commits = _run_git_log(repo_dir, since=since)
@@ -134,33 +163,49 @@ def extract_ci_failure_first_push_signals(
             pr_refs.setdefault(ref.number, ref)
 
     signals: list[DiagnosticSignal] = []
+    skipped_unattributable = 0
     for ref in pr_refs.values():
-        first_sha, status, hit_limit = _fetch_pr_first_status(
+        # Fetch the PR's first commit SHA first (cheap projection,
+        # 1 API call). Attribution check uses the local
+        # commit_to_session map (free) — so we can skip a wasted
+        # status fetch when the first commit pre-dates the lookback
+        # window or belongs to a session with no timestamped
+        # messages. This saves 1 API call per non-attributable PR.
+        first_sha, hit_limit = _fetch_pr_first_commit_sha(
             github_repo, ref.number, no_cache=no_cache,
         )
         if hit_limit:
             degraded = True
             continue
-        if first_sha is None or status is None:
+        if first_sha is None:
             continue
-        if status.get("state") not in _CI_FAILURE_STATES:
-            continue
-        # Only emit when the first commit is attributable to one of
-        # our sessions — the signal is about a specific agent's miss,
-        # so a first commit authored outside any analyzed session
-        # has no meaningful attribution.
+
         attributed = commit_to_session.get(first_sha)
         if attributed is None:
+            # First commit pre-dates lookback OR belongs to a
+            # session with no timestamped messages OR was squashed/
+            # force-pushed after our git-log snapshot. We can't
+            # attribute the miss to a specific agent, so skip.
+            skipped_unattributable += 1
             continue
-        failing = [
-            s for s in (status.get("statuses") or [])
-            if s.get("state") in _CI_FAILURE_STATES
-        ]
+
+        failing, hit_limit, hit_error = _fetch_failing_contexts(
+            github_repo, first_sha, no_cache=no_cache,
+        )
+        if hit_limit or hit_error:
+            degraded = True
+            continue
         if not failing:
-            # Defensive: combined state says failure but no individual
-            # context does. Skip rather than emit a vague signal.
             continue
         signals.append(_build_signal(ref, first_sha, failing))
+
+    if skipped_unattributable:
+        logger.info(
+            "CI_FAILURE_FIRST_PUSH: skipped %d PR(s) with unattributable "
+            "first commits (pre-lookback, squash/force-push, or session "
+            "without timestamped messages)",
+            skipped_unattributable,
+        )
 
     return signals, degraded
 
@@ -211,14 +256,26 @@ def _attribute_commits(
     return attributed
 
 
+def _log_rate_limit(e: RateLimitedError) -> None:
+    """Single-source rate-limit WARNING — keeps message format stable
+    across every gh_api call site in this module."""
+    logger.warning(
+        "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
+        e.endpoint, e.reset_at,
+    )
+
+
 def _fetch_prs_for_commit(
     github_repo: GitHubRepo, sha: str, *, no_cache: bool,
 ) -> tuple[list[_PRRef], bool]:
     """Return the PRs that include the given commit SHA.
 
-    Returns ``(refs, rate_limited)``. ``rate_limited`` short-circuits
-    further calls for this commit but doesn't poison the run — other
-    commits' fetches still proceed; the caller flags ``degraded``.
+    Returns ``(refs, rate_limited_or_recoverable_error)``. The boolean
+    flag is set both for explicit rate limits and for the broader
+    family of recoverable gh errors (transient 5xx, malformed JSON,
+    auth lapses mid-run). Treating recoverable errors as degradation
+    rather than silent skip lets the caller flip ``tier3_degraded``
+    so the user knows their results may be incomplete.
     """
     endpoint = f"repos/{github_repo.owner}/{github_repo.repo}/commits/{sha}/pulls"
     # Wrap in `[...]` so a multi-PR result lands as a single JSON
@@ -233,14 +290,14 @@ def _fetch_prs_for_commit(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
+        _log_rate_limit(e)
+        return [], True
+    except _GH_RECOVERABLE as e:
         logger.warning(
-            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
-            e.endpoint, e.reset_at,
+            "commits/%s/pulls failed (%s); marking Tier 3 degraded",
+            sha, type(e).__name__,
         )
         return [], True
-    except RuntimeError:
-        logger.debug("commits/%s/pulls failed; skipping", sha, exc_info=True)
-        return [], False
     if not isinstance(payload, list):
         return [], False
     refs: list[_PRRef] = []
@@ -257,15 +314,22 @@ def _fetch_prs_for_commit(
     return refs, False
 
 
-def _fetch_pr_first_status(
+def _fetch_pr_first_commit_sha(
     github_repo: GitHubRepo, pr_number: int, *, no_cache: bool,
-) -> tuple[str | None, dict[str, Any] | None, bool]:
-    """Fetch the first commit on a PR and its combined CI status.
+) -> tuple[str | None, bool]:
+    """Fetch just the first commit SHA on a PR.
 
-    Returns ``(first_sha, status_dict, rate_limited)``. Either of the
-    first two will be ``None`` on a non-rate-limit failure (malformed
-    response, empty PR, etc.); the third indicates whether the
-    caller should set ``degraded=True`` for the run.
+    Returns ``(sha, hit_limit)`` where ``hit_limit`` is True on rate
+    limit or recoverable error (caller flips ``tier3_degraded``).
+    Split out from the legacy combined ``_fetch_pr_first_status`` so
+    the caller can check session attribution against a free local map
+    before paying for the status / check-runs fetch.
+
+    Ordering note: GitHub's ``pulls/{N}/commits`` returns commits in
+    topological order (oldest first), so ``[0]`` is the historical
+    first commit on the PR — load-bearing for correctness. A future
+    refactor must preserve this; consider asserting via per_page=1 if
+    GitHub's ordering ever stops being contractually first-oldest.
     """
     owner = github_repo.owner
     repo = github_repo.repo
@@ -280,24 +344,52 @@ def _fetch_pr_first_status(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
+        _log_rate_limit(e)
+        return None, True
+    except _GH_RECOVERABLE as e:
         logger.warning(
-            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
-            e.endpoint, e.reset_at,
+            "pulls/%d/commits failed (%s); marking Tier 3 degraded",
+            pr_number, type(e).__name__,
         )
-        return None, None, True
-    except RuntimeError:
-        logger.debug(
-            "pulls/%d/commits failed; skipping", pr_number, exc_info=True,
-        )
-        return None, None, False
+        return None, True
     if not isinstance(commits_payload, list) or not commits_payload:
-        return None, None, False
+        return None, False
     try:
-        first_sha = str(commits_payload[0]["sha"])
+        return str(commits_payload[0]["sha"]), False
     except (KeyError, TypeError):
-        return None, None, False
+        return None, False
 
-    status_endpoint = f"repos/{owner}/{repo}/commits/{first_sha}/status"
+
+def _fetch_failing_contexts(
+    github_repo: GitHubRepo, sha: str, *, no_cache: bool,
+) -> tuple[list[dict[str, str]], bool, bool]:
+    """Return failing CI contexts for a commit.
+
+    Composes two GitHub endpoints to cover both legacy Statuses and
+    modern Check Runs (GitHub Actions):
+
+    1. ``/commits/{sha}/status`` — the legacy combined status. Used
+       first because it's the documented entry point and covers the
+       common ``CircleCI / Travis / Statuses-API-via-App`` cases.
+    2. ``/commits/{sha}/check-runs`` — the Check Runs API. Polled
+       when the legacy endpoint reports no failure, because Actions
+       checks do not appear in the Statuses combined state at all.
+
+    Returns ``(failing, hit_limit, hit_error)``:
+
+    - ``failing`` is a list of ``{context, state}`` dicts (one per
+      failing CI run). Empty when no failure was detected.
+    - ``hit_limit`` indicates a rate limit; caller flips
+      ``tier3_degraded``.
+    - ``hit_error`` indicates a recoverable gh error (transient,
+      auth lapse, etc.); caller also flips ``tier3_degraded``.
+    """
+    owner = github_repo.owner
+    repo = github_repo.repo
+
+    # 1. Legacy combined status. Cheapest path for repos using the
+    #    Statuses API (CircleCI, Travis, third-party CI Apps).
+    status_endpoint = f"repos/{owner}/{repo}/commits/{sha}/status"
     status_jq = "{state, statuses: [.statuses[] | {context, state}]}"
     try:
         status_payload = gh_api(
@@ -307,19 +399,89 @@ def _fetch_pr_first_status(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
+        _log_rate_limit(e)
+        return [], True, False
+    except _GH_RECOVERABLE as e:
         logger.warning(
-            "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
-            e.endpoint, e.reset_at,
+            "commits/%s/status failed (%s); marking Tier 3 degraded",
+            sha, type(e).__name__,
         )
-        return None, None, True
-    except RuntimeError:
-        logger.debug(
-            "commits/%s/status failed; skipping", first_sha, exc_info=True,
+        return [], False, True
+
+    if isinstance(status_payload, dict):
+        combined = status_payload.get("state")
+        statuses = status_payload.get("statuses") or []
+        if combined in _CI_FAILURE_STATES:
+            failing = [
+                {"context": str(s.get("context") or ""),
+                 "state": str(s.get("state") or "")}
+                for s in statuses
+                if s.get("state") in _CI_FAILURE_STATES
+            ]
+            if failing:
+                return failing, False, False
+
+    # 2. Check Runs fallback. Only reached when the legacy endpoint
+    #    reported no actionable failure — which is the dominant case
+    #    for repos using GitHub Actions exclusively. Without this
+    #    fallback the signal would have near-zero recall on modern
+    #    GitHub repos.
+    return _fetch_failing_check_runs(github_repo, sha, no_cache=no_cache)
+
+
+def _fetch_failing_check_runs(
+    github_repo: GitHubRepo, sha: str, *, no_cache: bool,
+) -> tuple[list[dict[str, str]], bool, bool]:
+    """Query Check Runs and return any with a failing conclusion.
+
+    Same return shape as :func:`_fetch_failing_contexts`. Limited to
+    the first 30 check-runs (gh default page size); PRs with more
+    runs would need pagination, deferred to v0.8.1+ — the spike spec
+    Section 4 notes this trade-off explicitly.
+    """
+    owner = github_repo.owner
+    repo = github_repo.repo
+    endpoint = f"repos/{owner}/{repo}/commits/{sha}/check-runs"
+    # The API wraps runs in {total_count, check_runs: [...]}; project
+    # to a flat list of {name, conclusion} dicts so we can re-use
+    # ``failing_contexts``-shape downstream.
+    jq = "[.check_runs[] | {name, conclusion}]"
+    try:
+        payload = gh_api(
+            endpoint,
+            jq_filter=jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
         )
-        return None, None, False
-    if not isinstance(status_payload, dict):
-        return None, None, False
-    return first_sha, status_payload, False
+    except RateLimitedError as e:
+        _log_rate_limit(e)
+        return [], True, False
+    except _GH_RECOVERABLE as e:
+        logger.warning(
+            "commits/%s/check-runs failed (%s); marking Tier 3 degraded",
+            sha, type(e).__name__,
+        )
+        return [], False, True
+
+    if not isinstance(payload, list):
+        return [], False, False
+
+    failing: list[dict[str, str]] = []
+    for run in payload:
+        if not isinstance(run, dict):
+            continue
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion not in _CI_FAILURE_CONCLUSIONS:
+            continue
+        failing.append({
+            "context": str(run.get("name") or ""),
+            # Normalize the Check Runs conclusion to a Statuses-API
+            # "state" so downstream consumers (correlator,
+            # signal.detail) see a single vocabulary regardless of
+            # which endpoint sourced the failure.
+            "state": "failure",
+        })
+    return failing, False, False
 
 
 def _build_signal(

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -591,18 +591,23 @@ class DiagnosticsResult(BaseModel):
     pipeline (#189). Empty list when sklearn isn't installed or no
     cluster met ``min_cluster_size``."""
 
-    # v0.8: added tier3_degraded (#399 infrastructure). Reserved for
-    # Tier 3 signal extractors (#400, #401) to flip when a `gh api`
-    # call returns 403/429 with a rate-limit signature. The
-    # infrastructure story (#399) ships the field, the
-    # ``RateLimitedError`` exception in :mod:`agentfluent.github`, and
-    # the wiring through :func:`run_diagnostics`; the actual
-    # producer/consumer pairing lands with the signal extractors.
+    # v0.8: added tier3_degraded (#399 infrastructure, #400 first
+    # producer). Tier 3 signal extractors set this to True when a
+    # ``gh api`` call hit a rate limit OR a recoverable error
+    # (transient 5xx, malformed JSON, auth lapse mid-run) OR when a
+    # required prerequisite was missing (e.g., ``git_repo=None``
+    # because the project's source path could not be resolved). The
+    # run still exits 0; the flag lets JSON / table consumers
+    # communicate "Tier 3 was incomplete" without forcing a hard fail.
     # Additive default keeps pre-v0.8 envelopes loadable.
     tier3_degraded: bool = False
-    """``True`` when at least one Tier 3 extractor was skipped due to
-    a GitHub API rate-limit response. ``False`` when Tier 3 ran cleanly
-    OR Tier 3 was not requested. Producer lands with #400/#401 signal
-    extractors; the infrastructure PR (#399) ships only the field and
-    the typed exception ``agentfluent.github.RateLimitedError`` that
-    extractors will catch to flip the flag."""
+    """``True`` when at least one Tier 3 extractor was unable to
+    complete cleanly — rate-limited (403/429), recoverable gh error,
+    or required prerequisite missing. ``False`` when Tier 3 ran
+    cleanly OR Tier 3 was not requested (``--github`` not passed).
+
+    Producers (as of v0.8): #400 ``CI_FAILURE_FIRST_PUSH`` and the
+    pipeline-level fallback in :func:`run_diagnostics` (sets True
+    when ``--github`` was requested but ``sessions`` or ``git_repo``
+    is None). Consumers: JSON envelope (Pydantic ``model_dump``) and
+    the table formatter's diagnostics footer banner."""

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -69,6 +69,10 @@ class SignalType(StrEnum):
     Local-git quality signals (extracted from `git log` history,
     opt-in via `--git`):
     - `FEAT_FIX_PROXIMITY`
+
+    Tier 3 GitHub quality signals (extracted via `gh api`, opt-in
+    via `--github`):
+    - `CI_FAILURE_FIRST_PUSH`
     """
 
     ERROR_PATTERN = "error_pattern"
@@ -86,6 +90,7 @@ class SignalType(StrEnum):
     FILE_REWORK = "file_rework"
     REVIEWER_CAUGHT = "reviewer_caught"
     FEAT_FIX_PROXIMITY = "feat_fix_proximity"
+    CI_FAILURE_FIRST_PUSH = "ci_failure_first_push"
 
 
 # Signal types emitted by the trace-level extractor. Used by the dedup

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -39,6 +39,9 @@ from agentfluent.diagnostics.delegation import (
     suggest_delegations,
 )
 from agentfluent.diagnostics.git_signals import extract_git_quality_signals
+from agentfluent.diagnostics.github_signals import (
+    extract_ci_failure_first_push_signals,
+)
 from agentfluent.diagnostics.mcp_assessment import (
     McpToolCall,
     audit_mcp_servers,
@@ -306,18 +309,33 @@ def run_diagnostics(
             git_repo is not None, sessions is not None,
         )
 
-    # Tier 3 GitHub-API quality signals (#399 infrastructure; #400, #401
-    # signal extractors). When `github_repo` is None the caller did not
-    # pass `--github` (or repo inference failed and the CLI exited
-    # before reaching here). Signal extraction itself lands in #400/#401;
-    # the infrastructure story just threads the parameters through.
-    # `github_no_cache` is forwarded so extractors can pass it to
-    # :func:`agentfluent.github.gh_api` per request.
-    if github_repo is not None:
+    # Tier 3 GitHub-API quality signals (#399 infrastructure; #400
+    # CI_FAILURE_FIRST_PUSH; #401 PR_REVIEW_COMMENT_DENSITY pending).
+    # Off unless the caller passes ``github_repo`` (set when the CLI's
+    # ``--github`` flag survived detection/consent/repo-resolution) AND
+    # ``git_repo`` (because we need local commit history to attribute
+    # commits to sessions). Each extractor returns
+    # ``(signals, degraded)``; we OR the degraded flag so a single
+    # rate-limit anywhere in Tier 3 surfaces on the result.
+    tier3_degraded = False
+    if (
+        github_repo is not None
+        and sessions is not None
+        and git_repo is not None
+    ):
+        ci_signals, ci_degraded = extract_ci_failure_first_push_signals(
+            sessions,
+            github_repo=github_repo,
+            repo_dir=git_repo,
+            no_cache=github_no_cache,
+        )
+        signals.extend(ci_signals)
+        tier3_degraded = tier3_degraded or ci_degraded
+    elif github_repo is not None:
         logger.debug(
-            "tier 3 github_repo received: %s/%s (no_cache=%s) — "
-            "extractors land in #400, #401",
-            github_repo.owner, github_repo.repo, github_no_cache,
+            "tier 3 signals skipped: github_repo=%s sessions=%s git_repo=%s",
+            github_repo is not None, sessions is not None,
+            git_repo is not None,
         )
 
     correlated_pairs = correlate(signals, configs_by_name)
@@ -364,4 +382,5 @@ def run_diagnostics(
         delegation_suggestions=delegation_suggestions,
         delegation_suggestions_skipped_reason=delegation_skipped_reason,
         offload_candidates=offload_candidates,
+        tier3_degraded=tier3_degraded,
     )

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -317,26 +317,48 @@ def run_diagnostics(
     # commits to sessions). Each extractor returns
     # ``(signals, degraded)``; we OR the degraded flag so a single
     # rate-limit anywhere in Tier 3 surfaces on the result.
+    #
+    # Each extractor is wrapped in a broad try/except: a Tier 3 bug
+    # must not destroy the Tier 1+Tier 2 signals already computed
+    # above. An unhandled exception flips ``tier3_degraded`` so the
+    # user sees that GitHub data was incomplete, and the analyze run
+    # continues normally.
     tier3_degraded = False
     if (
         github_repo is not None
         and sessions is not None
         and git_repo is not None
     ):
-        ci_signals, ci_degraded = extract_ci_failure_first_push_signals(
-            sessions,
-            github_repo=github_repo,
-            repo_dir=git_repo,
-            no_cache=github_no_cache,
-        )
-        signals.extend(ci_signals)
-        tier3_degraded = tier3_degraded or ci_degraded
+        try:
+            ci_signals, ci_degraded = extract_ci_failure_first_push_signals(
+                sessions,
+                github_repo=github_repo,
+                repo_dir=git_repo,
+                no_cache=github_no_cache,
+            )
+        except Exception:  # noqa: BLE001 — never let a Tier 3 bug crash diagnostics
+            logger.warning(
+                "CI_FAILURE_FIRST_PUSH extractor crashed; "
+                "marking Tier 3 degraded and continuing",
+                exc_info=True,
+            )
+            tier3_degraded = True
+        else:
+            signals.extend(ci_signals)
+            tier3_degraded = tier3_degraded or ci_degraded
     elif github_repo is not None:
-        logger.debug(
-            "tier 3 signals skipped: github_repo=%s sessions=%s git_repo=%s",
-            github_repo is not None, sessions is not None,
-            git_repo is not None,
+        # User passed --github but a prerequisite is missing (e.g.,
+        # ``resolve_project_disk_path`` returned None, or a
+        # programmatic caller forgot to pass sessions / git_repo).
+        # WARNING level — the user explicitly opted into Tier 3 and
+        # silently dropping it would misreport tier3_degraded=False
+        # as "ran cleanly". Flip the flag so JSON consumers can tell.
+        logger.warning(
+            "Tier 3 was requested but skipped because a prerequisite is "
+            "missing (sessions=%s, git_repo=%s). Marking tier3_degraded.",
+            sessions is not None, git_repo is not None,
         )
+        tier3_degraded = True
 
     correlated_pairs = correlate(signals, configs_by_name)
     recommendations = [rec for _, rec in correlated_pairs]

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -519,6 +519,43 @@
   recommendation_target: subagent
   related: [user_correction, file_rework, reviewer_caught, primary_axis]
 
+- name: ci_failure_first_push
+  category: signal_type
+  short: |
+    A PR's first commit failed CI -- the agent shipped code that did
+    not pass automated checks on first attempt, a direct quality miss.
+  long: |
+    Tier 3 GitHub quality-axis signal (v0.8). Off by default; runs
+    only when the CLI passes `--github` (which also requires
+    `--diagnostics` and implies `--git`). For each commit authored
+    within an analyzed session window, AgentFluent fetches the PRs
+    touching that commit via `gh api`, then for each unique PR
+    fetches the first commit and its combined CI status. When the
+    first commit's combined status is `failure` or `error`, one
+    `CI_FAILURE_FIRST_PUSH` signal fires per PR.
+
+    Cross-cutting (`agent_type=None`). Severity is always `warning`:
+    a first-push CI failure is a definite quality miss, but signal
+    strength varies with project conventions (some teams treat CI
+    as the first-class check rather than a pre-commit gate).
+
+    The signal is only emitted when the PR's first commit can be
+    attributed to a session in the analysis window -- a first commit
+    authored outside any analyzed session has no actionable
+    attribution. Force-push caveat: `pulls/{N}/commits` returns the
+    CURRENT first commit, so a PR that was force-pushed loses its
+    historical first-push failure. Detecting the original first push
+    would require the PR events API; deferred to v0.8.1+.
+
+    Rate-limit handling: if any `gh api` call returns 403/429 with a
+    rate-limit signature, that PR is skipped and
+    `DiagnosticsResult.tier3_degraded` is set to True. Other PRs
+    still produce signals; the run still exits 0.
+  example: "PR #42 ('Add session window filter') first push failed CI: pytest failure"
+  severity_range: warning
+  recommendation_target: subagent
+  related: [feat_fix_proximity, primary_axis]
+
 # =============================================================================
 # Severity
 # =============================================================================

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -517,7 +517,7 @@
   example: "feat a1b2c3d followed by 2 fixes on shared file(s) within 3d"
   severity_range: info -> warning
   recommendation_target: subagent
-  related: [user_correction, file_rework, reviewer_caught, primary_axis]
+  related: [user_correction, file_rework, reviewer_caught, ci_failure_first_push, primary_axis]
 
 - name: ci_failure_first_push
   category: signal_type

--- a/tests/unit/cli/test_tier3_degraded_banner.py
+++ b/tests/unit/cli/test_tier3_degraded_banner.py
@@ -1,0 +1,64 @@
+"""The table formatter must surface ``tier3_degraded`` as a banner.
+
+Pre-fix, the flag was set in ``DiagnosticsResult`` but no non-JSON
+renderer touched it — interactive CLI users had no way to tell that
+a Tier 3 rate-limit or recoverable error had silently truncated
+their results. The footer banner closes that observability gap.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.pipeline import AnalysisResult
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.cli.formatters.table import format_analysis_table
+from agentfluent.diagnostics.models import DiagnosticsResult
+
+
+def _result(*, tier3_degraded: bool, signals: list = None) -> AnalysisResult:
+    return AnalysisResult(
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=AgentMetrics(),
+        session_count=1,
+        diagnostics=DiagnosticsResult(
+            signals=signals or [],
+            tier3_degraded=tier3_degraded,
+        ),
+    )
+
+
+def _render(result: AnalysisResult, *, show_diagnostics: bool) -> str:
+    buf = StringIO()
+    format_analysis_table(
+        Console(file=buf, width=160, force_terminal=False),
+        result,
+        verbose=False,
+        show_diagnostics=show_diagnostics,
+    )
+    return buf.getvalue()
+
+
+def test_banner_renders_when_degraded() -> None:
+    out = _render(_result(tier3_degraded=True), show_diagnostics=True)
+    assert "Tier 3 (GitHub) data is incomplete" in out
+
+
+def test_banner_renders_in_summary_mode_too() -> None:
+    # The summary path (no --diagnostics) also gets the banner so
+    # users who run the default analyze command can still see Tier 3
+    # was incomplete. Verified via show_diagnostics=False.
+    out = _render(_result(tier3_degraded=True), show_diagnostics=False)
+    assert "Tier 3 (GitHub) data is incomplete" in out
+
+
+def test_banner_absent_when_not_degraded() -> None:
+    # Regression guard: a clean run must not flash the warning to
+    # users — otherwise the banner becomes meaningless noise.
+    out = _render(_result(tier3_degraded=False), show_diagnostics=True)
+    assert "Tier 3" not in out

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -835,6 +835,63 @@ class TestReviewerCaughtRule:
         assert "code-reviewer" in recs[0].action
 
 
+class TestCIFailureFirstPushRule:
+    """CI_FAILURE_FIRST_PUSH -> cross-cutting ``target='subagent'``
+    recommendation that names the PR and the failing context."""
+
+    @staticmethod
+    def _signal(
+        pr_number: int = 42,
+        pr_title: str = "Add window filter",
+        primary_context: str = "ci/pytest",
+        primary_state: str = "failure",
+    ) -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.CI_FAILURE_FIRST_PUSH,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message=(
+                f"PR #{pr_number} ({pr_title!r}) first push failed CI: "
+                f"{primary_context} {primary_state}"
+            ),
+            detail={
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_url": f"https://github.com/o/r/pull/{pr_number}",
+                "first_commit_sha": "abc1234",
+                "failing_contexts": [
+                    {"context": primary_context, "state": primary_state},
+                ],
+                "primary_context": primary_context,
+                "primary_state": primary_state,
+            },
+        )
+
+    def test_emits_subagent_target(self) -> None:
+        recs = correlate([self._signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "subagent"
+        assert rec.signal_types == [SignalType.CI_FAILURE_FIRST_PUSH]
+
+    def test_pr_number_appears_in_observation(self) -> None:
+        recs = correlate([self._signal(pr_number=42)])
+        # The observation lands in the message text; correlator wraps
+        # it as ``[quality] <observation>`` so the PR ref is searchable
+        # from the rendered recommendation.
+        assert "#42" in recs[0].message
+
+    def test_failing_context_appears_in_observation(self) -> None:
+        recs = correlate([self._signal(primary_context="ci/lint")])
+        assert "ci/lint" in recs[0].message
+
+    def test_action_mentions_pre_commit_validation(self) -> None:
+        recs = correlate([self._signal()])
+        action = recs[0].action.lower()
+        assert "pre-commit" in action or "validation" in action
+
+
 class TestRelpath:
     """``_relpath`` rewrites ``$HOME`` to ``~`` in message text (#340)."""
 

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -891,6 +891,31 @@ class TestCIFailureFirstPushRule:
         action = recs[0].action.lower()
         assert "pre-commit" in action or "validation" in action
 
+    def test_missing_pr_number_renders_unknown_sentinel(self) -> None:
+        # Defensive guard: a manually-constructed signal without
+        # pr_number in detail must not render `PR #None` in the
+        # user's report. The correlator falls back to "(unknown)".
+        sig = DiagnosticSignal(
+            signal_type=SignalType.CI_FAILURE_FIRST_PUSH,
+            severity=Severity.WARNING,
+            agent_type=None,
+            invocation_id=None,
+            message="malformed signal",
+            detail={
+                # No pr_number key.
+                "pr_title": "x",
+                "pr_url": "url",
+                "first_commit_sha": "abc",
+                "failing_contexts": [{"context": "ci", "state": "failure"}],
+                "primary_context": "ci",
+                "primary_state": "failure",
+            },
+        )
+        recs = correlate([sig])
+        assert len(recs) == 1
+        assert "#None" not in recs[0].message
+        assert "(unknown)" in recs[0].message
+
 
 class TestRelpath:
     """``_relpath`` rewrites ``$HOME`` to ``~`` in message text (#340)."""

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -854,3 +854,61 @@ class TestQualitySignalsWiring:
         assert SignalType.USER_CORRECTION in kinds
         assert SignalType.FILE_REWORK in kinds
         assert SignalType.REVIEWER_CAUGHT in kinds
+
+
+class TestTier3DegradationWiring:
+    """Tier 3 extractor errors must not crash the diagnostics run;
+    tier3_degraded carries the partial-failure signal forward."""
+
+    def test_extractor_crash_marks_degraded_and_continues(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        from agentfluent.github.models import GitHubRepo
+
+        def boom(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("simulated extractor bug")
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline."
+            "extract_ci_failure_first_push_signals",
+            boom,
+        )
+
+        # Need sessions + git_repo (alongside github_repo) to enter
+        # the Tier 3 branch.
+        sessions: list = []  # noqa: F841 — imported via run_diagnostics's
+                              # ``sessions`` kwarg below
+        result = run_diagnostics(
+            [_inv()],
+            sessions=[],
+            git_repo=tmp_path,
+            github_repo=GitHubRepo(owner="o", repo="r"),
+        )
+        # Run completes without re-raising the boom; degraded flag is
+        # set so the user sees that Tier 3 was incomplete.
+        assert result.tier3_degraded is True
+
+    def test_missing_prereqs_with_github_repo_marks_degraded(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # When --github was requested but git_repo or sessions is None
+        # (programmatic caller, or resolve_project_disk_path returned
+        # None), Tier 3 silently no-op'd with degraded=False pre-fix.
+        # Post-fix: flips degraded so the consumer can tell something
+        # was dropped.
+        from agentfluent.github.models import GitHubRepo
+
+        result = run_diagnostics(
+            [_inv()],
+            github_repo=GitHubRepo(owner="o", repo="r"),
+            # sessions=None, git_repo=None — the missing prereqs.
+        )
+        assert result.tier3_degraded is True
+
+    def test_no_github_request_keeps_degraded_false(self) -> None:
+        # Without --github, tier3_degraded must remain False (the
+        # baseline "Tier 3 was not requested" case). Regression guard
+        # against accidentally flipping the flag in the no-Tier-3
+        # path.
+        result = run_diagnostics([_inv()])
+        assert result.tier3_degraded is False

--- a/tests/unit/test_git_signals.py
+++ b/tests/unit/test_git_signals.py
@@ -149,28 +149,28 @@ class TestFeatFixPairing:
 class TestSubprocessErrorHandling:
     def test_missing_git_binary_returns_empty(self, tmp_path: Path) -> None:
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             side_effect=FileNotFoundError("git not found"),
         ):
             assert extract_git_quality_signals([], repo_dir=tmp_path) == []
 
     def test_non_zero_exit_returns_empty(self, tmp_path: Path) -> None:
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout="", returncode=128),
         ):
             assert extract_git_quality_signals([], repo_dir=tmp_path) == []
 
     def test_timeout_returns_empty(self, tmp_path: Path) -> None:
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd=["git"], timeout=30),
         ):
             assert extract_git_quality_signals([], repo_dir=tmp_path) == []
 
     def test_empty_log_returns_empty(self, tmp_path: Path) -> None:
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout="", returncode=0),
         ):
             assert extract_git_quality_signals([], repo_dir=tmp_path) == []
@@ -202,7 +202,7 @@ class TestSessionCorrelation:
             _session(feat_time - timedelta(minutes=1), ["architect", "general-purpose"]),
         ]
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout=feat_fix_stdout),
         ):
             signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
@@ -219,7 +219,7 @@ class TestSessionCorrelation:
             _session(feat_time - timedelta(minutes=1), ["pm", "general-purpose"]),
         ]
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout=feat_fix_stdout),
         ):
             signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
@@ -234,7 +234,7 @@ class TestSessionCorrelation:
         # All sessions end AFTER the feat commit -> no match.
         sessions = [_session(feat_time + timedelta(days=1), ["pm"])]
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout=feat_fix_stdout),
         ):
             signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)
@@ -248,7 +248,7 @@ class TestSessionCorrelation:
     ) -> None:
         sessions: list[SessionAnalysis] = []
         with patch(
-            "agentfluent.diagnostics.git_signals.subprocess.run",
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
             new=_fake_run(stdout=feat_fix_stdout),
         ):
             signals = extract_git_quality_signals(sessions, repo_dir=tmp_path)

--- a/tests/unit/test_github_signals_ci_failure.py
+++ b/tests/unit/test_github_signals_ci_failure.py
@@ -1,0 +1,453 @@
+"""Tests for the ``CI_FAILURE_FIRST_PUSH`` Tier 3 signal extractor.
+
+All ``gh_api`` calls are mocked end-to-end so the tests run without
+network access or `gh` on PATH. ``git log`` invocations are mocked
+via the shared ``_git_helpers`` subprocess hook the Tier 2 tests
+already use.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.pipeline import SessionAnalysis
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.config.models import Severity
+from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics._git_helpers import (
+    _GIT_LOG_COMMIT_SEPARATOR,
+    _GIT_LOG_FIELD_SEPARATOR,
+)
+from agentfluent.diagnostics.github_signals import (
+    extract_ci_failure_first_push_signals,
+)
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.github.models import GitHubRepo, RateLimitedError
+
+
+def _session(
+    *,
+    end: datetime,
+    agent_types: list[str],
+    duration: timedelta = timedelta(minutes=30),
+) -> SessionAnalysis:
+    """Minimal SessionAnalysis with two timestamped messages bracketing
+    a 30-minute window, plus synthetic invocations.
+
+    Two messages (not one) so the session's attribution window has
+    real width — commits authored mid-session fall inside
+    ``[end - duration, end + slack]``, matching real usage where an
+    agent's ``git commit`` lands during a multi-message session.
+    """
+    msgs = [
+        SessionMessage(type="user", timestamp=end - duration),
+        SessionMessage(type="user", timestamp=end),
+    ]
+    invs = [
+        AgentInvocation(
+            invocation_id=f"inv-{i}",
+            agent_type=at,
+            description=f"{at} call",
+            prompt="do work",
+            tool_use_id=f"toolu_{i}",
+            session_id="s",
+            session_path=Path("/x"),
+        )
+        for i, at in enumerate(agent_types)
+    ]
+    return SessionAnalysis(
+        session_path=Path("/tmp/session.jsonl"),
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=AgentMetrics(),
+        invocations=invs,
+        mcp_tool_calls=[],
+        messages=msgs,
+    )
+
+
+def _git_log_stdout(commits: list[tuple[str, datetime, str]]) -> str:
+    """Build the structured ``git log`` stdout that ``_parse_commits``
+    consumes. Each entry is (sha, timestamp, subject)."""
+    parts: list[str] = []
+    for sha, ts, subject in commits:
+        header = _GIT_LOG_FIELD_SEPARATOR.join([sha, ts.isoformat(), subject])
+        parts.append(f"{_GIT_LOG_COMMIT_SEPARATOR}{header}\n")
+    return "\n".join(parts) + "\n"
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> Any:
+    def runner(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=returncode, stdout=stdout, stderr="",
+        )
+    return runner
+
+
+@pytest.fixture
+def repo_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def github_repo() -> GitHubRepo:
+    return GitHubRepo(owner="o", repo="r")
+
+
+class _GhApiStub:
+    """Captures the call sequence and returns canned responses keyed
+    on endpoint prefix. Per-call counters power the rate-limit tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.responses: dict[str, Any] = {}
+        # Endpoints that should raise RateLimitedError on the Nth call.
+        self.rate_limit_after: dict[str, int] = {}
+        self._counts: dict[str, int] = {}
+
+    def __call__(self, endpoint: str, **_kwargs: Any) -> Any:
+        self.calls.append(endpoint)
+        # Match by prefix, longest match wins so a fully-specified
+        # endpoint shadows a shorter catch-all key. (Without this,
+        # rate-limit setup for ``repos/o/r/commits/<sha>/pulls`` would
+        # be hidden by a broader ``repos/o/r/commits/`` fallback.)
+        matches = sorted(
+            (p for p in self.responses if endpoint.startswith(p)),
+            key=len,
+            reverse=True,
+        )
+        if not matches:
+            raise AssertionError(f"unexpected gh_api call: {endpoint}")
+        prefix = matches[0]
+        count = self._counts.get(prefix, 0) + 1
+        self._counts[prefix] = count
+        limit = self.rate_limit_after.get(prefix)
+        if limit is not None and count > limit:
+            raise RateLimitedError(
+                reset_at=datetime.now(UTC) + timedelta(seconds=60),
+                endpoint=endpoint,
+            )
+        return self.responses[prefix]
+
+
+class TestSignalEmission:
+    def test_first_push_failure_emits_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["general-purpose"])
+        commit_sha = "abc1234567890abc"
+        # git log: the session's commit is the first commit on a PR.
+        commit_time = session_end - timedelta(minutes=5)
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(commit_sha, commit_time, "feat: x")])),
+        )
+
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{commit_sha}/pulls":
+                [{"number": 42, "title": "Add window filter",
+                  "html_url": "https://github.com/o/r/pull/42"}],
+            "repos/o/r/pulls/42/commits": [{"sha": commit_sha}],
+            f"repos/o/r/commits/{commit_sha}/status": {
+                "state": "failure",
+                "statuses": [
+                    {"context": "ci/pytest", "state": "failure"},
+                ],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == SignalType.CI_FAILURE_FIRST_PUSH
+        assert sig.severity == Severity.WARNING
+        assert sig.agent_type is None
+        assert sig.detail["pr_number"] == 42
+        assert sig.detail["first_commit_sha"] == commit_sha
+        assert sig.detail["primary_context"] == "ci/pytest"
+        assert "Add window filter" in sig.message
+
+    def test_first_push_success_emits_nothing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        commit_sha = "abc"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(commit_sha, session_end, "feat: x")])),
+        )
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{commit_sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1/commits": [{"sha": commit_sha}],
+            f"repos/o/r/commits/{commit_sha}/status": {
+                "state": "success", "statuses": [],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+    def test_pending_no_contexts_emits_nothing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        sha = "ab"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(sha, session_end, "feat")])),
+        )
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1/commits": [{"sha": sha}],
+            f"repos/o/r/commits/{sha}/status": {
+                "state": "pending", "statuses": [],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+    def test_first_commit_outside_window_skipped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Session authored commit B on a PR whose FIRST commit (A) was
+        # made outside any analyzed session window. The signal must
+        # NOT fire — attribution would be wrong (the failing first
+        # commit is not "our" agent's miss).
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        sha_b = "later000"
+        sha_a = "earlier0"
+        # Only sha_b lands in the session window; sha_a is older.
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (sha_b, session_end - timedelta(minutes=10), "fix: y"),
+            ])),
+        )
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha_b}/pulls":
+                [{"number": 7, "title": "x", "html_url": "url"}],
+            # PR's first commit is sha_a, NOT in our window.
+            "repos/o/r/pulls/7/commits": [{"sha": sha_a}],
+            f"repos/o/r/commits/{sha_a}/status": {
+                "state": "failure",
+                "statuses": [{"context": "ci", "state": "failure"}],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+
+class TestEarlyExits:
+    def test_no_commits_skips_all_api_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        # git log returns empty.
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(""),
+        )
+        stub = _GhApiStub()
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        assert stub.calls == []
+
+    def test_session_without_messages_excluded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Session with no timestamped messages -> no window -> no
+        # attribution -> early return. Commits in git_log are present
+        # but unattributable.
+        session = SessionAnalysis(
+            session_path=Path("/tmp/s.jsonl"),
+            token_metrics=TokenMetrics(),
+            tool_metrics=ToolMetrics(),
+            agent_metrics=AgentMetrics(),
+            invocations=[],
+            mcp_tool_calls=[],
+            messages=[],
+        )
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                ("abc", datetime.now(UTC) - timedelta(hours=1), "feat"),
+            ])),
+        )
+        stub = _GhApiStub()
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        assert stub.calls == []
+
+
+class TestRateLimitDegradation:
+    def test_rate_limit_on_pulls_lookup_marks_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Two sessions, two commits; one of the commits/{sha}/pulls
+        # calls raises RateLimitedError. The other commit proceeds
+        # normally; degraded is True; partial signal is returned.
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session_1 = _session(
+            end=session_end - timedelta(hours=2), agent_types=["pm"],
+        )
+        session_2 = _session(end=session_end, agent_types=["pm"])
+        sha_1 = "limited0"
+        sha_2 = "ok123456"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (sha_1, session_end - timedelta(hours=2, minutes=5),
+                 "feat: a"),
+                (sha_2, session_end - timedelta(minutes=5), "feat: b"),
+            ])),
+        )
+        stub = _GhApiStub()
+        # Rate-limit AFTER the first commits/{sha}/pulls succeeds — but
+        # we want the FIRST call to raise. Configure rate_limit_after=0.
+        stub.responses = {
+            "repos/o/r/commits/": [],  # default (won't be hit)
+            f"repos/o/r/commits/{sha_2}/pulls":
+                [{"number": 9, "title": "ok", "html_url": "url"}],
+            "repos/o/r/pulls/9/commits": [{"sha": sha_2}],
+            f"repos/o/r/commits/{sha_2}/status": {
+                "state": "failure",
+                "statuses": [{"context": "ci", "state": "failure"}],
+            },
+        }
+        # Override the response for sha_1's pulls endpoint to rate-limit.
+        stub.responses[f"repos/o/r/commits/{sha_1}/pulls"] = []
+        stub.rate_limit_after[f"repos/o/r/commits/{sha_1}/pulls"] = 0
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session_1, session_2],
+            github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is True
+        # Second session's PR still emits its signal.
+        assert len(signals) == 1
+        assert signals[0].detail["pr_number"] == 9
+
+
+class TestDeduplication:
+    def test_pr_touched_by_two_commits_emits_one_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Same PR appears in commits/{sha1}/pulls and
+        # commits/{sha2}/pulls. The extractor must dedup by PR number
+        # so we only fetch first-commit + status once and emit one
+        # signal.
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        sha_1 = "first000"
+        sha_2 = "second00"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (sha_1, session_end - timedelta(minutes=10), "feat"),
+                (sha_2, session_end - timedelta(minutes=5), "fix"),
+            ])),
+        )
+        stub = _GhApiStub()
+        pr_meta = [{"number": 5, "title": "x", "html_url": "url"}]
+        stub.responses = {
+            f"repos/o/r/commits/{sha_1}/pulls": pr_meta,
+            f"repos/o/r/commits/{sha_2}/pulls": pr_meta,
+            "repos/o/r/pulls/5/commits": [{"sha": sha_1}],
+            f"repos/o/r/commits/{sha_1}/status": {
+                "state": "failure",
+                "statuses": [{"context": "ci", "state": "failure"}],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        # Dedup happened — pulls/5/commits and the status endpoint
+        # are each called exactly once across two commits.
+        status_calls = [c for c in stub.calls if "/status" in c]
+        assert len(status_calls) == 1

--- a/tests/unit/test_github_signals_ci_failure.py
+++ b/tests/unit/test_github_signals_ci_failure.py
@@ -192,6 +192,10 @@ class TestSignalEmission:
         repo_dir: Path,
         github_repo: GitHubRepo,
     ) -> None:
+        # state=success on legacy status + empty check-runs response =>
+        # no failure, no signal. The check-runs fallback is always
+        # polled when the legacy endpoint reports nothing actionable
+        # (so we can detect Actions-only repos); the test must mock it.
         session_end = datetime.now(UTC) - timedelta(hours=1)
         session = _session(end=session_end, agent_types=["pm"])
         commit_sha = "abc"
@@ -207,6 +211,7 @@ class TestSignalEmission:
             f"repos/o/r/commits/{commit_sha}/status": {
                 "state": "success", "statuses": [],
             },
+            f"repos/o/r/commits/{commit_sha}/check-runs": [],
         }
         monkeypatch.setattr(
             "agentfluent.diagnostics.github_signals.gh_api", stub,
@@ -238,6 +243,8 @@ class TestSignalEmission:
             f"repos/o/r/commits/{sha}/status": {
                 "state": "pending", "statuses": [],
             },
+            # Check-runs fallback also reports nothing.
+            f"repos/o/r/commits/{sha}/check-runs": [],
         }
         monkeypatch.setattr(
             "agentfluent.diagnostics.github_signals.gh_api", stub,
@@ -247,6 +254,97 @@ class TestSignalEmission:
         )
         assert signals == []
         assert degraded is False
+
+    def test_github_actions_check_run_failure_emits_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Modern GitHub Actions case: legacy status returns
+        # state=success with no statuses (because Actions report via
+        # Check Runs, not Statuses). The check-runs fallback finds
+        # the failing run and surfaces a signal. Pre-fix this signal
+        # NEVER fired on Actions-only repos — that's the recall bug
+        # we're closing.
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["general-purpose"])
+        commit_sha = "actions0"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(commit_sha, session_end, "feat: x")])),
+        )
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{commit_sha}/pulls":
+                [{"number": 7, "title": "Actions only PR",
+                  "html_url": "https://github.com/o/r/pull/7"}],
+            "repos/o/r/pulls/7/commits": [{"sha": commit_sha}],
+            f"repos/o/r/commits/{commit_sha}/status": {
+                # The legacy endpoint sees no Statuses-API entries
+                # for an Actions-only repo. state defaults to
+                # "success" with empty statuses[].
+                "state": "success", "statuses": [],
+            },
+            f"repos/o/r/commits/{commit_sha}/check-runs": [
+                {"name": "build (3.12)", "conclusion": "failure"},
+                {"name": "lint", "conclusion": "success"},
+            ],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        sig = signals[0]
+        # Check Runs use the run's `name` field as the context.
+        assert sig.detail["primary_context"] == "build (3.12)"
+        # Conclusion is normalized to "failure" so downstream
+        # consumers see a single vocabulary.
+        assert sig.detail["primary_state"] == "failure"
+
+    def test_check_runs_skipped_when_legacy_reports_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Optimization: when the legacy status endpoint already
+        # reports a failure, the check-runs fallback is NOT polled
+        # (saves one API call per failing PR). Verified by asserting
+        # no check-runs response is required from the stub.
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        sha = "legacy00"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(sha, session_end, "feat")])),
+        )
+        stub = _GhApiStub()
+        # No check-runs entry — would AssertionError if the fallback
+        # were polled.
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 3, "title": "legacy", "html_url": "url"}],
+            "repos/o/r/pulls/3/commits": [{"sha": sha}],
+            f"repos/o/r/commits/{sha}/status": {
+                "state": "failure",
+                "statuses": [{"context": "circleci/build", "state": "failure"}],
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        # The check-runs fallback was NOT called.
+        assert not any("/check-runs" in c for c in stub.calls)
 
     def test_first_commit_outside_window_skipped(
         self,
@@ -377,10 +475,10 @@ class TestRateLimitDegradation:
             ])),
         )
         stub = _GhApiStub()
-        # Rate-limit AFTER the first commits/{sha}/pulls succeeds — but
-        # we want the FIRST call to raise. Configure rate_limit_after=0.
+        # All endpoints are explicit — no catch-all fallback, so the
+        # stub's AssertionError safety net catches any unintended call.
         stub.responses = {
-            "repos/o/r/commits/": [],  # default (won't be hit)
+            f"repos/o/r/commits/{sha_1}/pulls": [],
             f"repos/o/r/commits/{sha_2}/pulls":
                 [{"number": 9, "title": "ok", "html_url": "url"}],
             "repos/o/r/pulls/9/commits": [{"sha": sha_2}],
@@ -389,8 +487,7 @@ class TestRateLimitDegradation:
                 "statuses": [{"context": "ci", "state": "failure"}],
             },
         }
-        # Override the response for sha_1's pulls endpoint to rate-limit.
-        stub.responses[f"repos/o/r/commits/{sha_1}/pulls"] = []
+        # Configure sha_1's pulls endpoint to rate-limit on its first call.
         stub.rate_limit_after[f"repos/o/r/commits/{sha_1}/pulls"] = 0
 
         monkeypatch.setattr(
@@ -451,3 +548,103 @@ class TestDeduplication:
         # are each called exactly once across two commits.
         status_calls = [c for c in stub.calls if "/status" in c]
         assert len(status_calls) == 1
+
+
+class TestRecoverableErrors:
+    """Recoverable gh errors (ValueError on malformed JSON,
+    GhNotInstalledError/GhNotAuthenticatedError on mid-run state
+    change, RuntimeError on transient 5xx) must NOT crash the
+    extractor — they should flip tier3_degraded and let other PRs
+    proceed. Pre-fix, only RateLimitedError and RuntimeError were
+    caught; ValueError + the typed gh exceptions would bubble out
+    and abort the entire diagnostics run."""
+
+    def test_value_error_from_gh_api_is_caught_and_degrades(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        from agentfluent.diagnostics import github_signals
+
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        commit_sha = "valueerr"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (commit_sha, session_end - timedelta(minutes=5), "feat"),
+            ])),
+        )
+
+        def gh_api_raises_value_error(*_args: Any, **_kwargs: Any) -> Any:
+            raise ValueError("non-JSON response from gh api")
+
+        monkeypatch.setattr(github_signals, "gh_api", gh_api_raises_value_error)
+        signals, degraded = github_signals.extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        # No crash. Empty signals, degraded flipped.
+        assert signals == []
+        assert degraded is True
+
+    def test_gh_not_authenticated_mid_run_is_caught_and_degrades(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        from agentfluent.diagnostics import github_signals
+        from agentfluent.github.models import GhNotAuthenticatedError
+
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        commit_sha = "autherr0"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (commit_sha, session_end - timedelta(minutes=5), "feat"),
+            ])),
+        )
+
+        def gh_api_raises_auth(*_args: Any, **_kwargs: Any) -> Any:
+            raise GhNotAuthenticatedError("auth lapsed")
+
+        monkeypatch.setattr(github_signals, "gh_api", gh_api_raises_auth)
+        signals, degraded = github_signals.extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True
+
+    def test_runtime_error_now_flips_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Behavior change from pre-review: RuntimeError used to return
+        # (empty, degraded=False), silently dropping data. It now
+        # contributes to degraded=True so transient 5xxs are visible
+        # to the user via the tier3_degraded flag.
+        from agentfluent.diagnostics import github_signals
+
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end, agent_types=["pm"])
+        commit_sha = "runtime0"
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([
+                (commit_sha, session_end - timedelta(minutes=5), "feat"),
+            ])),
+        )
+
+        def gh_api_raises_runtime(*_args: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError("HTTP 502 Bad Gateway")
+
+        monkeypatch.setattr(github_signals, "gh_api", gh_api_raises_runtime)
+        signals, degraded = github_signals.extract_ci_failure_first_push_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True


### PR DESCRIPTION
## Summary

- First Tier 3 signal on the #399 infrastructure. `extract_ci_failure_first_push_signals` walks each session's commits, looks up PRs touching them via `gh api`, and emits one `CI_FAILURE_FIRST_PUSH` signal per PR whose first commit's combined CI status is `failure`/`error`.
- New shared module `diagnostics/_git_helpers.py` hosts `_run_git_log` / `_parse_commits` / `_GitCommit` so Tier 2 (`git_signals.py`) and Tier 3 (`github_signals.py`) share git infrastructure without cross-tier coupling — folds in the **important** refinement from the [architect's implementation-plan review](https://github.com/frederick-douglas-pearce/agentfluent/issues/400#issuecomment-4549556168).
- `tier3_degraded = False` initialized explicitly in `pipeline.py` and passed as an explicit kwarg to `DiagnosticsResult(...)`, per the architect's **suggestion** to avoid relying on the Pydantic default.

Resolves #400.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m "not integration"\` (1477 passed, +12 new)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage — 8 extractor cases (happy path, success skip, pending skip, attribution skip, early exits, rate-limit degradation, PR dedup) + 4 correlator-rule cases + 14 git_signals regressions after the helper extraction
- [x] Glossary regenerated via \`uv run python scripts/generate_glossary_md.py\` (drift test passes)
- [ ] Manual smoke test via \`uv run agentfluent analyze --github\` against this repo — gated on having a real failing first-push PR; will dogfood once #401 also lands

## Security review
Pick one. (If "Needs review", apply the \`needs-security-review\` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: \`.claude/hooks/\`, secret handling, \`pyproject.toml\`, \`.github/workflows/\`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

Network calls via the \`gh\` CLI (with the #399 wrapper), subprocess invocation (git log), and rendering of user-controlled strings (PR titles in signal messages — pre-escaped via \`!r\` in the correlator observation, but the signal's raw \`detail.pr_title\` is consumer-trusted). Label intentionally NOT applied yet per repo policy — will apply when dev-complete and CI is green.

## Breaking changes

None. Additions are additive: new \`SignalType\` value (downstream consumers iterate the enum), new \`SIGNAL_AXIS_MAP\` entry, new tuple return shape from the extractor (internal), new correlator rule appended to the list. \`DiagnosticsResult.tier3_degraded\` was already present from #399 as \`bool = False\`; this PR is the first producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)