### PR TITLE
docs(changelog): #392 — fold v0.7.0 breaking-changes prose into the [0.7.0] block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,9 @@
 ## [0.7.0](https://github.com/frederick-douglas-pearce/agentfluent/compare/v0.6.0...v0.7.0) (2026-05-17)
 
 
-### Features
+### ⚠ BREAKING CHANGES
 
-* **cli:** add `agentfluent report` command skeleton ([#353](https://github.com/frederick-douglas-pearce/agentfluent/issues/353)) ([#365](https://github.com/frederick-douglas-pearce/agentfluent/issues/365)) ([c6f3704](https://github.com/frederick-douglas-pearce/agentfluent/commit/c6f3704a7c68ff9a51217cc6ad7fed36fdb3691c))
-* **cli:** block --session + --latest combination, surface scope in table footer ([#358](https://github.com/frederick-douglas-pearce/agentfluent/issues/358)) ([#384](https://github.com/frederick-douglas-pearce/agentfluent/issues/384)) ([cbe1b45](https://github.com/frederick-douglas-pearce/agentfluent/commit/cbe1b45b703e6b107be52e51530ae0fb61c0d412))
-* **cli:** implement `agentfluent report` section renderers ([#354](https://github.com/frederick-douglas-pearce/agentfluent/issues/354)) ([#366](https://github.com/frederick-douglas-pearce/agentfluent/issues/366)) ([26c2eaa](https://github.com/frederick-douglas-pearce/agentfluent/commit/26c2eaa7495b5adbc59a3fe086d6fb0b768260db))
-* **cli:** surface --session scope on analyze envelope + pin diagnostics scope ([#357](https://github.com/frederick-douglas-pearce/agentfluent/issues/357)) ([#383](https://github.com/frederick-douglas-pearce/agentfluent/issues/383)) ([6f7c86c](https://github.com/frederick-douglas-pearce/agentfluent/commit/6f7c86c87602dbf25a48b8f6d38a48ddcdd575f3))
-* **diagnostics:** detect custom agents defined but never delegated to ([#346](https://github.com/frederick-douglas-pearce/agentfluent/issues/346)) ([#369](https://github.com/frederick-douglas-pearce/agentfluent/issues/369)) ([dfa5ec6](https://github.com/frederick-douglas-pearce/agentfluent/commit/dfa5ec6de95942b0e4ca729eb6d3af408edc84f4))
-* **diagnostics:** hide negative-savings offload + filter cluster-name stopwords ([#363](https://github.com/frederick-douglas-pearce/agentfluent/issues/363)) ([9c94983](https://github.com/frederick-douglas-pearce/agentfluent/commit/9c9498352391f7e1cc96557f4c870ae69e329c94))
-* **diagnostics:** local-git feat-then-fix proximity signal ([#275](https://github.com/frederick-douglas-pearce/agentfluent/issues/275)) ([#388](https://github.com/frederick-douglas-pearce/agentfluent/issues/388)) ([2452ebd](https://github.com/frederick-douglas-pearce/agentfluent/commit/2452ebd91b937ab5019ae7683502652103e6a5a8))
-* **diff:** propagate window + diagnostics-version into diff output ([#361](https://github.com/frederick-douglas-pearce/agentfluent/issues/361)) ([7d91861](https://github.com/frederick-douglas-pearce/agentfluent/commit/7d918616878d63fdeca69ffde992a48bde883c16))
-
-
-### Bug Fixes
-
-* **diff:** add Origin column to Token Metrics by Model table ([#343](https://github.com/frederick-douglas-pearce/agentfluent/issues/343)) ([#367](https://github.com/frederick-douglas-pearce/agentfluent/issues/367)) ([552cbe7](https://github.com/frederick-douglas-pearce/agentfluent/commit/552cbe7ed6337bc325f50725587c47817eafb639))
-
-## v0.7.0 — Breaking changes
-
-> Manual prose; release-please will add its auto-generated `## [0.7.0]` block (Features / Bug Fixes / etc.) above the v0.6.0 header when v0.7.0 is cut. Keep this section as-is across release-please regenerations.
-
-### `analyze --session` auto-scopes diagnostics
+#### `analyze --session` auto-scopes diagnostics
 
 In v0.6.0, `agentfluent analyze --project P --session <uuid> --diagnostics` scoped token/cost metrics to the named session but **rolled diagnostics up across all sessions in the project** — recommendations, offload candidates, and quality signals reflected the full window even though the metrics did not.
 
@@ -52,6 +34,23 @@ Two related changes shipped alongside:
 - `--session` + `--latest` is now an error instead of silently no-op'd ([#358](https://github.com/frederick-douglas-pearce/agentfluent/pull/384)).
 
 **Rationale:** see decision [D032](.claude/specs/decisions.md) — the v0.6 behavior was a latent inconsistency, not a feature anyone depended on. Per [D029](.claude/specs/decisions.md), the change is documented as a breaking note but kept under a `0.x` minor bump rather than a major bump, because the leading-zero version already signals "expect breaking changes."
+
+
+### Features
+
+* **cli:** add `agentfluent report` command skeleton ([#353](https://github.com/frederick-douglas-pearce/agentfluent/issues/353)) ([#365](https://github.com/frederick-douglas-pearce/agentfluent/issues/365)) ([c6f3704](https://github.com/frederick-douglas-pearce/agentfluent/commit/c6f3704a7c68ff9a51217cc6ad7fed36fdb3691c))
+* **cli:** block --session + --latest combination, surface scope in table footer ([#358](https://github.com/frederick-douglas-pearce/agentfluent/issues/358)) ([#384](https://github.com/frederick-douglas-pearce/agentfluent/issues/384)) ([cbe1b45](https://github.com/frederick-douglas-pearce/agentfluent/commit/cbe1b45b703e6b107be52e51530ae0fb61c0d412))
+* **cli:** implement `agentfluent report` section renderers ([#354](https://github.com/frederick-douglas-pearce/agentfluent/issues/354)) ([#366](https://github.com/frederick-douglas-pearce/agentfluent/issues/366)) ([26c2eaa](https://github.com/frederick-douglas-pearce/agentfluent/commit/26c2eaa7495b5adbc59a3fe086d6fb0b768260db))
+* **cli:** surface --session scope on analyze envelope + pin diagnostics scope ([#357](https://github.com/frederick-douglas-pearce/agentfluent/issues/357)) ([#383](https://github.com/frederick-douglas-pearce/agentfluent/issues/383)) ([6f7c86c](https://github.com/frederick-douglas-pearce/agentfluent/commit/6f7c86c87602dbf25a48b8f6d38a48ddcdd575f3))
+* **diagnostics:** detect custom agents defined but never delegated to ([#346](https://github.com/frederick-douglas-pearce/agentfluent/issues/346)) ([#369](https://github.com/frederick-douglas-pearce/agentfluent/issues/369)) ([dfa5ec6](https://github.com/frederick-douglas-pearce/agentfluent/commit/dfa5ec6de95942b0e4ca729eb6d3af408edc84f4))
+* **diagnostics:** hide negative-savings offload + filter cluster-name stopwords ([#363](https://github.com/frederick-douglas-pearce/agentfluent/issues/363)) ([9c94983](https://github.com/frederick-douglas-pearce/agentfluent/commit/9c9498352391f7e1cc96557f4c870ae69e329c94))
+* **diagnostics:** local-git feat-then-fix proximity signal ([#275](https://github.com/frederick-douglas-pearce/agentfluent/issues/275)) ([#388](https://github.com/frederick-douglas-pearce/agentfluent/issues/388)) ([2452ebd](https://github.com/frederick-douglas-pearce/agentfluent/commit/2452ebd91b937ab5019ae7683502652103e6a5a8))
+* **diff:** propagate window + diagnostics-version into diff output ([#361](https://github.com/frederick-douglas-pearce/agentfluent/issues/361)) ([7d91861](https://github.com/frederick-douglas-pearce/agentfluent/commit/7d918616878d63fdeca69ffde992a48bde883c16))
+
+
+### Bug Fixes
+
+* **diff:** add Origin column to Token Metrics by Model table ([#343](https://github.com/frederick-douglas-pearce/agentfluent/issues/343)) ([#367](https://github.com/frederick-douglas-pearce/agentfluent/issues/367)) ([552cbe7](https://github.com/frederick-douglas-pearce/agentfluent/commit/552cbe7ed6337bc325f50725587c47817eafb639))
 
 ## [0.6.0](https://github.com/frederick-douglas-pearce/agentfluent/compare/v0.5.1...v0.6.0) (2026-05-09)
 


### PR DESCRIPTION
## Summary
- Moves the manual `v0.7.0 — Breaking changes` section out of its top-level slot (between `[0.7.0]` and `[0.6.0]`) and into the `[0.7.0]` block as a leading `### ⚠ BREAKING CHANGES` subsection, ahead of Features / Bug Fixes.
- Matches conventional changelog ordering (breaking changes lead a release, not trail it) without altering v0.7.0 semantics.
- Ships Option A from #392. Filed #473 to investigate Option C (release-please `changelog-sections` config) for auto-placement on future breaking releases.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — N/A, docs-only change
- [x] Lint clean: `uv run ruff check src/ tests/` — N/A, docs-only change
- [x] Type check clean: `uv run mypy src/agentfluent/` — N/A, docs-only change
- [x] New/changed behavior has test coverage — N/A, docs-only change
- [x] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI output changes
- [ ] Visual: render `CHANGELOG.md` on GitHub after merge, confirm `[0.7.0]` block leads with `⚠ BREAKING CHANGES` followed by Features and Bug Fixes; `[0.6.0]` and earlier unchanged.
- [ ] Empirical Option-A validation (deferred): on the next release-please PR run, confirm the `[0.7.0]` block is not regenerated/clobbered. Update #473 with the result.

## Security review
- [x] **Skip review** — docs-only edit to `CHANGELOG.md`. No code, config, workflow, hook, or runtime surface touched.
- [ ] **Needs review**

## Breaking changes
None. This is a documentation reorganization of the already-shipped v0.7.0 release notes; no public contract changes.

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)