### PR TITLE
feat: per-agent-type model-turn rollup and efficiency ratios (#467)

### DIFF
--- a/src/agentfluent/analytics/agent_metrics.py
+++ b/src/agentfluent/analytics/agent_metrics.py
@@ -16,6 +16,33 @@ from dataclasses import dataclass, field
 from agentfluent.agents.models import AgentInvocation
 
 
+def _recompute_turn_ratios(metrics: AgentTypeMetrics) -> None:
+    """Set the four turn-based ratio fields from the stored totals.
+
+    Shared by ``compute_agent_metrics`` (single session) and
+    ``_merge_agent_metrics`` (multi-session) so the guard logic lives in
+    one place. ``estimated_avg_cost_per_turn_usd`` divides
+    ``estimated_total_cost_usd``, so the caller must set cost before
+    calling this. ``avg_turns_per_invocation`` is guarded on
+    ``invocations_with_turns`` (so a 0-turn trace yields 0.0, not None);
+    the per-turn ratios are guarded on ``total_model_turns`` (0 turns ->
+    None, division-by-zero guard).
+    """
+    if metrics.invocations_with_turns > 0:
+        metrics.avg_turns_per_invocation = (
+            metrics.total_model_turns / metrics.invocations_with_turns
+        )
+    if metrics.total_model_turns > 0:
+        metrics.avg_tool_calls_per_turn = (
+            metrics.total_tool_uses / metrics.total_model_turns
+        )
+        metrics.avg_tokens_per_turn = metrics.total_tokens / metrics.total_model_turns
+        if metrics.estimated_total_cost_usd > 0:
+            metrics.estimated_avg_cost_per_turn_usd = (
+                metrics.estimated_total_cost_usd / metrics.total_model_turns
+            )
+
+
 @dataclass
 class AgentTypeMetrics:
     """Execution metrics for a single agent type."""
@@ -30,6 +57,29 @@ class AgentTypeMetrics:
     """Estimate; see module docstring. Bounded by #143."""
     avg_tokens_per_tool_use: float | None = None
     avg_duration_per_tool_use: float | None = None
+
+    total_model_turns: int = 0
+    """Sum of ``model_turns`` across this agent type's invocations,
+    counting only invocations where ``model_turns is not None`` (a
+    subagent trace was linked). One model turn is one merged assistant
+    message -- one API round-trip (#467)."""
+
+    invocations_with_turns: int = 0
+    """Count of this agent type's invocations that had turn data
+    (``model_turns is not None``). The denominator for
+    ``avg_turns_per_invocation`` -- distinct from ``invocation_count``,
+    which includes trace-missing invocations. Lets a consumer see how
+    much of the population the turn averages actually cover (#467)."""
+
+    # Turn-based ratios. Stored (not @property) so they serialize: this
+    # is a stdlib dataclass nested in a Pydantic envelope, and Pydantic
+    # serializes dataclass *fields* but not their properties. Computed in
+    # compute_agent_metrics() / recomputed in _merge_agent_metrics(),
+    # mirroring avg_tokens_per_tool_use above.
+    avg_turns_per_invocation: float | None = None
+    avg_tool_calls_per_turn: float | None = None
+    avg_tokens_per_turn: float | None = None
+    estimated_avg_cost_per_turn_usd: float | None = None
 
     @property
     def avg_tokens_per_invocation(self) -> float | None:
@@ -68,6 +118,9 @@ class AgentMetrics:
     """Agent tokens as percentage of session total tokens (0-100).
     Set by the caller who has session-level token data."""
 
+    total_model_turns: int = 0
+    """Sum of ``total_model_turns`` across all agent types (#467)."""
+
 
 def compute_agent_metrics(
     invocations: list[AgentInvocation],
@@ -105,6 +158,12 @@ def compute_agent_metrics(
             metrics.total_tool_uses += inv.tool_uses
         if inv.duration_ms is not None:
             metrics.total_duration_ms += inv.duration_ms
+        # ``is not None`` (not truthiness): a 0-turn trace still has turn
+        # data, so it counts toward invocations_with_turns and yields a
+        # legitimate 0.0 average, distinct from a trace-missing gap.
+        if inv.model_turns is not None:
+            metrics.total_model_turns += inv.model_turns
+            metrics.invocations_with_turns += 1
 
     # Session-level blended rate: total_cost / total_tokens. Per-agent
     # cost is then `agent_tokens * rate`. This is an estimate — without
@@ -127,11 +186,14 @@ def compute_agent_metrics(
                 )
         if blended_rate > 0 and metrics.total_tokens > 0:
             metrics.estimated_total_cost_usd = metrics.total_tokens * blended_rate
+        # After cost is set: cost-per-turn divides the value above.
+        _recompute_turn_ratios(metrics)
 
     # Aggregate totals
     total_invocations = sum(m.invocation_count for m in by_type.values())
     total_agent_tokens = sum(m.total_tokens for m in by_type.values())
     total_agent_duration = sum(m.total_duration_ms for m in by_type.values())
+    total_turns = sum(m.total_model_turns for m in by_type.values())
     builtin_count = sum(m.invocation_count for m in by_type.values() if m.is_builtin)
     custom_count = sum(m.invocation_count for m in by_type.values() if not m.is_builtin)
 
@@ -149,4 +211,5 @@ def compute_agent_metrics(
         builtin_invocations=builtin_count,
         custom_invocations=custom_count,
         agent_token_percentage=agent_token_pct,
+        total_model_turns=total_turns,
     )

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -16,6 +16,7 @@ from agentfluent.agents.models import AgentInvocation
 from agentfluent.analytics.agent_metrics import (
     AgentMetrics,
     AgentTypeMetrics,
+    _recompute_turn_ratios,
     compute_agent_metrics,
 )
 from agentfluent.analytics.tokens import (
@@ -333,6 +334,8 @@ def _merge_agent_metrics(
                     total_tool_uses=m.total_tool_uses,
                     total_duration_ms=m.total_duration_ms,
                     estimated_total_cost_usd=m.estimated_total_cost_usd,
+                    total_model_turns=m.total_model_turns,
+                    invocations_with_turns=m.invocations_with_turns,
                 )
             else:
                 existing.invocation_count += m.invocation_count
@@ -340,10 +343,12 @@ def _merge_agent_metrics(
                 existing.total_tool_uses += m.total_tool_uses
                 existing.total_duration_ms += m.total_duration_ms
                 existing.estimated_total_cost_usd += m.estimated_total_cost_usd
+                existing.total_model_turns += m.total_model_turns
+                existing.invocations_with_turns += m.invocations_with_turns
 
     # estimated_total_cost_usd is summed at each session's blended rate
     # so the per-invocation average property reads correctly. Tool-use
-    # averages have to be recomputed because the per-tool-use ratio
+    # and turn ratios have to be recomputed because the per-unit ratio
     # changes when invocations from different sessions merge.
     for m in merged.values():
         if m.total_tool_uses > 0:
@@ -351,10 +356,12 @@ def _merge_agent_metrics(
                 m.avg_tokens_per_tool_use = m.total_tokens / m.total_tool_uses
             if m.total_duration_ms > 0:
                 m.avg_duration_per_tool_use = m.total_duration_ms / m.total_tool_uses
+        _recompute_turn_ratios(m)
 
     total_invocations = sum(m.invocation_count for m in merged.values())
     total_agent_tokens = sum(m.total_tokens for m in merged.values())
     total_agent_duration = sum(m.total_duration_ms for m in merged.values())
+    total_turns = sum(m.total_model_turns for m in merged.values())
     builtin_count = sum(m.invocation_count for m in merged.values() if m.is_builtin)
     custom_count = sum(m.invocation_count for m in merged.values() if not m.is_builtin)
 
@@ -372,6 +379,7 @@ def _merge_agent_metrics(
         builtin_invocations=builtin_count,
         custom_invocations=custom_count,
         agent_token_percentage=agent_token_pct,
+        total_model_turns=total_turns,
     )
 
 

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -193,11 +193,17 @@ def format_analysis_table(
         agent_table = Table(title="Agent Invocations", show_header=True)
         agent_table.add_column("Agent Type", style="cyan")
         agent_table.add_column("Count", justify="right")
+        agent_table.add_column("Avg Turns", justify="right")
         agent_table.add_column("Tokens", justify="right")
         agent_table.add_column("Avg Tokens/Call", justify="right")
         agent_table.add_column("Duration", justify="right")
         for _key, m in sorted(am.by_agent_type.items()):
             label = f"{m.agent_type} {'(builtin)' if m.is_builtin else ''}"
+            avg_turns = (
+                f"{m.avg_turns_per_invocation:.1f}"
+                if m.avg_turns_per_invocation is not None
+                else "-"
+            )
             avg_tok = (
                 format_tokens(int(m.avg_tokens_per_invocation))
                 if m.avg_tokens_per_invocation
@@ -207,15 +213,17 @@ def format_analysis_table(
             agent_table.add_row(
                 label.strip(),
                 str(m.invocation_count),
+                avg_turns,
                 format_tokens(m.total_tokens),
                 avg_tok,
                 duration,
             )
-        agent_table.add_row("", "", "", "", "")
-        agent_table.add_row("Total", str(am.total_invocations), "", "", "")
+        agent_table.add_row("", "", "", "", "", "")
+        agent_table.add_row("Total", str(am.total_invocations), "", "", "", "")
         agent_table.add_row(
             "Agent token %",
             f"{am.agent_token_percentage}%",
+            "",
             "",
             "",
             "",

--- a/tests/unit/test_agent_metrics.py
+++ b/tests/unit/test_agent_metrics.py
@@ -4,6 +4,7 @@ import pytest
 
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.analytics.agent_metrics import compute_agent_metrics
+from agentfluent.traces.models import SubagentTrace
 
 
 def _invocation(
@@ -11,8 +12,9 @@ def _invocation(
     total_tokens: int | None = 10000,
     tool_uses: int | None = 5,
     duration_ms: int | None = 30000,
+    model_turns: int | None = None,
 ) -> AgentInvocation:
-    return AgentInvocation(
+    inv = AgentInvocation(
         agent_type=agent_type,
         description="test",
         prompt="do something",
@@ -21,6 +23,14 @@ def _invocation(
         tool_uses=tool_uses,
         duration_ms=duration_ms,
     )
+    # ``model_turns`` is derived from a linked trace; attach a minimal
+    # one carrying the requested count. ``None`` leaves the invocation
+    # trace-less (the honest-gap case from #466).
+    if model_turns is not None:
+        inv.trace = SubagentTrace(
+            agent_id="a", delegation_prompt="x", model_turns=model_turns,
+        )
+    return inv
 
 
 class TestComputeAgentMetrics:
@@ -237,3 +247,71 @@ class TestPerAgentCost:
         assert explore.estimated_total_cost_usd == pytest.approx(0.70)
         # Cost preserves the input/output dollar total.
         assert pm.estimated_total_cost_usd + explore.estimated_total_cost_usd == pytest.approx(1.0)
+
+
+class TestModelTurnRollup:
+    """#467: per-agent-type turn totals and derived efficiency ratios."""
+
+    def test_total_and_avg_skips_trace_missing(self) -> None:
+        # turns [4, 6, None]: the trace-missing invocation is counted
+        # toward invocation_count but excluded from the turn average.
+        invocations = [
+            _invocation(model_turns=4),
+            _invocation(model_turns=6),
+            _invocation(model_turns=None),
+        ]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.invocation_count == 3
+        assert pm.total_model_turns == 10
+        assert pm.invocations_with_turns == 2
+        assert pm.avg_turns_per_invocation == 5.0
+
+    def test_all_turns_missing_yields_none(self) -> None:
+        invocations = [_invocation(model_turns=None), _invocation(model_turns=None)]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.total_model_turns == 0
+        assert pm.invocations_with_turns == 0
+        assert pm.avg_turns_per_invocation is None
+        assert pm.avg_tool_calls_per_turn is None
+        assert pm.avg_tokens_per_turn is None
+        assert pm.estimated_avg_cost_per_turn_usd is None
+
+    def test_tool_calls_per_turn(self) -> None:
+        # 20 tool calls across 5 turns -> 4.0 calls/turn.
+        invocations = [_invocation(tool_uses=20, model_turns=5)]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.avg_tool_calls_per_turn == 4.0
+
+    def test_tokens_and_cost_per_turn(self) -> None:
+        # 10k tokens / 5 turns -> 2000 tokens/turn. Session 10k @ $1.00
+        # blended -> agent cost $1.00 / 5 turns -> $0.20/turn.
+        invocations = [_invocation(total_tokens=10000, tool_uses=5, model_turns=5)]
+        pm = compute_agent_metrics(
+            invocations, session_total_tokens=10000, session_total_cost=1.0,
+        ).by_agent_type["pm"]
+        assert pm.avg_tokens_per_turn == 2000.0
+        assert pm.estimated_avg_cost_per_turn_usd == pytest.approx(0.20)
+
+    def test_zero_turn_trace_guards_per_turn_ratios(self) -> None:
+        # Trace exists but has 0 assistant messages: invocations_with_turns
+        # counts it (turn data IS present), avg_turns_per_invocation is a
+        # legitimate 0.0, but per-turn ratios are None (no division by 0).
+        invocations = [_invocation(total_tokens=10000, tool_uses=5, model_turns=0)]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.invocations_with_turns == 1
+        assert pm.total_model_turns == 0
+        assert pm.avg_turns_per_invocation == 0.0
+        assert pm.avg_tool_calls_per_turn is None
+        assert pm.avg_tokens_per_turn is None
+        assert pm.estimated_avg_cost_per_turn_usd is None
+
+    def test_aggregate_total_across_types(self) -> None:
+        invocations = [
+            _invocation(agent_type="pm", model_turns=4),
+            _invocation(agent_type="pm", model_turns=6),
+            _invocation(agent_type="Explore", model_turns=3),
+        ]
+        metrics = compute_agent_metrics(invocations)
+        assert metrics.total_model_turns == 13
+        assert metrics.by_agent_type["pm"].total_model_turns == 10
+        assert metrics.by_agent_type["explore"].total_model_turns == 3

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -2,10 +2,11 @@
 
 from pathlib import Path
 
-from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.agent_metrics import AgentMetrics, AgentTypeMetrics
 from agentfluent.analytics.pipeline import (
     AnalysisResult,
     SessionAnalysis,
+    _merge_agent_metrics,
     analyze_session,
     analyze_sessions,
 )
@@ -140,3 +141,41 @@ class TestModelTurns:
         assert dumped["sessions"][0]["model_turns"] == 5
         # Backing field stays for backward compat.
         assert dumped["sessions"][0]["assistant_message_count"] == 5
+
+
+class TestMergeAgentMetricsTurns:
+    """#467: _merge_agent_metrics carries turn totals across sessions and
+    recomputes the turn ratios from the merged totals."""
+
+    @staticmethod
+    def _metrics(total_turns: int, with_turns: int, tool_uses: int) -> AgentMetrics:
+        t = AgentTypeMetrics(
+            agent_type="pm",
+            is_builtin=False,
+            invocation_count=with_turns,
+            total_tool_uses=tool_uses,
+            total_model_turns=total_turns,
+            invocations_with_turns=with_turns,
+        )
+        return AgentMetrics(by_agent_type={"pm": t}, total_invocations=with_turns)
+
+    def test_turn_fields_summed_and_ratios_recomputed(self) -> None:
+        # Session A: 6 turns over 2 invocations, 12 tool calls.
+        # Session B: 4 turns over 1 invocation, 8 tool calls.
+        merged = _merge_agent_metrics(
+            [self._metrics(6, 2, 12), self._metrics(4, 1, 8)],
+        )
+        pm = merged.by_agent_type["pm"]
+        assert pm.total_model_turns == 10
+        assert pm.invocations_with_turns == 3
+        assert merged.total_model_turns == 10
+        # Ratios recomputed from merged totals, not averaged.
+        assert pm.avg_turns_per_invocation == 10 / 3
+        assert pm.avg_tool_calls_per_turn == 20 / 10
+
+    def test_first_seen_branch_preserves_turn_fields(self) -> None:
+        # A single-session merge exercises only the first-seen
+        # constructor branch — turn fields must survive it.
+        pm = _merge_agent_metrics([self._metrics(6, 2, 12)]).by_agent_type["pm"]
+        assert pm.total_model_turns == 6
+        assert pm.invocations_with_turns == 2


### PR DESCRIPTION
## Summary
- Aggregates **model-turn counts by agent type** and derives efficiency ratios that normalize existing metrics ("20 tool errors" → "0.8 per turn across 25 turns"). Builds on #466's per-invocation `model_turns`.
- `AgentTypeMetrics` gains stored fields `total_model_turns`, `invocations_with_turns`, and four ratios: `avg_turns_per_invocation`, `avg_tool_calls_per_turn`, `avg_tokens_per_turn`, `estimated_avg_cost_per_turn_usd`. Stored (not `@property`) so they serialize from the dataclass nested in the Pydantic envelope — matching the existing `avg_tokens_per_tool_use` precedent. `AgentMetrics` gains aggregate `total_model_turns`.
- `compute_agent_metrics` accumulates `model_turns` with an `is not None` guard (a 0-turn trace counts toward `invocations_with_turns` → legitimate 0.0 avg, distinct from a trace-missing gap). A shared `_recompute_turn_ratios` helper computes ratios after cost is set; `_merge_agent_metrics` reuses it and carries the new totals through **both** merge branches.
- CLI: Agent Invocations table gains an "Avg Turns" column. JSON: all six per-type turn fields + aggregate `total_model_turns`.

## Design note
Per the [architect review](https://github.com/frederick-douglas-pearce/agentfluent/issues/467#issuecomment-4586164711), the optional Pydantic migration of `AgentTypeMetrics` is **deferred to #488** to keep this story S-sized and make the JSON-contract change (which would expose three existing `@property` ratios) deliberate rather than a side effect.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1572 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New behavior has coverage: turns [4,6,None]→total 10/with_turns 2/avg 5.0; all-None→avg None; 20 tools/5 turns→4.0 calls/turn; 0-turn trace→per-turn ratios None (div-by-zero guarded) while avg_turns=0.0; multi-type aggregation; `_merge_agent_metrics` preserves turn fields across both merge branches
- [x] Manual smoke test: Avg Turns column renders; JSON shows all six ratios (e.g. architect: 12.4 turns/inv, 1.8 calls/turn, 55 of 59 invocations had turn data)

## Security review
- [x] **Skip review** — additive numeric analytics fields + one CLI column; no new user-controlled string rendering or security-sensitive surface.

## Breaking changes
None. All new fields are additive; `SCHEMA_VERSION` stays at "2". Dataclass defaults (0 / None) keep pre-turn-era envelopes safe to deserialize.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)