### PR TITLE
feat: add TOOL_INVENTORY_OVERSIZED diagnostic signal (#372, #404)

### DIFF
--- a/.claude/specs/prd-advanced-tool-use-diagnostics.md
+++ b/.claude/specs/prd-advanced-tool-use-diagnostics.md
@@ -153,10 +153,15 @@ This is a step toward "apply fix" automation without crossing the auto-apply non
 Unchanged from #372's specification. Key updates from the article:
 
 - **Quantitative anchor update:** Add the article's Opus 4.5 benchmark (79.5% -> 88.1%) alongside the RAG-MCP research (43% vs 14%). The article provides a stronger authority source for the recommendation.
-- **Configuration syntax update:** The recommendation text should reference the platform-level `defer_loading: true` syntax from the article, not just Claude Code's internal implementation.
+- **Configuration syntax update:** The recommendation text should reference the platform-level `defer_loading: true` syntax from the article, not just Claude Code's internal implementation. Specifically:
+  - API/SDK agents: add a `tool_search_tool_regex_20251119` tool to the `tools[]` array and set `defer_loading: true` on the individual tools that should load lazily.
+  - MCP servers: use an `mcp_toolset` block with `default_config: {"defer_loading": true}`.
+  - Claude Code agents: `defer_loading: true` in agent frontmatter (the original Claude Code-only path).
 - **Priority upgrade:** From `priority:medium` to `priority:high` given the article's confirmation that the feature is production-ready on the platform.
 
-No structural changes to #372's acceptance criteria.
+The verbatim Observation/Reason/Action recommendation text (refreshed for the article) lives on #372's implementation checklist; the developer should copy it from there.
+
+No structural changes to #372's acceptance criteria, thresholds (30 tools, 0.5 utilization ratio), or the `SIGNAL_AXIS_MAP` (cost) entry.
 
 ---
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -572,6 +572,43 @@ invocations across 11 analyzed sessions.
 
 **Related:** [`target_description`](#target_description), [`mcp_unused_server`](#mcp_unused_server)
 
+### `tool_inventory_oversized`
+
+**Short:** An agent declares a large tool list (>30 tools) but exercises fewer than
+half of them in the analyzed window.
+
+**Detail:** Triggered when a config-declared agent's `tools:` list (or an SDK
+agent's `allowed_tools`) exceeds 30 entries AND its utilization ratio
+— unique observed tools divided by declared tools — falls below 0.5.
+Observed tool diversity comes from `toolStats` on the agent's
+`toolUseResult` metadata, unioned across every invocation of that
+agent type. RAG-MCP (arXiv 2505.03275) places the tool-selection
+accuracy inflection point at ~30 tools (43% with retrieval vs 14%
+without); Anthropic's "Advanced Tool Use" article reports the Tool
+Search Tool lifts Opus 4.5 accuracy from 79.5% to 88.1% while
+preserving ~85% of the context window. Two suppression rules avoid
+false positives: agents whose declared list is a wildcard (`*`) are
+skipped (undefined denominator), and agents whose invocations carry
+no `toolStats` are skipped (observed diversity unknown, not zero).
+Scope is config-declared agents only — built-in agents (Explore,
+Plan, general-purpose) are excluded because there is no
+declared-tool-count data source for them.
+
+**Example:**
+
+```
+Agent 'researcher' declares 42 tools but used only 9 unique tools
+(21% utilization) across 11 analyzed sessions.
+```
+
+**Severity:** info
+
+**Threshold:** >30 declared tools and <0.5 utilization ratio
+
+**Recommendation target:** `tools`
+
+**Related:** [`unused_agent`](#unused_agent), [`token_outlier`](#token_outlier), [`target_tools`](#target_tools)
+
 ### `user_correction`
 
 **Short:** The user interrupted or redirected the parent thread mid-flight ("no, do X

--- a/src/agentfluent/agents/extractor.py
+++ b/src/agentfluent/agents/extractor.py
@@ -44,12 +44,14 @@ def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvoc
             tool_uses_count = None
             duration_ms = None
             agent_id = None
+            tool_stats = None
 
             if container is not None and container.metadata is not None:
                 total_tokens = container.metadata.total_tokens
                 tool_uses_count = container.metadata.tool_uses
                 duration_ms = container.metadata.duration_ms
                 agent_id = container.metadata.agent_id
+                tool_stats = container.metadata.tool_stats
 
             invocations.append(
                 AgentInvocation(
@@ -61,6 +63,7 @@ def extract_agent_invocations(messages: list[SessionMessage]) -> list[AgentInvoc
                     tool_uses=tool_uses_count,
                     duration_ms=duration_ms,
                     agent_id=agent_id,
+                    tool_stats=tool_stats,
                     output_text=output_text,
                 )
             )

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -67,6 +67,12 @@ class AgentInvocation(BaseModel):
     tool_uses: int | None = None
     duration_ms: int | None = None
     agent_id: str | None = None
+    tool_stats: dict[str, int] | None = None
+    """Per-tool invocation counts from ``toolUseResult.toolStats`` (keyed
+    by tool name). ``None`` when the result carried no ``toolStats``.
+    The keys are observed tool diversity for this invocation; the
+    ``tool_inventory_oversized`` audit (#372) unions them across an
+    agent type's invocations to compute a utilization ratio."""
 
     # From tool_result content
     output_text: str = ""
@@ -75,6 +81,14 @@ class AgentInvocation(BaseModel):
     # otherwise (e.g., older sessions predating trace capture). Serves as the
     # evidence layer for trace-level diagnostics.
     trace: SubagentTrace | None = None
+
+    @property
+    def observed_tool_names(self) -> set[str]:
+        """Unique tool names this invocation called, from ``tool_stats``
+        keys. Empty set when ``tool_stats`` is ``None`` or empty — callers
+        that need to distinguish "unknown" from "none observed" should
+        check ``tool_stats is None`` directly."""
+        return set(self.tool_stats or {})
 
     @property
     def is_builtin(self) -> bool:

--- a/src/agentfluent/cli/commands/explain.py
+++ b/src/agentfluent/cli/commands/explain.py
@@ -42,6 +42,10 @@ Examples:
       Show only the signal-type terms.
 """
 
+# Cap on how many fuzzy suggestions to print before truncating with an
+# "...and N more" note. Keeps a broad query from flooding the terminal.
+_MAX_FUZZY_SUGGESTIONS = 5
+
 app = typer.Typer(help="Look up an AgentFluent term.")
 console = Console()
 err_console = Console(stderr=True)
@@ -131,12 +135,23 @@ def _explain_lookup(term: str, entries: list[GlossaryEntry]) -> int:
         )
         _render_entry(only, prefix_note=note)
         return EXIT_OK
-    if 2 <= len(candidates) <= 5:
+    if len(candidates) >= 2:
+        # Cap the displayed list so a broad query (e.g. a single letter)
+        # doesn't flood the terminal, but still tell the user there were
+        # more matches rather than collapsing to the "not found" message
+        # — distinguishing "too many matches" from "no matches at all".
+        shown = candidates[:_MAX_FUZZY_SUGGESTIONS]
         err_console.print(
             f"[yellow]No exact match for {term!r}. Did you mean:[/yellow]",
         )
-        for c in candidates:
+        for c in shown:
             err_console.print(f"  [cyan]{c.name}[/cyan] -- {c.short.strip()}")
+        extra = len(candidates) - len(shown)
+        if extra:
+            err_console.print(
+                f"  [dim]...and {extra} more. Run "
+                "[cyan]agentfluent explain --list[/cyan] to see all terms.[/dim]",
+            )
         return EXIT_USER_ERROR
     err_console.print(
         f"[red]Term {term!r} not found.[/red] "

--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -89,6 +89,13 @@ class ToolResultMetadata(BaseModel):
     tool_uses: int | None = Field(None, alias="totalToolUseCount")
     duration_ms: int | None = Field(None, alias="totalDurationMs")
     agent_id: str | None = Field(None, alias="agentId")
+    tool_stats: dict[str, int] | None = Field(None, alias="toolStats")
+    """Per-tool invocation counts keyed by tool name (e.g.
+    ``{"Read": 3, "Bash": 1}``). ``None`` when ``toolStats`` is absent
+    from the result — distinct from an empty dict so consumers can tell
+    "no data" apart from "ran but recorded no tool calls". Keys are the
+    source of observed tool *diversity* (vs ``tool_uses``, which is only
+    a count). Used by the ``tool_inventory_oversized`` audit (#372)."""
 
 
 class SessionMessage(BaseModel):

--- a/src/agentfluent/diagnostics/agent_audit.py
+++ b/src/agentfluent/diagnostics/agent_audit.py
@@ -1,10 +1,15 @@
-"""Configured-vs-observed agent-definition audit (#346).
+"""Configured-vs-observed agent-definition audits.
 
-Emits ``UNUSED_AGENT`` for each custom agent defined in
-``~/.claude/agents/`` (or the project-scoped equivalent) with zero
-invocations in the analyzed window. Built-ins excluded per D033;
-empty-window suppression so the surface stays useful — callers who
-want config-only checks have ``agentfluent config-check``.
+- ``audit_unused_agents`` (#346): emits ``UNUSED_AGENT`` for each custom
+  agent defined in ``~/.claude/agents/`` (or the project-scoped
+  equivalent) with zero invocations in the analyzed window. Built-ins
+  excluded per D033; empty-window suppression so the surface stays
+  useful — callers who want config-only checks have
+  ``agentfluent config-check``.
+- ``audit_tool_inventory`` (#372): emits ``TOOL_INVENTORY_OVERSIZED``
+  for agents that declare a large tool list but exercise few of those
+  tools (low utilization), the configured-vs-observed analog applied to
+  the ``tools:`` surface rather than delegation.
 """
 
 from __future__ import annotations
@@ -12,6 +17,17 @@ from __future__ import annotations
 from agentfluent.agents.models import AgentInvocation, is_builtin_agent
 from agentfluent.config.models import AgentConfig, Severity
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
+
+# RAG-MCP (arXiv 2505.03275) heatmap inflection point: tool-selection
+# accuracy degrades once an agent declares more than ~30 tools. Below
+# this, full-schema loading is fine. Anthropic's "Advanced Tool Use"
+# article corroborates with a first-party benchmark (#404).
+TOOL_INVENTORY_THRESHOLD = 30
+
+# Utilization gate: declared count alone isn't enough — an agent that
+# declares 40 tools and uses 38 is fine. Fire only when fewer than half
+# the declared tools are ever observed in the window.
+TOOL_UTILIZATION_THRESHOLD = 0.5
 
 
 def audit_unused_agents(
@@ -53,6 +69,95 @@ def audit_unused_agents(
                     "agent_name": config.name,
                     "source_file": str(config.file_path),
                     "description": config.description,
+                    "sessions_analyzed": sessions_analyzed,
+                },
+            ),
+        )
+    return signals
+
+
+def audit_tool_inventory(
+    invocations: list[AgentInvocation],
+    agent_configs: list[AgentConfig],
+    *,
+    sessions_analyzed: int,
+    declared_threshold: int = TOOL_INVENTORY_THRESHOLD,
+    utilization_threshold: float = TOOL_UTILIZATION_THRESHOLD,
+) -> list[DiagnosticSignal]:
+    """Emit ``TOOL_INVENTORY_OVERSIZED`` for oversized, under-used tool lists.
+
+    A signal fires for an agent config when ALL of the following hold:
+
+    - it declares more than ``declared_threshold`` tools (the RAG-MCP
+      inflection point), and the declared list is not a wildcard (``*``),
+      which leaves the denominator undefined;
+    - the agent was invoked at least once in the window (zero-invocation
+      agents are :func:`audit_unused_agents`'s domain, not this one);
+    - at least one of those invocations reported ``toolStats`` so observed
+      tool diversity is *known* (an agent whose invocations all lack
+      ``toolStats`` is suppressed rather than scored as zero-utilization —
+      missing data must not masquerade as a finding);
+    - the utilization ratio (unique observed tools / declared tools) is
+      below ``utilization_threshold``.
+
+    Scope is config-declared agents only (custom ``.md`` agents and SDK
+    ``allowed_tools``). Built-in agents are excluded because there is no
+    declared-tool-count data source for them; see #372 for the deferred
+    built-in-coverage follow-up.
+    """
+    if not invocations:
+        return []
+
+    observed_by_agent: dict[str, set[str]] = {}
+    invoked_agents: set[str] = set()
+    for inv in invocations:
+        key = inv.agent_type.lower()
+        invoked_agents.add(key)
+        if inv.tool_stats:
+            observed_by_agent.setdefault(key, set()).update(inv.tool_stats)
+
+    signals: list[DiagnosticSignal] = []
+    for config in agent_configs:
+        declared = config.tools
+        if "*" in declared:
+            continue
+        declared_count = len(declared)
+        if declared_count <= declared_threshold:
+            continue
+
+        key = config.name.lower()
+        if key not in invoked_agents:
+            continue
+
+        observed = observed_by_agent.get(key, set())
+        if not observed:
+            # Invoked, but no invocation reported toolStats — observed
+            # diversity is unknown. Suppress rather than report 0%.
+            continue
+
+        observed_count = len(observed)
+        ratio = observed_count / declared_count
+        if ratio >= utilization_threshold:
+            continue
+
+        signals.append(
+            DiagnosticSignal(
+                signal_type=SignalType.TOOL_INVENTORY_OVERSIZED,
+                severity=Severity.INFO,
+                agent_type=config.name,
+                message=(
+                    f"Agent '{config.name}' declares {declared_count} tools "
+                    f"but used only {observed_count} unique tools "
+                    f"({ratio:.0%} utilization) across {sessions_analyzed} "
+                    "analyzed sessions."
+                ),
+                detail={
+                    "agent_name": config.name,
+                    "source_file": str(config.file_path),
+                    "declared_count": declared_count,
+                    "observed_count": observed_count,
+                    "utilization_ratio": ratio,
+                    "observed_tools": sorted(observed),
                     "sessions_analyzed": sessions_analyzed,
                 },
             ),

--- a/src/agentfluent/diagnostics/agent_audit.py
+++ b/src/agentfluent/diagnostics/agent_audit.py
@@ -109,12 +109,11 @@ def audit_tool_inventory(
         return []
 
     observed_by_agent: dict[str, set[str]] = {}
-    invoked_agents: set[str] = set()
     for inv in invocations:
-        key = inv.agent_type.lower()
-        invoked_agents.add(key)
         if inv.tool_stats:
-            observed_by_agent.setdefault(key, set()).update(inv.tool_stats)
+            observed_by_agent.setdefault(inv.agent_type.lower(), set()).update(
+                inv.tool_stats,
+            )
 
     signals: list[DiagnosticSignal] = []
     for config in agent_configs:
@@ -125,14 +124,13 @@ def audit_tool_inventory(
         if declared_count <= declared_threshold:
             continue
 
-        key = config.name.lower()
-        if key not in invoked_agents:
-            continue
-
-        observed = observed_by_agent.get(key, set())
+        # An agent only appears in observed_by_agent when at least one of
+        # its invocations reported toolStats, so an empty set covers both
+        # suppressed cases: never invoked in the window (that's the
+        # unused-agent audit's domain), and invoked but with no toolStats
+        # (observed diversity unknown — suppress rather than report 0%).
+        observed = observed_by_agent.get(config.name.lower(), set())
         if not observed:
-            # Invoked, but no invocation reported toolStats — observed
-            # diversity is unknown. Suppress rather than report 0%.
             continue
 
         observed_count = len(observed)

--- a/src/agentfluent/diagnostics/aggregation.py
+++ b/src/agentfluent/diagnostics/aggregation.py
@@ -88,6 +88,7 @@ SIGNAL_AXIS_MAP: dict[SignalType, Axis] = {
     SignalType.PERMISSION_FAILURE: Axis.SPEED,
     SignalType.MCP_MISSING_SERVER: Axis.SPEED,
     SignalType.UNUSED_AGENT: Axis.COST,
+    SignalType.TOOL_INVENTORY_OVERSIZED: Axis.COST,
     SignalType.USER_CORRECTION: Axis.QUALITY,
     SignalType.FILE_REWORK: Axis.QUALITY,
     SignalType.REVIEWER_CAUGHT: Axis.QUALITY,

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -805,6 +805,61 @@ class UnusedAgentRule:
         )
 
 
+class ToolInventoryOversizedRule:
+    """``TOOL_INVENTORY_OVERSIZED`` -> recommend Tool Search + trimming.
+
+    Targets the ``tools`` surface: an oversized declared inventory with
+    low observed utilization both wastes context-window tokens on unused
+    schemas and degrades tool-selection accuracy. The fix is to defer
+    schema loading (Tool Search) and prune tools that are never called.
+    """
+
+    def matches(self, signal: DiagnosticSignal, config: AgentConfig | None) -> bool:
+        return signal.signal_type == SignalType.TOOL_INVENTORY_OVERSIZED
+
+    def recommend(
+        self, signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        observation = signal.message
+        source_file = str(signal.detail.get("source_file", ""))
+
+        reason = (
+            "Large tool inventories consume context-window tokens for schema "
+            "definitions and degrade tool-selection accuracy. RAG-MCP "
+            "(arXiv 2505.03275) shows retrieval-based tool selection outperforms "
+            "full-schema dumps above ~30 tools (43% vs 14% accuracy); Anthropic's "
+            "Advanced Tool Use article reports the Tool Search Tool lifts Opus 4.5 "
+            "accuracy from 79.5% to 88.1% while preserving ~85% of the context "
+            "window."
+        )
+        file_clause = (
+            f" File: {_relpath(Path(source_file))}." if source_file else ""
+        )
+        action = (
+            "Enable the Tool Search Tool so schemas load on demand. For API/SDK "
+            "agents, add a `tool_search_tool_regex_20251119` tool to the `tools[]` "
+            "array and set `defer_loading: true` on the individual tools that "
+            'should load lazily; for MCP servers, use an `mcp_toolset` block with '
+            '`default_config: {"defer_loading": true}`. (Claude Code agents can '
+            "set `defer_loading: true` in agent frontmatter.) Also review the "
+            "declared tool list for tools that are never invoked and consider "
+            f"removing them.{file_clause}"
+        )
+
+        return DiagnosticRecommendation(
+            target="tools",
+            severity=signal.severity,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file=source_file,
+            signal_types=[signal.signal_type],
+        )
+
+
 class _QualityRule(ABC):
     """Shared base for cross-cutting and per-agent quality-axis rules.
 
@@ -1159,6 +1214,7 @@ RULES: list[CorrelationRule] = [
     ToolOrchestrationRule(),
     McpAuditRule(),
     UnusedAgentRule(),
+    ToolInventoryOversizedRule(),
     UserCorrectionRule(),
     FileReworkRule(),
     ReviewerCaughtRule(),

--- a/src/agentfluent/diagnostics/models.py
+++ b/src/agentfluent/diagnostics/models.py
@@ -61,7 +61,7 @@ class SignalType(StrEnum):
     - `MCP_UNUSED_SERVER`, `MCP_MISSING_SERVER`
 
     Agent audit signals (configured-vs-observed agent delegation):
-    - `UNUSED_AGENT`
+    - `UNUSED_AGENT`, `TOOL_INVENTORY_OVERSIZED`
 
     Quality signals (extracted from parent-thread message patterns):
     - `USER_CORRECTION`, `FILE_REWORK`, `REVIEWER_CAUGHT`
@@ -89,6 +89,7 @@ class SignalType(StrEnum):
     MCP_UNUSED_SERVER = "mcp_unused_server"
     MCP_MISSING_SERVER = "mcp_missing_server"
     UNUSED_AGENT = "unused_agent"
+    TOOL_INVENTORY_OVERSIZED = "tool_inventory_oversized"
     USER_CORRECTION = "user_correction"
     FILE_REWORK = "file_rework"
     REVIEWER_CAUGHT = "reviewer_caught"

--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -27,7 +27,10 @@ from agentfluent.config.mcp_discovery import discover_mcp_servers
 from agentfluent.config.models import AgentConfig
 from agentfluent.config.scanner import scan_agents
 from agentfluent.core.session import SessionMessage
-from agentfluent.diagnostics.agent_audit import audit_unused_agents
+from agentfluent.diagnostics.agent_audit import (
+    audit_tool_inventory,
+    audit_unused_agents,
+)
 from agentfluent.diagnostics.aggregation import aggregate_recommendations
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.delegation import (
@@ -236,6 +239,13 @@ def run_diagnostics(
 
     signals.extend(
         audit_unused_agents(
+            invocations, agent_configs,
+            sessions_analyzed=session_count,
+        ),
+    )
+
+    signals.extend(
+        audit_tool_inventory(
             invocations, agent_configs,
             sessions_analyzed=session_count,
         ),

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -419,6 +419,36 @@
   recommendation_target: description
   related: [target_description, mcp_unused_server]
 
+- name: tool_inventory_oversized
+  category: signal_type
+  short: |
+    An agent declares a large tool list (>30 tools) but exercises fewer than
+    half of them in the analyzed window.
+  long: |
+    Triggered when a config-declared agent's `tools:` list (or an SDK
+    agent's `allowed_tools`) exceeds 30 entries AND its utilization ratio
+    — unique observed tools divided by declared tools — falls below 0.5.
+    Observed tool diversity comes from `toolStats` on the agent's
+    `toolUseResult` metadata, unioned across every invocation of that
+    agent type. RAG-MCP (arXiv 2505.03275) places the tool-selection
+    accuracy inflection point at ~30 tools (43% with retrieval vs 14%
+    without); Anthropic's "Advanced Tool Use" article reports the Tool
+    Search Tool lifts Opus 4.5 accuracy from 79.5% to 88.1% while
+    preserving ~85% of the context window. Two suppression rules avoid
+    false positives: agents whose declared list is a wildcard (`*`) are
+    skipped (undefined denominator), and agents whose invocations carry
+    no `toolStats` are skipped (observed diversity unknown, not zero).
+    Scope is config-declared agents only — built-in agents (Explore,
+    Plan, general-purpose) are excluded because there is no
+    declared-tool-count data source for them.
+  example: |
+    Agent 'researcher' declares 42 tools but used only 9 unique tools
+    (21% utilization) across 11 analyzed sessions.
+  severity_range: info
+  threshold: ">30 declared tools and <0.5 utilization ratio"
+  recommendation_target: tools
+  related: [unused_agent, token_outlier, target_tools]
+
 - name: user_correction
   category: signal_type
   short: |

--- a/tests/unit/cli/test_explain.py
+++ b/tests/unit/cli/test_explain.py
@@ -36,12 +36,15 @@ class TestFuzzyLookup:
     ) -> None:
         result = runner.invoke(cli_app, ["explain", "tools"])
         assert result.exit_code != 0
-        # `tools` substring matches at least target_tools and concern_tools
-        # (and others); the "did you mean" branch uses stderr.
+        # `tools` substring matches more than five `tool*` terms; the
+        # "did you mean" branch fires (uses stderr), caps the displayed
+        # list, and reports the remainder as "...and N more" rather than
+        # collapsing into the "not found" message.
         combined = result.stdout + result.stderr
         assert "Did you mean" in combined
         assert "target_tools" in combined
         assert "concern_tools" in combined
+        assert "more" in combined
 
     def test_unknown_term_exits_with_user_error(
         self, runner: CliRunner, cli_app: typer.Typer,

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -519,6 +519,58 @@ class TestUnusedAgentCorrelation:
         assert 'Current description: ""' not in rec.action
 
 
+class TestToolInventoryOversizedCorrelation:
+    def _oversized_signal(
+        self,
+        agent_name: str = "researcher",
+        source_file: str = "/home/u/.claude/agents/researcher.md",
+    ) -> DiagnosticSignal:
+        return _signal(
+            signal_type=SignalType.TOOL_INVENTORY_OVERSIZED,
+            severity=Severity.INFO,
+            agent_type=agent_name,
+            message=(
+                f"Agent '{agent_name}' declares 42 tools but used only 9 "
+                "unique tools (21% utilization) across 11 analyzed sessions."
+            ),
+            detail={
+                "agent_name": agent_name,
+                "source_file": source_file,
+                "declared_count": 42,
+                "observed_count": 9,
+                "utilization_ratio": 9 / 42,
+                "sessions_analyzed": 11,
+            },
+        )
+
+    def test_produces_tools_target_recommendation(self) -> None:
+        recs = correlate([self._oversized_signal()])
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "tools"
+        assert rec.severity == Severity.INFO
+        assert rec.agent_type == "researcher"
+        assert rec.config_file == "/home/u/.claude/agents/researcher.md"
+        assert rec.signal_types == [SignalType.TOOL_INVENTORY_OVERSIZED]
+        # Action references the platform-level Tool Search syntax (#404).
+        assert "tool_search_tool_regex_20251119" in rec.action
+        assert "defer_loading" in rec.action
+        assert "mcp_toolset" in rec.action
+        assert "researcher.md" in rec.action
+        # Reason cites both research anchors.
+        assert "43% vs 14%" in rec.reason
+        assert "79.5% to 88.1%" in rec.reason
+
+    def test_action_points_at_source_file_when_present(self) -> None:
+        recs = correlate([self._oversized_signal()])
+        assert "File:" in recs[0].action
+
+    def test_missing_source_file_omits_file_clause(self) -> None:
+        recs = correlate([self._oversized_signal(source_file="")])
+        assert len(recs) == 1
+        assert "File:" not in recs[0].action
+
+
 def _builtin_signal(signal_type: SignalType, agent_type: str = "explore") -> DiagnosticSignal:
     detail: dict[str, object] = {}
     if signal_type == SignalType.ERROR_PATTERN:

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -258,6 +258,7 @@ class TestExtractFromConstructedMessages:
                     tool_uses=14,
                     duration_ms=122963,
                     agent_id="uuid-real",
+                    tool_stats={"Read": 8, "Bash": 6},
                 ),
             ),
         ]
@@ -270,6 +271,10 @@ class TestExtractFromConstructedMessages:
         assert inv.duration_ms == 122963
         assert inv.agent_id == "uuid-real"
         assert inv.output_text == "Agent finished successfully."
+        # toolStats flows through to the invocation (#372); its keys are
+        # the observed-tool-diversity source for the tool-inventory audit.
+        assert inv.tool_stats == {"Read": 8, "Bash": 6}
+        assert inv.observed_tool_names == {"Read", "Bash"}
 
     def test_missing_subagent_type_defaults_to_general_purpose(self) -> None:
         # Some caller-side skills and older Claude Code versions invoke

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -342,6 +342,9 @@ class TestToolUseResultOnUserMessage:
         assert len(messages) == 1
         assert messages[0].metadata is not None
         assert messages[0].metadata.total_tokens == 100
+        # `toolStats` is now a modeled field (#372): its keys are the
+        # source of observed tool diversity for the tool-inventory audit.
+        assert messages[0].metadata.tool_stats == {"Read": 1}
 
     def test_user_message_without_tool_use_result(self, tmp_path: Path) -> None:
         """Regular user messages (no toolUseResult) have metadata=None."""

--- a/tests/unit/test_tool_inventory_audit.py
+++ b/tests/unit/test_tool_inventory_audit.py
@@ -1,0 +1,204 @@
+"""Tests for the tool-inventory audit (#372).
+
+Covers ``audit_tool_inventory``: the declared-count threshold, the
+utilization-ratio gate, union of observed tools across an agent type's
+invocations, and the two suppression rules (wildcard ``*`` declared
+list, and invoked-but-no-``toolStats`` "observed unknown"). The signal
+detail surface here is what the correlator's ``ToolInventoryOversizedRule``
+relies on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentfluent.agents.models import AgentInvocation
+from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.diagnostics.agent_audit import audit_tool_inventory
+from agentfluent.diagnostics.models import SignalType
+
+
+def _config(name: str, *, tool_count: int, wildcard: bool = False) -> AgentConfig:
+    tools = ["*"] if wildcard else [f"Tool{i}" for i in range(tool_count)]
+    return AgentConfig(
+        name=name,
+        file_path=Path(f"/home/u/.claude/agents/{name}.md"),
+        scope=Scope.USER,
+        tools=tools,
+    )
+
+
+def _invocation(
+    agent_type: str,
+    *,
+    tool_stats: dict[str, int] | None = None,
+    suffix: str = "",
+) -> AgentInvocation:
+    return AgentInvocation(
+        tool_use_id=f"toolu_{agent_type}{suffix}",
+        agent_type=agent_type,
+        description="...",
+        prompt="...",
+        tool_stats=tool_stats,
+    )
+
+
+def _stats(n: int) -> dict[str, int]:
+    """toolStats with ``n`` distinct observed tool names."""
+    return {f"Tool{i}": 1 for i in range(n)}
+
+
+class TestAuditToolInventory:
+    def test_oversized_low_utilization_fires(self) -> None:
+        # 35 declared, 8 observed unique -> 23% utilization -> fires.
+        configs = [_config("researcher", tool_count=35)]
+        invocations = [_invocation("researcher", tool_stats=_stats(8))]
+
+        signals = audit_tool_inventory(
+            invocations, configs, sessions_analyzed=10,
+        )
+
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == SignalType.TOOL_INVENTORY_OVERSIZED
+        assert sig.severity == Severity.INFO
+        assert sig.agent_type == "researcher"
+        assert sig.detail["declared_count"] == 35
+        assert sig.detail["observed_count"] == 8
+        assert sig.detail["utilization_ratio"] == 8 / 35
+        assert sig.detail["sessions_analyzed"] == 10
+        assert str(sig.detail["source_file"]).endswith("researcher.md")
+        assert "35 tools" in sig.message
+        assert "8 unique tools" in sig.message
+        assert "23% utilization" in sig.message
+
+    def test_oversized_high_utilization_does_not_fire(self) -> None:
+        # 35 declared, 25 observed -> 71% utilization -> no signal.
+        configs = [_config("researcher", tool_count=35)]
+        invocations = [_invocation("researcher", tool_stats=_stats(25))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_below_count_threshold_does_not_fire(self) -> None:
+        # 15 declared (<= 30), 3 observed -> below threshold -> no signal,
+        # even though utilization is low.
+        configs = [_config("small", tool_count=15)]
+        invocations = [_invocation("small", tool_stats=_stats(3))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_zero_invocations_suppressed(self) -> None:
+        # 35 declared but the agent is never invoked in the window: that's
+        # the unused-agent audit's domain, not this one.
+        configs = [_config("researcher", tool_count=35)]
+        invocations = [_invocation("other", tool_stats=_stats(2))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_empty_invocations_returns_empty(self) -> None:
+        configs = [_config("researcher", tool_count=35)]
+        assert audit_tool_inventory([], configs, sessions_analyzed=0) == []
+
+    def test_invoked_without_toolstats_suppressed(self) -> None:
+        # Invoked, oversized, but no invocation reported toolStats:
+        # observed diversity is unknown -> suppress rather than score 0%.
+        configs = [_config("researcher", tool_count=35)]
+        invocations = [_invocation("researcher", tool_stats=None)]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_wildcard_declared_list_suppressed(self) -> None:
+        # `Tools: *` leaves the denominator undefined -> skip.
+        configs = [_config("everything", tool_count=0, wildcard=True)]
+        invocations = [_invocation("everything", tool_stats=_stats(3))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_count_threshold_is_strict_greater_than(self) -> None:
+        # Exactly 30 declared is NOT oversized (threshold is > 30).
+        configs = [_config("boundary", tool_count=30)]
+        invocations = [_invocation("boundary", tool_stats=_stats(1))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_ratio_at_threshold_does_not_fire(self) -> None:
+        # Exactly 0.5 utilization (>= threshold) -> no signal.
+        configs = [_config("half", tool_count=40)]
+        invocations = [_invocation("half", tool_stats=_stats(20))]
+
+        assert (
+            audit_tool_inventory(invocations, configs, sessions_analyzed=10)
+            == []
+        )
+
+    def test_observed_tools_unioned_across_invocations(self) -> None:
+        # Two invocations of the same agent type each call disjoint tools;
+        # the union determines utilization, not any single invocation.
+        configs = [_config("researcher", tool_count=40)]
+        invocations = [
+            _invocation(
+                "researcher",
+                tool_stats={"Tool0": 1, "Tool1": 1, "Tool2": 1},
+                suffix="a",
+            ),
+            _invocation(
+                "researcher",
+                tool_stats={"Tool2": 1, "Tool3": 1, "Tool4": 1},
+                suffix="b",
+            ),
+        ]
+
+        signals = audit_tool_inventory(
+            invocations, configs, sessions_analyzed=10,
+        )
+
+        assert len(signals) == 1
+        # Union of {0,1,2} and {2,3,4} = 5 distinct tools.
+        assert signals[0].detail["observed_count"] == 5
+        assert signals[0].detail["observed_tools"] == [
+            "Tool0", "Tool1", "Tool2", "Tool3", "Tool4",
+        ]
+
+    def test_case_insensitive_agent_matching(self) -> None:
+        # Frontmatter name casing differs from observed invocation casing.
+        configs = [_config("Researcher", tool_count=35)]
+        invocations = [_invocation("researcher", tool_stats=_stats(5))]
+
+        signals = audit_tool_inventory(
+            invocations, configs, sessions_analyzed=10,
+        )
+        assert len(signals) == 1
+        assert signals[0].agent_type == "Researcher"
+
+    def test_partial_toolstats_still_scores(self) -> None:
+        # One invocation has toolStats, another doesn't; the known one
+        # supplies observed diversity, so the signal still fires.
+        configs = [_config("researcher", tool_count=35)]
+        invocations = [
+            _invocation("researcher", tool_stats=None, suffix="a"),
+            _invocation("researcher", tool_stats=_stats(4), suffix="b"),
+        ]
+
+        signals = audit_tool_inventory(
+            invocations, configs, sessions_analyzed=10,
+        )
+        assert len(signals) == 1
+        assert signals[0].detail["observed_count"] == 4


### PR DESCRIPTION
## Summary
- Adds the `TOOL_INVENTORY_OVERSIZED` diagnostic signal: flags config-declared agents that declare >30 tools but exercise <50% of them, recommending the Tool Search Tool (`defer_loading`) and pruning unused tools. Structural analog of `UNUSED_AGENT` (#346).
- Captures `toolStats` from `toolUseResult` (previously dropped) → threads it through the extractor onto `AgentInvocation` so observed tool diversity has ~100% metadata coverage vs trace-only ~80%. Unblocks future PARAMETER_RETRY Tier B work for free.
- Wires in the enum, `SIGNAL_AXIS_MAP` (→ COST), correlator rule, glossary entry, and pipeline integration. Scoped to config-declared agents per the architect review on #372 (built-ins deferred to #494). Also completes #404's PRD sync.

## Design notes
- **Suppression rules** (architect review): skip agents whose declared list is a wildcard (`*`, undefined denominator) and agents invoked without any `toolStats` (observed diversity unknown — must not be scored as 0% utilization).
- **Built-ins out of scope:** declared-tool counts come from `AgentConfig`, and built-ins have no config file / `tools:` list. Deferred to **#494** per the human spec decision (CLAUDE.md "infeasible spec → report back").
- **Drive-by fix:** the new glossary term pushed `explain tools` from 5→6 fuzzy matches, exposing a latent bug where >5 matches collapsed into the "not found" message. `_explain_lookup` now caps-and-reports ("…and N more") for any ≥2 matches.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1632 passed (+16 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — audit, correlator, parser, extractor, explain
- [x] Manual smoke test via `uv run agentfluent explain tool_inventory_oversized` and `explain tools`

## Security review
Pick one.
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

_(Touches JSONL parsing — new `toolStats` field on `ToolResultMetadata` — and renders tool/agent names in recommendation text. Per CLAUDE.md I'll apply the `needs-security-review` label only once this is dev-complete and CI is green, so the single review covers the final SHA.)_

## Breaking changes
None. Additive: one optional `tool_stats` field on `ToolResultMetadata`/`AgentInvocation`, one new `SignalType`, one new correlator rule. No public contract changes.

Closes #372. Closes #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)