### PR TITLE
feat(diagnostics): #401 — PR_REVIEW_COMMENT_DENSITY Tier 3 signal

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -644,7 +644,7 @@ falls below PARENT_ACTED_HEALTHY_BAND_LOW (0.25).
 
 **Recommendation target:** `subagent`
 
-**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`primary_axis`](#primary_axis)
+**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`pr_review_comment_density`](#pr_review_comment_density), [`primary_axis`](#primary_axis)
 
 ### `feat_fix_proximity`
 
@@ -685,7 +685,57 @@ feat a1b2c3d followed by 2 fixes on shared file(s) within 3d
 
 **Recommendation target:** `subagent`
 
-**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`ci_failure_first_push`](#ci_failure_first_push), [`primary_axis`](#primary_axis)
+**Related:** [`user_correction`](#user_correction), [`file_rework`](#file_rework), [`reviewer_caught`](#reviewer_caught), [`ci_failure_first_push`](#ci_failure_first_push), [`pr_review_comment_density`](#pr_review_comment_density), [`primary_axis`](#primary_axis)
+
+### `pr_review_comment_density`
+
+**Short:** External review comments per line changed exceeded the configured
+threshold — the PR pulled enough human-reviewer effort that an
+agent-side reviewer could plausibly have caught the issues
+pre-PR.
+
+**Detail:** Tier 3 GitHub quality-axis signal (v0.8). Off by default; runs
+only when the CLI passes `--github` (which also requires
+`--diagnostics` and implies `--git`). For each PR touched by an
+analyzed session, AgentFluent fetches the PR detail
+(`/pulls/{N}`) to get `additions + deletions` and the PR author,
+then fetches the inline-review-comment list
+(`/pulls/{N}/comments`). Comments authored by the PR author are
+excluded (self-reviews don't count); the remaining "external"
+inline comments divided by `lines_changed` give the density.
+
+Cross-cutting (`agent_type=None`). Severity branches on density:
+`INFO` at the configured threshold (default 0.1, i.e. 1 comment
+per 10 lines changed), upgraded to `WARNING` at 2x the threshold
+(default 0.2). PRs with fewer than 20 lines changed are
+suppressed regardless of density — a single comment on a 3-line
+PR gives density 0.33, which would fire spuriously without the
+gate.
+
+Endpoint note: `gh api /pulls/{N}/comments` returns the inline
+review-comment list (one entry per file-level comment). The
+related `/pulls/{N}/reviews` endpoint returns review-level
+objects (state, body, user) without per-review inline counts, so
+AgentFluent skips it — counting inline comments directly is the
+cleaner shape for this signal.
+
+Rate-limit handling: if any `gh api` call returns 403/429 with a
+rate-limit signature OR a recoverable gh error (transient 5xx,
+malformed JSON), that PR is skipped and
+`DiagnosticsResult.tier3_degraded` is set to True. Other PRs
+still produce signals; the run still exits 0.
+
+**Example:**
+
+```
+PR #42 ('Add window filter') received 12 external review comments across 80 lines changed (density: 0.15)
+```
+
+**Severity:** info -> warning
+
+**Recommendation target:** `subagent`
+
+**Related:** [`ci_failure_first_push`](#ci_failure_first_push), [`feat_fix_proximity`](#feat_fix_proximity), [`reviewer_caught`](#reviewer_caught), [`primary_axis`](#primary_axis)
 
 ### `ci_failure_first_push`
 
@@ -729,7 +779,7 @@ PR #42 ('Add session window filter') first push failed CI: pytest failure
 
 **Recommendation target:** `subagent`
 
-**Related:** [`feat_fix_proximity`](#feat_fix_proximity), [`primary_axis`](#primary_axis)
+**Related:** [`feat_fix_proximity`](#feat_fix_proximity), [`pr_review_comment_density`](#pr_review_comment_density), [`primary_axis`](#primary_axis)
 
 
 ---

--- a/src/agentfluent/diagnostics/_git_helpers.py
+++ b/src/agentfluent/diagnostics/_git_helpers.py
@@ -66,12 +66,26 @@ class _GitCommit:
     files: frozenset[str] = field(default_factory=frozenset)
 
 
-def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
+def _run_git_log(
+    repo_dir: Path, *, since: datetime,
+) -> tuple[list[_GitCommit], bool]:
     """Run ``git log --since=<since>`` and parse the output.
 
-    Returns ``[]`` on any error: missing git binary, non-repo
-    directory, empty window, timeout, or parse failure. Caller does
-    not need a try/except wrapper.
+    Returns ``(commits, ok)``:
+
+    - ``commits`` is the parsed list (possibly empty when the window
+      is genuinely empty).
+    - ``ok`` is ``True`` when the git subprocess completed
+      successfully (returncode 0), ``False`` on any failure: missing
+      git binary, non-repo directory, timeout, or non-zero exit.
+
+    Pre-fix this returned just the list, conflating "no commits in
+    window" with "git failed entirely" — Tier 3 callers couldn't
+    detect git misconfiguration and reported a clean run with zero
+    signals. The tuple return lets callers (especially
+    :func:`agentfluent.diagnostics.github_signals._enumerate_attributed_prs`)
+    flip ``tier3_degraded`` when git itself is broken vs. when the
+    repo simply has no recent commits.
 
     The subprocess invocation is bounded by :data:`_GIT_TIMEOUT_SEC`
     and uses a fixed-shape ``--format`` that pairs cleanly with
@@ -94,13 +108,13 @@ def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
         )
     except FileNotFoundError:
         logger.debug("git binary not found on PATH; returning empty commit list")
-        return []
+        return [], False
     except subprocess.TimeoutExpired:
         logger.warning(
             "git log timed out after %ds; returning empty commit list",
             _GIT_TIMEOUT_SEC,
         )
-        return []
+        return [], False
 
     if result.returncode != 0:
         # Not a repo, or another git error. Stderr is human-readable
@@ -109,9 +123,9 @@ def _run_git_log(repo_dir: Path, *, since: datetime) -> list[_GitCommit]:
             "git log returned %d: %s",
             result.returncode, result.stderr.strip(),
         )
-        return []
+        return [], False
 
-    return _parse_commits(result.stdout)
+    return _parse_commits(result.stdout), True
 
 
 def _parse_commits(stdout: str) -> list[_GitCommit]:

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -91,6 +91,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.REVIEWER_CAUGHT: Axis.QUALITY,
     SignalType.FEAT_FIX_PROXIMITY: Axis.QUALITY,
     SignalType.CI_FAILURE_FIRST_PUSH: Axis.QUALITY,
+    SignalType.PR_REVIEW_COMMENT_DENSITY: Axis.QUALITY,
 }
 
 # Signal types that carry comparable scalar metrics in ``detail``. Only

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -983,14 +983,20 @@ class PRReviewCommentDensityRule(_QualityRule):
         )
         pr_title = d.get("pr_title") or "(no title)"
         comments = d.get("external_comment_count")
+        comments_disp = (
+            f"{comments}" if isinstance(comments, int) else "(unknown)"
+        )
         lines = d.get("lines_changed")
+        lines_disp = (
+            f"{lines}" if isinstance(lines, int) else "(unknown)"
+        )
         density = d.get("density")
         density_disp = (
             f"{density:.2f}" if isinstance(density, (int, float)) else "?"
         )
         observation = (
-            f"PR {pr_number_disp} ({pr_title!r}) received {comments} review "
-            f"comment(s) across {lines} line(s) changed "
+            f"PR {pr_number_disp} ({pr_title!r}) received {comments_disp} "
+            f"review comment(s) across {lines_disp} line(s) changed "
             f"(density: {density_disp})."
         )
         reason = (

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -954,6 +954,57 @@ class CIFailureFirstPushRule(_QualityRule):
         return observation, reason, action
 
 
+class PRReviewCommentDensityRule(_QualityRule):
+    """PR_REVIEW_COMMENT_DENSITY -> recommend an architect / code-review
+    subagent before opening similar PRs.
+
+    Tier 3 signal (#401). Cross-cutting (``agent_type=None``) because
+    the signal is about a PR's reviewer-effort cost, not a specific
+    subagent's behavior. Recommendation copy nudges the user toward
+    invoking an architect or code-review subagent before opening PRs
+    when this kind of work tends to attract heavy review.
+    """
+
+    SIGNAL_TYPE = SignalType.PR_REVIEW_COMMENT_DENSITY
+
+    def _observation_reason_action(
+        self, signal: DiagnosticSignal,
+    ) -> tuple[str, str, str]:
+        d = signal.detail
+        # All detail keys are populated by the extractor, but the
+        # correlator runs against any DiagnosticSignal carrying this
+        # type — including manually-constructed ones in tests and
+        # future emitters. Guard each access so a malformed signal
+        # still renders a coherent message instead of "PR #None ..."
+        # (parity with CIFailureFirstPushRule's defensive guard).
+        pr_number = d.get("pr_number")
+        pr_number_disp = (
+            f"#{pr_number}" if pr_number is not None else "(unknown)"
+        )
+        pr_title = d.get("pr_title") or "(no title)"
+        comments = d.get("external_comment_count")
+        lines = d.get("lines_changed")
+        density = d.get("density")
+        density_disp = (
+            f"{density:.2f}" if isinstance(density, (int, float)) else "?"
+        )
+        observation = (
+            f"PR {pr_number_disp} ({pr_title!r}) received {comments} review "
+            f"comment(s) across {lines} line(s) changed "
+            f"(density: {density_disp})."
+        )
+        reason = (
+            "High review comment density suggests the code needed "
+            "substantial human review. An architect or code-review "
+            "agent could catch common issues before the PR is opened."
+        )
+        action = (
+            "Consider invoking an architect or code-review agent "
+            "before opening PRs for this type of work."
+        )
+        return observation, reason, action
+
+
 RULES: list[CorrelationRule] = [
     AccessErrorRule(),
     ErrorHandlingRule(),
@@ -971,6 +1022,7 @@ RULES: list[CorrelationRule] = [
     ReviewerCaughtRule(),
     FeatFixProximityRule(),
     CIFailureFirstPushRule(),
+    PRReviewCommentDensityRule(),
 ]
 
 

--- a/src/agentfluent/diagnostics/git_signals.py
+++ b/src/agentfluent/diagnostics/git_signals.py
@@ -127,7 +127,10 @@ def extract_git_quality_signals(
     empty window, timeout). The caller does not need a try/except.
     """
     since = datetime.now().astimezone() - timedelta(days=lookback_days)
-    commits = _run_git_log(repo_dir, since=since)
+    # _run_git_log now returns (commits, ok); Tier 2 silently skips
+    # on either git failure or empty window — the original behavior
+    # is preserved by collapsing both cases to an empty return.
+    commits, _ok = _run_git_log(repo_dir, since=since)
     if not commits:
         return []
 

--- a/src/agentfluent/diagnostics/github_signals.py
+++ b/src/agentfluent/diagnostics/github_signals.py
@@ -79,6 +79,19 @@ _GH_RECOVERABLE: tuple[type[Exception], ...] = (
     GhNotAuthenticatedError,
 )
 
+# PR_REVIEW_COMMENT_DENSITY defaults. All configurable via the
+# public extractor's kwargs.
+#
+# ``density_threshold`` is the floor above which we emit an INFO
+# signal. ``warning_multiplier`` doubles the threshold for the WARNING
+# tier (per the issue body: "INFO ... or WARNING if density is 2x
+# threshold"). ``min_lines_changed`` suppresses noisy small-PR signals
+# (a single comment on a 3-line PR gives density 0.33, which would
+# fire spuriously); the issue body explicitly suggests a 20-line gate.
+DEFAULT_DENSITY_THRESHOLD = 0.1
+DEFAULT_WARNING_MULTIPLIER = 2.0
+DEFAULT_MIN_LINES_CHANGED = 20
+
 
 class _PRRef(NamedTuple):
     """Minimal PR identifier — the fields we need for attribution and
@@ -135,32 +148,17 @@ def extract_ci_failure_first_push_signals(
     ``/commits/{sha}/check-runs`` so Actions-only repos still produce
     signals.
     """
-    since = datetime.now().astimezone() - timedelta(days=lookback_days)
-    commits = _run_git_log(repo_dir, since=since)
-    if not commits:
-        return [], False
-
-    session_windows = _build_session_windows(
-        sessions, slack=commit_slack_seconds,
+    pr_refs, commit_to_session, degraded = _enumerate_attributed_prs(
+        sessions,
+        github_repo=github_repo,
+        repo_dir=repo_dir,
+        no_cache=no_cache,
+        lookback_days=lookback_days,
+        commit_slack_seconds=commit_slack_seconds,
+        signal_name="CI_FAILURE_FIRST_PUSH",
     )
-    if not session_windows:
-        return [], False
-
-    commit_to_session = _attribute_commits(commits, session_windows)
-    if not commit_to_session:
-        return [], False
-
-    degraded = False
-    pr_refs: dict[int, _PRRef] = {}
-    for sha in commit_to_session:
-        result, hit_limit = _fetch_prs_for_commit(
-            github_repo, sha, no_cache=no_cache,
-        )
-        if hit_limit:
-            degraded = True
-            continue
-        for ref in result:
-            pr_refs.setdefault(ref.number, ref)
+    if not pr_refs and not commit_to_session:
+        return [], degraded
 
     signals: list[DiagnosticSignal] = []
     skipped_unattributable = 0
@@ -197,7 +195,7 @@ def extract_ci_failure_first_push_signals(
             continue
         if not failing:
             continue
-        signals.append(_build_signal(ref, first_sha, failing))
+        signals.append(_build_ci_failure_signal(ref, first_sha, failing))
 
     if skipped_unattributable:
         logger.info(
@@ -206,6 +204,110 @@ def extract_ci_failure_first_push_signals(
             "without timestamped messages)",
             skipped_unattributable,
         )
+
+    return signals, degraded
+
+
+def extract_pr_review_comment_density_signals(
+    sessions: list[SessionAnalysis],
+    *,
+    github_repo: GitHubRepo,
+    repo_dir: Path,
+    no_cache: bool = False,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    commit_slack_seconds: int = DEFAULT_COMMIT_SLACK_SEC,
+    density_threshold: float = DEFAULT_DENSITY_THRESHOLD,
+    warning_multiplier: float = DEFAULT_WARNING_MULTIPLIER,
+    min_lines_changed: int = DEFAULT_MIN_LINES_CHANGED,
+) -> tuple[list[DiagnosticSignal], bool]:
+    """Emit one ``PR_REVIEW_COMMENT_DENSITY`` signal per PR where the
+    external review-comment density crosses the threshold.
+
+    "Density" = external inline comments per line changed, where
+    ``lines_changed = additions + deletions``. "External" excludes
+    self-reviews (comments authored by the same user who opened the
+    PR) — the signal measures the reviewer effort an agent-side
+    review subagent could have shortcut, not the author's own
+    self-annotation.
+
+    Severity is ``INFO`` at and above ``density_threshold``,
+    upgraded to ``WARNING`` at ``density_threshold *
+    warning_multiplier``. Below the threshold (or below the
+    ``min_lines_changed`` gate, or with zero external comments) no
+    signal is emitted.
+
+    Returns ``(signals, degraded)``. ``degraded`` is True when at
+    least one ``gh api`` call hit a rate limit or recoverable error
+    (transient 5xx, malformed JSON, mid-run auth lapse); partial
+    signals are still returned (per-extractor degradation policy
+    from the spike spec section 3).
+
+    Endpoint choice: the issue body suggests "use the ``reviews``
+    endpoint which returns both" inline + body comments, but the
+    GitHub API surface disagrees — ``/pulls/{N}/reviews`` returns
+    review-level objects (state, body, user) without per-review
+    inline counts. We use ``/pulls/{N}/comments`` directly for the
+    inline-comment list, plus ``/pulls/{N}`` for size and author.
+    Two API calls per PR, matching the spike's budget estimate.
+    """
+    pr_refs, _commit_to_session, degraded = _enumerate_attributed_prs(
+        sessions,
+        github_repo=github_repo,
+        repo_dir=repo_dir,
+        no_cache=no_cache,
+        lookback_days=lookback_days,
+        commit_slack_seconds=commit_slack_seconds,
+        signal_name="PR_REVIEW_COMMENT_DENSITY",
+    )
+    if not pr_refs:
+        return [], degraded
+
+    signals: list[DiagnosticSignal] = []
+    for ref in pr_refs.values():
+        detail, hit_limit_or_error = _fetch_pr_detail(
+            github_repo, ref.number, no_cache=no_cache,
+        )
+        if hit_limit_or_error:
+            degraded = True
+            continue
+        if detail is None:
+            continue
+        lines_changed = int(detail.get("additions") or 0) + int(
+            detail.get("deletions") or 0,
+        )
+        if lines_changed < min_lines_changed:
+            continue
+        author = str(((detail.get("user") or {}).get("login")) or "")
+
+        external_count, hit_limit_or_error = _fetch_external_comment_count(
+            github_repo, ref.number, author=author, no_cache=no_cache,
+        )
+        if hit_limit_or_error:
+            degraded = True
+            continue
+        if external_count <= 0:
+            continue
+        density = external_count / max(lines_changed, 1)
+        if density < density_threshold:
+            continue
+        # Prefer the freshly-fetched title (the PR-detail call gives
+        # us the current title, while the helper's _PRRef.title may
+        # be stale due to setdefault first-write-wins across multiple
+        # commit/{sha}/pulls responses).
+        title = str(detail.get("title") or ref.title)
+        url = str(detail.get("html_url") or ref.url)
+        signals.append(_build_density_signal(
+            pr_number=ref.number,
+            pr_title=title,
+            pr_url=url,
+            author=author,
+            additions=int(detail.get("additions") or 0),
+            deletions=int(detail.get("deletions") or 0),
+            external_count=external_count,
+            density=density,
+            density_threshold=density_threshold,
+            warning_multiplier=warning_multiplier,
+        ))
 
     return signals, degraded
 
@@ -256,17 +358,95 @@ def _attribute_commits(
     return attributed
 
 
-def _log_rate_limit(e: RateLimitedError) -> None:
+def _enumerate_attributed_prs(
+    sessions: list[SessionAnalysis],
+    *,
+    github_repo: GitHubRepo,
+    repo_dir: Path,
+    no_cache: bool,
+    lookback_days: int,
+    commit_slack_seconds: int,
+    signal_name: str,
+) -> tuple[dict[int, _PRRef], dict[str, int], bool]:
+    """Enumerate PRs touched by sessions in the analysis window.
+
+    Shared first half of every per-PR Tier 3 extractor:
+
+    1. ``git log --since`` to enumerate commits in the lookback window
+       (local; no API call cost).
+    2. Build per-session ``(start, end + slack)`` windows from each
+       session's timestamped messages.
+    3. Attribute commits to sessions by timestamp containment
+       (first-match wins on overlap).
+    4. For each session-attributed commit, fetch the PRs that
+       include it via ``gh api commits/{sha}/pulls`` and dedup by
+       PR number.
+
+    Returns ``(pr_refs, commit_to_session, degraded)``:
+
+    - ``pr_refs`` maps each unique PR number to a minimal
+      :class:`_PRRef`. Empty when no PRs match.
+    - ``commit_to_session`` maps each session-attributed commit SHA
+      to ``id(session)``. Empty when no commits were attributable.
+    - ``degraded`` is True when at least one ``commits/{sha}/pulls``
+      fetch hit a rate limit or recoverable gh error. The caller
+      forwards this to the per-extractor ``degraded`` accumulator.
+
+    ``signal_name`` is forwarded to the per-call log helpers so
+    warnings name the calling signal honestly. Architect note 1 in
+    the #401 implementation-plan review (PR comment) called this
+    out: pre-fix, the rate-limit log message hardcoded
+    ``CI_FAILURE_FIRST_PUSH`` even when triggered by another
+    signal's call path.
+    """
+    since = datetime.now().astimezone() - timedelta(days=lookback_days)
+    commits = _run_git_log(repo_dir, since=since)
+    if not commits:
+        return {}, {}, False
+
+    session_windows = _build_session_windows(
+        sessions, slack=commit_slack_seconds,
+    )
+    if not session_windows:
+        return {}, {}, False
+
+    commit_to_session = _attribute_commits(commits, session_windows)
+    if not commit_to_session:
+        return {}, {}, False
+
+    degraded = False
+    pr_refs: dict[int, _PRRef] = {}
+    for sha in commit_to_session:
+        result, hit_limit = _fetch_prs_for_commit(
+            github_repo, sha, no_cache=no_cache, signal_name=signal_name,
+        )
+        if hit_limit:
+            degraded = True
+            continue
+        for ref in result:
+            pr_refs.setdefault(ref.number, ref)
+    return pr_refs, commit_to_session, degraded
+
+
+def _log_rate_limit(e: RateLimitedError, *, signal_name: str) -> None:
     """Single-source rate-limit WARNING — keeps message format stable
-    across every gh_api call site in this module."""
+    across every ``gh_api`` call site in this module.
+
+    ``signal_name`` is required so the WARNING attribution is honest
+    when shared helpers (``_fetch_prs_for_commit``,
+    ``_enumerate_attributed_prs``) are called from multiple signal
+    extractors. Pre-fix the helper hardcoded ``CI_FAILURE_FIRST_PUSH``,
+    which would silently misattribute the rate-limit to one signal
+    when triggered by another.
+    """
     logger.warning(
-        "CI_FAILURE_FIRST_PUSH rate-limited at %s; resets at %s",
-        e.endpoint, e.reset_at,
+        "%s rate-limited at %s; resets at %s",
+        signal_name, e.endpoint, e.reset_at,
     )
 
 
 def _fetch_prs_for_commit(
-    github_repo: GitHubRepo, sha: str, *, no_cache: bool,
+    github_repo: GitHubRepo, sha: str, *, no_cache: bool, signal_name: str,
 ) -> tuple[list[_PRRef], bool]:
     """Return the PRs that include the given commit SHA.
 
@@ -276,6 +456,13 @@ def _fetch_prs_for_commit(
     auth lapses mid-run). Treating recoverable errors as degradation
     rather than silent skip lets the caller flip ``tier3_degraded``
     so the user knows their results may be incomplete.
+
+    ``signal_name`` is forwarded to log messages so rate-limit /
+    degraded warnings name the correct signal — this helper is
+    shared by every per-PR extractor (via
+    :func:`_enumerate_attributed_prs`), so hardcoding a name would
+    misattribute warnings when one signal's call path triggers a
+    rate limit that affects another.
     """
     endpoint = f"repos/{github_repo.owner}/{github_repo.repo}/commits/{sha}/pulls"
     # Wrap in `[...]` so a multi-PR result lands as a single JSON
@@ -290,12 +477,12 @@ def _fetch_prs_for_commit(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
-        _log_rate_limit(e)
+        _log_rate_limit(e, signal_name=signal_name)
         return [], True
     except _GH_RECOVERABLE as e:
         logger.warning(
-            "commits/%s/pulls failed (%s); marking Tier 3 degraded",
-            sha, type(e).__name__,
+            "%s: commits/%s/pulls failed (%s); marking Tier 3 degraded",
+            signal_name, sha, type(e).__name__,
         )
         return [], True
     if not isinstance(payload, list):
@@ -344,7 +531,7 @@ def _fetch_pr_first_commit_sha(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
-        _log_rate_limit(e)
+        _log_rate_limit(e, signal_name="CI_FAILURE_FIRST_PUSH")
         return None, True
     except _GH_RECOVERABLE as e:
         logger.warning(
@@ -399,7 +586,7 @@ def _fetch_failing_contexts(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
-        _log_rate_limit(e)
+        _log_rate_limit(e, signal_name="CI_FAILURE_FIRST_PUSH")
         return [], True, False
     except _GH_RECOVERABLE as e:
         logger.warning(
@@ -454,7 +641,7 @@ def _fetch_failing_check_runs(
             no_cache=no_cache,
         )
     except RateLimitedError as e:
-        _log_rate_limit(e)
+        _log_rate_limit(e, signal_name="CI_FAILURE_FIRST_PUSH")
         return [], True, False
     except _GH_RECOVERABLE as e:
         logger.warning(
@@ -484,7 +671,7 @@ def _fetch_failing_check_runs(
     return failing, False, False
 
 
-def _build_signal(
+def _build_ci_failure_signal(
     pr: _PRRef,
     first_commit_sha: str,
     failing_contexts: list[dict[str, Any]],
@@ -523,5 +710,168 @@ def _build_signal(
             ],
             "primary_context": primary_context,
             "primary_state": primary_state,
+        },
+    )
+
+
+def _fetch_pr_detail(
+    github_repo: GitHubRepo, pr_number: int, *, no_cache: bool,
+) -> tuple[dict[str, Any] | None, bool]:
+    """Fetch the PR detail object projected to the fields we need.
+
+    Returns ``(detail, hit_limit_or_error)``. ``detail`` is a dict
+    carrying ``additions``, ``deletions``, ``user.login``, ``title``,
+    ``html_url`` — or ``None`` when the projection failed to parse.
+    The boolean covers both rate-limit and recoverable-error paths
+    (the caller flips ``tier3_degraded`` either way).
+    """
+    endpoint = (
+        f"repos/{github_repo.owner}/{github_repo.repo}/pulls/{pr_number}"
+    )
+    jq = "{additions, deletions, user: {login}, title, html_url}"
+    try:
+        payload = gh_api(
+            endpoint,
+            jq_filter=jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
+        )
+    except RateLimitedError as e:
+        _log_rate_limit(e, signal_name="PR_REVIEW_COMMENT_DENSITY")
+        return None, True
+    except _GH_RECOVERABLE as e:
+        logger.warning(
+            "PR_REVIEW_COMMENT_DENSITY: pulls/%d failed (%s); "
+            "marking Tier 3 degraded",
+            pr_number, type(e).__name__,
+        )
+        return None, True
+    if not isinstance(payload, dict):
+        return None, False
+    return payload, False
+
+
+def _fetch_external_comment_count(
+    github_repo: GitHubRepo,
+    pr_number: int,
+    *,
+    author: str,
+    no_cache: bool,
+) -> tuple[int, bool]:
+    """Count inline review comments on a PR, excluding self-reviews.
+
+    The ``author`` parameter is the PR author's GitHub login;
+    comments whose ``user.login`` equals it are filtered out so the
+    density signal measures *external* review effort rather than the
+    author's own self-annotation.
+
+    Empty / unrecognized author (None / empty string) disables the
+    filter — better to count everyone than to silently exclude
+    nobody when we couldn't resolve the author.
+
+    Returns ``(count, hit_limit_or_error)``. The boolean covers both
+    rate-limit and recoverable-error paths.
+    """
+    endpoint = (
+        f"repos/{github_repo.owner}/{github_repo.repo}"
+        f"/pulls/{pr_number}/comments"
+    )
+    jq = "[.[] | {user: {login}}]"
+    try:
+        payload = gh_api(
+            endpoint,
+            jq_filter=jq,
+            cache_ttl=TTL_OPEN_PR_OR_CI,
+            no_cache=no_cache,
+        )
+    except RateLimitedError as e:
+        _log_rate_limit(e, signal_name="PR_REVIEW_COMMENT_DENSITY")
+        return 0, True
+    except _GH_RECOVERABLE as e:
+        logger.warning(
+            "PR_REVIEW_COMMENT_DENSITY: pulls/%d/comments failed (%s); "
+            "marking Tier 3 degraded",
+            pr_number, type(e).__name__,
+        )
+        return 0, True
+    if not isinstance(payload, list):
+        return 0, False
+    count = 0
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        login = str(((item.get("user") or {}).get("login")) or "")
+        if author and login == author:
+            # Self-review: the PR author commenting on their own
+            # diff. The density signal measures EXTERNAL reviewer
+            # effort, so skip.
+            continue
+        count += 1
+    return count, False
+
+
+def _build_density_signal(
+    *,
+    pr_number: int,
+    pr_title: str,
+    pr_url: str,
+    author: str,
+    additions: int,
+    deletions: int,
+    external_count: int,
+    density: float,
+    density_threshold: float,
+    warning_multiplier: float,
+) -> DiagnosticSignal:
+    """Construct one ``PR_REVIEW_COMMENT_DENSITY`` signal.
+
+    ``agent_type=None`` matches the Tier 2 ``FEAT_FIX_PROXIMITY``
+    and Tier 3 ``CI_FAILURE_FIRST_PUSH`` conventions: the signal is
+    cross-cutting (about a PR's reviewer-effort cost), not
+    attributable to a single subagent type. Per-agent attribution
+    can be revisited in v0.8.1+.
+
+    Severity tiers:
+
+    - ``WARNING`` when ``density >= density_threshold * warning_multiplier``
+      — the PR pulled significant reviewer effort, strongly suggesting
+      an architect / code-review subagent could have caught issues
+      pre-PR.
+    - ``INFO`` at or above ``density_threshold`` — the PR pulled
+      enough reviewer effort to be worth noting, but not so much it
+      demands action.
+    """
+    lines_changed = additions + deletions
+    title_disp = pr_title if pr_title else "(no title)"
+    severity = (
+        Severity.WARNING
+        if density >= density_threshold * warning_multiplier
+        else Severity.INFO
+    )
+    comment_word = "comment" if external_count == 1 else "comments"
+    line_word = "line" if lines_changed == 1 else "lines"
+    message = (
+        f"PR #{pr_number} ({title_disp!r}) received {external_count} "
+        f"external review {comment_word} across {lines_changed} "
+        f"{line_word} changed (density: {density:.2f})"
+    )
+    return DiagnosticSignal(
+        signal_type=SignalType.PR_REVIEW_COMMENT_DENSITY,
+        severity=severity,
+        agent_type=None,
+        invocation_id=None,
+        message=message,
+        detail={
+            "pr_number": pr_number,
+            "pr_title": pr_title,
+            "pr_url": pr_url,
+            "author": author,
+            "additions": additions,
+            "deletions": deletions,
+            "lines_changed": lines_changed,
+            "external_comment_count": external_count,
+            "density": density,
+            "threshold": density_threshold,
+            "warning_multiplier": warning_multiplier,
         },
     )

--- a/src/agentfluent/diagnostics/github_signals.py
+++ b/src/agentfluent/diagnostics/github_signals.py
@@ -250,6 +250,17 @@ def extract_pr_review_comment_density_signals(
     inline-comment list, plus ``/pulls/{N}`` for size and author.
     Two API calls per PR, matching the spike's budget estimate.
     """
+    # Input validation. The defaults are safe, but a programmatic
+    # caller (or future CLI override) passing degenerate values
+    # would silently break severity tiering — every PR with one
+    # external comment would emit at WARNING. Fail loudly instead.
+    if density_threshold <= 0:
+        raise ValueError(
+            f"density_threshold must be > 0 (got {density_threshold}); "
+            "a non-positive threshold disables severity tiering "
+            "and fires WARNING on every external comment",
+        )
+
     pr_refs, _commit_to_session, degraded = _enumerate_attributed_prs(
         sessions,
         github_repo=github_repo,
@@ -263,53 +274,216 @@ def extract_pr_review_comment_density_signals(
         return [], degraded
 
     signals: list[DiagnosticSignal] = []
+    # Skip-reason counters for end-of-extractor observability. CI's
+    # extractor logs ``skipped_unattributable``; the density signal
+    # has more failure modes (gate / no-author / no-external /
+    # below-threshold) and operators tuning the threshold need to
+    # see how many PRs each gate dropped to interpret a zero-signal
+    # run. Without these counters, debugging a "why didn't this PR
+    # fire?" question requires bisecting the gates by inspection.
+    skipped_no_detail = 0
+    skipped_below_gate = 0
+    skipped_no_author = 0
+    skipped_no_external = 0
+    skipped_below_threshold = 0
     for ref in pr_refs.values():
-        detail, hit_limit_or_error = _fetch_pr_detail(
-            github_repo, ref.number, no_cache=no_cache,
-        )
-        if hit_limit_or_error:
+        # Per-PR try/except: a malformed payload (KeyError /
+        # ValueError / AttributeError post-gh_api) on one PR must not
+        # destroy the signals computed for prior PRs in the loop.
+        # The outer pipeline's broad except still catches anything
+        # we miss, but isolating per-PR limits blast radius to one
+        # signal instead of the whole extractor.
+        try:
+            sig = _build_density_signal_for_pr(
+                ref,
+                github_repo=github_repo,
+                no_cache=no_cache,
+                density_threshold=density_threshold,
+                warning_multiplier=warning_multiplier,
+                min_lines_changed=min_lines_changed,
+            )
+        except (KeyError, ValueError, AttributeError, TypeError) as e:
+            logger.warning(
+                "PR_REVIEW_COMMENT_DENSITY: malformed payload for PR #%d "
+                "(%s); marking Tier 3 degraded",
+                ref.number, type(e).__name__,
+            )
             degraded = True
             continue
-        if detail is None:
+        if sig is _PR_SKIPPED_DEGRADED:
+            degraded = True
             continue
-        lines_changed = int(detail.get("additions") or 0) + int(
-            detail.get("deletions") or 0,
-        )
-        if lines_changed < min_lines_changed:
+        if sig is _PR_SKIPPED_NO_DETAIL:
+            skipped_no_detail += 1
             continue
-        author = str(((detail.get("user") or {}).get("login")) or "")
+        if sig is _PR_SKIPPED_BELOW_GATE:
+            skipped_below_gate += 1
+            continue
+        if sig is _PR_SKIPPED_NO_AUTHOR:
+            skipped_no_author += 1
+            continue
+        if sig is _PR_SKIPPED_NO_EXTERNAL:
+            skipped_no_external += 1
+            continue
+        if sig is _PR_SKIPPED_BELOW_THRESHOLD:
+            skipped_below_threshold += 1
+            continue
+        if isinstance(sig, DiagnosticSignal):
+            signals.append(sig)
 
-        external_count, hit_limit_or_error = _fetch_external_comment_count(
-            github_repo, ref.number, author=author, no_cache=no_cache,
+    if any((
+        skipped_no_detail, skipped_below_gate, skipped_no_author,
+        skipped_no_external, skipped_below_threshold,
+    )):
+        logger.info(
+            "PR_REVIEW_COMMENT_DENSITY: skipped PRs by reason — "
+            "no_detail=%d, below_lines_gate=%d, no_author=%d, "
+            "no_external_comments=%d, below_density_threshold=%d",
+            skipped_no_detail, skipped_below_gate, skipped_no_author,
+            skipped_no_external, skipped_below_threshold,
         )
-        if hit_limit_or_error:
-            degraded = True
-            continue
-        if external_count <= 0:
-            continue
-        density = external_count / max(lines_changed, 1)
-        if density < density_threshold:
-            continue
-        # Prefer the freshly-fetched title (the PR-detail call gives
-        # us the current title, while the helper's _PRRef.title may
-        # be stale due to setdefault first-write-wins across multiple
-        # commit/{sha}/pulls responses).
-        title = str(detail.get("title") or ref.title)
-        url = str(detail.get("html_url") or ref.url)
-        signals.append(_build_density_signal(
-            pr_number=ref.number,
-            pr_title=title,
-            pr_url=url,
-            author=author,
-            additions=int(detail.get("additions") or 0),
-            deletions=int(detail.get("deletions") or 0),
-            external_count=external_count,
-            density=density,
-            density_threshold=density_threshold,
-            warning_multiplier=warning_multiplier,
-        ))
 
     return signals, degraded
+
+
+# Sentinel return values from :func:`_build_density_signal_for_pr`
+# distinguishing skip reasons from a real signal. Using object()
+# sentinels keeps the per-PR function's return type compact (no
+# tuple gymnastics) while letting the caller increment the right
+# counter. ``_PR_SKIPPED_DEGRADED`` is distinct so the caller flips
+# tier3_degraded; the others are clean skips.
+_PR_SKIPPED_DEGRADED = object()
+_PR_SKIPPED_NO_DETAIL = object()
+_PR_SKIPPED_BELOW_GATE = object()
+_PR_SKIPPED_NO_AUTHOR = object()
+_PR_SKIPPED_NO_EXTERNAL = object()
+_PR_SKIPPED_BELOW_THRESHOLD = object()
+
+
+def _build_density_signal_for_pr(
+    ref: _PRRef,
+    *,
+    github_repo: GitHubRepo,
+    no_cache: bool,
+    density_threshold: float,
+    warning_multiplier: float,
+    min_lines_changed: int,
+) -> DiagnosticSignal | object:
+    """Evaluate one PR for the density signal; return either a
+    :class:`DiagnosticSignal` or one of the ``_PR_SKIPPED_*`` /
+    ``_PR_SKIPPED_DEGRADED`` sentinels so the caller can attribute
+    skip reasons for the end-of-extractor observability log.
+
+    Extracted from :func:`extract_pr_review_comment_density_signals`
+    so the per-PR try/except (which catches KeyError /
+    AttributeError / TypeError / ValueError) wraps a single
+    function call rather than the entire per-PR body — keeps the
+    error-isolation point obvious and the counter accumulation
+    branching shallow.
+    """
+    detail, hit_limit_or_error = _fetch_pr_detail(
+        github_repo, ref.number, no_cache=no_cache,
+    )
+    if hit_limit_or_error:
+        return _PR_SKIPPED_DEGRADED
+    if not isinstance(detail, dict):
+        return _PR_SKIPPED_NO_DETAIL
+
+    lines_changed = _safe_int(detail.get("additions")) + _safe_int(
+        detail.get("deletions"),
+    )
+    # Two-step gate. ``min_lines_changed`` is the user-configurable
+    # noise floor; ``lines_changed == 0`` is an absolute math guard
+    # (avoids the misleading ``count / max(0, 1) = count`` result for
+    # pure-merge / pure-revert PRs when a caller sets
+    # ``min_lines_changed=0``).
+    if lines_changed == 0:
+        return _PR_SKIPPED_BELOW_GATE
+    if lines_changed < min_lines_changed:
+        return _PR_SKIPPED_BELOW_GATE
+
+    user_obj = detail.get("user")
+    author = ""
+    if isinstance(user_obj, dict):
+        login = user_obj.get("login")
+        if isinstance(login, str):
+            author = login
+    if not author:
+        # We need the PR author to filter self-reviews; without it
+        # the signal would either silently count the author's own
+        # comments as external (over-firing) or be unable to
+        # distinguish at all. Skip is the right call — the docstring
+        # promises the signal measures EXTERNAL reviewer effort.
+        return _PR_SKIPPED_NO_AUTHOR
+
+    external_count, hit_limit_or_error = _fetch_external_comment_count(
+        github_repo, ref.number, author=author, no_cache=no_cache,
+    )
+    if hit_limit_or_error:
+        return _PR_SKIPPED_DEGRADED
+    if external_count <= 0:
+        return _PR_SKIPPED_NO_EXTERNAL
+
+    density = external_count / lines_changed
+    if density < density_threshold:
+        return _PR_SKIPPED_BELOW_THRESHOLD
+
+    # Title refresh: use the freshly-fetched title when the PR-detail
+    # call actually returned one (use explicit key+truthiness check
+    # rather than ``or`` so a genuinely empty detail title doesn't
+    # silently fall through to the stale ``ref.title``).
+    raw_title = detail.get("title")
+    if isinstance(raw_title, str) and raw_title:
+        title = raw_title
+    else:
+        title = ref.title
+    raw_url = detail.get("html_url")
+    if isinstance(raw_url, str) and raw_url:
+        url = raw_url
+    else:
+        url = ref.url
+    return _build_density_signal(
+        pr_number=ref.number,
+        pr_title=title,
+        pr_url=url,
+        author=author,
+        additions=_safe_int(detail.get("additions")),
+        deletions=_safe_int(detail.get("deletions")),
+        external_count=external_count,
+        density=density,
+        density_threshold=density_threshold,
+        warning_multiplier=warning_multiplier,
+    )
+
+
+def _safe_int(value: Any) -> int:
+    """Coerce a JSON-derived value to int, returning 0 on anything
+    that can't be coerced cleanly. Tolerates int, float, str (digit),
+    bool, and None; rejects exotic shapes (list, dict, non-digit
+    string) by returning 0 rather than raising. The bool case maps
+    True→1 / False→0, matching ``int()`` semantics, which is safe
+    because GitHub never returns bool for these numeric fields.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        # Must come before ``isinstance(value, int)`` because
+        # bool subclasses int in Python.
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                # "42.5" → 42 (truncate; matches int(float(...)))
+                return int(float(value))
+            except ValueError:
+                return 0
+    return 0
 
 
 def _build_session_windows(
@@ -400,7 +574,20 @@ def _enumerate_attributed_prs(
     signal's call path.
     """
     since = datetime.now().astimezone() - timedelta(days=lookback_days)
-    commits = _run_git_log(repo_dir, since=since)
+    commits, git_ok = _run_git_log(repo_dir, since=since)
+    if not git_ok:
+        # git subprocess failed (missing binary, timeout, non-repo
+        # dir). Pre-fix this returned ({}, {}, False) and the
+        # extractor reported a clean run with zero signals; users
+        # had no way to tell their Tier 3 setup was misconfigured.
+        # Flip degraded so the table-formatter banner and JSON
+        # envelope surface the failure.
+        logger.warning(
+            "%s: git log failed in %s; marking Tier 3 degraded "
+            "(install git, check repo, or use --repo OWNER/NAME)",
+            signal_name, repo_dir,
+        )
+        return {}, {}, True
     if not commits:
         return {}, {}, False
 
@@ -486,9 +673,20 @@ def _fetch_prs_for_commit(
         )
         return [], True
     if not isinstance(payload, list):
-        return [], False
+        # Malformed response — gh succeeded but the shape isn't a
+        # list when we expected one. Treat as degraded so the user
+        # sees that data was lost, rather than silently dropping
+        # this SHA's PRs.
+        logger.warning(
+            "%s: commits/%s/pulls returned non-list payload; "
+            "marking Tier 3 degraded",
+            signal_name, sha,
+        )
+        return [], True
     refs: list[_PRRef] = []
     for item in payload:
+        if not isinstance(item, dict):
+            continue
         try:
             refs.append(_PRRef(
                 number=int(item["number"]),
@@ -539,12 +737,41 @@ def _fetch_pr_first_commit_sha(
             pr_number, type(e).__name__,
         )
         return None, True
-    if not isinstance(commits_payload, list) or not commits_payload:
-        return None, False
-    try:
-        return str(commits_payload[0]["sha"]), False
-    except (KeyError, TypeError):
-        return None, False
+    if not isinstance(commits_payload, list):
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH: pulls/%d/commits returned non-list "
+            "payload; marking Tier 3 degraded",
+            pr_number,
+        )
+        return None, True
+    if not commits_payload:
+        # An empty commit list for a real PR is structurally
+        # malformed (every PR has at least one commit by definition).
+        # Treat as degraded — the alternative is silently dropping
+        # the PR with no signal to the user that something is off.
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH: pulls/%d/commits returned empty; "
+            "marking Tier 3 degraded",
+            pr_number,
+        )
+        return None, True
+    first = commits_payload[0]
+    if not isinstance(first, dict):
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH: pulls/%d/commits[0] is not a dict; "
+            "marking Tier 3 degraded",
+            pr_number,
+        )
+        return None, True
+    sha = first.get("sha")
+    if not isinstance(sha, str) or not sha:
+        logger.warning(
+            "CI_FAILURE_FIRST_PUSH: pulls/%d/commits[0].sha missing; "
+            "marking Tier 3 degraded",
+            pr_number,
+        )
+        return None, True
+    return sha, False
 
 
 def _fetch_failing_contexts(
@@ -597,7 +824,8 @@ def _fetch_failing_contexts(
 
     if isinstance(status_payload, dict):
         combined = status_payload.get("state")
-        statuses = status_payload.get("statuses") or []
+        statuses_raw = status_payload.get("statuses") or []
+        statuses = [s for s in statuses_raw if isinstance(s, dict)]
         if combined in _CI_FAILURE_STATES:
             failing = [
                 {"context": str(s.get("context") or ""),
@@ -747,8 +975,28 @@ def _fetch_pr_detail(
         )
         return None, True
     if not isinstance(payload, dict):
-        return None, False
+        logger.warning(
+            "PR_REVIEW_COMMENT_DENSITY: pulls/%d returned non-dict "
+            "payload; marking Tier 3 degraded",
+            pr_number,
+        )
+        return None, True
     return payload, False
+
+
+# Max page size accepted by GitHub for list endpoints. Bumping from
+# the default 30 to 100 covers the vast majority of PRs in a single
+# call; the explicit page-cursor loop below handles the remainder.
+_GH_PER_PAGE_MAX = 100
+
+# Pagination ceiling per PR. Each page is one cached API call; even
+# 100 pages × 100 comments = 10,000 inline comments per PR is far
+# beyond any realistic review effort. The cap prevents a degenerate
+# response (server keeps returning a non-empty page indefinitely)
+# from spinning forever and exhausting the rate-limit budget. A PR
+# that legitimately exceeds it would have its tail truncated; the
+# WARNING surfaces the truncation to the operator.
+_COMMENT_PAGE_CAP = 100
 
 
 def _fetch_external_comment_count(
@@ -761,52 +1009,107 @@ def _fetch_external_comment_count(
     """Count inline review comments on a PR, excluding self-reviews.
 
     The ``author`` parameter is the PR author's GitHub login;
-    comments whose ``user.login`` equals it are filtered out so the
-    density signal measures *external* review effort rather than the
-    author's own self-annotation.
+    comments whose ``user.login`` matches (case-insensitive — GitHub
+    logins are case-insensitive in practice, so a payload returning
+    ``"Bob"`` and a comment by ``"bob"`` refer to the same person)
+    are filtered out so the density signal measures *external*
+    review effort rather than the author's own self-annotation.
 
-    Empty / unrecognized author (None / empty string) disables the
-    filter — better to count everyone than to silently exclude
-    nobody when we couldn't resolve the author.
+    Pre-fix the helper had three correctness gaps the
+    code-review pass surfaced:
 
-    Returns ``(count, hit_limit_or_error)``. The boolean covers both
-    rate-limit and recoverable-error paths.
+    1. **No pagination** — gh's default 30-per-page cap silently
+       truncated heavily-reviewed PRs (the signal's primary
+       targets). Fixed by looping pages with ``per_page=100`` until
+       a partial page is returned.
+    2. **Case-sensitive comparison** — ``"alice" == "Alice"`` was
+       False, letting self-reviews escape. Fixed by ``casefold()``.
+    3. **Non-dict ``item['user']`` raised AttributeError** that
+       escaped ``_GH_RECOVERABLE`` and crashed the whole extractor.
+       Fixed by explicit ``isinstance(user_obj, dict)`` guard.
+
+    Returns ``(count, hit_limit_or_error)``. The boolean covers
+    rate-limit, recoverable gh error, and malformed-payload paths
+    so the caller flips ``tier3_degraded`` instead of silently
+    dropping data.
     """
     endpoint = (
         f"repos/{github_repo.owner}/{github_repo.repo}"
         f"/pulls/{pr_number}/comments"
     )
     jq = "[.[] | {user: {login}}]"
-    try:
-        payload = gh_api(
-            endpoint,
-            jq_filter=jq,
-            cache_ttl=TTL_OPEN_PR_OR_CI,
-            no_cache=no_cache,
-        )
-    except RateLimitedError as e:
-        _log_rate_limit(e, signal_name="PR_REVIEW_COMMENT_DENSITY")
-        return 0, True
-    except _GH_RECOVERABLE as e:
-        logger.warning(
-            "PR_REVIEW_COMMENT_DENSITY: pulls/%d/comments failed (%s); "
-            "marking Tier 3 degraded",
-            pr_number, type(e).__name__,
-        )
-        return 0, True
-    if not isinstance(payload, list):
-        return 0, False
+    # Normalize author once for case-insensitive comparison.
+    author_cf = author.casefold() if author else ""
     count = 0
-    for item in payload:
-        if not isinstance(item, dict):
-            continue
-        login = str(((item.get("user") or {}).get("login")) or "")
-        if author and login == author:
-            # Self-review: the PR author commenting on their own
-            # diff. The density signal measures EXTERNAL reviewer
-            # effort, so skip.
-            continue
-        count += 1
+    for page in range(1, _COMMENT_PAGE_CAP + 1):
+        try:
+            payload = gh_api(
+                endpoint,
+                jq_filter=jq,
+                cache_ttl=TTL_OPEN_PR_OR_CI,
+                no_cache=no_cache,
+                query_params={
+                    "per_page": str(_GH_PER_PAGE_MAX),
+                    "page": str(page),
+                },
+            )
+        except RateLimitedError as e:
+            _log_rate_limit(e, signal_name="PR_REVIEW_COMMENT_DENSITY")
+            return count, True
+        except _GH_RECOVERABLE as e:
+            logger.warning(
+                "PR_REVIEW_COMMENT_DENSITY: pulls/%d/comments "
+                "page=%d failed (%s); marking Tier 3 degraded",
+                pr_number, page, type(e).__name__,
+            )
+            return count, True
+        if not isinstance(payload, list):
+            logger.warning(
+                "PR_REVIEW_COMMENT_DENSITY: pulls/%d/comments "
+                "page=%d returned non-list payload; marking "
+                "Tier 3 degraded",
+                pr_number, page,
+            )
+            return count, True
+        if not payload:
+            break
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            # ``user`` can be a dict, None, or (in pathological
+            # responses) a non-dict scalar. The explicit isinstance
+            # guard prevents AttributeError when a string slipped
+            # through; that error would otherwise escape
+            # ``_GH_RECOVERABLE`` and crash the whole extractor
+            # (losing all later PRs' signals).
+            user_obj = item.get("user")
+            if not isinstance(user_obj, dict):
+                # Malformed-comment shape. Count as external — the
+                # alternative (skip) would systematically under-count
+                # when GitHub anonymizes deleted users.
+                count += 1
+                continue
+            login_raw = user_obj.get("login")
+            login = (
+                login_raw.casefold()
+                if isinstance(login_raw, str)
+                else ""
+            )
+            if author_cf and login == author_cf:
+                # Self-review: the PR author commenting on their own
+                # diff (case-insensitive). The density signal
+                # measures EXTERNAL reviewer effort, so skip.
+                continue
+            count += 1
+        # Partial page = no more results to fetch.
+        if len(payload) < _GH_PER_PAGE_MAX:
+            break
+    else:
+        logger.warning(
+            "PR_REVIEW_COMMENT_DENSITY: pulls/%d/comments hit "
+            "pagination cap (%d pages × %d items); truncating",
+            pr_number, _COMMENT_PAGE_CAP, _GH_PER_PAGE_MAX,
+        )
     return count, False
 
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -73,6 +73,7 @@ class SignalType(StrEnum):
     Tier 3 GitHub quality signals (extracted via `gh api`, opt-in
     via `--github`):
     - `CI_FAILURE_FIRST_PUSH`
+    - `PR_REVIEW_COMMENT_DENSITY`
     """
 
     ERROR_PATTERN = "error_pattern"
@@ -91,6 +92,7 @@ class SignalType(StrEnum):
     REVIEWER_CAUGHT = "reviewer_caught"
     FEAT_FIX_PROXIMITY = "feat_fix_proximity"
     CI_FAILURE_FIRST_PUSH = "ci_failure_first_push"
+    PR_REVIEW_COMMENT_DENSITY = "pr_review_comment_density"
 
 
 # Signal types emitted by the trace-level extractor. Used by the dedup

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -41,6 +41,7 @@ from agentfluent.diagnostics.delegation import (
 from agentfluent.diagnostics.git_signals import extract_git_quality_signals
 from agentfluent.diagnostics.github_signals import (
     extract_ci_failure_first_push_signals,
+    extract_pr_review_comment_density_signals,
 )
 from agentfluent.diagnostics.mcp_assessment import (
     McpToolCall,
@@ -346,6 +347,26 @@ def run_diagnostics(
         else:
             signals.extend(ci_signals)
             tier3_degraded = tier3_degraded or ci_degraded
+
+        try:
+            density_signals, density_degraded = (
+                extract_pr_review_comment_density_signals(
+                    sessions,
+                    github_repo=github_repo,
+                    repo_dir=git_repo,
+                    no_cache=github_no_cache,
+                )
+            )
+        except Exception:  # noqa: BLE001 — never let a Tier 3 bug crash diagnostics
+            logger.warning(
+                "PR_REVIEW_COMMENT_DENSITY extractor crashed; "
+                "marking Tier 3 degraded and continuing",
+                exc_info=True,
+            )
+            tier3_degraded = True
+        else:
+            signals.extend(density_signals)
+            tier3_degraded = tier3_degraded or density_degraded
     elif github_repo is not None:
         # User passed --github but a prerequisite is missing (e.g.,
         # ``resolve_project_disk_path`` returned None, or a

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -483,7 +483,7 @@
     Severity escalates from INFO to WARNING when parent_acted_rate
     falls below PARENT_ACTED_HEALTHY_BAND_LOW (0.25).
   recommendation_target: subagent
-  related: [user_correction, file_rework, primary_axis]
+  related: [user_correction, file_rework, pr_review_comment_density, primary_axis]
 
 - name: feat_fix_proximity
   category: signal_type
@@ -517,7 +517,50 @@
   example: "feat a1b2c3d followed by 2 fixes on shared file(s) within 3d"
   severity_range: info -> warning
   recommendation_target: subagent
-  related: [user_correction, file_rework, reviewer_caught, ci_failure_first_push, primary_axis]
+  related: [user_correction, file_rework, reviewer_caught, ci_failure_first_push, pr_review_comment_density, primary_axis]
+
+- name: pr_review_comment_density
+  category: signal_type
+  short: |
+    External review comments per line changed exceeded the configured
+    threshold — the PR pulled enough human-reviewer effort that an
+    agent-side reviewer could plausibly have caught the issues
+    pre-PR.
+  long: |
+    Tier 3 GitHub quality-axis signal (v0.8). Off by default; runs
+    only when the CLI passes `--github` (which also requires
+    `--diagnostics` and implies `--git`). For each PR touched by an
+    analyzed session, AgentFluent fetches the PR detail
+    (`/pulls/{N}`) to get `additions + deletions` and the PR author,
+    then fetches the inline-review-comment list
+    (`/pulls/{N}/comments`). Comments authored by the PR author are
+    excluded (self-reviews don't count); the remaining "external"
+    inline comments divided by `lines_changed` give the density.
+
+    Cross-cutting (`agent_type=None`). Severity branches on density:
+    `INFO` at the configured threshold (default 0.1, i.e. 1 comment
+    per 10 lines changed), upgraded to `WARNING` at 2x the threshold
+    (default 0.2). PRs with fewer than 20 lines changed are
+    suppressed regardless of density — a single comment on a 3-line
+    PR gives density 0.33, which would fire spuriously without the
+    gate.
+
+    Endpoint note: `gh api /pulls/{N}/comments` returns the inline
+    review-comment list (one entry per file-level comment). The
+    related `/pulls/{N}/reviews` endpoint returns review-level
+    objects (state, body, user) without per-review inline counts, so
+    AgentFluent skips it — counting inline comments directly is the
+    cleaner shape for this signal.
+
+    Rate-limit handling: if any `gh api` call returns 403/429 with a
+    rate-limit signature OR a recoverable gh error (transient 5xx,
+    malformed JSON), that PR is skipped and
+    `DiagnosticsResult.tier3_degraded` is set to True. Other PRs
+    still produce signals; the run still exits 0.
+  example: "PR #42 ('Add window filter') received 12 external review comments across 80 lines changed (density: 0.15)"
+  severity_range: info -> warning
+  recommendation_target: subagent
+  related: [ci_failure_first_push, feat_fix_proximity, reviewer_caught, primary_axis]
 
 - name: ci_failure_first_push
   category: signal_type
@@ -554,7 +597,7 @@
   example: "PR #42 ('Add session window filter') first push failed CI: pytest failure"
   severity_range: warning
   recommendation_target: subagent
-  related: [feat_fix_proximity, primary_axis]
+  related: [feat_fix_proximity, pr_review_comment_density, primary_axis]
 
 # =============================================================================
 # Severity

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -1022,6 +1022,32 @@ class TestPRReviewCommentDensityRule:
         assert len(recs) == 1
         assert "density: ?" in recs[0].message
 
+    def test_missing_comments_and_lines_render_unknown_sentinels(self) -> None:
+        # Defensive guards must cover comments AND lines too —
+        # pre-fix only density and pr_number had sentinels, so a
+        # signal missing both rendered 'received None review
+        # comment(s) across None line(s) changed' (literal None
+        # in the observation text).
+        sig = DiagnosticSignal(
+            signal_type=SignalType.PR_REVIEW_COMMENT_DENSITY,
+            severity=Severity.INFO,
+            agent_type=None,
+            invocation_id=None,
+            message="malformed",
+            detail={
+                "pr_number": 1,
+                "pr_title": "x",
+                # No external_comment_count, no lines_changed.
+                "density": 0.15,
+            },
+        )
+        recs = correlate([sig])
+        assert len(recs) == 1
+        msg = recs[0].message
+        assert "None" not in msg
+        assert "(unknown) review comment(s)" in msg
+        assert "(unknown) line(s) changed" in msg
+
 
 class TestRelpath:
     """``_relpath`` rewrites ``$HOME`` to ``~`` in message text (#340)."""

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -917,6 +917,112 @@ class TestCIFailureFirstPushRule:
         assert "(unknown)" in recs[0].message
 
 
+class TestPRReviewCommentDensityRule:
+    """PR_REVIEW_COMMENT_DENSITY -> cross-cutting subagent-target
+    recommendation; surfaces density, comment count, line count, and
+    PR number in the observation text."""
+
+    @staticmethod
+    def _signal(
+        pr_number: int = 42,
+        pr_title: str = "Add window filter",
+        external_comment_count: int = 12,
+        lines_changed: int = 80,
+        density: float = 0.15,
+        severity: Severity = Severity.INFO,
+    ) -> DiagnosticSignal:
+        return DiagnosticSignal(
+            signal_type=SignalType.PR_REVIEW_COMMENT_DENSITY,
+            severity=severity,
+            agent_type=None,
+            invocation_id=None,
+            message=(
+                f"PR #{pr_number} ({pr_title!r}) received "
+                f"{external_comment_count} external review comments "
+                f"across {lines_changed} lines changed "
+                f"(density: {density:.2f})"
+            ),
+            detail={
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_url": f"https://github.com/o/r/pull/{pr_number}",
+                "author": "bob",
+                "additions": 40,
+                "deletions": 40,
+                "lines_changed": lines_changed,
+                "external_comment_count": external_comment_count,
+                "density": density,
+                "threshold": 0.1,
+                "warning_multiplier": 2.0,
+            },
+        )
+
+    def test_emits_subagent_target(self) -> None:
+        recs = correlate([self._signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "subagent"
+        assert rec.signal_types == [SignalType.PR_REVIEW_COMMENT_DENSITY]
+
+    def test_pr_number_density_and_counts_in_observation(self) -> None:
+        recs = correlate([self._signal(
+            pr_number=99, external_comment_count=18, lines_changed=60,
+            density=0.30,
+        )])
+        msg = recs[0].message
+        assert "#99" in msg
+        assert "18" in msg
+        assert "60" in msg
+        # Density rendered with 2 decimal places.
+        assert "0.30" in msg
+
+    def test_action_mentions_architect_or_code_review(self) -> None:
+        recs = correlate([self._signal()])
+        action = recs[0].action.lower()
+        assert "architect" in action or "code-review" in action
+
+    def test_missing_pr_number_renders_unknown_sentinel(self) -> None:
+        sig = DiagnosticSignal(
+            signal_type=SignalType.PR_REVIEW_COMMENT_DENSITY,
+            severity=Severity.INFO,
+            agent_type=None,
+            invocation_id=None,
+            message="malformed",
+            detail={
+                # No pr_number.
+                "pr_title": "x",
+                "external_comment_count": 5,
+                "lines_changed": 30,
+                "density": 0.17,
+            },
+        )
+        recs = correlate([sig])
+        assert len(recs) == 1
+        assert "#None" not in recs[0].message
+        assert "(unknown)" in recs[0].message
+
+    def test_missing_density_renders_question_sentinel(self) -> None:
+        # If density is missing, the f-string would otherwise crash
+        # with TypeError on `.2f` formatting. Defensive guard.
+        sig = DiagnosticSignal(
+            signal_type=SignalType.PR_REVIEW_COMMENT_DENSITY,
+            severity=Severity.INFO,
+            agent_type=None,
+            invocation_id=None,
+            message="malformed",
+            detail={
+                "pr_number": 1,
+                "pr_title": "x",
+                "external_comment_count": 5,
+                "lines_changed": 30,
+                # No density key.
+            },
+        )
+        recs = correlate([sig])
+        assert len(recs) == 1
+        assert "density: ?" in recs[0].message
+
+
 class TestRelpath:
     """``_relpath`` rewrites ``$HOME`` to ``~`` in message text (#340)."""
 

--- a/tests/unit/test_github_signals_density.py
+++ b/tests/unit/test_github_signals_density.py
@@ -83,20 +83,41 @@ def _completed(stdout: str = "", returncode: int = 0) -> Any:
 
 
 class _GhApiStub:
-    """Same prefix-match-with-AssertionError-on-unknown stub as #400's
-    test file. Longest-prefix wins so a specific PR endpoint shadows
-    a shorter catch-all (intentionally we use no catch-alls)."""
+    """Prefix-match endpoint stub with paging support.
+
+    - ``responses[prefix]``: single canned response returned for every
+      call matching ``prefix``.
+    - ``paged_responses[prefix]``: list of per-page payloads consumed
+      in order; the stub inspects the ``query_params['page']`` kwarg
+      to disambiguate. After all pages are returned, subsequent
+      calls return ``[]`` (signals end-of-pagination).
+    - ``rate_limit_after[prefix]``: raise ``RateLimitedError`` after
+      this many calls have matched ``prefix``.
+    - ``calls`` / ``call_kwargs``: per-call audit log so tests can
+      assert pagination/query params reached ``gh_api``.
+
+    Longest-prefix wins for both response tables (a more specific
+    endpoint shadows a less specific one).
+    """
 
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.call_kwargs: list[dict[str, Any]] = []
         self.responses: dict[str, Any] = {}
+        self.paged_responses: dict[str, list[Any]] = {}
         self.rate_limit_after: dict[str, int] = {}
         self._counts: dict[str, int] = {}
+        self._page_indices: dict[str, int] = {}
 
-    def __call__(self, endpoint: str, **_kwargs: Any) -> Any:
+    def __call__(self, endpoint: str, **kwargs: Any) -> Any:
         self.calls.append(endpoint)
+        self.call_kwargs.append(kwargs)
+        # Longest-prefix match across both response tables, so a
+        # paged_responses key that exactly matches an endpoint
+        # shadows a more general responses entry.
+        all_prefixes = set(self.responses) | set(self.paged_responses)
         matches = sorted(
-            (p for p in self.responses if endpoint.startswith(p)),
+            (p for p in all_prefixes if endpoint.startswith(p)),
             key=len,
             reverse=True,
         )
@@ -111,6 +132,15 @@ class _GhApiStub:
                 reset_at=datetime.now(UTC) + timedelta(seconds=60),
                 endpoint=endpoint,
             )
+        if prefix in self.paged_responses:
+            idx = self._page_indices.get(prefix, 0)
+            pages = self.paged_responses[prefix]
+            self._page_indices[prefix] = idx + 1
+            if idx >= len(pages):
+                # Pagination exhausted — return empty list so the
+                # caller's loop terminates.
+                return []
+            return pages[idx]
         return self.responses[prefix]
 
 
@@ -494,3 +524,581 @@ class TestEarlyExits:
         assert signals == []
         assert degraded is False
         assert stub.calls == []
+
+
+class TestPagination:
+    """The /pulls/{N}/comments endpoint must be paginated; pre-fix
+    the extractor used gh's default 30-per-page cap and silently
+    truncated PRs with >30 inline review comments — exactly the
+    PRs the signal is designed to surface."""
+
+    def test_pagination_loops_until_partial_page(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 250 inline comments across 100 lines: pre-fix capped at
+        # 30 (density 0.30 → INFO). Post-fix counts all 250 across
+        # 3 pages (density 2.50 → WARNING).
+        sha = "shaPAG1"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        stub.paged_responses = {
+            "repos/o/r/pulls/1/comments": [
+                # Page 1: 100 comments (max page size).
+                [{"user": {"login": "alice"}}] * 100,
+                # Page 2: 100 comments (still max).
+                [{"user": {"login": "alice"}}] * 100,
+                # Page 3: 50 comments (partial → break).
+                [{"user": {"login": "alice"}}] * 50,
+            ],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        assert signals[0].detail["external_comment_count"] == 250
+        assert signals[0].detail["density"] == pytest.approx(2.5)
+        assert signals[0].severity == Severity.WARNING
+
+        # Verify gh_api received per_page=100 + sequential page=
+        # values, not just one call with defaults.
+        comment_kwargs = [
+            kw for c, kw in zip(stub.calls, stub.call_kwargs)
+            if c == "repos/o/r/pulls/1/comments"
+        ]
+        assert len(comment_kwargs) == 3
+        pages_requested = [
+            kw.get("query_params", {}).get("page") for kw in comment_kwargs
+        ]
+        assert pages_requested == ["1", "2", "3"]
+        per_page_values = {
+            kw.get("query_params", {}).get("per_page") for kw in comment_kwargs
+        }
+        assert per_page_values == {"100"}
+
+    def test_pagination_stops_at_partial_page(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # A 50-comment PR fits in one partial page (< per_page=100),
+        # so the helper stops after the first call.
+        sha = "shaPAG2"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        stub.paged_responses = {
+            "repos/o/r/pulls/1/comments": [
+                [{"user": {"login": "alice"}}] * 50,
+            ],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        assert signals[0].detail["external_comment_count"] == 50
+        # Only one /comments call — the partial-page early-exit
+        # avoids the wasted second-page roundtrip.
+        comment_calls = [c for c in stub.calls if "/comments" in c]
+        assert len(comment_calls) == 1
+
+
+class TestMalformedPayloads:
+    """Wrapper helpers must flip degraded (not silently return)
+    when gh succeeds but the payload shape is unexpected."""
+
+    def test_non_dict_user_in_comments_does_not_crash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # `(item.get('user') or {}).get('login')` pre-fix raised
+        # AttributeError when user was a non-dict value (e.g.,
+        # string). The exception was NOT in _GH_RECOVERABLE, so it
+        # crashed the extractor mid-loop. Post-fix: isinstance
+        # guards, malformed entries counted as external (the
+        # liberal-count design choice).
+        sha = "shaMAL"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            # Mixed shapes: dict, string (the trap), null, missing
+            # user, valid external dict.
+            "repos/o/r/pulls/1/comments": [
+                {"user": {"login": "bob"}},      # self-review → skip
+                {"user": "stringly-typed"},      # would crash pre-fix
+                {"user": None},                  # null user
+                {},                              # missing user key
+                {"user": {"login": "alice"}},    # external
+                {"user": {"login": "carol"}},    # external
+            ],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        # Self-review (bob): 1 skip. Stringly-typed, None-user,
+        # missing-user: 3 counted as external (liberal count to
+        # avoid systematic under-count when GitHub anonymizes
+        # deleted users). Plus alice and carol: 2 real external.
+        # Total external = 5; density = 5/100 = 0.05 < 0.1 → no signal.
+        assert signals == []
+
+    def test_non_dict_user_in_pr_detail_does_not_crash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Same trap on the PR-detail call site. detail.get("user")
+        # is a non-dict scalar — pre-fix: AttributeError, crash;
+        # post-fix: author resolves to empty string → skip the PR
+        # with NO_AUTHOR (no signal emitted for that PR).
+        sha = "shaMAL2"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": "ghost-string",  # the trap
+                "title": "x", "html_url": "url",
+            },
+        }
+        # No /comments stub — the PR should be skipped at the
+        # no-author gate before the comments fetch.
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        # The comments endpoint must NOT have been called — the
+        # no-author skip short-circuits before it.
+        assert not any("/comments" in c for c in stub.calls)
+
+    def test_non_dict_pr_detail_marks_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # gh_api succeeded but returned a non-dict (jq quirk, API
+        # surface change). Pre-fix returned (None, False) — silent
+        # drop with no degraded flag. Post-fix: degraded=True so
+        # the user sees data was lost.
+        sha = "shaMAL3"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": "not-a-dict",  # malformed response
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True
+
+
+class TestCaseInsensitiveSelfReview:
+    """GitHub logins are logically case-insensitive; mixed-case
+    self-reviews must NOT escape the filter."""
+
+    def test_mixed_case_author_and_commenter_treated_as_self(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # PR author 'Alice' (canonical), 12 comments from 'alice'
+        # (lowercased). Pre-fix: case-sensitive == treats them as
+        # different users → all 12 count as external → density 0.12
+        # INFO. Post-fix: casefold compare → all 12 self-reviews
+        # filtered → no signal.
+        sha = "shaCAS"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "Alice"},  # canonical case
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/1/comments":
+                [{"user": {"login": "alice"}}] * 12,  # lowercased
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+
+class TestNoAuthorSkip:
+    """When PR author can't be resolved, the signal must skip the
+    PR (not silently disable the filter and count author comments
+    as external)."""
+
+    def test_null_user_skips_pr(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        sha = "shaAUTH"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": None,  # deleted account / ghost
+                "title": "x", "html_url": "url",
+            },
+        }
+        # No /comments stub — the no-author skip is before the
+        # comments fetch; if the skip is broken the stub's
+        # AssertionError safety net would trigger.
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        assert not any("/comments" in c for c in stub.calls)
+
+
+class TestGitFailureDegrades:
+    """When git itself fails (binary missing, timeout, non-repo
+    dir), the helper must flip degraded so the user sees that
+    Tier 3 was incomplete, not a clean zero-signal run."""
+
+    def test_git_log_failure_marks_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end)
+
+        # Simulate git not on PATH: subprocess.run raises FileNotFoundError.
+        def fake_run(*_a: Any, **_kw: Any) -> Any:
+            raise FileNotFoundError("no git")
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run", fake_run,
+        )
+        stub = _GhApiStub()
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True
+        # No API calls — git failure short-circuits before any
+        # commits-to-PRs fetch.
+        assert stub.calls == []
+
+
+class TestThresholdValidation:
+    """Non-positive density_threshold disables severity tiering;
+    the extractor must reject it loudly rather than silently
+    flooding the user with WARNINGs."""
+
+    def test_zero_threshold_raises(
+        self,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        with pytest.raises(ValueError, match="must be > 0"):
+            extract_pr_review_comment_density_signals(
+                [], github_repo=github_repo, repo_dir=repo_dir,
+                density_threshold=0.0,
+            )
+
+    def test_negative_threshold_raises(
+        self,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        with pytest.raises(ValueError, match="must be > 0"):
+            extract_pr_review_comment_density_signals(
+                [], github_repo=github_repo, repo_dir=repo_dir,
+                density_threshold=-0.1,
+            )
+
+
+class TestZeroLinesGate:
+    """An explicit ``lines_changed == 0`` gate must short-circuit
+    even when the user-configurable ``min_lines_changed`` is 0 —
+    otherwise the divisor's ``max(0, 1) = 1`` defensive guard
+    produces a nonsense density of N comments per 0 lines."""
+
+    def test_pure_merge_pr_with_zero_lines_is_gated_even_with_min_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        sha = "shaZ"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 0, "deletions": 0,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        # No /comments stub: the zero-lines gate must short-circuit
+        # before fetching comments. If broken, the AssertionError
+        # safety net catches the unexpected call.
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+            min_lines_changed=0,  # user lowers the gate
+        )
+        assert signals == []
+        assert degraded is False
+
+
+class TestPerPRErrorIsolation:
+    """A malformed payload on one PR must not destroy signals
+    computed for OTHER PRs in the same run."""
+
+    def test_one_pr_raises_others_still_emit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end)
+        sha = "shaERR"
+        commit_time = session_end - timedelta(minutes=5)
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(sha, commit_time, "feat")])),
+        )
+        # Two PRs touched by the same commit.
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls": [
+                {"number": 1, "title": "bad", "html_url": "url1"},
+                {"number": 2, "title": "good", "html_url": "url2"},
+            ],
+            # PR #1: detail.additions is a list (jq quirk).
+            # `_safe_int` returns 0 for non-coercible values, so
+            # lines_changed = 0 + 0 = 0 → gated, NO signal. Per-PR
+            # try/except guards the iteration regardless.
+            "repos/o/r/pulls/1": {
+                "additions": ["broken"],  # genuinely bad shape
+                "deletions": ["broken"],
+                "user": {"login": "bob"},
+                "title": "bad", "html_url": "url1",
+            },
+            # PR #2: well-formed.
+            "repos/o/r/pulls/2": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "good", "html_url": "url2",
+            },
+            "repos/o/r/pulls/2/comments":
+                [{"user": {"login": "alice"}}] * 15,  # 15/100 = 0.15
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        # PR #2 still emits its signal (15 comments / 100 lines = 0.15).
+        assert len(signals) == 1
+        assert signals[0].detail["pr_number"] == 2
+
+
+class TestTitleRefreshFix:
+    """Title refresh uses explicit `isinstance + truthiness` check
+    rather than `or`, so a PR with genuinely empty title doesn't
+    silently fall through to the stale _PRRef.title."""
+
+    def test_empty_detail_title_falls_back_to_ref_title(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Detail returns empty title; ref.title was set from the
+        # earlier commits/{sha}/pulls call. Behavior: fall back to
+        # ref.title since empty is unhelpful.
+        sha = "shaT"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "Cached title",
+                  "html_url": "https://github.com/o/r/pull/1"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "",  # detail title is empty
+                "html_url": "https://github.com/o/r/pull/1",
+            },
+            "repos/o/r/pulls/1/comments":
+                [{"user": {"login": "alice"}}] * 15,
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert len(signals) == 1
+        # Falls back to ref.title since detail title was empty.
+        assert signals[0].detail["pr_title"] == "Cached title"
+
+
+class TestObservabilityCounters:
+    """Density extractor emits an INFO log summarizing PR skip
+    reasons. Pre-fix, all skips were silent — operators tuning
+    thresholds had no visibility into why PRs weren't firing."""
+
+    def test_skip_reasons_logged_at_end(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        # Two PRs both below the lines gate.
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end)
+        sha = "shaOBS"
+        commit_time = session_end - timedelta(minutes=5)
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(_git_log_stdout([(sha, commit_time, "feat")])),
+        )
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls": [
+                {"number": 1, "title": "x", "html_url": "url"},
+                {"number": 2, "title": "y", "html_url": "url"},
+            ],
+            "repos/o/r/pulls/1": {
+                "additions": 5, "deletions": 3,  # below 20-line gate
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/2": {
+                "additions": 3, "deletions": 4,  # below 20-line gate
+                "user": {"login": "bob"},
+                "title": "y", "html_url": "url",
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        with caplog.at_level(
+            logging.INFO,
+            logger="agentfluent.diagnostics.github_signals",
+        ):
+            signals, degraded = extract_pr_review_comment_density_signals(
+                [session], github_repo=github_repo, repo_dir=repo_dir,
+            )
+        assert signals == []
+        assert degraded is False
+        # The summary INFO line must name the below-gate count.
+        log_text = "\n".join(r.message for r in caplog.records)
+        assert "below_lines_gate=2" in log_text
+
+
+class TestSafeInt:
+    """Verify the integer coercion helper doesn't raise on
+    unexpected types (the int(str_or_int or 0) pattern would
+    propagate ValueError to the pipeline's outer except)."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0, 0),
+            (42, 42),
+            (None, 0),
+            (True, 1),
+            (False, 0),
+            ("0", 0),
+            ("42", 42),
+            ("42.7", 42),
+            ("not-a-number", 0),
+            ([], 0),
+            ({}, 0),
+            (42.7, 42),
+        ],
+    )
+    def test_safe_int(self, value: Any, expected: int) -> None:
+        from agentfluent.diagnostics.github_signals import _safe_int
+        assert _safe_int(value) == expected

--- a/tests/unit/test_github_signals_density.py
+++ b/tests/unit/test_github_signals_density.py
@@ -1,0 +1,496 @@
+"""Tests for the ``PR_REVIEW_COMMENT_DENSITY`` Tier 3 signal.
+
+All ``gh_api`` calls are mocked end-to-end so the tests run without
+network access or `gh` on PATH. ``git log`` invocations are mocked
+via the shared ``_git_helpers`` subprocess hook the other tests use.
+
+Reuses the ``_session`` fixture shape and ``_GhApiStub`` pattern
+from ``test_github_signals_ci_failure.py``; if those test
+infrastructure pieces drift, this file's setup will need the same
+updates.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.pipeline import SessionAnalysis
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.config.models import Severity
+from agentfluent.core.session import SessionMessage
+from agentfluent.diagnostics._git_helpers import (
+    _GIT_LOG_COMMIT_SEPARATOR,
+    _GIT_LOG_FIELD_SEPARATOR,
+)
+from agentfluent.diagnostics.github_signals import (
+    extract_pr_review_comment_density_signals,
+)
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.github.models import GitHubRepo, RateLimitedError
+
+
+def _session(
+    *,
+    end: datetime,
+    duration: timedelta = timedelta(minutes=30),
+) -> SessionAnalysis:
+    msgs = [
+        SessionMessage(type="user", timestamp=end - duration),
+        SessionMessage(type="user", timestamp=end),
+    ]
+    inv = AgentInvocation(
+        invocation_id="inv-0",
+        agent_type="general-purpose",
+        description="x",
+        prompt="y",
+        tool_use_id="toolu_0",
+        session_id="s",
+        session_path=Path("/x"),
+    )
+    return SessionAnalysis(
+        session_path=Path("/tmp/session.jsonl"),
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=AgentMetrics(),
+        invocations=[inv],
+        mcp_tool_calls=[],
+        messages=msgs,
+    )
+
+
+def _git_log_stdout(commits: list[tuple[str, datetime, str]]) -> str:
+    parts: list[str] = []
+    for sha, ts, subject in commits:
+        header = _GIT_LOG_FIELD_SEPARATOR.join([sha, ts.isoformat(), subject])
+        parts.append(f"{_GIT_LOG_COMMIT_SEPARATOR}{header}\n")
+    return "\n".join(parts) + "\n"
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> Any:
+    def runner(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=returncode, stdout=stdout, stderr="",
+        )
+    return runner
+
+
+class _GhApiStub:
+    """Same prefix-match-with-AssertionError-on-unknown stub as #400's
+    test file. Longest-prefix wins so a specific PR endpoint shadows
+    a shorter catch-all (intentionally we use no catch-alls)."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.responses: dict[str, Any] = {}
+        self.rate_limit_after: dict[str, int] = {}
+        self._counts: dict[str, int] = {}
+
+    def __call__(self, endpoint: str, **_kwargs: Any) -> Any:
+        self.calls.append(endpoint)
+        matches = sorted(
+            (p for p in self.responses if endpoint.startswith(p)),
+            key=len,
+            reverse=True,
+        )
+        if not matches:
+            raise AssertionError(f"unexpected gh_api call: {endpoint}")
+        prefix = matches[0]
+        count = self._counts.get(prefix, 0) + 1
+        self._counts[prefix] = count
+        limit = self.rate_limit_after.get(prefix)
+        if limit is not None and count > limit:
+            raise RateLimitedError(
+                reset_at=datetime.now(UTC) + timedelta(seconds=60),
+                endpoint=endpoint,
+            )
+        return self.responses[prefix]
+
+
+@pytest.fixture
+def repo_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def github_repo() -> GitHubRepo:
+    return GitHubRepo(owner="o", repo="r")
+
+
+def _wire_session_with_commit(
+    monkeypatch: pytest.MonkeyPatch, sha: str = "abc12345",
+) -> SessionAnalysis:
+    """Plant a single session + one commit in its window; return the
+    session for use as an `extract_*([session], ...)` arg."""
+    session_end = datetime.now(UTC) - timedelta(hours=1)
+    session = _session(end=session_end)
+    monkeypatch.setattr(
+        "agentfluent.diagnostics._git_helpers.subprocess.run",
+        _completed(_git_log_stdout([
+            (sha, session_end - timedelta(minutes=5), "feat: x"),
+        ])),
+    )
+    return session
+
+
+class TestThresholdBands:
+    def test_density_above_warning_threshold_emits_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 50 comments / 100 lines = 0.5 = 5x threshold → WARNING.
+        sha = "shaA"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 42, "title": "Add window filter",
+                  "html_url": "https://github.com/o/r/pull/42"}],
+            "repos/o/r/pulls/42/comments":
+                [{"user": {"login": "alice"}} for _ in range(50)],
+            "repos/o/r/pulls/42": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},  # author != commenter
+                "title": "Add window filter",
+                "html_url": "https://github.com/o/r/pull/42",
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == SignalType.PR_REVIEW_COMMENT_DENSITY
+        assert sig.severity == Severity.WARNING
+        assert sig.agent_type is None
+        assert sig.detail["pr_number"] == 42
+        assert sig.detail["density"] == pytest.approx(0.5)
+        assert sig.detail["external_comment_count"] == 50
+        assert sig.detail["lines_changed"] == 100
+
+    def test_density_at_threshold_emits_info(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 10 comments / 100 lines = 0.1 = exactly threshold → INFO.
+        # Confirms `>=` semantics at the boundary.
+        sha = "shaB"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1/comments":
+                [{"user": {"login": "alice"}} for _ in range(10)],
+            "repos/o/r/pulls/1": {
+                "additions": 50, "deletions": 50,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        assert signals[0].severity == Severity.INFO
+        assert signals[0].detail["density"] == pytest.approx(0.1)
+
+    def test_density_below_threshold_emits_nothing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 2 comments / 500 lines = 0.004 << threshold → no signal.
+        sha = "shaC"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1/comments":
+                [{"user": {"login": "alice"}}, {"user": {"login": "alice"}}],
+            "repos/o/r/pulls/1": {
+                "additions": 250, "deletions": 250,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+
+class TestGates:
+    def test_min_lines_changed_gate_suppresses_small_prs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 10 comments / 5 lines would be density 2.0 but the PR is
+        # below the min_lines_changed gate (20) — no signal.
+        sha = "shaD"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 3, "deletions": 2,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            # Note: no /comments stub. The gate hits BEFORE the
+            # comments fetch, so the AssertionError safety net
+            # would fire if the gate were broken.
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        # Verify the /comments endpoint was NOT called — the gate
+        # short-circuits before the second API call to save budget.
+        assert not any("/comments" in c for c in stub.calls)
+
+    def test_zero_lines_changed_no_divide_by_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # Pure-merge / pure-revert PRs report additions=0, deletions=0.
+        # No signal (gate catches it), no division-by-zero crash.
+        sha = "shaE"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 0, "deletions": 0,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+    def test_zero_external_comments_no_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        sha = "shaF"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 50, "deletions": 50,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/1/comments": [],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+
+class TestSelfReviewExclusion:
+    def test_self_review_comments_filtered_out(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # PR author == 'bob'; 10 comments all by bob → 0 external →
+        # no signal. Without the filter this would fire at density
+        # 0.1 (INFO) — the test guards against accidentally treating
+        # self-reviews as external feedback.
+        sha = "shaG"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 50, "deletions": 50,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/1/comments":
+                [{"user": {"login": "bob"}} for _ in range(10)],
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+
+    def test_mixed_author_and_external_only_counts_external(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # 6 by author + 12 by external reviewers / 100 lines = 0.12
+        # (external-only) → above 0.1 threshold → INFO.
+        sha = "shaH"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        comments = [{"user": {"login": "bob"}} for _ in range(6)]
+        comments.extend([{"user": {"login": "alice"}} for _ in range(12)])
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 60, "deletions": 40,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/1/comments": comments,
+        }
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert degraded is False
+        assert len(signals) == 1
+        assert signals[0].severity == Severity.INFO
+        assert signals[0].detail["external_comment_count"] == 12
+
+
+class TestDegradation:
+    def test_rate_limit_on_comments_marks_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        sha = "shaI"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        stub = _GhApiStub()
+        stub.responses = {
+            f"repos/o/r/commits/{sha}/pulls":
+                [{"number": 1, "title": "x", "html_url": "url"}],
+            "repos/o/r/pulls/1": {
+                "additions": 50, "deletions": 50,
+                "user": {"login": "bob"},
+                "title": "x", "html_url": "url",
+            },
+            "repos/o/r/pulls/1/comments": [],
+        }
+        stub.rate_limit_after["repos/o/r/pulls/1/comments"] = 0
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True
+
+    def test_value_error_on_pr_detail_marks_degraded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        # ValueError (non-JSON gh output) on the PR-detail call
+        # must NOT crash the extractor — it should flip degraded
+        # and let other PRs proceed.
+        from agentfluent.diagnostics import github_signals
+
+        sha = "shaJ"
+        session = _wire_session_with_commit(monkeypatch, sha=sha)
+        # The /pulls helper succeeds and returns a PR ref; then the
+        # detail call raises ValueError.
+        call_log: list[str] = []
+
+        def fake_gh_api(endpoint: str, **_kwargs: Any) -> Any:
+            call_log.append(endpoint)
+            if endpoint.endswith("/pulls") and "/commits/" in endpoint:
+                return [{"number": 1, "title": "x", "html_url": "url"}]
+            if endpoint.endswith("/pulls/1"):
+                raise ValueError("non-JSON")
+            raise AssertionError(f"unexpected: {endpoint}")
+
+        monkeypatch.setattr(github_signals, "gh_api", fake_gh_api)
+        signals, degraded = github_signals.extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is True
+
+
+class TestEarlyExits:
+    def test_no_commits_no_api_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        repo_dir: Path,
+        github_repo: GitHubRepo,
+    ) -> None:
+        session_end = datetime.now(UTC) - timedelta(hours=1)
+        session = _session(end=session_end)
+        monkeypatch.setattr(
+            "agentfluent.diagnostics._git_helpers.subprocess.run",
+            _completed(""),
+        )
+        stub = _GhApiStub()
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.github_signals.gh_api", stub,
+        )
+        signals, degraded = extract_pr_review_comment_density_signals(
+            [session], github_repo=github_repo, repo_dir=repo_dir,
+        )
+        assert signals == []
+        assert degraded is False
+        assert stub.calls == []


### PR DESCRIPTION
## Summary

- Second Tier 3 quality signal — closes epic #398's v0.8 stream. Detects PRs where external (non-self) inline review-comment density exceeds the threshold; nudges users toward an architect / code-review subagent before opening similar PRs.
- Shared `_enumerate_attributed_prs` helper extracted from #400 and refactored to back both extractors (architect's important note from the [#401 implementation-plan review](https://github.com/frederick-douglas-pearce/agentfluent/issues/401#issuecomment-4552263301)). \`_log_rate_limit\` widened to take \`signal_name=...\` so shared-helper warnings name the calling signal honestly.
- New extractor at \`diagnostics/github_signals.py:extract_pr_review_comment_density_signals\` returning \`(signals, degraded)\`. Reuses #400's error-handling pattern: \`RateLimitedError\` + \`_GH_RECOVERABLE\` → \`tier3_degraded=True\` and continue; pipeline-level try/except for unhandled exceptions.
- Defaults: \`density_threshold=0.1\`, \`warning_multiplier=2.0\`, \`min_lines_changed=20\`. All configurable as kwargs. Conservative for v0.8 dogfood; calibrate in v0.8.x.

Resolves #401. Closes epic #398's last open child.

## Test plan
- [x] Unit tests pass: \`uv run pytest -m "not integration"\` (1505 passed, +16 new)
- [x] Lint clean: \`uv run ruff check src/ tests/\`
- [x] Type check clean: \`uv run mypy src/agentfluent/\`
- [x] New/changed behavior has test coverage — 11 extractor cases (threshold bands, gates, self-review exclusion, degradation, early exit) + 5 correlator-rule cases. Existing #400 tests (13) still pass after the helper refactor.
- [x] Glossary regenerated via \`uv run python scripts/generate_glossary_md.py\`
- [ ] Manual smoke test via \`uv run agentfluent analyze --github\` against this repo — gated on having a PR with substantive external review comments; will dogfood post-merge

## Security review
Pick one. (If "Needs review", apply the \`needs-security-review\` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: \`.claude/hooks/\`, secret handling, \`pyproject.toml\`, \`.github/workflows/\`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

Network calls via the \`gh\` CLI (with the existing #399 wrapper) and rendering of user-controlled strings (PR titles + comment-author logins, both pre-escaped via \`!r\` in correlator observations and Pydantic-typed in detail payloads). Label intentionally NOT applied yet per repo policy — will apply when dev-complete and CI is green.

## Breaking changes

None. Additions are additive: new \`SignalType\` enum value (consumers iterate the enum, drift test guards), new \`SIGNAL_AXIS_MAP\` entry, new correlator rule appended to the list, new extractor in a new try/except branch. The \`_enumerate_attributed_prs\` helper extraction is internal — preserves the existing public signature of \`extract_ci_failure_first_push_signals\` (verified: all 13 of #400's existing tests pass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)