### PR TITLE
feat: add PARAMETER_RETRY diagnostic signal (Tier A) with paste-ready input_examples

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -320,6 +320,53 @@ without progress.
 
 **Related:** [`retry_loop`](#retry_loop)
 
+### `parameter_retry`
+
+**Short:** A subagent retried the same tool with a **different parameter shape**
+after an initial error -- it's guessing at the input format.
+
+**Detail:** Trace-level signal (Tier A). Triggered when 2+ consecutive calls to
+the same tool show (a) the first call errored (`is_error`, or a
+validation keyword -- `invalid`, `validation`, `missing required`,
+`type error`, `schema` -- in the leading window of the result) AND
+(b) the `input` shape changed between attempts. Shape change is
+measured primarily by the set of top-level keys (a key added,
+removed, or renamed) and secondarily by nested-value structure or a
+scalar type change when the full input was captured. This is
+high-precision: an error followed by an input-shape change is strong
+evidence the agent doesn't know the parameter format.
+
+Scanned directly from `tool_calls`, independent of the
+similarity-based retry detector -- a parameter-shape retry varies the
+input enough that it may not register as a `retry_loop` at all. Takes
+precedence over `stuck_pattern`, `retry_loop`, and
+`tool_error_sequence`: indices it claims are suppressed for those
+signals, because the `input_examples` fix is more specific and more
+actionable.
+
+When a subsequent call to the same tool succeeded, AgentFluent
+extracts that call's `input` dict and surfaces it as a paste-ready
+`input_examples` entry in the recommendation (informational only; the
+user copies it manually -- see D002). Adding `input_examples` to a
+tool definition improves accuracy from 72% to 90% on complex
+parameter handling (Anthropic benchmark).
+
+**Example:**
+
+```
+Subagent 'general-purpose' retried tool 'mcp__github__create_issue' 3
+times with different parameter shapes before succeeding. First attempt
+failed with: 'validation error: missing required field "title"'.
+```
+
+**Severity:** warning
+
+**Threshold:** 2+ consecutive same-tool calls; first errored; input shape changed
+
+**Recommendation target:** `tools`
+
+**Related:** [`retry_loop`](#retry_loop), [`stuck_pattern`](#stuck_pattern), [`tool_error_sequence`](#tool_error_sequence), [`target_tools`](#target_tools)
+
 ### `permission_failure`
 
 **Short:** A tool result contained a permission-denied keyword.

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -83,6 +83,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.RETRY_LOOP: Axis.SPEED,
     SignalType.STUCK_PATTERN: Axis.SPEED,
     SignalType.TOOL_ERROR_SEQUENCE: Axis.SPEED,
+    SignalType.PARAMETER_RETRY: Axis.SPEED,
     SignalType.ERROR_PATTERN: Axis.SPEED,
     SignalType.PERMISSION_FAILURE: Axis.SPEED,
     SignalType.MCP_MISSING_SERVER: Axis.SPEED,

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -7,6 +7,7 @@ for extensibility.
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import ClassVar, Protocol
@@ -28,6 +29,7 @@ from agentfluent.diagnostics.quality_signals import (
     PARENT_ACTED_HEALTHY_BAND_LOW,
 )
 from agentfluent.diagnostics.tool_orchestration import ESTIMATED_TOKEN_SAVINGS_KEY
+from agentfluent.diagnostics.trace_signals import PARAMETER_RETRY_EXAMPLE_KEY
 
 
 def _relpath(path: Path) -> str:
@@ -640,6 +642,63 @@ class ToolOrchestrationRule:
         )
 
 
+class ParameterRetryRule:
+    """PARAMETER_RETRY -> recommend `input_examples` on the tool definition.
+
+    The agent retried the same tool with different parameter shapes after
+    an initial error -- it's guessing at the input format. The fix is an
+    ``input_examples`` array on the *tool definition* (MCP server, SDK
+    tool, or custom tool), not the agent's own prompt/tools config. This
+    rule therefore does NOT branch on built-in agents the way
+    prompt/tools/model rules do: ``input_examples`` helps whoever calls
+    the tool regardless of whether the caller is a built-in agent. When
+    the trace captured a subsequent successful call, its ``input`` dict
+    is surfaced as a paste-ready example (D002: informational, never
+    auto-applied).
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.PARAMETER_RETRY
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        tool_name = str(signal.detail.get("tool_name", "the tool"))
+        observation = signal.message
+        reason = (
+            "Parameter-retry patterns indicate the agent is guessing at "
+            "input formats. Adding concrete examples to the tool definition "
+            "(an `input_examples` array) improves accuracy from 72% to 90% "
+            "on complex parameter handling (Anthropic benchmark)."
+        )
+
+        action_parts = [
+            f"Add an `input_examples` array to the '{tool_name}' tool "
+            "definition showing the expected parameter shape.",
+        ]
+        example = signal.detail.get(PARAMETER_RETRY_EXAMPLE_KEY)
+        if isinstance(example, dict):
+            rendered = json.dumps(example, indent=2, ensure_ascii=False)
+            action_parts.append(
+                f"Suggested `input_examples` entry for tool '{tool_name}' "
+                f"based on the observed successful call:\n{rendered}",
+            )
+        action = "\n".join(action_parts)
+
+        return DiagnosticRecommendation(
+            target="tools",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+
 # Module-level rule registry. Add new rules here.
 class McpAuditRule:
     """MCP server audit signals -> recommend mcpServers config edit.
@@ -1095,6 +1154,7 @@ RULES: list[CorrelationRule] = [
     RetryLoopRule(),
     StuckPatternRule(),
     ErrorSequenceRule(),
+    ParameterRetryRule(),
     ModelRoutingRule(),
     ToolOrchestrationRule(),
     McpAuditRule(),

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -52,7 +52,7 @@ class SignalType(StrEnum):
 
     Trace-level signals (extracted from `SubagentTrace` evidence):
     - `TOOL_ERROR_SEQUENCE`, `RETRY_LOOP`, `PERMISSION_FAILURE`,
-      `STUCK_PATTERN`
+      `STUCK_PATTERN`, `PARAMETER_RETRY`
 
     Aggregate-level signals (extracted from per-agent-type rollups):
     - `MODEL_MISMATCH`, `TOOL_ORCHESTRATION_CHAIN`
@@ -83,6 +83,7 @@ class SignalType(StrEnum):
     RETRY_LOOP = "retry_loop"
     PERMISSION_FAILURE = "permission_failure"
     STUCK_PATTERN = "stuck_pattern"
+    PARAMETER_RETRY = "parameter_retry"
     MODEL_MISMATCH = "model_mismatch"
     TOOL_ORCHESTRATION_CHAIN = "tool_orchestration_chain"
     MCP_UNUSED_SERVER = "mcp_unused_server"
@@ -111,6 +112,7 @@ TRACE_SIGNAL_TYPES: frozenset[SignalType] = frozenset(
         SignalType.RETRY_LOOP,
         SignalType.PERMISSION_FAILURE,
         SignalType.STUCK_PATTERN,
+        SignalType.PARAMETER_RETRY,
     },
 )
 

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -45,7 +45,6 @@ Different remediation axes.
 
 from __future__ import annotations
 
-import json
 import re
 
 from agentfluent.config.models import Severity
@@ -257,11 +256,12 @@ def _input_shape_changed(run_calls: list[SubagentToolCall]) -> bool:
     if len(key_shapes) > 1:
         return True
     if all(c.input_data is not None for c in run_calls):
-        value_shapes = {
-            json.dumps(_value_shape(c.input_data), sort_keys=True)
-            for c in run_calls
-        }
-        return len(value_shapes) > 1
+        # `_value_shape` returns nested dicts of type-name strings, which
+        # compare structurally with `==` — no need to serialize to compare.
+        first_shape = _value_shape(run_calls[0].input_data)
+        return any(
+            _value_shape(c.input_data) != first_shape for c in run_calls[1:]
+        )
     return False
 
 
@@ -353,8 +353,8 @@ def _extract_parameter_retries(
         j = i + 1
         while j < n and calls[j].tool_name == calls[i].tool_name:
             j += 1
-        run_indices = list(range(i, j))
-        if len(run_indices) >= _PARAMETER_RETRY_MIN_ATTEMPTS:
+        if j - i >= _PARAMETER_RETRY_MIN_ATTEMPTS:
+            run_indices = list(range(i, j))
             signal = _build_parameter_retry_signal(
                 calls, run_indices, agent_type, invocation_id,
             )

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -8,6 +8,10 @@ trace-specific signal types:
 
 - `PERMISSION_FAILURE` — a tool result contains a permission-denied
   keyword. Specific remediation: grant the tool in the agent's config.
+- `PARAMETER_RETRY` — 2+ consecutive calls to the same tool where the
+  first errored and the `input` shape changed between attempts.
+  Indicates the agent is guessing at the parameter format; remediation
+  is `input_examples` on the tool definition.
 - `STUCK_PATTERN` — 4+ consecutive identical calls to the same tool.
   Indicates a missing exit condition in the prompt.
 - `RETRY_LOOP` — a `RetrySequence` with `attempts >= 3` that is not
@@ -16,31 +20,76 @@ trace-specific signal types:
   are not covered by a STUCK or RETRY sequence. Indicates missing
   fallback instructions.
 
-STUCK and RETRY are mutually exclusive: a single `RetrySequence` emits
-exactly one of them, never both, and TOOL_ERROR_SEQUENCE never emits
-for indices already covered by STUCK or RETRY. This invariant keeps the
-principle "one observed pattern → one signal" — a future dev must not
-"fix" this to independent emission without updating the downstream
-correlator contract.
+PARAMETER_RETRY, STUCK, RETRY, and TOOL_ERROR_SEQUENCE share one
+`covered` index set, enforcing "one observed pattern → one signal" with
+the precedence **PARAMETER_RETRY > STUCK_PATTERN > RETRY_LOOP >
+TOOL_ERROR_SEQUENCE**. PARAMETER_RETRY runs first and is the most
+specific/actionable (it yields a concrete `input_examples` fix), so its
+indices suppress any overlapping RETRY_LOOP/STUCK_PATTERN/error
+sequence. STUCK and RETRY remain mutually exclusive per `RetrySequence`.
+A future dev must not "fix" this to independent emission without
+updating the downstream correlator contract.
 
-PERMISSION_FAILURE is intentionally NOT mutually exclusive with
-TOOL_ERROR_SEQUENCE: a permission-denied run produces both a
-specialized recommendation (grant the tool) and the general fallback
-signal. Different remediation axes.
+PARAMETER_RETRY scans `tool_calls` directly rather than reusing
+`trace.retry_sequences`: a parameter-shape retry changes the `input`
+enough that the similarity-based retry detector (`traces.retry`, 0.80
+threshold) may not group the calls into a `RetrySequence` at all. The
+two detectors answer different questions — "same args, no progress"
+(retry) vs "different arg shape after an error" (parameter).
+
+PERMISSION_FAILURE is intentionally NOT mutually exclusive with the
+above: a permission-denied run produces both a specialized
+recommendation (grant the tool) and the general fallback signal.
+Different remediation axes.
 """
 
 from __future__ import annotations
 
+import json
 import re
 
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
 from agentfluent.traces.models import (
     RESULT_SUMMARY_MAX_CHARS,
     RetrySequence,
     SubagentToolCall,
     SubagentTrace,
 )
+
+# Producer/consumer contract: ``_extract_parameter_retries`` stores the
+# extracted paste-ready input dict under this key in the signal's
+# ``detail`` (only when a successful call's ``input_data`` is available);
+# ``correlator.ParameterRetryRule`` reads it to format the suggested
+# ``input_examples`` block. Absent when no successful call followed the
+# retries or its input exceeded the capture cap.
+PARAMETER_RETRY_EXAMPLE_KEY = "input_example"
+
+# Validation-flavored error keywords that signal parameter/schema
+# confusion specifically (a superset trigger for PARAMETER_RETRY beyond
+# the generic ``is_error`` flag). Kept separate from
+# ``signals.ERROR_PATTERNS`` (which governs the metadata ERROR_PATTERN
+# signal): these terms are too narrow to flag a generic failure but are
+# strong evidence the agent supplied a malformed ``input``. Matched
+# against the leading window only, reusing the FP-defense bound that
+# ``signals.detect_is_error_from_text`` applies.
+_PARAM_ERROR_KEYWORDS = (
+    "invalid",
+    "validation",
+    "missing required",
+    "type error",
+    "schema",
+)
+_PARAM_ERROR_REGEX = re.compile(
+    "|".join(re.escape(k) for k in _PARAM_ERROR_KEYWORDS),
+    re.IGNORECASE,
+)
+
+# Minimum consecutive same-tool calls to consider a parameter-retry run.
+_PARAMETER_RETRY_MIN_ATTEMPTS = 2
+# First-error summary length cap in the signal message.
+_PARAM_ERROR_SUMMARY_MAX_CHARS = 120
 
 # Keywords that signal an authorization/access failure in a tool_result.
 # Substring match is intentional — "not allowed" inside a longer message
@@ -164,11 +213,165 @@ def _extract_permission_failures(
     return signals
 
 
+def _is_param_error(call: SubagentToolCall) -> bool:
+    """Whether ``call`` looks like a parameter/validation failure.
+
+    The parser-supplied ``is_error`` flag (generic error detection) OR a
+    validation-flavored keyword in the leading window of the result. The
+    window bound mirrors ``signals.detect_is_error_from_text``'s
+    FP-defense — keep keyword matches to the start of the result, where
+    real error messages lead.
+    """
+    if call.is_error:
+        return True
+    window = call.result_summary[:ERROR_DETECTION_WINDOW_CHARS]
+    return bool(_PARAM_ERROR_REGEX.search(window))
+
+
+def _value_shape(value: object) -> object:
+    """Recursively reduce a JSON value to its structural shape.
+
+    Dicts recurse (sorted keys mapped to nested shapes) so nested-object
+    differences and added/removed nested keys are detected; every other
+    value collapses to its type name, so a scalar type change
+    (``"str"`` -> ``"int"``) registers while same-typed value changes
+    (two different file paths) do not. Lists collapse to ``"list"`` —
+    element-level drift is out of scope for shape comparison.
+    """
+    if isinstance(value, dict):
+        return {k: _value_shape(v) for k, v in sorted(value.items())}
+    return type(value).__name__
+
+
+def _input_shape_changed(run_calls: list[SubagentToolCall]) -> bool:
+    """Whether the ``input`` shape changed across a same-tool run.
+
+    Primary signal: the set of top-level keys differs between calls
+    (a key added, removed, or renamed). Secondary signal (only when every
+    call captured ``input_data``): the nested value structure differs —
+    a nested key change or a scalar type change. Returns ``False`` when
+    no shape evidence exists (all inputs empty / uncaptured), so a run
+    with no observable parameter variation never fires PARAMETER_RETRY.
+    """
+    key_shapes = {tuple(sorted(c.input_keys)) for c in run_calls}
+    if len(key_shapes) > 1:
+        return True
+    if all(c.input_data is not None for c in run_calls):
+        value_shapes = {
+            json.dumps(_value_shape(c.input_data), sort_keys=True)
+            for c in run_calls
+        }
+        return len(value_shapes) > 1
+    return False
+
+
+def _extract_successful_example(
+    run_calls: list[SubagentToolCall],
+) -> dict[str, object] | None:
+    """The most-evolved successful ``input_data`` in the run, if any.
+
+    Scans from the end so the last (most-corrected) successful shape is
+    preferred. Returns ``None`` when no non-error call carries captured
+    ``input_data`` — the paste-ready section is then omitted while the
+    signal still fires.
+    """
+    for call in reversed(run_calls):
+        if not call.is_error and call.input_data is not None:
+            return call.input_data
+    return None
+
+
+def _build_parameter_retry_signal(
+    calls: list[SubagentToolCall],
+    run_indices: list[int],
+    agent_type: str,
+    invocation_id: str | None,
+) -> DiagnosticSignal | None:
+    """Emit PARAMETER_RETRY for a same-tool run, or ``None`` if it doesn't
+    qualify (first call not an error, or no input-shape change)."""
+    run_calls = [calls[i] for i in run_indices]
+    if not _is_param_error(run_calls[0]):
+        return None
+    if not _input_shape_changed(run_calls):
+        return None
+
+    tool_name = run_calls[0].tool_name
+    attempts = len(run_calls)
+    eventual_success = not run_calls[-1].is_error
+    error_summary = " ".join(run_calls[0].result_summary.split())[
+        :_PARAM_ERROR_SUMMARY_MAX_CHARS
+    ]
+    suffix = " before succeeding" if eventual_success else ""
+
+    detail: dict[str, object] = {
+        "tool_calls": _cap_evidence(run_calls, run_indices),
+        "tool_name": tool_name,
+        "retry_count": attempts,
+        "first_error_message": run_calls[0].result_summary,
+        "eventual_success": eventual_success,
+    }
+    example = _extract_successful_example(run_calls)
+    if example is not None:
+        detail[PARAMETER_RETRY_EXAMPLE_KEY] = example
+
+    return DiagnosticSignal(
+        signal_type=SignalType.PARAMETER_RETRY,
+        severity=Severity.WARNING,
+        agent_type=agent_type,
+        invocation_id=invocation_id,
+        message=(
+            f"Subagent '{agent_type}' retried tool '{tool_name}' "
+            f"{attempts} times with different parameter shapes{suffix}. "
+            f"First attempt failed with: '{error_summary}'."
+        ),
+        detail=detail,
+    )
+
+
+def _extract_parameter_retries(
+    trace: SubagentTrace,
+    agent_type: str,
+    *,
+    invocation_id: str | None = None,
+) -> tuple[list[DiagnosticSignal], set[int]]:
+    """Emit PARAMETER_RETRY for consecutive same-tool runs that show an
+    initial error followed by an input-shape change.
+
+    Scans ``tool_calls`` directly (independent of ``retry_sequences``) for
+    maximal runs of 2+ calls sharing a ``tool_name``. The returned
+    ``covered`` set lists every index claimed by an emitted signal so the
+    retry/stuck and error-sequence extractors skip the same evidence —
+    PARAMETER_RETRY wins the precedence.
+    """
+    signals: list[DiagnosticSignal] = []
+    covered: set[int] = set()
+    calls = trace.tool_calls
+    n = len(calls)
+
+    i = 0
+    while i < n:
+        j = i + 1
+        while j < n and calls[j].tool_name == calls[i].tool_name:
+            j += 1
+        run_indices = list(range(i, j))
+        if len(run_indices) >= _PARAMETER_RETRY_MIN_ATTEMPTS:
+            signal = _build_parameter_retry_signal(
+                calls, run_indices, agent_type, invocation_id,
+            )
+            if signal is not None:
+                signals.append(signal)
+                covered.update(run_indices)
+        i = j
+
+    return signals, covered
+
+
 def _extract_retry_and_stuck(
     trace: SubagentTrace,
     agent_type: str,
     *,
     invocation_id: str | None = None,
+    exclude: set[int] | None = None,
 ) -> tuple[list[DiagnosticSignal], set[int]]:
     """Emit STUCK_PATTERN or RETRY_LOOP — never both — per `RetrySequence`.
 
@@ -181,12 +384,19 @@ def _extract_retry_and_stuck(
     The returned `covered` set lists all `tool_call_indices` consumed by
     emitted STUCK or RETRY signals so `_extract_error_sequences` can
     avoid double-emitting TOOL_ERROR_SEQUENCE on the same bytes.
+
+    `exclude` carries the indices already claimed by PARAMETER_RETRY
+    (higher precedence); any `RetrySequence` overlapping it is skipped so
+    a parameter-shape retry doesn't also surface as a RETRY_LOOP.
     """
+    exclude = exclude or set()
     signals: list[DiagnosticSignal] = []
     covered: set[int] = set()
 
     for seq in trace.retry_sequences:
         if seq.attempts < _RETRY_LOOP_MIN_ATTEMPTS:
+            continue
+        if exclude.intersection(seq.tool_call_indices):
             continue
 
         calls = [trace.tool_calls[i] for i in seq.tool_call_indices]
@@ -341,8 +551,10 @@ def extract_trace_signals(
 
     Handles `None` (unlinked invocation) and empty traces by returning
     an empty list. Order of signals: PERMISSION_FAILURE first
-    (remediation-specific), then STUCK/RETRY (indexed), then
-    TOOL_ERROR_SEQUENCE (filtered by STUCK/RETRY coverage).
+    (remediation-specific, non-exclusive), then PARAMETER_RETRY (claims
+    its indices), then STUCK/RETRY (skipping PARAMETER_RETRY-covered
+    sequences), then TOOL_ERROR_SEQUENCE (filtered by all prior
+    coverage).
 
     `agent_type` overrides `trace.agent_type` on emitted signals when
     provided. The pipeline passes the parent `AgentInvocation.agent_type`
@@ -365,13 +577,23 @@ def extract_trace_signals(
             trace, effective_agent_type, invocation_id=invocation_id,
         ),
     )
-    retry_stuck, covered = _extract_retry_and_stuck(
+    param_signals, param_covered = _extract_parameter_retries(
         trace, effective_agent_type, invocation_id=invocation_id,
+    )
+    signals.extend(param_signals)
+    retry_stuck, retry_covered = _extract_retry_and_stuck(
+        trace,
+        effective_agent_type,
+        invocation_id=invocation_id,
+        exclude=param_covered,
     )
     signals.extend(retry_stuck)
     signals.extend(
         _extract_error_sequences(
-            trace, covered, effective_agent_type, invocation_id=invocation_id,
+            trace,
+            param_covered | retry_covered,
+            effective_agent_type,
+            invocation_id=invocation_id,
         ),
     )
     return signals

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -229,6 +229,46 @@
   recommendation_target: prompt
   related: [retry_loop]
 
+- name: parameter_retry
+  category: signal_type
+  short: |
+    A subagent retried the same tool with a **different parameter shape**
+    after an initial error -- it's guessing at the input format.
+  long: |
+    Trace-level signal (Tier A). Triggered when 2+ consecutive calls to
+    the same tool show (a) the first call errored (`is_error`, or a
+    validation keyword -- `invalid`, `validation`, `missing required`,
+    `type error`, `schema` -- in the leading window of the result) AND
+    (b) the `input` shape changed between attempts. Shape change is
+    measured primarily by the set of top-level keys (a key added,
+    removed, or renamed) and secondarily by nested-value structure or a
+    scalar type change when the full input was captured. This is
+    high-precision: an error followed by an input-shape change is strong
+    evidence the agent doesn't know the parameter format.
+
+    Scanned directly from `tool_calls`, independent of the
+    similarity-based retry detector -- a parameter-shape retry varies the
+    input enough that it may not register as a `retry_loop` at all. Takes
+    precedence over `stuck_pattern`, `retry_loop`, and
+    `tool_error_sequence`: indices it claims are suppressed for those
+    signals, because the `input_examples` fix is more specific and more
+    actionable.
+
+    When a subsequent call to the same tool succeeded, AgentFluent
+    extracts that call's `input` dict and surfaces it as a paste-ready
+    `input_examples` entry in the recommendation (informational only; the
+    user copies it manually -- see D002). Adding `input_examples` to a
+    tool definition improves accuracy from 72% to 90% on complex
+    parameter handling (Anthropic benchmark).
+  example: |
+    Subagent 'general-purpose' retried tool 'mcp__github__create_issue' 3
+    times with different parameter shapes before succeeding. First attempt
+    failed with: 'validation error: missing required field "title"'.
+  severity_range: warning
+  threshold: 2+ consecutive same-tool calls; first errored; input shape changed
+  recommendation_target: tools
+  related: [retry_loop, stuck_pattern, tool_error_sequence, target_tools]
+
 - name: permission_failure
   category: signal_type
   short: A tool result contained a permission-denied keyword.

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
@@ -25,6 +26,15 @@ from agentfluent.core.session import Usage
 
 INPUT_SUMMARY_MAX_CHARS = 200
 RESULT_SUMMARY_MAX_CHARS = 500
+# Cap on the serialized size of ``SubagentToolCall.input_data``. The full
+# raw input dict is captured for paste-ready ``input_examples`` extraction
+# (#405), but tool inputs can be large (a Bash heredoc or a Write payload
+# runs to tens of KB), so we only retain the dict when its JSON form fits
+# this budget. Oversized inputs store ``None`` -- the PARAMETER_RETRY
+# paste-ready section is omitted rather than emitting a truncated,
+# invalid-JSON example. ``input_keys`` is always captured regardless of
+# size, since shape comparison only needs the keys.
+INPUT_DATA_MAX_CHARS = 2000
 UNKNOWN_AGENT_TYPE = "unknown"
 
 
@@ -54,6 +64,25 @@ class SubagentToolCall(BaseModel):
     usage: Usage = Field(default_factory=Usage)
     timestamp: datetime | None = None
     result_timestamp: datetime | None = None
+
+    input_keys: list[str] = Field(default_factory=list)
+    """Top-level keys of the ``tool_use`` input dict, in source order.
+    The primary evidence for PARAMETER_RETRY (#405) input-shape comparison:
+    keys added/removed between consecutive same-tool calls signal that the
+    agent is guessing at the parameter shape. Always captured (cheap and
+    size-independent), unlike ``input_data``. Empty when the call had no
+    input or the input wasn't a dict."""
+
+    input_data: dict[str, Any] | None = None
+    """The full ``tool_use`` input dict, JSON-normalized (``json.dumps``
+    round-trip with ``default=str``) so it holds only plain JSON types and
+    is safe to re-serialize. ``None`` when the input was absent OR its
+    serialized form exceeded ``INPUT_DATA_MAX_CHARS`` -- see that constant
+    for the rationale. Used by PARAMETER_RETRY (#405) to extract a
+    paste-ready ``input_examples`` entry from a successful call. Carries
+    raw tool arguments, which may include paths or other user content;
+    consumers render it under the D002 "informational, never auto-applied"
+    caveat."""
 
 
 class RetrySequence(BaseModel):

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -62,41 +62,36 @@ IDLE_GAP_K = 5
 IDLE_GAP_FLOOR_MS = 60_000
 
 
-def _truncate_input(input_dict: dict[str, Any] | None) -> str:
-    """Serialize a tool_use input dict and truncate to the model's max.
+def _summarize_input(
+    input_dict: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any] | None]:
+    """Serialize a tool_use input ONCE and derive both views the trace needs.
+
+    Returns ``(input_summary, input_data)``:
+
+    - ``input_summary`` — the serialized form truncated to
+      ``INPUT_SUMMARY_MAX_CHARS`` for display.
+    - ``input_data`` — a JSON-normalized copy (round-tripped through
+      ``json.loads`` so it holds only plain JSON types and is guaranteed
+      re-serializable for paste-ready ``input_examples`` output), or
+      ``None`` when the input is absent/empty or its serialized form
+      exceeds ``INPUT_DATA_MAX_CHARS`` (oversized inputs omit the
+      paste-ready example rather than store a truncated, invalid dict).
 
     ``default=str`` handles non-serializable values (datetimes, Paths);
-    ``ensure_ascii=False`` preserves unicode for readability. Python str
-    slicing is codepoint-aware, so the truncation never produces invalid
-    unicode (though it can split extended grapheme clusters — acceptable
-    for summary display).
+    ``ensure_ascii=False`` preserves unicode. Python str slicing is
+    codepoint-aware, so truncation never produces invalid unicode (it can
+    split a grapheme cluster — acceptable for summary display). Serializing
+    once here avoids paying ``json.dumps`` twice per tool call at parse time.
     """
     if input_dict is None:
-        return ""
+        return "", None
     serialized = json.dumps(input_dict, default=str, ensure_ascii=False)
-    return serialized[:INPUT_SUMMARY_MAX_CHARS]
-
-
-def _capped_input_data(
-    input_dict: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Return a JSON-normalized copy of ``input_dict`` if it fits the cap.
-
-    Serializes with ``default=str`` (matching ``_truncate_input``) to
-    measure size, then round-trips through ``json.loads`` so the stored
-    dict holds only plain JSON types -- datetimes/Paths become strings,
-    and the result is guaranteed re-serializable for paste-ready output.
-    Returns ``None`` when the input is absent or its serialized form
-    exceeds ``INPUT_DATA_MAX_CHARS`` (oversized inputs omit the
-    paste-ready example rather than store a truncated, invalid dict).
-    """
-    if not input_dict:
-        return None
-    serialized = json.dumps(input_dict, default=str, ensure_ascii=False)
-    if len(serialized) > INPUT_DATA_MAX_CHARS:
-        return None
-    normalized: dict[str, Any] = json.loads(serialized)
-    return normalized
+    summary = serialized[:INPUT_SUMMARY_MAX_CHARS]
+    if not input_dict or len(serialized) > INPUT_DATA_MAX_CHARS:
+        return summary, None
+    data: dict[str, Any] = json.loads(serialized)
+    return summary, data
 
 
 def _truncate_result(text: str | None) -> str:
@@ -179,12 +174,13 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
                 is_error = False
                 result_text = None
                 result_ts = None
+            input_summary, input_data = _summarize_input(block.input)
             tool_calls.append(
                 SubagentToolCall(
                     tool_name=block.name or "",
-                    input_summary=_truncate_input(block.input),
+                    input_summary=input_summary,
                     input_keys=list(block.input.keys()) if block.input else [],
-                    input_data=_capped_input_data(block.input),
+                    input_data=input_data,
                     result_summary=_truncate_result(result_text),
                     is_error=is_error,
                     timestamp=msg.timestamp,

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -32,6 +32,7 @@ from agentfluent.core.session import ContentBlock, SessionMessage, Usage
 from agentfluent.diagnostics.signals import detect_is_error_from_text
 from agentfluent.traces.discovery import AGENT_FILENAME_PATTERN
 from agentfluent.traces.models import (
+    INPUT_DATA_MAX_CHARS,
     INPUT_SUMMARY_MAX_CHARS,
     RESULT_SUMMARY_MAX_CHARS,
     UNKNOWN_AGENT_TYPE,
@@ -74,6 +75,28 @@ def _truncate_input(input_dict: dict[str, Any] | None) -> str:
         return ""
     serialized = json.dumps(input_dict, default=str, ensure_ascii=False)
     return serialized[:INPUT_SUMMARY_MAX_CHARS]
+
+
+def _capped_input_data(
+    input_dict: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a JSON-normalized copy of ``input_dict`` if it fits the cap.
+
+    Serializes with ``default=str`` (matching ``_truncate_input``) to
+    measure size, then round-trips through ``json.loads`` so the stored
+    dict holds only plain JSON types -- datetimes/Paths become strings,
+    and the result is guaranteed re-serializable for paste-ready output.
+    Returns ``None`` when the input is absent or its serialized form
+    exceeds ``INPUT_DATA_MAX_CHARS`` (oversized inputs omit the
+    paste-ready example rather than store a truncated, invalid dict).
+    """
+    if not input_dict:
+        return None
+    serialized = json.dumps(input_dict, default=str, ensure_ascii=False)
+    if len(serialized) > INPUT_DATA_MAX_CHARS:
+        return None
+    normalized: dict[str, Any] = json.loads(serialized)
+    return normalized
 
 
 def _truncate_result(text: str | None) -> str:
@@ -160,6 +183,8 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
                 SubagentToolCall(
                     tool_name=block.name or "",
                     input_summary=_truncate_input(block.input),
+                    input_keys=list(block.input.keys()) if block.input else [],
+                    input_data=_capped_input_data(block.input),
                     result_summary=_truncate_result(result_text),
                     is_error=is_error,
                     timestamp=msg.timestamp,

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -1077,3 +1077,63 @@ class TestRelpath:
         # Programmatic field keeps the absolute path for JSON consumers.
         assert recs[0].config_file == str(Path.home() / ".claude/agents/pm.md")
 
+
+
+class TestParameterRetryRule:
+    """PARAMETER_RETRY -> `input_examples` recommendation on the tool def."""
+
+    def _param_signal(
+        self,
+        *,
+        with_example: bool = True,
+        agent_type: str = "general-purpose",
+    ) -> DiagnosticSignal:
+        detail: dict[str, object] = {
+            "tool_name": "Edit",
+            "retry_count": 2,
+            "eventual_success": with_example,
+        }
+        if with_example:
+            detail["input_example"] = {
+                "file_path": "a.py",
+                "old_string": "x",
+                "new_string": "y",
+            }
+        return _signal(
+            signal_type=SignalType.PARAMETER_RETRY,
+            severity=Severity.WARNING,
+            agent_type=agent_type,
+            message="Subagent 'general-purpose' retried tool 'Edit' 2 times.",
+            detail=detail,
+        )
+
+    def test_recommends_input_examples_on_tools_target(self) -> None:
+        recs = correlate([self._param_signal()], None)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+        assert recs[0].severity == Severity.WARNING
+        assert "input_examples" in recs[0].action
+        assert "'Edit'" in recs[0].action
+
+    def test_includes_paste_ready_example_when_available(self) -> None:
+        recs = correlate([self._param_signal(with_example=True)], None)
+        action = recs[0].action
+        assert "Suggested `input_examples` entry" in action
+        # The extracted dict is rendered as indented JSON.
+        assert '"file_path": "a.py"' in action
+        assert '"new_string": "y"' in action
+
+    def test_omits_paste_ready_when_no_example(self) -> None:
+        recs = correlate([self._param_signal(with_example=False)], None)
+        action = recs[0].action
+        assert "input_examples" in action
+        assert "Suggested `input_examples` entry" not in action
+
+    def test_fires_for_builtin_agent_without_builtin_branch(self) -> None:
+        # The fix targets the tool definition, not the agent config, so a
+        # built-in agent still gets the input_examples recommendation
+        # (not the generic "route to a custom subagent" built-in action).
+        recs = correlate([self._param_signal(agent_type="Explore")], None)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+        assert "input_examples" in recs[0].action

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -985,3 +985,60 @@ class TestTier3DegradationWiring:
         # path.
         result = run_diagnostics([_inv()])
         assert result.tier3_degraded is False
+
+
+def _param_retry_trace(agent_type: str = "general-purpose") -> SubagentTrace:
+    """A trace where the agent guesses at a tool's parameter shape: the
+    first call errors with a validation message, then a reshaped call
+    succeeds."""
+    return SubagentTrace(
+        agent_id="agent-pr",
+        agent_type=agent_type,
+        delegation_prompt="edit the file",
+        tool_calls=[
+            SubagentToolCall(
+                tool_name="Edit",
+                input_summary='{"path": "a.py"}',
+                input_keys=["path"],
+                input_data={"path": "a.py"},
+                result_summary="validation error: missing required field",
+                is_error=True,
+            ),
+            SubagentToolCall(
+                tool_name="Edit",
+                input_summary='{"file_path": "a.py", "old_string": "x"}',
+                input_keys=["file_path", "old_string", "new_string"],
+                input_data={
+                    "file_path": "a.py",
+                    "old_string": "x",
+                    "new_string": "y",
+                },
+                result_summary="ok",
+                is_error=False,
+            ),
+        ],
+        retry_sequences=[],
+    )
+
+
+class TestParameterRetryPipeline:
+    """#405: PARAMETER_RETRY flows through run_diagnostics end-to-end."""
+
+    def test_parameter_retry_signal_and_recommendation_surface(self) -> None:
+        inv = _inv(agent_type="general-purpose", trace=_param_retry_trace())
+        result = run_diagnostics([inv])
+
+        param_signals = [
+            s for s in result.signals if s.signal_type == SignalType.PARAMETER_RETRY
+        ]
+        assert len(param_signals) == 1
+
+        param_recs = [
+            r
+            for r in result.recommendations
+            if SignalType.PARAMETER_RETRY in r.signal_types
+        ]
+        assert len(param_recs) == 1
+        assert param_recs[0].target == "tools"
+        # Paste-ready example extracted from the successful call.
+        assert '"file_path": "a.py"' in param_recs[0].action

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -1,10 +1,15 @@
 """Tests for trace-level signal extraction."""
 
+import json
+
 import pytest
 
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import SignalType
-from agentfluent.diagnostics.trace_signals import extract_trace_signals
+from agentfluent.diagnostics.trace_signals import (
+    PARAMETER_RETRY_EXAMPLE_KEY,
+    extract_trace_signals,
+)
 from agentfluent.traces.models import (
     RESULT_SUMMARY_MAX_CHARS,
     RetrySequence,
@@ -346,3 +351,169 @@ class TestMutualExclusion:
         seqs = [s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE]
         # Only the uncovered [0, 1] run should be reported.
         assert seqs[0].detail["error_count"] == 2
+
+
+def _ptc(
+    tool: str = "Edit",
+    inp: dict[str, object] | None = None,
+    res: str = "ok",
+    err: bool = False,
+    *,
+    capture_data: bool = True,
+) -> SubagentToolCall:
+    """Build a tool call with structured ``input_keys`` / ``input_data``.
+
+    ``capture_data=False`` simulates an oversized input the parser
+    dropped (``input_data is None``) while still recording ``input_keys``.
+    """
+    inp = inp if inp is not None else {}
+    return SubagentToolCall(
+        tool_name=tool,
+        input_summary=json.dumps(inp),
+        input_keys=list(inp.keys()),
+        input_data=inp if capture_data else None,
+        result_summary=res,
+        is_error=err,
+    )
+
+
+def _param_signals(trace: SubagentTrace) -> list:
+    return [
+        s
+        for s in extract_trace_signals(trace)
+        if s.signal_type == SignalType.PARAMETER_RETRY
+    ]
+
+
+class TestParameterRetry:
+    def test_first_error_keys_differ_fires(self) -> None:
+        calls = [
+            _ptc("Edit", {"path": "a.py", "old": "x"}, res="validation error", err=True),
+            _ptc(
+                "Edit",
+                {"file_path": "a.py", "old_string": "x", "new_string": "y"},
+                err=False,
+            ),
+        ]
+        sigs = _param_signals(_trace(calls=calls))
+        assert len(sigs) == 1
+        assert sigs[0].severity == Severity.WARNING
+        assert sigs[0].detail["tool_name"] == "Edit"
+        assert sigs[0].detail["retry_count"] == 2
+        assert sigs[0].detail["eventual_success"] is True
+
+    def test_both_succeed_no_signal(self) -> None:
+        calls = [
+            _ptc("Edit", {"path": "a"}, err=False),
+            _ptc("Edit", {"file_path": "a", "old": "x"}, err=False),
+        ]
+        assert _param_signals(_trace(calls=calls)) == []
+
+    def test_different_tools_no_signal(self) -> None:
+        calls = [
+            _ptc("Edit", {"path": "a"}, res="error", err=True),
+            _ptc("Read", {"file_path": "a"}, err=False),
+        ]
+        assert _param_signals(_trace(calls=calls)) == []
+
+    def test_same_keys_same_types_no_signal(self) -> None:
+        # Different target (file not found then retried elsewhere), same
+        # shape -> not a parameter-format problem.
+        calls = [
+            _ptc("Read", {"file_path": "a.py"}, res="error: not found", err=True),
+            _ptc("Read", {"file_path": "b.py"}, err=False),
+        ]
+        assert _param_signals(_trace(calls=calls)) == []
+
+    def test_paste_ready_example_extracted(self) -> None:
+        success_input = {
+            "file_path": "a.py",
+            "old_string": "x",
+            "new_string": "y",
+        }
+        calls = [
+            _ptc("Edit", {"path": "a.py"}, res="invalid", err=True),
+            _ptc("Edit", success_input, err=False),
+        ]
+        sigs = _param_signals(_trace(calls=calls))
+        assert len(sigs) == 1
+        assert sigs[0].detail[PARAMETER_RETRY_EXAMPLE_KEY] == success_input
+
+    def test_no_success_signal_without_paste_ready(self) -> None:
+        calls = [
+            _ptc("Edit", {"path": "a"}, res="invalid", err=True),
+            _ptc("Edit", {"file_path": "a", "old": "x"}, res="invalid", err=True),
+        ]
+        sigs = _param_signals(_trace(calls=calls))
+        assert len(sigs) == 1
+        assert sigs[0].detail["eventual_success"] is False
+        assert PARAMETER_RETRY_EXAMPLE_KEY not in sigs[0].detail
+
+    def test_nested_dict_shape_change_fires(self) -> None:
+        # Top-level keys identical ({"cfg"}); nested key added.
+        calls = [
+            _ptc("Run", {"cfg": {"a": 1}}, res="schema error", err=True),
+            _ptc("Run", {"cfg": {"a": 1, "b": 2}}, err=False),
+        ]
+        assert len(_param_signals(_trace(calls=calls))) == 1
+
+    def test_optional_top_level_field_added_fires(self) -> None:
+        calls = [
+            _ptc("Run", {"a": 1}, res="missing required", err=True),
+            _ptc("Run", {"a": 1, "b": 2}, err=False),
+        ]
+        assert len(_param_signals(_trace(calls=calls))) == 1
+
+    def test_scalar_type_change_same_keys_fires(self) -> None:
+        # Same key, value type str -> int (secondary signal).
+        calls = [
+            _ptc("Run", {"timeout": "30"}, res="type error", err=True),
+            _ptc("Run", {"timeout": 30}, err=False),
+        ]
+        assert len(_param_signals(_trace(calls=calls))) == 1
+
+    def test_validation_keyword_triggers_without_is_error(self) -> None:
+        calls = [
+            _ptc(
+                "Run",
+                {"a": 1},
+                res="Schema validation failed: missing required field 'b'",
+                err=False,
+            ),
+            _ptc("Run", {"a": 1, "b": 2}, err=False),
+        ]
+        assert len(_param_signals(_trace(calls=calls))) == 1
+
+    def test_no_shape_evidence_no_signal(self) -> None:
+        # First errored but inputs uncaptured and keys empty -> can't
+        # observe a shape change, so no signal.
+        calls = [
+            _ptc("Run", {}, res="invalid", err=True, capture_data=False),
+            _ptc("Run", {}, err=False, capture_data=False),
+        ]
+        assert _param_signals(_trace(calls=calls)) == []
+
+    def test_precedence_suppresses_retry_loop(self) -> None:
+        calls = [
+            _ptc("Edit", {"path": "a"}, res="invalid", err=True),
+            _ptc("Edit", {"file_path": "a"}, res="invalid", err=True),
+            _ptc(
+                "Edit",
+                {"file_path": "a", "old_string": "x", "new_string": "y"},
+                err=False,
+            ),
+        ]
+        seqs = [
+            RetrySequence(
+                tool_name="Edit",
+                attempts=3,
+                tool_call_indices=[0, 1, 2],
+                eventual_success=True,
+            ),
+        ]
+        types = {
+            s.signal_type for s in extract_trace_signals(_trace(calls=calls, sequences=seqs))
+        }
+        assert SignalType.PARAMETER_RETRY in types
+        assert SignalType.RETRY_LOOP not in types
+        assert SignalType.TOOL_ERROR_SEQUENCE not in types

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -11,6 +11,7 @@ import pytest
 
 from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
 from agentfluent.traces.models import (
+    INPUT_DATA_MAX_CHARS,
     INPUT_SUMMARY_MAX_CHARS,
     RESULT_SUMMARY_MAX_CHARS,
     UNKNOWN_AGENT_TYPE,
@@ -222,6 +223,54 @@ class TestInputResultSummaries:
         trace = parse_subagent_trace(path)
         assert "café" in trace.tool_calls[0].input_summary
         assert "résumé" in trace.tool_calls[0].result_summary
+
+    def test_input_keys_and_data_captured(self, write_jsonl: WriteJSONL) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1", "Edit", {"file_path": "a.py", "old": "x"})],
+                ),
+                _user([_tool_result("t1")]),
+            ],
+        )
+        call = parse_subagent_trace(path).tool_calls[0]
+        assert call.input_keys == ["file_path", "old"]
+        assert call.input_data == {"file_path": "a.py", "old": "x"}
+
+    def test_oversized_input_data_dropped_but_keys_kept(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        big_value = "x" * (INPUT_DATA_MAX_CHARS + 100)
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"cmd": big_value})]),
+                _user([_tool_result("t1")]),
+            ],
+        )
+        call = parse_subagent_trace(path).tool_calls[0]
+        # Keys are always captured; the oversized dict is dropped so the
+        # paste-ready example is omitted rather than truncated/invalid.
+        assert call.input_keys == ["cmd"]
+        assert call.input_data is None
+
+    def test_empty_input_yields_no_keys_or_data(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash")]),
+                _user([_tool_result("t1")]),
+            ],
+        )
+        call = parse_subagent_trace(path).tool_calls[0]
+        assert call.input_keys == []
+        assert call.input_data is None
 
 
 class TestIsErrorDetection:

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -196,7 +196,7 @@ class TestInputResultSummaries:
     def test_non_serializable_input_does_not_crash(self, write_jsonl: WriteJSONL) -> None:
         # Input dict from JSONL only contains JSON-native types, so a
         # non-serializable value can't actually round-trip through the
-        # file; simulate by injecting on-disk-valid JSON that _truncate_input
+        # file; simulate by injecting on-disk-valid JSON that _summarize_input
         # will pass through json.dumps cleanly.
         path = write_jsonl(
             "agent-x.jsonl",


### PR DESCRIPTION
## Summary
- Adds the `PARAMETER_RETRY` diagnostic signal (Tier A, trace-required, `WARNING`): fires when a subagent trace shows 2+ consecutive calls to the same tool where the first errored **and** the input shape changed — the signature of an agent guessing at a tool's parameter format. Recommends an `input_examples` array on the tool definition (Anthropic: 72% → 90% accuracy on complex parameter handling).
- Extracts the successful call's `input` dict from the trace and renders it as a **paste-ready `input_examples` JSON block** in the recommendation (informational only, never auto-applied per D002).
- Extends `SubagentToolCall` with `input_keys` (always captured) + `input_data` (full dict, JSON-normalized, capped at `INPUT_DATA_MAX_CHARS=2000`; oversized → `None`); the trace parser populates both.
- Precedence in `trace_signals.py`: `PERMISSION_FAILURE > PARAMETER_RETRY > STUCK_PATTERN > RETRY_LOOP > TOOL_ERROR_SEQUENCE` via the shared `covered`-index set. PARAMETER_RETRY scans `tool_calls` independently of `retry_sequences`.
- `ParameterRetryRule` correlator (`target=tools`); glossary entry + regenerated `docs/GLOSSARY.md`.
- Closes #405. Tier B (metadata/`toolStats` fallback) descoped to #492 per the architect review on #405.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1617 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (trace detector incl. nested/optional/type-change shapes + precedence; parser capture/oversize/empty; correlator paste-ready/omit/builtin; pipeline end-to-end)
- [x] Manual smoke test: `uv run agentfluent explain parameter_retry` renders the new glossary entry

## Security review
Pick one.
- [ ] **Skip review** — no security-sensitive surface.
- [x] **Needs review** — touches JSONL parsing (trace parser now captures `input_data` from parsed session JSONL) and rendering of user-controlled strings (the captured input dict is rendered into recommendation/paste-ready output). Mitigations: `input_data` is JSON-normalized and size-capped (2000 chars), and surfaced under the D002 "informational, never auto-applied" caveat. Label will be applied when dev-complete per CONTRIBUTING/CLAUDE.md.

## Breaking changes
None. All model changes are additive (`SubagentToolCall.input_keys`/`input_data` default empty/`None`; `extra="ignore"` preserved) and `SignalType.PARAMETER_RETRY` is a new enum member added to `SIGNAL_AXIS_MAP` (keeping the `set(SIGNAL_AXIS_MAP) == set(SignalType)` invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)