### PR TITLE
feat: add model-turn count to SubagentTrace and AgentInvocation (#466)

### DIFF
--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -140,6 +140,24 @@ class AgentInvocation(BaseModel):
         work, and either annotate or filter them out."""
         return self.trace is not None
 
+    # mypy + pydantic ``@computed_field`` interaction (pydantic/pydantic#6709).
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def model_turns(self) -> int | None:
+        """Number of model turns in this invocation's subagent trace --
+        one merged assistant message (one API round-trip) (#466).
+
+        ``None`` when no trace is linked (~20% of invocations in the
+        dogfood corpus, see #468): turns can't be counted without the
+        trace, and estimating from ``tool_uses`` would erase the
+        turns-vs-tools distinction that makes the metric valuable, so we
+        report the honest gap. Distinct from ``tool_uses`` — neither
+        bounds the other (a turn can have zero or many tool calls).
+        Emitted in ``model_dump`` output as a computed field."""
+        if self.trace is None:
+            return None
+        return self.trace.model_turns
+
     @property
     def active_duration_per_tool_use(self) -> float | None:
         """Average active duration (ms) per tool call. Falls back to

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -246,12 +246,17 @@ def format_analysis_table(
         inv_table.add_column("Agent", style="cyan")
         inv_table.add_column("Description")
         inv_table.add_column("Tokens", justify="right")
+        inv_table.add_column("Turns", justify="right")
         inv_table.add_column("Tool uses", justify="right")
         inv_table.add_column("Duration", justify="right")
         any_unreliable = False
         for s in result.sessions:
             for inv in s.invocations:
                 tokens = format_tokens(inv.total_tokens) if inv.total_tokens else "-"
+                # None (no trace) and 0 turns both render "-": a linked
+                # trace always has >= 1 assistant message, so 0 only
+                # occurs for empty/degenerate traces where "-" is apt.
+                turns = str(inv.model_turns) if inv.model_turns else "-"
                 tools = str(inv.tool_uses) if inv.tool_uses else "-"
                 # Gate on idle_gap_ms, not (active vs duration) diff:
                 # the two come from different sources (JSONL timestamps
@@ -274,6 +279,7 @@ def format_analysis_table(
                     escape(inv.agent_type),
                     escape(desc),
                     tokens,
+                    turns,
                     tools,
                     duration,
                 )

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -107,6 +107,17 @@ class SubagentTrace(BaseModel):
     retry_sequences: list[RetrySequence] = Field(default_factory=list)
     total_errors: int = 0
     total_retries: int = 0
+
+    model_turns: int = 0
+    """Number of model turns in this subagent trace -- one merged
+    assistant message (one API round-trip). Set at parse time by
+    counting ``type == "assistant"`` messages after fragment-merging
+    (#466). Independent of ``tool_calls``: a single turn can carry zero
+    ``tool_use`` blocks (text/thinking/refusal) or many (parallel tool
+    use), so neither count bounds the other. Always definitive for a
+    trace (``0`` for an empty trace); ``AgentInvocation.model_turns`` is
+    ``int | None`` because the trace itself may be absent."""
+
     usage: Usage = Field(default_factory=Usage)
     duration_ms: int | None = None
     idle_gap_ms: int | None = None

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -237,6 +237,7 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
         retry_sequences=retry_sequences,
         total_errors=sum(1 for tc in tool_calls if tc.is_error),
         total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
+        model_turns=sum(1 for m in messages if m.type == "assistant"),
         usage=_sum_usage(messages),
         duration_ms=_compute_duration_ms(messages),
         idle_gap_ms=_compute_idle_gap_ms(tool_calls),

--- a/tests/unit/cli/test_axis_json_contract.py
+++ b/tests/unit/cli/test_axis_json_contract.py
@@ -52,3 +52,33 @@ class TestAnalyzeAxisJsonContract:
             for value in scores.values():
                 # JSON numerics arrive as int OR float; both are valid.
                 assert isinstance(value, (int, float))
+
+
+class TestAnalyzeModelTurnsJsonContract:
+    """#466: every invocation in the analyze envelope exposes
+    ``model_turns`` — an int when a subagent trace is linked, ``null``
+    otherwise (honest gap)."""
+
+    def test_invocations_carry_model_turns(
+        self,
+        runner: CliRunner,
+        cli_app: typer.Typer,
+        populated_home_with_traces: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_app, ["analyze", "--project", "project", "--format", "json"],
+        )
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        invocations = [
+            inv
+            for s in payload["data"]["sessions"]
+            for inv in s["invocations"]
+        ]
+        assert invocations, "expected at least one invocation"
+        for inv in invocations:
+            assert "model_turns" in inv
+            assert inv["model_turns"] is None or isinstance(inv["model_turns"], int)
+        # The traces fixture links every invocation, so at least one
+        # invocation reports a concrete (non-null) turn count.
+        assert any(inv["model_turns"] for inv in invocations)

--- a/tests/unit/test_agent_models.py
+++ b/tests/unit/test_agent_models.py
@@ -181,3 +181,37 @@ class TestDurationReliable:
         inv.trace = self._trace(idle_gap_ms=60_000)  # type: ignore[assignment]
         payload = inv.model_dump(mode="json")
         assert payload["duration_reliable"] is True
+
+
+class TestModelTurns:
+    """`model_turns` delegates to the linked trace's count, or is None
+    when no trace is linked (honest gap, #466)."""
+
+    @staticmethod
+    def _trace(*, model_turns: int) -> object:
+        from agentfluent.traces.models import SubagentTrace
+
+        return SubagentTrace(
+            agent_id="abc",
+            agent_type="pm",
+            delegation_prompt="x",
+            model_turns=model_turns,
+        )
+
+    def test_no_trace_returns_none(self) -> None:
+        inv = _full_invocation()
+        assert inv.trace is None
+        assert inv.model_turns is None
+
+    def test_trace_returns_trace_count(self) -> None:
+        inv = _full_invocation()
+        inv.trace = self._trace(model_turns=3)  # type: ignore[assignment]
+        assert inv.model_turns == 3
+
+    def test_serialized_in_json(self) -> None:
+        inv = _full_invocation()
+        payload = inv.model_dump(mode="json")
+        assert payload["model_turns"] is None
+        inv.trace = self._trace(model_turns=7)  # type: ignore[assignment]
+        payload = inv.model_dump(mode="json")
+        assert payload["model_turns"] == 7

--- a/tests/unit/test_traces_fixtures.py
+++ b/tests/unit/test_traces_fixtures.py
@@ -50,6 +50,14 @@ class TestBasicTrace:
     def test_agent_id_from_filename(self, subagent_basic_path: Path) -> None:
         assert parse_subagent_trace(subagent_basic_path).agent_id == "basic"
 
+    def test_model_turns_counts_assistant_messages(
+        self, subagent_basic_path: Path,
+    ) -> None:
+        # 4 assistant messages -> 4 turns, distinct from the 3 tool calls.
+        trace = parse_subagent_trace(subagent_basic_path)
+        assert trace.model_turns == 4
+        assert len(trace.tool_calls) == 3
+
     def test_agent_type_is_unknown(self, subagent_basic_path: Path) -> None:
         # Linker overwrites; parser leaves UNKNOWN.
         assert parse_subagent_trace(subagent_basic_path).agent_type == UNKNOWN_AGENT_TYPE
@@ -132,6 +140,7 @@ class TestEmptyFile:
         assert trace.delegation_prompt == ""
         assert trace.usage.total_tokens == 0
         assert trace.duration_ms is None
+        assert trace.model_turns == 0
 
     def test_agent_id_still_from_filename(
         self, subagent_empty_path: Path,

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -655,3 +655,47 @@ class TestIdleGapDetection:
             idle_gap_ms=5000,
         )
         assert trace.active_duration_ms == 0
+
+
+class TestModelTurns:
+    """``model_turns`` counts merged assistant messages (round-trips),
+    independent of ``tool_calls`` (actions) — #466."""
+
+    def test_three_assistant_messages(self, write_jsonl: WriteJSONL) -> None:
+        # Three distinct turns (distinct message_ids so the parser's
+        # fragment-merge doesn't collapse them), each with one tool call.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Read")], message_id="m1"),
+                _user([_tool_result("t1", "ok")]),
+                _assistant([_tool_use("t2", "Grep")], message_id="m2"),
+                _user([_tool_result("t2", "ok")]),
+                _assistant([_tool_use("t3", "Bash")], message_id="m3"),
+                _user([_tool_result("t3", "ok")]),
+            ],
+        )
+        assert parse_subagent_trace(path).model_turns == 3
+
+    def test_one_turn_many_parallel_tool_uses(self, write_jsonl: WriteJSONL) -> None:
+        # A single assistant message with 5 parallel tool_use blocks is
+        # ONE turn, not five — turns count round-trips, not actions.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use(f"t{i}", "Read", {"file_path": f"/f{i}"}) for i in range(5)],
+                    message_id="m1",
+                ),
+                _user([_tool_result(f"t{i}", "ok") for i in range(5)]),
+            ],
+        )
+        trace = parse_subagent_trace(path)
+        assert trace.model_turns == 1
+        assert len(trace.tool_calls) == 5
+
+    def test_zero_assistant_messages(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl("agent-x.jsonl", [_user("go, no response")])
+        assert parse_subagent_trace(path).model_turns == 0


### PR DESCRIPTION
## Summary
- Adds per-invocation **model-turn counts** for subagent calls, complementing the parent-session turns from #465. A *model turn* is one merged assistant message (one API round-trip) — independent of `tool_calls` (a turn can carry zero or many `tool_use` blocks; parallel tool use means neither count bounds the other).
- `SubagentTrace.model_turns`: stored `int`, populated by `parse_subagent_trace()` counting `type == "assistant"` messages after fragment-merging. Always definitive (`0` for an empty trace).
- `AgentInvocation.model_turns`: `@computed_field` `int | None` — the linked trace's count, or `None` when no trace exists. Per the issue's design note, we report the honest gap rather than estimating from `tool_uses` (which would erase the turns-vs-tools distinction; see #468). Serialized into `model_dump`/JSON.
- CLI: verbose Per-Invocation Detail table gains a "Turns" column (`None` and `0` both render `-`). JSON: `model_turns` per invocation (`null` when no trace).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1564 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage: 3 assistant→3, 1 assistant w/ 5 parallel `tool_use`→1 (not 5), 0→0, invocation with/without trace, fixture assertions, and an end-to-end JSON contract test
- [x] Manual smoke test: `analyze --verbose` shows the Turns column; JSON shows per-invocation `model_turns` distinct from `tool_uses` (e.g. 6 turns / 13 tools)

## Security review
- [x] **Skip review** — additive analytics field (integer count) + one CLI column; no new user-controlled string rendering or security-sensitive surface.

## Breaking changes
None. Both fields are additive; `SCHEMA_VERSION` stays at "2". `SubagentTrace.model_turns` defaults to `0` so deserializing pre-#466 envelopes is safe.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)