### PR TITLE
feat: warn when Claude Code cleanupPeriodDays truncates the session corpus (#481)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ uvx agentfluent list
 
 - **`agentfluent[clustering]`** — installs `scikit-learn` and enables delegation clustering, which proposes new specialized subagents from recurring `general-purpose` invocations. Without this extra, `agentfluent analyze --diagnostics` still runs all other diagnostics, but `delegation_suggestions` is always empty in JSON output and the "Suggested Subagents" section is omitted from terminal output. Install with `uv tool install 'agentfluent[clustering]'` or `pip install 'agentfluent[clustering]'`.
 
+### Preserve your session history (one-time, recommended)
+
+AgentFluent can only analyze the sessions Claude Code still has on disk — and **Claude Code deletes session files older than 30 days by default.** That default silently bounds every longitudinal analysis (regression detection, baselines, multi-month trends), and the deletion is unrecoverable (Claude Code deletes, it doesn't archive).
+
+Before you accumulate history you'll want later, raise the retention window once by adding `cleanupPeriodDays` to `~/.claude/settings.json`:
+
+```jsonc
+{
+  "cleanupPeriodDays": 3650  // ~10 years; keeps sessions for long-term analysis
+}
+```
+
+`agentfluent analyze` checks this setting at runtime and prints a warning when retention is at or below the default, quoting the exact file path to edit. Raising it does not recover already-deleted sessions — it only protects future ones — so it's worth doing on day one.
+
 ### First run
 
 ```bash

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -32,6 +32,7 @@ from agentfluent.analytics.tools import (
     ToolMetrics,
     compute_tool_metrics,
 )
+from agentfluent.config.models import EnvironmentWarning
 from agentfluent.core.filtering import WindowMetadata
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import SessionMessage
@@ -129,6 +130,14 @@ class AnalysisResult(BaseModel):
     otherwise. Surfaced so consumers can verify scope at a glance: when
     set, every metric and diagnostic in this envelope reflects exactly
     one session. Stamped by :mod:`agentfluent.cli.commands.analyze` (#357)."""
+
+    warnings: list[EnvironmentWarning] = Field(default_factory=list)
+    """Non-fatal warnings about the analysis *environment* (not the
+    agent's config) — e.g., Claude Code's ``cleanupPeriodDays`` silently
+    truncating the session corpus (#481). Populated at discovery time by
+    :mod:`agentfluent.cli.commands.analyze`; additive field, empty on
+    legacy envelopes. Rendered as a banner above the normal output and
+    carried in the JSON envelope."""
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/agentfluent/cli/commands/analyze.py
+++ b/src/agentfluent/cli/commands/analyze.py
@@ -14,11 +14,16 @@ from agentfluent import __version__
 from agentfluent.analytics.pipeline import AnalysisResult, analyze_sessions
 from agentfluent.cli._time_args import parse_time_window
 from agentfluent.cli.exit_codes import EXIT_NO_DATA, EXIT_USER_ERROR
-from agentfluent.cli.formatters.helpers import format_cost, format_tokens
+from agentfluent.cli.formatters.helpers import (
+    format_cost,
+    format_tokens,
+    render_environment_warnings,
+)
 from agentfluent.cli.formatters.json_output import format_json_output
 from agentfluent.cli.formatters.table import format_analysis_table
 from agentfluent.config.mcp_discovery import resolve_project_disk_path
 from agentfluent.config.models import SEVERITY_RANK, Severity
+from agentfluent.config.retention import check_cleanup_retention
 from agentfluent.core.discovery import SessionInfo, find_project
 from agentfluent.core.filtering import WindowMetadata, filter_sessions_by_time
 from agentfluent.core.paths import projects_dir_for
@@ -202,6 +207,7 @@ err_console = Console(stderr=True)
 
 def _print_quiet(result: AnalysisResult, project_name: str) -> None:
     """Print a one-line summary."""
+    render_environment_warnings(console, result.warnings)
     tm = result.token_metrics
     am = result.agent_metrics
     signal_count = len(result.diagnostics.signals) if result.diagnostics else 0
@@ -227,6 +233,11 @@ def _print_json(result: AnalysisResult, *, quiet: bool, project_name: str) -> No
             "total_tokens": tm.total_tokens,
             "total_invocations": am.total_invocations,
             "diagnostic_signal_count": signal_count,
+            # Environment warnings ride inside the envelope (never the
+            # stdout banner) so the JSON stays valid; mirror them in the
+            # quiet payload so JSON consumers don't have to use full mode
+            # to see a truncated-corpus warning (#481).
+            "warnings": [w.model_dump(mode="json") for w in result.warnings],
         }
     else:
         payload = result.model_dump(mode="json")
@@ -492,6 +503,16 @@ def analyze(
     project_disk_path = resolve_project_disk_path(
         project_info.slug, claude_config_dir=config_dir,
     )
+
+    # Environment-level retention check: Claude Code's cleanupPeriodDays
+    # silently bounds the corpus by deleting old sessions (#481). Runs
+    # regardless of --diagnostics — it describes the host install, not
+    # agent behavior — so even a --no-diagnostics run surfaces it.
+    retention_warning = check_cleanup_retention(
+        claude_config_dir=config_dir, project_dir=project_disk_path,
+    )
+    if retention_warning is not None:
+        result.warnings.append(retention_warning)
 
     # Tier 3 setup runs whenever the user passed --github (which requires
     # --diagnostics, enforced earlier). Lifted out of the

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from rich.console import Console
+from rich.markup import escape
+
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import Axis
 
 if TYPE_CHECKING:
-    from agentfluent.config.models import ConfigScore
+    from agentfluent.config.models import ConfigScore, EnvironmentWarning
 
 SEVERITY_COLORS: dict[Severity, str] = {
     Severity.CRITICAL: "red",
@@ -39,6 +42,22 @@ def severity_cell(severity: Severity) -> str:
     """Rich-markup cell for a ``Severity`` value."""
     color = SEVERITY_COLORS[severity]
     return f"[{color}]{severity.value}[/{color}]"
+
+
+def render_environment_warnings(
+    console: Console, warnings: list[EnvironmentWarning],
+) -> None:
+    """Print environment warnings as a banner above the normal output.
+
+    No-op when ``warnings`` is empty. Each warning renders on its own
+    ``⚠``-prefixed line, colored by severity. The message is escaped so
+    embedded paths/backticks can't be misread as Rich markup. Callers
+    must not invoke this on the JSON path — banner text on stdout would
+    corrupt the envelope (the warnings ride inside it instead).
+    """
+    for warning in warnings:
+        color = SEVERITY_COLORS[warning.severity]
+        console.print(f"[{color}]⚠ {escape(warning.message)}[/{color}]")
 
 
 def axis_label(axis: Axis) -> str:

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -24,6 +24,7 @@ from agentfluent.cli.formatters.helpers import (
     format_date,
     format_size,
     format_tokens,
+    render_environment_warnings,
     score_color,
     severity_cell,
     truncate,
@@ -140,6 +141,10 @@ def format_analysis_table(
     tm = result.token_metrics
     am = result.agent_metrics
     tlm = result.tool_metrics
+
+    # Environment warnings (e.g., cleanupPeriodDays truncation) render
+    # first so they're seen before the metrics they may have bounded.
+    render_environment_warnings(console, result.warnings)
 
     token_table = Table(title="Token Usage", show_header=True)
     token_table.add_column("Metric", style="cyan")

--- a/src/agentfluent/config/models.py
+++ b/src/agentfluent/config/models.py
@@ -53,6 +53,36 @@ intrinsic ordering, so consumers that need >= / <= comparisons (priority
 scoring, ``--fail-on`` thresholds) look up integers here."""
 
 
+class EnvironmentWarning(BaseModel):
+    """A non-fatal warning about the analysis environment itself.
+
+    Distinct from :class:`ConfigRecommendation` (which targets the
+    *agent's* config) — this flags problems with the host Claude Code
+    install or filesystem state that bound or distort what AgentFluent
+    can analyze (e.g., a low ``cleanupPeriodDays`` silently truncating
+    the session corpus). Surfaced at discovery time, attached to
+    ``AnalysisResult.warnings``, and rendered as a banner above the
+    normal output. A generic shape so future discovery-time warnings
+    reuse it rather than each adding a bespoke field.
+    """
+
+    code: str
+    """Stable machine-readable identifier (e.g.,
+    ``"cleanup_period_truncation"``). Lets JSON consumers branch on the
+    warning kind without parsing ``message``."""
+
+    severity: Severity
+    """How important this warning is. Drives banner color."""
+
+    message: str
+    """Human-readable warning text, ready to render as-is."""
+
+    remediation_path: Path | None = None
+    """Filesystem path the user should edit to resolve the warning
+    (e.g., ``~/.claude/settings.json``). ``None`` when the warning has
+    no single actionable file."""
+
+
 class AgentConfig(BaseModel):
     """Parsed agent definition from a `.md` file.
 

--- a/src/agentfluent/config/retention.py
+++ b/src/agentfluent/config/retention.py
@@ -34,11 +34,14 @@ DEFAULT_CLEANUP_PERIOD_DAYS = 30
 Sessions older than this are deleted, so a *missing* key is treated the
 same as an explicit ``30``."""
 
-WARN_THRESHOLD_DAYS = 30
-"""Warn when the effective retention is at or below this many days.
+WARN_THRESHOLD_DAYS = DEFAULT_CLEANUP_PERIOD_DAYS
+"""Warn when the effective retention is no better than Claude Code's
+unconfigured default — i.e. at or below ``DEFAULT_CLEANUP_PERIOD_DAYS``.
 Above it (31+), the user has deliberately raised retention past the
 default, so no warning fires (#481 AC: no warning at ``>= 365``; the
-31–364 band is a deliberate user choice and likewise stays quiet)."""
+31–364 band is a deliberate user choice and likewise stays quiet).
+Deriving from the default (rather than a second ``30`` literal) keeps
+the "warn at-or-below default" relationship explicit and single-sourced."""
 
 RECOMMENDED_RETENTION_DAYS = 3650
 """The long-retention value (~10 years) the warning recommends adding."""
@@ -151,8 +154,13 @@ def check_cleanup_retention(
     if value is not None and value > WARN_THRESHOLD_DAYS:
         return None
 
-    effective_days = DEFAULT_CLEANUP_PERIOD_DAYS if value is None else value
-    default_note = " (unset — Claude Code's 30-day default applies)" if value is None else ""
+    is_unset = value is None
+    effective_days = DEFAULT_CLEANUP_PERIOD_DAYS if is_unset else value
+    default_note = (
+        f" (unset — Claude Code's {DEFAULT_CLEANUP_PERIOD_DAYS}-day default applies)"
+        if is_unset
+        else ""
+    )
 
     message = (
         f"Claude Code `{SETTINGS_KEY}` is {effective_days} days{default_note}. "

--- a/src/agentfluent/config/retention.py
+++ b/src/agentfluent/config/retention.py
@@ -1,0 +1,171 @@
+"""Detect Claude Code's session-retention setting (``cleanupPeriodDays``).
+
+Claude Code deletes session JSONL files older than ``cleanupPeriodDays``
+from ``~/.claude/projects/`` — and the default is **30 days**. Users
+rarely know this setting exists, so the corpus AgentFluent can analyze
+is silently bounded: multi-month longitudinal analysis (regression
+detection, baselines) quietly loses its oldest data with no recovery
+path (Claude Code deletes, it does not archive).
+
+This module reads the effective ``cleanupPeriodDays`` at analysis time
+and produces an :class:`EnvironmentWarning` when retention is at or
+below the default — surfacing the problem the AgentFluent product story
+is built on: *the tool tells you what your environment isn't telling
+you*. See issue #481.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from agentfluent.config.models import EnvironmentWarning, Severity
+from agentfluent.core.paths import settings_path_for
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_KEY = "cleanupPeriodDays"
+
+DEFAULT_CLEANUP_PERIOD_DAYS = 30
+"""Claude Code's default retention when ``cleanupPeriodDays`` is unset.
+Sessions older than this are deleted, so a *missing* key is treated the
+same as an explicit ``30``."""
+
+WARN_THRESHOLD_DAYS = 30
+"""Warn when the effective retention is at or below this many days.
+Above it (31+), the user has deliberately raised retention past the
+default, so no warning fires (#481 AC: no warning at ``>= 365``; the
+31–364 band is a deliberate user choice and likewise stays quiet)."""
+
+RECOMMENDED_RETENTION_DAYS = 3650
+"""The long-retention value (~10 years) the warning recommends adding."""
+
+PROJECT_SETTINGS_SUBDIR = ".claude"
+PROJECT_SETTINGS_FILENAME = "settings.json"
+PROJECT_SETTINGS_LOCAL_FILENAME = "settings.local.json"
+
+
+@lru_cache(maxsize=16)
+def _load_settings(path: Path) -> dict[str, Any] | None:
+    """Read and decode a Claude Code ``settings.json``-style file.
+
+    Returns ``None`` for missing files (silent — most projects have no
+    local settings), logs a warning and returns ``None`` for malformed
+    JSON or a non-object root. Cached per-path; tests that need a fresh
+    read call ``_load_settings.cache_clear()`` in setup.
+    """
+    if not path.exists():
+        return None
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        logger.warning("Malformed JSON in Claude settings file: %s", path)
+        return None
+    except OSError:
+        logger.warning("Could not read Claude settings file: %s", path, exc_info=True)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Claude settings file root is not an object: %s", path)
+        return None
+    return data
+
+
+def _read_cleanup_value(path: Path) -> int | None:
+    """Return a valid integer ``cleanupPeriodDays`` from ``path``, else ``None``.
+
+    ``None`` covers every "not configured here" case: the file is
+    missing/malformed, the key is absent, or the value is not a usable
+    integer (booleans and floats with a fractional part are rejected —
+    a non-int retention is meaningless and treated as unset).
+    """
+    data = _load_settings(path)
+    if data is None:
+        return None
+    value = data.get(SETTINGS_KEY)
+    # bool is an int subclass; reject it explicitly.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def resolve_cleanup_period_days(
+    claude_config_dir: Path | None,
+    project_dir: Path | None,
+) -> tuple[int | None, Path]:
+    """Resolve the effective ``cleanupPeriodDays`` and the remediation path.
+
+    Mirrors Claude Code's settings precedence
+    (``project_local > project_shared > user``): the first file in that
+    order to define an integer ``cleanupPeriodDays`` wins. Reading
+    ``settings.local.json`` matters — power users (the ones most likely
+    to adopt AgentFluent) often set retention there, and skipping it
+    would raise a false-positive warning.
+
+    Returns ``(value_or_None, user_settings_path)``. ``value_or_None`` is
+    ``None`` only when *no* source defined the key (Claude Code then
+    applies its 30-day default). ``user_settings_path`` is always
+    ``~/.claude/settings.json`` (or the ``--claude-config-dir``
+    equivalent) — the file the warning tells the user to edit, since a
+    user-scope override is the durable, project-independent fix.
+    """
+    user_settings_path = settings_path_for(claude_config_dir)
+
+    candidates: list[Path] = []
+    if project_dir is not None:
+        project_claude = project_dir / PROJECT_SETTINGS_SUBDIR
+        candidates.append(project_claude / PROJECT_SETTINGS_LOCAL_FILENAME)
+        candidates.append(project_claude / PROJECT_SETTINGS_FILENAME)
+    candidates.append(user_settings_path)
+
+    for candidate in candidates:
+        value = _read_cleanup_value(candidate)
+        if value is not None:
+            return value, user_settings_path
+
+    return None, user_settings_path
+
+
+def check_cleanup_retention(
+    claude_config_dir: Path | None,
+    project_dir: Path | None,
+) -> EnvironmentWarning | None:
+    """Return a retention warning when ``cleanupPeriodDays`` is at/below default.
+
+    Fires when the effective value is missing (Claude Code's 30-day
+    default applies) or explicitly ``<= 30``. Returns ``None`` when the
+    user has raised retention above the default — they have made a
+    deliberate choice and need no nudge.
+    """
+    value, user_settings_path = resolve_cleanup_period_days(
+        claude_config_dir, project_dir,
+    )
+
+    if value is not None and value > WARN_THRESHOLD_DAYS:
+        return None
+
+    effective_days = DEFAULT_CLEANUP_PERIOD_DAYS if value is None else value
+    default_note = " (unset — Claude Code's 30-day default applies)" if value is None else ""
+
+    message = (
+        f"Claude Code `{SETTINGS_KEY}` is {effective_days} days{default_note}. "
+        f"Sessions older than {effective_days} days have been deleted from "
+        f"~/.claude/projects/ and cannot be recovered, so this analysis may "
+        f"cover less history than expected. To preserve session data for "
+        f'future analysis, add "{SETTINGS_KEY}": {RECOMMENDED_RETENTION_DAYS} '
+        f"to {user_settings_path}."
+    )
+
+    return EnvironmentWarning(
+        code="cleanup_period_truncation",
+        severity=Severity.WARNING,
+        message=message,
+        remediation_path=user_settings_path,
+    )

--- a/src/agentfluent/core/paths.py
+++ b/src/agentfluent/core/paths.py
@@ -67,6 +67,24 @@ def claude_json_for(config_root: Path | None) -> Path:
     return config_root.parent / ".claude.json"
 
 
+def settings_path_for(config_root: Path | None) -> Path:
+    """Path to the user's ``~/.claude/settings.json`` file.
+
+    Claude Code stores user-scope settings (hooks, ``cleanupPeriodDays``,
+    and other knobs) in ``settings.json`` *inside* the ``.claude/``
+    directory — unlike ``.claude.json``, which is a sibling of it.
+
+    When ``config_root`` is given (e.g., from ``--claude-config-dir``),
+    the settings file resolves inside the override
+    (``<config_root>/settings.json``); otherwise the default
+    ``~/.claude/settings.json`` applies. This is the file the
+    ``cleanupPeriodDays`` retention warning quotes as the place to add a
+    longer-retention override.
+    """
+    root = config_root if config_root else DEFAULT_CLAUDE_CONFIG_DIR
+    return root / "settings.json"
+
+
 def validate_claude_config_dir(override: Path | None) -> Path | None:
     """Validate an override path for the Claude config directory.
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -75,6 +75,17 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(
         "agentfluent.config.scanner.DEFAULT_USER_AGENTS_DIR", user_agents_dir,
     )
+    # Redirect the default Claude config root so the #481 cleanupPeriodDays
+    # check reads this hermetic tmp home, not the host's real
+    # ~/.claude/settings.json. Without a settings file the check would warn
+    # (missing key == 30-day default) and inject a ⚠ banner into every
+    # analyze table test on CI. Give it an explicit long-retention value so
+    # unrelated tests see no truncation warning; tests that exercise the
+    # warning build their own config dirs.
+    monkeypatch.setattr(
+        "agentfluent.core.paths.DEFAULT_CLAUDE_CONFIG_DIR", tmp_path,
+    )
+    (tmp_path / "settings.json").write_text(json.dumps({"cleanupPeriodDays": 3650}))
     monkeypatch.chdir(tmp_path)
 
     return tmp_path

--- a/tests/unit/cli/test_cleanup_warning_cli.py
+++ b/tests/unit/cli/test_cleanup_warning_cli.py
@@ -26,6 +26,18 @@ def _make_config_with_project(root: Path, fixtures_dir: Path) -> None:
     shutil.copy(fixtures_dir / "session_basic.jsonl", project_dir / "s1.jsonl")
 
 
+def _despace(text: str) -> str:
+    """Collapse all whitespace so wrap-split tokens match again.
+
+    Rich hard-wraps the long warning banner at terminal width (80 in
+    CI), inserting ``\\n`` mid-token — e.g. a remediation path can land
+    as ``.../setti\\nngs.json``. Rich only ever inserts newlines (never
+    hyphens) at a fold, so removing every run of whitespace rejoins the
+    pieces, making substring assertions width-independent.
+    """
+    return "".join(text.split())
+
+
 def _analyze(
     runner: CliRunner, cli_app: typer.Typer, config_dir: Path, *extra: str,
 ) -> str:
@@ -46,14 +58,14 @@ def test_missing_settings_warns_in_table(
     # No settings.json written -> Claude Code's 30-day default applies.
 
     out = _analyze(runner, cli_app, cfg)
+    flat = _despace(out)
 
     assert "⚠" in out
-    assert "cleanupPeriodDays" in out
-    # Rich may wrap the long remediation path across lines, so assert on
-    # wrap-stable fragments; the full-path contract is covered at the
-    # message level in test_retention.py.
-    assert "settings.json" in out
-    assert "3650" in out
+    assert "cleanupPeriodDays" in flat
+    # The full remediation path and recommended value are present once
+    # wrap-inserted newlines are normalized away.
+    assert _despace(str(cfg / "settings.json")) in flat
+    assert "3650" in flat
 
 
 def test_long_retention_no_warning_in_table(

--- a/tests/unit/cli/test_cleanup_warning_cli.py
+++ b/tests/unit/cli/test_cleanup_warning_cli.py
@@ -1,0 +1,84 @@
+"""End-to-end CLI coverage for the cleanupPeriodDays warning (#481).
+
+Drives ``agentfluent analyze`` against a ``--claude-config-dir`` whose
+``settings.json`` is missing, low, or long, and asserts the warning
+banner appears (table) and the warning rides in the JSON envelope —
+while a long-retention config stays silent.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from agentfluent.cli.exit_codes import EXIT_OK
+from agentfluent.cli.formatters.json_output import parse_json_output
+from agentfluent.config.retention import _load_settings
+
+
+def _make_config_with_project(root: Path, fixtures_dir: Path) -> None:
+    project_dir = root / "projects" / "-home-user-test-project"
+    project_dir.mkdir(parents=True)
+    shutil.copy(fixtures_dir / "session_basic.jsonl", project_dir / "s1.jsonl")
+
+
+def _analyze(
+    runner: CliRunner, cli_app: typer.Typer, config_dir: Path, *extra: str,
+) -> str:
+    _load_settings.cache_clear()
+    result = runner.invoke(
+        cli_app,
+        ["--claude-config-dir", str(config_dir), "analyze", "--project", "project", *extra],
+    )
+    assert result.exit_code == EXIT_OK, result.stdout
+    return result.stdout
+
+
+def test_missing_settings_warns_in_table(
+    runner: CliRunner, cli_app: typer.Typer, tmp_path: Path, fixtures_dir: Path,
+) -> None:
+    cfg = tmp_path / "claude"
+    _make_config_with_project(cfg, fixtures_dir)
+    # No settings.json written -> Claude Code's 30-day default applies.
+
+    out = _analyze(runner, cli_app, cfg)
+
+    assert "⚠" in out
+    assert "cleanupPeriodDays" in out
+    # Rich may wrap the long remediation path across lines, so assert on
+    # wrap-stable fragments; the full-path contract is covered at the
+    # message level in test_retention.py.
+    assert "settings.json" in out
+    assert "3650" in out
+
+
+def test_long_retention_no_warning_in_table(
+    runner: CliRunner, cli_app: typer.Typer, tmp_path: Path, fixtures_dir: Path,
+) -> None:
+    cfg = tmp_path / "claude"
+    _make_config_with_project(cfg, fixtures_dir)
+    (cfg / "settings.json").write_text(json.dumps({"cleanupPeriodDays": 3650}))
+
+    out = _analyze(runner, cli_app, cfg)
+
+    assert "cleanupPeriodDays" not in out
+
+
+def test_warning_in_json_envelope(
+    runner: CliRunner, cli_app: typer.Typer, tmp_path: Path, fixtures_dir: Path,
+) -> None:
+    cfg = tmp_path / "claude"
+    _make_config_with_project(cfg, fixtures_dir)
+
+    out = _analyze(runner, cli_app, cfg, "--json")
+
+    data = parse_json_output(out, expected_command="analyze")
+    warnings = data["warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["code"] == "cleanup_period_truncation"
+    assert warnings[0]["severity"] == "warning"
+    assert warnings[0]["remediation_path"] == str(cfg / "settings.json")

--- a/tests/unit/cli/test_environment_warning_banner.py
+++ b/tests/unit/cli/test_environment_warning_banner.py
@@ -1,0 +1,77 @@
+"""The table formatter must surface ``AnalysisResult.warnings`` as a banner.
+
+The cleanupPeriodDays retention warning (#481) is an environment-level
+signal: it's attached to ``AnalysisResult.warnings`` at discovery time
+and must render above the metrics it may have bounded, in both the full
+and summary table paths. JSON consumers read the warnings from the
+envelope instead; that path must not emit the banner.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from rich.console import Console
+
+from agentfluent.analytics.agent_metrics import AgentMetrics
+from agentfluent.analytics.pipeline import AnalysisResult
+from agentfluent.analytics.tokens import TokenMetrics
+from agentfluent.analytics.tools import ToolMetrics
+from agentfluent.cli.formatters.table import format_analysis_table
+from agentfluent.config.models import EnvironmentWarning, Severity
+
+
+def _result(*, warnings: list[EnvironmentWarning] | None = None) -> AnalysisResult:
+    return AnalysisResult(
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=AgentMetrics(),
+        session_count=1,
+        warnings=warnings or [],
+    )
+
+
+def _warning() -> EnvironmentWarning:
+    return EnvironmentWarning(
+        code="cleanup_period_truncation",
+        severity=Severity.WARNING,
+        message="Claude Code `cleanupPeriodDays` is 30 days. Sessions older "
+        "than 30 days have been deleted.",
+        remediation_path=Path("/home/u/.claude/settings.json"),
+    )
+
+
+def _render(result: AnalysisResult, *, show_diagnostics: bool = False) -> str:
+    buf = StringIO()
+    format_analysis_table(
+        Console(file=buf, width=200, force_terminal=False),
+        result,
+        verbose=False,
+        show_diagnostics=show_diagnostics,
+    )
+    return buf.getvalue()
+
+
+def test_banner_renders_when_warning_present() -> None:
+    out = _render(_result(warnings=[_warning()]))
+    assert "⚠" in out
+    assert "cleanupPeriodDays" in out
+
+
+def test_banner_renders_in_diagnostics_mode_too() -> None:
+    out = _render(_result(warnings=[_warning()]), show_diagnostics=True)
+    assert "cleanupPeriodDays" in out
+
+
+def test_no_banner_when_no_warnings() -> None:
+    out = _render(_result(warnings=[]))
+    assert "⚠" not in out
+
+
+def test_warning_serialized_in_json_envelope() -> None:
+    """The warning survives a model_dump round-trip for the JSON path."""
+    result = _result(warnings=[_warning()])
+    dumped = result.model_dump(mode="json")
+    assert dumped["warnings"][0]["code"] == "cleanup_period_truncation"
+    assert dumped["warnings"][0]["severity"] == "warning"

--- a/tests/unit/cli/test_json_output.py
+++ b/tests/unit/cli/test_json_output.py
@@ -77,6 +77,9 @@ class TestAnalyzeJsonEnvelope:
             "total_tokens",
             "total_invocations",
             "diagnostic_signal_count",
+            # #481: environment warnings (e.g., cleanupPeriodDays
+            # truncation) ride in the quiet payload too.
+            "warnings",
         }
 
 

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -13,6 +13,7 @@ from agentfluent.core.paths import (
     XDG_CONFIG_HOME_ENV_VAR,
     agentfluent_cache_dir,
     agentfluent_config_dir,
+    settings_path_for,
     validate_claude_config_dir,
 )
 
@@ -23,6 +24,14 @@ class TestDefaults:
 
     def test_env_var_name(self) -> None:
         assert CLAUDE_CONFIG_DIR_ENV_VAR == "CLAUDE_CONFIG_DIR"
+
+
+class TestSettingsPathFor:
+    def test_default_under_home_dot_claude(self) -> None:
+        assert settings_path_for(None) == Path.home() / ".claude" / "settings.json"
+
+    def test_override_resolves_inside_config_root(self, tmp_path: Path) -> None:
+        assert settings_path_for(tmp_path) == tmp_path / "settings.json"
 
 
 class TestValidateClaudeConfigDir:

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -1,0 +1,183 @@
+"""Tests for cleanupPeriodDays retention detection (config/retention.py).
+
+Covers the three states called out in #481 -- missing key (Claude
+Code's 30-day default), explicit default/low value, and an explicit
+long retention -- plus the settings precedence chain
+(``settings.local.json`` > ``settings.json`` > user
+``~/.claude/settings.json``), the 31-364 "deliberate choice" band, and
+defensive handling of malformed / non-int values.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentfluent.config.models import EnvironmentWarning, Severity
+from agentfluent.config.retention import (
+    RECOMMENDED_RETENTION_DAYS,
+    _load_settings,
+    check_cleanup_retention,
+    resolve_cleanup_period_days,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> None:
+    """Reset the per-path settings cache so each test reads fresh files."""
+    _load_settings.cache_clear()
+
+
+def _write_settings(path: Path, **keys: object) -> None:
+    """Write a ``settings.json``-style file with the given top-level keys."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(keys))
+
+
+def _user_cfg(tmp_path: Path) -> Path:
+    """Create and return a stand-in for ``~/.claude/`` under ``tmp_path``."""
+    cfg = tmp_path / "user" / ".claude"
+    cfg.mkdir(parents=True)
+    return cfg
+
+
+# --- The three AC states ---------------------------------------------------
+
+
+def test_missing_key_warns_with_default_30(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    warning = check_cleanup_retention(claude_config_dir=cfg, project_dir=None)
+
+    assert isinstance(warning, EnvironmentWarning)
+    assert warning.code == "cleanup_period_truncation"
+    assert warning.severity is Severity.WARNING
+    assert "30 days" in warning.message
+    assert "unset" in warning.message
+    # Recommends the long-retention value and quotes the user settings path.
+    assert str(RECOMMENDED_RETENTION_DAYS) in warning.message
+    assert str(cfg / "settings.json") in warning.message
+    assert warning.remediation_path == cfg / "settings.json"
+
+
+def test_explicit_default_value_warns(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=30)
+
+    warning = check_cleanup_retention(claude_config_dir=cfg, project_dir=None)
+
+    assert warning is not None
+    assert "30 days" in warning.message
+    assert "unset" not in warning.message
+
+
+def test_long_retention_no_warning(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=3650)
+
+    assert check_cleanup_retention(claude_config_dir=cfg, project_dir=None) is None
+
+
+# --- Threshold bands -------------------------------------------------------
+
+
+def test_low_explicit_value_warns(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=7)
+
+    warning = check_cleanup_retention(claude_config_dir=cfg, project_dir=None)
+
+    assert warning is not None
+    assert "7 days" in warning.message
+
+
+@pytest.mark.parametrize("days", [31, 60, 364])
+def test_mid_band_no_warning(tmp_path: Path, days: int) -> None:
+    """31-364 days is a deliberate raise above default -- stays quiet."""
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=days)
+
+    assert check_cleanup_retention(claude_config_dir=cfg, project_dir=None) is None
+
+
+def test_boundary_365_no_warning(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=365)
+
+    assert check_cleanup_retention(claude_config_dir=cfg, project_dir=None) is None
+
+
+# --- Precedence chain ------------------------------------------------------
+
+
+def test_project_local_overrides_user(tmp_path: Path) -> None:
+    """settings.local.json wins over a warn-worthy user value (no warning)."""
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=30)
+    proj = tmp_path / "proj"
+    _write_settings(proj / ".claude" / "settings.local.json", cleanupPeriodDays=3650)
+
+    value, remediation = resolve_cleanup_period_days(cfg, proj)
+
+    assert value == 3650
+    # Remediation always points at the user file -- the durable fix.
+    assert remediation == cfg / "settings.json"
+    assert check_cleanup_retention(cfg, proj) is None
+
+
+def test_project_shared_overrides_user(tmp_path: Path) -> None:
+    """settings.json (shared) overrides user; a low value still warns."""
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=3650)
+    proj = tmp_path / "proj"
+    _write_settings(proj / ".claude" / "settings.json", cleanupPeriodDays=7)
+
+    value, _ = resolve_cleanup_period_days(cfg, proj)
+    assert value == 7
+
+    warning = check_cleanup_retention(cfg, proj)
+    assert warning is not None
+    assert "7 days" in warning.message
+
+
+def test_local_beats_shared(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    proj = tmp_path / "proj"
+    _write_settings(proj / ".claude" / "settings.json", cleanupPeriodDays=10)
+    _write_settings(proj / ".claude" / "settings.local.json", cleanupPeriodDays=3650)
+
+    value, _ = resolve_cleanup_period_days(cfg, proj)
+    assert value == 3650
+
+
+# --- Defensive parsing -----------------------------------------------------
+
+
+def test_malformed_json_treated_as_missing(tmp_path: Path) -> None:
+    cfg = _user_cfg(tmp_path)
+    (cfg / "settings.json").write_text("{ not valid json")
+
+    # Falls through to "missing" -> warns at the 30-day default.
+    warning = check_cleanup_retention(claude_config_dir=cfg, project_dir=None)
+    assert warning is not None
+    assert "unset" in warning.message
+
+
+@pytest.mark.parametrize("bad_value", ["30", True, 30.5, None, [30]])
+def test_non_int_value_treated_as_missing(tmp_path: Path, bad_value: object) -> None:
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=bad_value)
+
+    value, _ = resolve_cleanup_period_days(cfg, None)
+    assert value is None
+
+
+def test_float_integer_value_accepted(tmp_path: Path) -> None:
+    """A whole-number float (e.g. JSON ``3650.0``) is read as that int."""
+    cfg = _user_cfg(tmp_path)
+    _write_settings(cfg / "settings.json", cleanupPeriodDays=3650.0)
+
+    value, _ = resolve_cleanup_period_days(cfg, None)
+    assert value == 3650
+    assert check_cleanup_retention(cfg, None) is None


### PR DESCRIPTION
## Summary
- Detect Claude Code's `cleanupPeriodDays` at analysis time and warn when retention is missing or `<= 30` days — the default silently deletes sessions older than 30 days from `~/.claude/projects/`, bounding the corpus AgentFluent can analyze (unrecoverable; Claude Code deletes, doesn't archive).
- New `config/retention.py` resolves the effective value with Claude Code's precedence (project `.claude/settings.local.json` > project `.claude/settings.json` > user `~/.claude/settings.json`), recommends `3650`, and quotes the user `settings.json` path to edit. No warning at `31+` days (deliberate user choice).
- Surfaced as a generic `EnvironmentWarning` (`code`/`severity`/`message`/`remediation_path`) on a new additive `AnalysisResult.warnings` field: yellow `⚠` banner above table/quiet output, and in the JSON envelope (full + quiet). Never printed to stdout in JSON mode. README "Preserve your session history" setup note added.

Closes #481. Design reviewed by the architect agent ([comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/481#issuecomment-4596639337)) — adopted both findings (generic model in `config/models.py`; `settings.local.json` in the precedence chain).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1659 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `test_retention.py` (3 AC states, threshold bands, precedence, defensive parsing), `test_environment_warning_banner.py`, `test_cleanup_warning_cli.py` (end-to-end), `test_paths.py`
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent` (real settings = 3650 → no banner; JSON envelope carries `warnings: []`)

## Security review
- [x] **Needs review** — touches path resolution (`settings_path_for`), reads a new config file (`settings.json` I/O), and renders a filesystem path in user-facing output (escaped via Rich `escape()`).

(Per repo convention, the `needs-security-review` label will be applied only when the PR is dev-complete and CI is green, so the single review covers the final state.)

## Breaking changes
None. `AnalysisResult.warnings` is additive (defaults to `[]`, absent on legacy envelopes); `diff`/`report` consume raw dicts so unknown/new keys are ignored. No SCHEMA_VERSION bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)