### PR TITLE
feat: add TOOL_ORCHESTRATION_CHAIN diagnostic signal (Tier A)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -407,6 +407,41 @@ claude-haiku-4-5.
 
 **Related:** [`complexity_tier`](#complexity_tier), [`overspec`](#overspec), [`underspec`](#underspec), [`target_model`](#target_model)
 
+### `tool_orchestration_chain`
+
+**Short:** An agent runs long tool-call chains whose large intermediate results
+pass through the context window unnecessarily.
+
+**Detail:** Per-agent-type signal (Tier A, metadata-only). Flags invocations that
+make 10+ tool calls AND average more than 2,000 tokens per call -- a
+proxy for orchestration chains where each `tool_result` enters the
+context window even though only the final output is needed. Fires when
+3+ invocations of the same agent type match the pattern. Recommends
+Programmatic Tool Calling (`allowed_callers:
+["code_execution_20250825"]`), which runs the orchestration in a
+code-execution sandbox so intermediate results stay out of context.
+Severity is `info`, not `warning`: the metadata-only proxy cannot tell
+a true chain (intermediates discarded) from an agent that legitimately
+needs each intermediate in context for reasoning. Estimated precision
+is 60-70%; this is the first LLM-call augmentation candidate (D035).
+
+**Example:**
+
+```
+Agent 'general-purpose' made 47 tool calls consuming 132,000 tokens
+across 3 invocations. Average token cost per tool call: 2,809 tokens.
+Estimated savings ~48,840 tokens at the 37% benchmark by migrating to
+code-execution orchestration.
+```
+
+**Severity:** info
+
+**Threshold:** 10+ tool calls AND >2000 tokens/call per invocation; min 3 invocations
+
+**Recommendation target:** `tools`
+
+**Related:** [`token_outlier`](#token_outlier), [`target_tools`](#target_tools), [`model_mismatch`](#model_mismatch)
+
 ### `mcp_unused_server`
 
 **Short:** An MCP server is configured but never called in observed sessions.

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -77,6 +77,7 @@ from agentfluent.diagnostics.models import (
 SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.TOKEN_OUTLIER: Axis.COST,
     SignalType.MODEL_MISMATCH: Axis.COST,
+    SignalType.TOOL_ORCHESTRATION_CHAIN: Axis.COST,
     SignalType.MCP_UNUSED_SERVER: Axis.COST,
     SignalType.DURATION_OUTLIER: Axis.SPEED,
     SignalType.RETRY_LOOP: Axis.SPEED,

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -27,6 +27,7 @@ from agentfluent.diagnostics.quality_signals import (
     PARENT_ACTED_HEALTHY_BAND_HIGH,
     PARENT_ACTED_HEALTHY_BAND_LOW,
 )
+from agentfluent.diagnostics.tool_orchestration import ESTIMATED_TOKEN_SAVINGS_KEY
 
 
 def _relpath(path: Path) -> str:
@@ -565,6 +566,74 @@ class ModelRoutingRule:
         )
 
 
+class ToolOrchestrationRule:
+    """TOOL_ORCHESTRATION_CHAIN -> recommend Programmatic Tool Calling.
+
+    The agent orchestrates long tool-call chains whose large intermediate
+    results pass through the context window. Recommends migrating the
+    chained tools to ``allowed_callers: ["code_execution_20250825"]`` so
+    intermediates stay in the code-execution sandbox. Severity stays
+    ``INFO`` (carried from the signal) to reflect the Tier A metadata-only
+    precision limitation.
+    """
+
+    _ARTICLE_URL = "https://www.anthropic.com/engineering/advanced-tool-use"
+    _builtin_target = "tools"
+    _builtin_concern: BuiltinConcern = "tools"
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.TOOL_ORCHESTRATION_CHAIN
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        savings = signal.detail.get(ESTIMATED_TOKEN_SAVINGS_KEY)
+
+        observation = signal.message
+        reason = (
+            "Sequential tool-call chains with large intermediate payloads "
+            "inflate context-window usage. Programmatic Tool Calling lets "
+            "the agent orchestrate tool calls in a sandboxed code-execution "
+            "environment where intermediate results don't enter the context "
+            "window. Anthropic reports a 37% token reduction on complex "
+            "research tasks."
+        )
+
+        if rec := _check_builtin(self, signal, reason):
+            return rec
+
+        action_parts = [
+            "Consider migrating the tools this agent calls to "
+            '`allowed_callers: ["code_execution_20250825"]` so intermediate '
+            "results are processed in the code-execution sandbox",
+        ]
+        if isinstance(savings, int) and savings > 0:
+            action_parts.append(
+                f"(estimated savings: ~{savings:,} tokens at the 37% benchmark)",
+            )
+        if config:
+            action_parts.append(
+                f"— edit the tool definitions referenced by "
+                f"{_relpath(config.file_path)}.",
+            )
+        else:
+            action_parts.append(f"— see {self._ARTICLE_URL}.")
+        action = " ".join(action_parts)
+
+        return DiagnosticRecommendation(
+            target="tools",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
 # Module-level rule registry. Add new rules here.
 class McpAuditRule:
     """MCP server audit signals -> recommend mcpServers config edit.
@@ -1021,6 +1090,7 @@ RULES: list[CorrelationRule] = [
     StuckPatternRule(),
     ErrorSequenceRule(),
     ModelRoutingRule(),
+    ToolOrchestrationRule(),
     McpAuditRule(),
     UnusedAgentRule(),
     UserCorrectionRule(),

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -578,6 +578,12 @@ class ToolOrchestrationRule:
     """
 
     _ARTICLE_URL = "https://www.anthropic.com/engineering/advanced-tool-use"
+    # "tools" is the closest fit in the coarse concern taxonomy
+    # (scope/recovery/tools/model): the fix is a tool-coordination change
+    # (migrate to ``allowed_callers``), not a grant/deny of tools. The
+    # built-in action ("route to a custom subagent with explicit tool
+    # grants") still lands the user in the right place. Revisit if a 3rd
+    # orchestration-pattern signal makes a dedicated concern worthwhile.
     _builtin_target = "tools"
     _builtin_concern: BuiltinConcern = "tools"
 

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -55,7 +55,7 @@ class SignalType(StrEnum):
       `STUCK_PATTERN`
 
     Aggregate-level signals (extracted from per-agent-type rollups):
-    - `MODEL_MISMATCH`
+    - `MODEL_MISMATCH`, `TOOL_ORCHESTRATION_CHAIN`
 
     MCP audit signals (configured-vs-observed MCP server usage):
     - `MCP_UNUSED_SERVER`, `MCP_MISSING_SERVER`
@@ -84,6 +84,7 @@ class SignalType(StrEnum):
     PERMISSION_FAILURE = "permission_failure"
     STUCK_PATTERN = "stuck_pattern"
     MODEL_MISMATCH = "model_mismatch"
+    TOOL_ORCHESTRATION_CHAIN = "tool_orchestration_chain"
     MCP_UNUSED_SERVER = "mcp_unused_server"
     MCP_MISSING_SERVER = "mcp_missing_server"
     UNUSED_AGENT = "unused_agent"

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -63,6 +63,9 @@ from agentfluent.diagnostics.models import (
 from agentfluent.diagnostics.parent_workload import build_offload_candidates
 from agentfluent.diagnostics.quality_signals import extract_quality_signals
 from agentfluent.diagnostics.signals import extract_signals
+from agentfluent.diagnostics.tool_orchestration import (
+    extract_tool_orchestration_signals,
+)
 from agentfluent.diagnostics.trace_signals import extract_trace_signals
 
 logger = logging.getLogger(__name__)
@@ -225,6 +228,11 @@ def run_diagnostics(
     # Aggregate-level signals (model-routing) use the same config lookup
     # the correlator will read from; fold them in before correlation.
     signals.extend(extract_model_routing_signals(invocations, configs_by_name))
+
+    # Tool-orchestration-chain signals (Tier A, metadata-only) — same
+    # aggregate-level phase as model-routing; uses only invocation
+    # metadata, so it doesn't need configs.
+    signals.extend(extract_tool_orchestration_signals(invocations))
 
     signals.extend(
         audit_unused_agents(

--- a/src/agentfluent/diagnostics/tool_orchestration.py
+++ b/src/agentfluent/diagnostics/tool_orchestration.py
@@ -1,0 +1,154 @@
+"""Tool-orchestration-chain diagnostics (Tier A, metadata-only).
+
+Detects agent invocations that orchestrate long sequential tool-call
+chains with large intermediate payloads -- a pattern where each
+``tool_result`` enters the context window even though the agent only
+needs the final output. Programmatic Tool Calling
+(``allowed_callers: ["code_execution_20250825"]``) addresses this by
+running the orchestration in a code-execution sandbox where intermediate
+results stay out of the context window. Anthropic reports a 37% token
+reduction on complex research tasks (see the Advanced Tool Use article).
+
+**Tier A scope (#406).** This is a coarse, metadata-only proxy built
+from the parent session's ``toolUseResult`` fields
+(``AgentInvocation.tool_uses`` and ``.total_tokens``). It fires on
+invocations with a high tool-call count *and* a high per-call token
+average, aggregated to 3+ matching invocations per agent type. Tier B
+(trace-enhanced, per-call inspection) is a deferred follow-up.
+
+**Known precision risk.** The proxy cannot distinguish true orchestration
+chains (intermediate results consumed and discarded) from agents that
+genuinely need each intermediate result in context for reasoning. Severity
+is therefore ``INFO``, not ``WARNING``. This is the first LLM-call
+augmentation candidate (D035): an LLM classifying intermediate-result
+relevance could lift precision from an estimated 60-70% to 85-90%. A
+calibration story validates the thresholds against dogfood data.
+
+**Threshold calibration.** The three thresholds below are the PRD's
+starting defaults, exposed as module-level constants so the calibration
+story can tune them against real session data without touching the
+detection logic.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from agentfluent.config.models import Severity
+from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+
+if TYPE_CHECKING:
+    from agentfluent.agents.models import AgentInvocation
+
+__all__ = [
+    "ESTIMATED_TOKEN_SAVINGS_KEY",
+    "TOKEN_REDUCTION_FACTOR",
+    "extract_tool_orchestration_signals",
+]
+
+# Per-invocation match predicate. An invocation is part of an
+# orchestration chain when it makes many tool calls AND each call carries
+# a large average token payload (the proxy for "big intermediate results
+# passing through context").
+_MIN_TOOL_CALLS = 10
+_MIN_TOKENS_PER_TOOL_CALL = 2000.0
+
+# Aggregate gate: require the pattern across multiple invocations of the
+# same agent type before emitting, mirroring MODEL_MISMATCH's
+# `_MIN_INVOCATIONS_FOR_ANALYSIS`. A single unusual invocation isn't
+# enough signal to recommend a config change (OQ1 in the PRD).
+_MIN_MATCHING_INVOCATIONS = 3
+
+# Estimated token savings from migrating to Programmatic Tool Calling,
+# anchored on Anthropic's reported 37% reduction (43,588 -> 27,297) on
+# complex research tasks. Applied to the summed tokens of the matching
+# invocations as a rough projection, surfaced in the recommendation.
+TOKEN_REDUCTION_FACTOR = 0.37
+
+# Producer/consumer contract: this module stores the projected token
+# savings under this key in the signal's ``detail`` dict;
+# ``correlator.ToolOrchestrationRule`` reads it to build the action text.
+# Distinct from MODEL_MISMATCH's ``estimated_savings_usd`` -- this is a
+# token count, not a dollar figure.
+ESTIMATED_TOKEN_SAVINGS_KEY = "estimated_token_savings"
+
+
+def _is_orchestration_chain(inv: AgentInvocation) -> bool:
+    """Whether a single invocation matches the Tier A chain predicate.
+
+    Requires both metadata fields and a non-zero tool count; invocations
+    missing ``tool_uses`` or ``total_tokens`` (older sessions, interrupted
+    runs) can't be classified and don't match.
+    """
+    if inv.tool_uses is None or inv.tool_uses < _MIN_TOOL_CALLS:
+        return False
+    ratio = inv.tokens_per_tool_use
+    return ratio is not None and ratio > _MIN_TOKENS_PER_TOOL_CALL
+
+
+def _build_signal(
+    agent_type: str,
+    matching: list[AgentInvocation],
+) -> DiagnosticSignal:
+    """Build one aggregate ``TOOL_ORCHESTRATION_CHAIN`` signal.
+
+    Sums tool calls and tokens across the matching invocations so the
+    recommendation can quote concrete totals and a blended per-call
+    ratio. ``estimated_token_savings`` projects the article's 37%
+    reduction onto the summed tokens.
+    """
+    total_tool_calls = sum(i.tool_uses or 0 for i in matching)
+    total_tokens = sum(i.total_tokens or 0 for i in matching)
+    invocation_count = len(matching)
+    ratio = total_tokens / total_tool_calls if total_tool_calls else 0.0
+    estimated_savings = int(total_tokens * TOKEN_REDUCTION_FACTOR)
+
+    message = (
+        f"Agent '{agent_type}' made {total_tool_calls} tool calls consuming "
+        f"{total_tokens:,} tokens across {invocation_count} invocations. "
+        f"Average token cost per tool call: {ratio:,.0f} tokens."
+    )
+    return DiagnosticSignal(
+        signal_type=SignalType.TOOL_ORCHESTRATION_CHAIN,
+        severity=Severity.INFO,
+        agent_type=agent_type,
+        message=message,
+        detail={
+            "invocation_count": invocation_count,
+            "total_tool_calls": total_tool_calls,
+            "total_tokens": total_tokens,
+            "mean_tokens_per_tool_call": ratio,
+            ESTIMATED_TOKEN_SAVINGS_KEY: estimated_savings,
+        },
+    )
+
+
+def extract_tool_orchestration_signals(
+    invocations: list[AgentInvocation],
+) -> list[DiagnosticSignal]:
+    """Public entry: group by agent type, gate, emit one signal per type.
+
+    Each invocation is tested against the per-invocation chain predicate
+    (``_is_orchestration_chain``). For an agent type with
+    ``_MIN_MATCHING_INVOCATIONS`` or more matching invocations, a single
+    aggregated ``INFO`` signal is emitted carrying summed evidence.
+    Returns an empty list when no agent type clears the gate.
+    """
+    if not invocations:
+        return []
+
+    # Group case-insensitively (real data varies: "PM" vs "pm") so case
+    # variants don't split across the min-invocation gate. The canonical
+    # display name is the first-seen casing; the correlator lowercases
+    # again for its config lookup.
+    matching_by_type: dict[str, list[AgentInvocation]] = defaultdict(list)
+    for inv in invocations:
+        if _is_orchestration_chain(inv):
+            matching_by_type[inv.agent_type.lower()].append(inv)
+
+    signals: list[DiagnosticSignal] = []
+    for matching in matching_by_type.values():
+        if len(matching) >= _MIN_MATCHING_INVOCATIONS:
+            signals.append(_build_signal(matching[0].agent_type, matching))
+    return signals

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -291,6 +291,34 @@
   recommendation_target: model
   related: [complexity_tier, overspec, underspec, target_model]
 
+- name: tool_orchestration_chain
+  category: signal_type
+  short: |
+    An agent runs long tool-call chains whose large intermediate results
+    pass through the context window unnecessarily.
+  long: |
+    Per-agent-type signal (Tier A, metadata-only). Flags invocations that
+    make 10+ tool calls AND average more than 2,000 tokens per call -- a
+    proxy for orchestration chains where each `tool_result` enters the
+    context window even though only the final output is needed. Fires when
+    3+ invocations of the same agent type match the pattern. Recommends
+    Programmatic Tool Calling (`allowed_callers:
+    ["code_execution_20250825"]`), which runs the orchestration in a
+    code-execution sandbox so intermediate results stay out of context.
+    Severity is `info`, not `warning`: the metadata-only proxy cannot tell
+    a true chain (intermediates discarded) from an agent that legitimately
+    needs each intermediate in context for reasoning. Estimated precision
+    is 60-70%; this is the first LLM-call augmentation candidate (D035).
+  example: |
+    Agent 'general-purpose' made 47 tool calls consuming 132,000 tokens
+    across 3 invocations. Average token cost per tool call: 2,809 tokens.
+    Estimated savings ~48,840 tokens at the 37% benchmark by migrating to
+    code-execution orchestration.
+  severity_range: info
+  threshold: "10+ tool calls AND >2000 tokens/call per invocation; min 3 invocations"
+  recommendation_target: tools
+  related: [token_outlier, target_tools, model_mismatch]
+
 - name: mcp_unused_server
   category: signal_type
   short: An MCP server is configured but never called in observed sessions.

--- a/tests/unit/test_tool_orchestration.py
+++ b/tests/unit/test_tool_orchestration.py
@@ -1,0 +1,177 @@
+"""Tests for the TOOL_ORCHESTRATION_CHAIN signal (#406, Tier A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.diagnostics.correlator import correlate
+from agentfluent.diagnostics.models import SignalType
+from agentfluent.diagnostics.tool_orchestration import (
+    ESTIMATED_TOKEN_SAVINGS_KEY,
+    TOKEN_REDUCTION_FACTOR,
+    extract_tool_orchestration_signals,
+)
+
+
+def _inv(
+    agent_type: str = "researcher",
+    total_tokens: int | None = 40_000,
+    tool_uses: int | None = 15,
+    tool_use_id: str = "tool_1",
+) -> AgentInvocation:
+    return AgentInvocation(
+        agent_type=agent_type,
+        description="test",
+        prompt="do something",
+        tool_use_id=tool_use_id,
+        total_tokens=total_tokens,
+        tool_uses=tool_uses,
+    )
+
+
+def _matching_invs(count: int, agent_type: str = "researcher") -> list[AgentInvocation]:
+    # 15 calls / 40k tokens => 2,667 tokens/call: clears both thresholds.
+    return [
+        _inv(agent_type=agent_type, tool_use_id=f"tool_{i}") for i in range(count)
+    ]
+
+
+def _config(name: str = "researcher") -> AgentConfig:
+    return AgentConfig(
+        name=name,
+        file_path=Path(f"/home/user/.claude/agents/{name}.md"),
+        scope=Scope.USER,
+    )
+
+
+# --- per-invocation predicate boundaries -------------------------------
+
+
+def test_high_count_high_ratio_fires() -> None:
+    """15 tool calls, 40k tokens (2,667/call) across 3 invocations -> signal."""
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.signal_type == SignalType.TOOL_ORCHESTRATION_CHAIN
+    assert sig.severity == Severity.INFO
+    assert sig.agent_type == "researcher"
+
+
+def test_low_per_call_overhead_does_not_fire() -> None:
+    """15 tool calls but only 10k tokens (667/call) -> below ratio gate."""
+    invs = [
+        _inv(total_tokens=10_000, tool_uses=15, tool_use_id=f"t_{i}")
+        for i in range(3)
+    ]
+    assert extract_tool_orchestration_signals(invs) == []
+
+
+def test_below_tool_count_does_not_fire() -> None:
+    """5 tool calls, 15k tokens (3,000/call) -> below tool-count gate."""
+    invs = [
+        _inv(total_tokens=15_000, tool_uses=5, tool_use_id=f"t_{i}")
+        for i in range(3)
+    ]
+    assert extract_tool_orchestration_signals(invs) == []
+
+
+# --- aggregate (min-invocation) gate -----------------------------------
+
+
+def test_single_matching_invocation_does_not_fire() -> None:
+    """A lone matching invocation is below the 3+ min-invocation gate."""
+    assert extract_tool_orchestration_signals(_matching_invs(1)) == []
+
+
+def test_two_matching_invocations_does_not_fire() -> None:
+    """Two matching invocations still below the gate."""
+    assert extract_tool_orchestration_signals(_matching_invs(2)) == []
+
+
+def test_three_matching_invocations_aggregates_evidence() -> None:
+    """3+ matching invocations -> one signal with summed evidence."""
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    assert len(signals) == 1
+    detail = signals[0].detail
+    assert detail["invocation_count"] == 3
+    assert detail["total_tool_calls"] == 45  # 3 x 15
+    assert detail["total_tokens"] == 120_000  # 3 x 40k
+    assert detail["mean_tokens_per_tool_call"] == 120_000 / 45
+    assert detail[ESTIMATED_TOKEN_SAVINGS_KEY] == int(120_000 * TOKEN_REDUCTION_FACTOR)
+
+
+def test_non_matching_invocations_excluded_from_aggregate() -> None:
+    """Only matching invocations count toward the gate and the totals."""
+    invs = [
+        *_matching_invs(3),
+        _inv(total_tokens=1_000, tool_uses=2, tool_use_id="small"),
+    ]
+    signals = extract_tool_orchestration_signals(invs)
+    assert len(signals) == 1
+    assert signals[0].detail["invocation_count"] == 3
+
+
+def test_groups_by_agent_type_case_insensitively() -> None:
+    """Case variants of the same agent type merge across the gate."""
+    invs = [
+        _inv(agent_type="Researcher", tool_use_id="a"),
+        _inv(agent_type="researcher", tool_use_id="b"),
+        _inv(agent_type="RESEARCHER", tool_use_id="c"),
+    ]
+    signals = extract_tool_orchestration_signals(invs)
+    assert len(signals) == 1
+    assert signals[0].detail["invocation_count"] == 3
+
+
+def test_missing_metadata_does_not_match() -> None:
+    """Invocations lacking tool_uses/total_tokens can't be classified."""
+    invs = [
+        _inv(total_tokens=None, tool_use_id="a"),
+        _inv(tool_uses=None, tool_use_id="b"),
+        _inv(tool_use_id="c"),
+    ]
+    # Only the third (fully populated) matches -> below the gate.
+    assert extract_tool_orchestration_signals(invs) == []
+
+
+def test_empty_input() -> None:
+    assert extract_tool_orchestration_signals([]) == []
+
+
+# --- correlator --------------------------------------------------------
+
+
+def test_recommendation_includes_savings_and_citation() -> None:
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    pairs = correlate(signals, {"researcher": _config()})
+    assert len(pairs) == 1
+    _signal, rec = pairs[0]
+    assert rec.target == "tools"
+    assert rec.severity == Severity.INFO
+    assert "allowed_callers" in rec.action
+    assert "code_execution_20250825" in rec.action
+    assert "tokens" in rec.action  # estimated savings phrase
+    assert "37%" in rec.reason
+
+
+def test_recommendation_without_config_cites_article_url() -> None:
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    pairs = correlate(signals, None)
+    assert len(pairs) == 1
+    _signal, rec = pairs[0]
+    assert "anthropic.com/engineering/advanced-tool-use" in rec.action
+    assert rec.config_file == ""
+
+
+def test_builtin_agent_gets_builtin_action() -> None:
+    """A built-in agent type routes to the built-in (non-editable) action."""
+    signals = extract_tool_orchestration_signals(
+        _matching_invs(3, agent_type="general-purpose"),
+    )
+    pairs = correlate(signals, None)
+    assert len(pairs) == 1
+    _signal, rec = pairs[0]
+    assert rec.is_builtin is True
+    assert "not user-editable" in rec.action


### PR DESCRIPTION
## Summary
- New `TOOL_ORCHESTRATION_CHAIN` diagnostic (Tier A, metadata-only): per agent type, flags invocations that make ≥10 tool calls **and** average >2,000 tokens/call, gated to 3+ matching invocations, emitting one aggregated **INFO** signal on the **cost** axis.
- Recommends Programmatic Tool Calling (`allowed_callers: ["code_execution_20250825"]`) with a projected token saving at Anthropic's 37% benchmark; thresholds are tunable module-level constants for the follow-up calibration story.
- Wires through the full pipeline: `SignalType` enum, `SIGNAL_AXIS_MAP`, `ToolOrchestrationRule` correlator (with built-in-agent branching), pipeline extraction, glossary entry + regenerated `docs/GLOSSARY.md`.

Closes #406. Spec: `.claude/specs/prd-advanced-tool-use-diagnostics.md` §5.1. Severity is INFO to reflect the Tier A precision limit — this is the first LLM-call augmentation candidate (D035).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1597 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (100% on `tool_orchestration.py`; covers all six issue cases + correlator/built-in paths)
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output-shape change; new signal flows through existing formatters)

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface. Rule-based arithmetic over already-parsed `AgentInvocation` metadata (`tool_uses`, `total_tokens`); no new input parsing, network, subprocess, or user-controlled string rendering.
- [ ] **Needs review**

## Breaking changes
None. Additive: new `SignalType` enum member and a new diagnostics module. JSON envelope gains an additional possible signal type but no field is renamed or removed; pre-existing recommendations score identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)