### PR TITLE
feat: integrate model-turn metrics into `agentfluent diff` (#470)

### DIFF
--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -313,14 +313,7 @@ def _render_agent_metrics(
     *,
     verbose: bool,
 ) -> None:
-    rows = [
-        d for d in result.by_agent_type
-        if verbose
-        or d.invocation_count_delta != 0
-        or d.total_tokens_delta != 0
-        or d.estimated_cost_delta_usd != 0
-        or d.total_model_turns_delta != 0
-    ]
+    rows = [d for d in result.by_agent_type if verbose or d.has_change]
     if not rows:
         return
 
@@ -336,11 +329,13 @@ def _render_agent_metrics(
     )
 
     for row in rows:
-        avg_turns_delta = _derive_avg_turns(
-            row.current_total_model_turns, row.current_invocations_with_turns,
-        ) - _derive_avg_turns(
+        baseline_avg = _derive_avg_turns(
             row.baseline_total_model_turns, row.baseline_invocations_with_turns,
         )
+        current_avg = _derive_avg_turns(
+            row.current_total_model_turns, row.current_invocations_with_turns,
+        )
+        avg_turns_delta = current_avg - baseline_avg
         table.add_row(
             row.agent_type,
             _signed_int(row.invocation_count_delta),

--- a/src/agentfluent/cli/formatters/diff_table.py
+++ b/src/agentfluent/cli/formatters/diff_table.py
@@ -268,6 +268,12 @@ def _render_token_metrics(console: Console, result: DiffResult) -> None:
             higher_is_better=True,
         ),
     )
+    table.add_row(
+        "Model turns",
+        f"{tm.baseline_model_turns:,}",
+        f"{tm.current_model_turns:,}",
+        _signed_int(tm.model_turns_delta),
+    )
     console.print(table)
     console.print()
 
@@ -313,6 +319,7 @@ def _render_agent_metrics(
         or d.invocation_count_delta != 0
         or d.total_tokens_delta != 0
         or d.estimated_cost_delta_usd != 0
+        or d.total_model_turns_delta != 0
     ]
     if not rows:
         return
@@ -322,20 +329,41 @@ def _render_agent_metrics(
     table.add_column("Invocations Δ", justify="right")
     table.add_column("Tokens Δ", justify="right")
     table.add_column("Cost Δ", justify="right")
+    table.add_column("Avg Turns Δ", justify="right")
 
     rows.sort(
         key=lambda d: (-abs(d.estimated_cost_delta_usd), d.agent_type),
     )
 
     for row in rows:
+        avg_turns_delta = _derive_avg_turns(
+            row.current_total_model_turns, row.current_invocations_with_turns,
+        ) - _derive_avg_turns(
+            row.baseline_total_model_turns, row.baseline_invocations_with_turns,
+        )
         table.add_row(
             row.agent_type,
             _signed_int(row.invocation_count_delta),
             _signed_int(row.total_tokens_delta),
             _signed_cost(row.estimated_cost_delta_usd),
+            _signed_float(avg_turns_delta, precision=2),
         )
     console.print(table)
     console.print()
+
+
+def _derive_avg_turns(total_model_turns: int, invocations_with_turns: int) -> float:
+    """Avg model turns per invocation, derived from stored totals (#470).
+
+    Mirrors ``analyze``'s derivation (#467) rather than precomputing an
+    avg-delta field, so the two surfaces never disagree. Guards the
+    denominator: zero invocations-with-turns yields ``0.0``, not a
+    ``ZeroDivisionError`` — matching the ``invocations_with_turns > 0``
+    guard in :mod:`agentfluent.analytics.agent_metrics`.
+    """
+    if invocations_with_turns <= 0:
+        return 0.0
+    return total_model_turns / invocations_with_turns
 
 
 def _render_regression_footer(console: Console, result: DiffResult) -> None:

--- a/src/agentfluent/diff/compute.py
+++ b/src/agentfluent/diff/compute.py
@@ -267,6 +267,13 @@ def _diff_token_metrics(
     baseline_cache = float(baseline_tm.get("cache_efficiency", 0.0) or 0.0)
     current_cache = float(current_tm.get("cache_efficiency", 0.0) or 0.0)
 
+    # Parent-session model turns live at the envelope top level (#465),
+    # alongside ``session_count`` — NOT under ``token_metrics``. Read from
+    # the full envelope dicts, not ``*_tm``. Pre-#465 envelopes lack the
+    # key; ``or 0`` covers both missing and ``None``.
+    baseline_turns = int(baseline.get("total_model_turns", 0) or 0)
+    current_turns = int(current.get("total_model_turns", 0) or 0)
+
     by_model = _diff_by_model(
         baseline_tm.get("by_model") or [],
         current_tm.get("by_model") or [],
@@ -282,6 +289,9 @@ def _diff_token_metrics(
         baseline_cache_efficiency=baseline_cache,
         current_cache_efficiency=current_cache,
         cache_efficiency_delta=current_cache - baseline_cache,
+        baseline_model_turns=baseline_turns,
+        current_model_turns=current_turns,
+        model_turns_delta=current_turns - baseline_turns,
         by_model=by_model,
     )
 
@@ -384,6 +394,14 @@ def _diff_agent_metrics(
         b_cost = float(b.get("estimated_total_cost_usd", 0.0) or 0.0)
         c_cost = float(c.get("estimated_total_cost_usd", 0.0) or 0.0)
 
+        # Model-turn totals (#467). Legacy-envelope fallback: pre-turn
+        # entries lack both keys and resolve to 0, so the delta shows the
+        # full current value as new (correct — there was nothing to compare).
+        b_turns = int(b.get("total_model_turns", 0) or 0)
+        c_turns = int(c.get("total_model_turns", 0) or 0)
+        b_with_turns = int(b.get("invocations_with_turns", 0) or 0)
+        c_with_turns = int(c.get("invocations_with_turns", 0) or 0)
+
         # is_builtin is identity-bound to the agent name; if either side
         # has it set we can trust it.
         is_builtin = bool(c.get("is_builtin", False) or b.get("is_builtin", False))
@@ -401,6 +419,11 @@ def _diff_agent_metrics(
                 baseline_estimated_cost_usd=b_cost,
                 current_estimated_cost_usd=c_cost,
                 estimated_cost_delta_usd=c_cost - b_cost,
+                baseline_total_model_turns=b_turns,
+                current_total_model_turns=c_turns,
+                total_model_turns_delta=c_turns - b_turns,
+                baseline_invocations_with_turns=b_with_turns,
+                current_invocations_with_turns=c_with_turns,
             ),
         )
     return deltas

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -159,6 +159,22 @@ class AgentTypeDelta(BaseModel):
     keeping the two outputs from diverging. No precomputed avg-delta field
     exists by design."""
 
+    @property
+    def has_change(self) -> bool:
+        """``True`` iff any tracked metric delta is nonzero.
+
+        Centralizes the "is this row worth showing" policy so the diff
+        renderer's zero-row filter stays stable as new metric deltas are
+        added — each new metric extends this one predicate instead of
+        growing an OR-chain at the call site. A plain ``@property`` (not a
+        ``computed_field``) so it stays out of the JSON envelope."""
+        return bool(
+            self.invocation_count_delta
+            or self.total_tokens_delta
+            or self.estimated_cost_delta_usd
+            or self.total_model_turns_delta,
+        )
+
 
 class DiffResult(BaseModel):
     """Complete diff output. JSON envelope wraps ``model_dump(mode='json')``.

--- a/src/agentfluent/diff/models.py
+++ b/src/agentfluent/diff/models.py
@@ -113,6 +113,15 @@ class TokenMetricsDelta(BaseModel):
     current_cache_efficiency: float = 0.0
     cache_efficiency_delta: float = 0.0
 
+    baseline_model_turns: int = 0
+    current_model_turns: int = 0
+    model_turns_delta: int = 0
+    """Parent-session model-turn delta (#470). Sourced from the envelope's
+    top-level ``total_model_turns`` (#465), not from the nested
+    ``token_metrics`` block — it lives here because ``TokenMetricsDelta``
+    already holds session-shape metrics. Pre-#465 envelopes lack the field
+    and fall back to ``0`` on both sides (delta ``0``)."""
+
     by_model: list[ModelTokenDelta] = Field(default_factory=list)
     """One entry per model that appears in either baseline or current. A
     model present on only one side has zero on the missing side."""
@@ -135,6 +144,20 @@ class AgentTypeDelta(BaseModel):
     baseline_estimated_cost_usd: float = 0.0
     current_estimated_cost_usd: float = 0.0
     estimated_cost_delta_usd: float = 0.0
+
+    baseline_total_model_turns: int = 0
+    current_total_model_turns: int = 0
+    total_model_turns_delta: int = 0
+    """Per-agent-type model-turn delta (#470), summed across this type's
+    invocations (#467). Pre-#467 envelopes lack the field and fall back to
+    ``0`` on both sides."""
+
+    baseline_invocations_with_turns: int = 0
+    current_invocations_with_turns: int = 0
+    """Denominator for avg-turns-per-invocation, stored (not averaged) so
+    the diff renderer derives the avg the same way ``analyze`` does (#467),
+    keeping the two outputs from diverging. No precomputed avg-delta field
+    exists by design."""
 
 
 class DiffResult(BaseModel):

--- a/tests/unit/cli/test_diff_table_signed.py
+++ b/tests/unit/cli/test_diff_table_signed.py
@@ -8,6 +8,7 @@ of cost/token deltas.
 from __future__ import annotations
 
 from agentfluent.cli.formatters.diff_table import (
+    _derive_avg_turns,
     _signed,
     _signed_cost,
     _signed_float,
@@ -55,3 +56,19 @@ class TestHigherIsBetterInversion:
             -1.5, precision=1, suffix="%", higher_is_better=True,
         )
         assert rendered == "[red]-1.5%[/red]"
+
+
+class TestDeriveAvgTurns:
+    """#470 — avg turns per invocation is derived in the renderer from
+    stored totals, not precomputed as a delta field."""
+
+    def test_derives_avg_from_stored_totals(self) -> None:
+        assert _derive_avg_turns(20, 4) == 5.0
+
+    def test_zero_invocations_with_turns_guards_division(self) -> None:
+        assert _derive_avg_turns(0, 0) == 0.0
+
+    def test_nonzero_turns_zero_denominator_still_guarded(self) -> None:
+        # Defensive: a malformed envelope with turns but no counted
+        # invocations must not raise.
+        assert _derive_avg_turns(7, 0) == 0.0

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -374,6 +374,29 @@ class TestAgentTypeDelta:
         assert delta.estimated_cost_delta_usd == -0.30
 
 
+class TestAgentTypeDeltaHasChange:
+    """``has_change`` drives the diff renderer's zero-row filter; any
+    nonzero metric delta keeps the row visible (#470)."""
+
+    def test_all_zero_deltas_is_unchanged(self) -> None:
+        entry = {"invocation_count": 3, "total_tokens": 1, "estimated_total_cost_usd": 0.5}
+        result = compute_diff(
+            _envelope(by_agent={"pm": entry}), _envelope(by_agent={"pm": entry}),
+        )
+        delta = next(d for d in result.by_agent_type if d.agent_type == "pm")
+        assert delta.has_change is False
+
+    def test_turn_only_delta_counts_as_change(self) -> None:
+        # Tokens/cost/invocations identical; only model turns differ.
+        result = compute_diff(
+            _envelope(by_agent={"pm": _agent_entry(total_model_turns=4, invocations_with_turns=2)}),
+            _envelope(by_agent={"pm": _agent_entry(total_model_turns=8, invocations_with_turns=2)}),
+        )
+        delta = next(d for d in result.by_agent_type if d.agent_type == "pm")
+        assert delta.invocation_count_delta == 0
+        assert delta.has_change is True
+
+
 def _agent_entry(
     *,
     invocation_count: int = 1,

--- a/tests/unit/diff/test_compute.py
+++ b/tests/unit/diff/test_compute.py
@@ -28,6 +28,7 @@ def _envelope(
     total_cost: float = 0.0,
     cache_efficiency: float = 0.0,
     session_count: int = 1,
+    total_model_turns: int | None = None,
 ) -> dict[str, Any]:
     by_model_payload: dict[str, Any] | list[Any]
     if by_model is None:
@@ -36,7 +37,7 @@ def _envelope(
         by_model_payload = []
     else:
         by_model_payload = by_model
-    return {
+    envelope: dict[str, Any] = {
         "session_count": session_count,
         "token_metrics": {
             "input_tokens": 100,
@@ -55,6 +56,11 @@ def _envelope(
             "aggregated_recommendations": aggregated_recs or [],
         } if aggregated_recs is not None else None,
     }
+    # Parent-session model turns live at the envelope top level (#465).
+    # Pass ``None`` to omit the key entirely, simulating a pre-#465 envelope.
+    if total_model_turns is not None:
+        envelope["total_model_turns"] = total_model_turns
+    return envelope
 
 
 def _agg_rec(
@@ -366,6 +372,105 @@ class TestAgentTypeDelta:
         assert delta.invocation_count_delta == -6
         assert delta.total_tokens_delta == -3000
         assert delta.estimated_cost_delta_usd == -0.30
+
+
+def _agent_entry(
+    *,
+    invocation_count: int = 1,
+    total_model_turns: int | None = None,
+    invocations_with_turns: int | None = None,
+) -> dict[str, Any]:
+    """Build a ``by_agent_type`` entry. Omit turn keys to simulate a
+    pre-#467 envelope (the ``None`` sentinels drop the keys entirely)."""
+    entry: dict[str, Any] = {
+        "invocation_count": invocation_count,
+        "total_tokens": 1000,
+        "estimated_total_cost_usd": 0.10,
+    }
+    if total_model_turns is not None:
+        entry["total_model_turns"] = total_model_turns
+    if invocations_with_turns is not None:
+        entry["invocations_with_turns"] = invocations_with_turns
+    return entry
+
+
+class TestModelTurnDeltas:
+    """#470 — parent-session and per-agent-type model-turn deltas."""
+
+    def test_parent_session_turn_delta(self) -> None:
+        baseline = _envelope(total_model_turns=40)
+        current = _envelope(total_model_turns=55)
+        result = compute_diff(baseline, current)
+        assert result.token_metrics.baseline_model_turns == 40
+        assert result.token_metrics.current_model_turns == 55
+        assert result.token_metrics.model_turns_delta == 15
+
+    def test_parent_session_turns_legacy_baseline_falls_back_to_zero(self) -> None:
+        # Pre-#465 baseline has no ``total_model_turns`` key at all.
+        baseline = _envelope(total_model_turns=None)
+        current = _envelope(total_model_turns=30)
+        result = compute_diff(baseline, current)
+        assert result.token_metrics.baseline_model_turns == 0
+        assert result.token_metrics.model_turns_delta == 30
+
+    def test_parent_session_turns_both_zero_yields_zero_delta(self) -> None:
+        baseline = _envelope(total_model_turns=0)
+        current = _envelope(total_model_turns=0)
+        result = compute_diff(baseline, current)
+        assert result.token_metrics.model_turns_delta == 0
+
+    def test_per_agent_turn_delta(self) -> None:
+        baseline = _envelope(by_agent={
+            "pm": _agent_entry(total_model_turns=12, invocations_with_turns=3),
+        })
+        current = _envelope(by_agent={
+            "pm": _agent_entry(total_model_turns=20, invocations_with_turns=4),
+        })
+        result = compute_diff(baseline, current)
+        delta = next(d for d in result.by_agent_type if d.agent_type == "pm")
+        assert delta.baseline_total_model_turns == 12
+        assert delta.current_total_model_turns == 20
+        assert delta.total_model_turns_delta == 8
+        assert delta.baseline_invocations_with_turns == 3
+        assert delta.current_invocations_with_turns == 4
+
+    def test_per_agent_turns_legacy_baseline_falls_back_to_zero(self) -> None:
+        # Pre-#467 baseline entry lacks both turn keys → graceful 0, no crash.
+        baseline = _envelope(by_agent={"pm": _agent_entry()})
+        current = _envelope(by_agent={
+            "pm": _agent_entry(total_model_turns=20, invocations_with_turns=4),
+        })
+        result = compute_diff(baseline, current)
+        delta = next(d for d in result.by_agent_type if d.agent_type == "pm")
+        assert delta.baseline_total_model_turns == 0
+        assert delta.baseline_invocations_with_turns == 0
+        assert delta.total_model_turns_delta == 20
+
+    def test_per_agent_turns_both_zero_yields_zero_delta(self) -> None:
+        baseline = _envelope(by_agent={
+            "pm": _agent_entry(total_model_turns=0, invocations_with_turns=0),
+        })
+        current = _envelope(by_agent={
+            "pm": _agent_entry(total_model_turns=0, invocations_with_turns=0),
+        })
+        result = compute_diff(baseline, current)
+        delta = next(d for d in result.by_agent_type if d.agent_type == "pm")
+        assert delta.total_model_turns_delta == 0
+
+    def test_turn_fields_serialize_in_json_dump(self) -> None:
+        baseline = _envelope(
+            total_model_turns=10,
+            by_agent={"pm": _agent_entry(total_model_turns=5, invocations_with_turns=2)},
+        )
+        current = _envelope(
+            total_model_turns=18,
+            by_agent={"pm": _agent_entry(total_model_turns=9, invocations_with_turns=3)},
+        )
+        dumped = compute_diff(baseline, current).model_dump(mode="json")
+        assert dumped["token_metrics"]["model_turns_delta"] == 8
+        agent_row = next(d for d in dumped["by_agent_type"] if d["agent_type"] == "pm")
+        assert agent_row["total_model_turns_delta"] == 4
+        assert agent_row["current_invocations_with_turns"] == 3
 
 
 class TestForwardCompat:


### PR DESCRIPTION
## Summary
- Adds model-turn deltas to `agentfluent diff`, completing the model-turn batch (#465/#466/#467) so turn data is visible in the comparison workflow.
- Per-agent-type: `AgentTypeDelta` gains turn totals + invocations-with-turns; avg turns is **derived in the renderer** (`_derive_avg_turns`) from stored totals — not a precomputed delta field — staying DRY with #467 / `analyze`.
- Parent-session: `TokenMetricsDelta` gains `model_turns_delta`, sourced from the envelope's **top-level** `total_model_turns` (where #465 placed it), surfaced as a `Model turns` row.
- Backward compatible: pre-turn envelopes resolve to `0` on both sides via the established `int(d.get(..., 0) or 0)` fallback (delta shows the full current value as new).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1582 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (per-agent + parent deltas, legacy fallback, current-only, both-zero, renderer avg derivation, JSON serialization)
- [x] Manual smoke test via `uv run agentfluent diff ...` — confirmed both the table (`Model turns` row, `Avg Turns Δ` column) and the JSON envelope render correctly

## Security review
- [x] **Skip review** — no security-sensitive surface. Additive analytics fields read from already-parsed envelope dicts and rendered into Rich tables; no new parsing, path resolution, network, subprocess, or user-controlled-string rendering.
- [ ] **Needs review**

## Breaking changes
None. All fields are additive with defaults; the JSON envelope `version` is unchanged. Pre-turn envelopes diff cleanly (turn deltas read as `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)