### PR TITLE
fix: TOOL_ORCHESTRATION_CHAIN low-confidence caveat from #407 calibration + cwd-independent hook paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/block_secret_reads.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block_secret_reads.py\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/detect_secrets_in_output.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect_secrets_in_output.py\""
           }
         ]
       }

--- a/.claude/specs/analysis/407-calibration/calibration.md
+++ b/.claude/specs/analysis/407-calibration/calibration.md
@@ -141,33 +141,49 @@ FPs (`tokens/call > 7000`) eliminates *every* detection, i.e. it disables the si
 rather than tuning it. **Threshold tuning cannot rescue precision here.** The limitation
 is the proxy itself, not its constants.
 
-## Recommendation
+## Recommendation (analysis) and disposition (decided)
 
 The AC's tuning lever does not apply (no threshold band reaches 70% while retaining
-detections). The honest dispositions, in order of preference:
+detections). Two honest analytical dispositions were on the table: (1) gate emission off
+for v0.9 until Tier B/D035 lands; (2) keep it emitting at `INFO` with an explicit
+low-confidence caveat. The architect review ([#407 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/407#issuecomment-4600895787))
+recommended (1).
 
-1. **Do not ship `TOOL_ORCHESTRATION_CHAIN` as a rule-only INFO signal in v0.9.**
-   At 0% dogfood precision it is pure noise, and noise undermines the trust theme the
-   diagnostics output depends on. Gate its emission off (keep the code + tests) pending
-   Tier B or LLM augmentation. **This changes v0.9 signal scope → needs Fred/PM sign-off
-   and a `decisions.md` entry.**
-2. If it must ship, emit only with an explicit low-confidence caveat in the message and
-   keep `INFO` severity — but (1) is cleaner.
+**Decision (Fred, 2026-06-02): option (2) — keep the signal live with a low-confidence
+caveat.** Rationale that overrides the gate-off recommendation: the 0% precision is an
+**artifact of the current dogfood corpus**, which contains only reasoning/review/scoping
+subagents (no agents that run genuine tool-orchestration chains). Fred expects to run
+agents that *do* generate real orchestration-chain true positives in future dogfood
+sessions; gating the signal off would mean those future TPs never surface. Keeping it
+emitting (with the caveat managing the present noise) preserves the detection surface for
+the corpus it was designed for. **Tier B is the precision fix**, not a precondition for
+shipping.
+
+Concretely for v0.9: the signal continues to emit at `INFO`; its message carries an
+explicit "metadata-only proxy, low precision until trace-level Tier B" caveat; the
+calibration result is recorded in the module docstring; PRD §11 criterion #3 (≥70%
+precision) is an **accepted known limitation for v0.9** (not met, not deferred-by-removal),
+with Tier B tracked as the path to meeting it.
 
 This is **strong evidence for D035** (LLM-call augmentation candidate #1): the rule-based
-baseline FP rate is ~100%, far above the 30% threshold that the PRD set as the bar for
-"LLM augmentation would pay off." A viable signal needs trace-level inspection (compare
-summed tool-result token size vs. final-output size — Tier B) or an LLM relevance
+baseline FP rate is ~100% *on this corpus*, far above the 30% threshold the PRD set for
+"LLM augmentation would pay off." A higher-precision signal needs trace-level inspection
+(summed tool-result token size vs. final-output size — Tier B) or an LLM relevance
 classifier; the metadata proxy alone cannot distinguish orchestration from reasoning.
 
-## Follow-ups to file (pending Fred's disposition call)
+## Follow-ups (per the decision above)
 
-- **Signal disposition issue** — gate Tier A emission off for v0.9; track Tier B /
-  D035 LLM-augmentation as the path to a shippable version. Capture the
-  "`anthropic-research` is the only plausibly-TP type but sits below the min-invocation
-  gate" observation.
-- **D035 candidate entry** (PRD §9) — annotate with this calibration's ~100% rule-based
-  FP rate as the measured baseline LLM augmentation would improve upon.
+- **Caveat + docstring (v0.9, code):** add the low-confidence caveat to the signal
+  message and document this calibration in `tool_orchestration.py`. *(Parent-thread
+  implementation.)*
+- **`decisions.md` entry + PRD updates:** record the disposition; mark §11 criterion #3
+  as an accepted known limitation; annotate §9 / D035 with the ~100% rule-based FP
+  baseline. *(pm.)*
+- **Tier B story:** trace-level orchestration detection (summed tool-result tokens vs.
+  final-output size) as the precision fix. Note the architect's caution that the size
+  ratio is still a proxy (re-run this calibration harness against Tier B before shipping;
+  keep anchor #80 as a regression fixture) and the "`anthropic-research` is the only
+  plausibly-TP type but sits below the min-invocation gate" observation. *(pm.)*
 
 ## Forward note: automated-classifier candidate
 

--- a/.claude/specs/analysis/407-calibration/calibration.md
+++ b/.claude/specs/analysis/407-calibration/calibration.md
@@ -1,0 +1,180 @@
+# #407 — `TOOL_ORCHESTRATION_CHAIN` precision calibration
+
+**Date:** 2026-06-02
+**Corpus:** `agentfluent` + `codefluent` dogfood sessions in `~/.claude/projects/`
+**Population:** 195 matching invocations (predicate: `tool_uses >= 10` AND `tokens_per_tool_use > 2000`)
+**Sample size:** 30 of 195, seeded (`random.seed(407)`), stratified across the four emitting agent types
+**Reproducibility (scripts in this directory):** `export.py` (corpus → `detections.tsv`, mirrors the pipeline's per-session load + trace linking), `sample.py` (seeded stratified sample), `tune.py` (threshold simulation). `detections.tsv` is the full 195-row population.
+**Reference precedent:** #402 (`FEAT_FIX_PROXIMITY`, structural analog)
+
+## What the signal fires on
+
+The Tier A proxy aggregates per agent **type** and emits when ≥3 invocations of that
+type match. In this corpus exactly four types clear the gate:
+
+| agent_type | matching invocations |
+|---|---:|
+| `architect` | 62 |
+| `general-purpose` | 62 |
+| `pm` | 37 |
+| `explore` | 28 |
+| *(below gate: `candidate-promoter` 2, `plan` 2, `anthropic-research` 1, `claude-code-guide` 1)* | |
+
+All four emitting types are **reasoning / review / scoping** subagents. The one type
+whose work most resembles a genuine tool-orchestration chain — `anthropic-research`
+(WebFetch/WebSearch over many sources) — has a single matching invocation, below the
+`_MIN_MATCHING_INVOCATIONS = 3` gate, so it never emits.
+
+## Rubric
+
+Each matching invocation is one subagent run that made many tool calls at a high
+average token cost. Classified as:
+
+- **TP (true positive)** — the intermediate tool results were *truly unnecessary in
+  context*: a mechanical orchestration chain (loop → fetch → filter/aggregate) where
+  the model only needs the final computed output, and the large intermediate payloads
+  pass through context as plumbing. This is the case Programmatic Tool Calling
+  (`allowed_callers: ["code_execution_20250825"]`) actually fixes.
+- **FP (false positive)** — the agent *genuinely needed each intermediate result in
+  context for reasoning*: it Read code/diffs/issues/PRDs specifically to form a
+  judgment about that content (design review, code review, exploration, spec scoping).
+  The tool result *is* the input to the model's reasoning, so it cannot be offloaded
+  to a code-execution sandbox.
+
+**Classification basis (per AC):** subagent trace when available (185/195 have one);
+agent type + task description as context clues otherwise (10/195, all trace-missing
+from session `08b03d83`, cf. #468). Three rows were **deep-read** from their full
+traces as evidence anchors (tool-name breakdown + final-output dependency check).
+
+## Deep-read evidence anchors
+
+| # | agent | trace | finding |
+|---|---|---|---|
+| 80 | `architect` | `a77a221…` (22 calls: 13 Read, 6 Grep, 2 get_issue, 1 add_comment) | Final verdict explicitly cites file contents it Read — *"`len(invocations)` is invocation count, not session count"*, *"`Axis.COST` is correct"*, *"new `agent_audit.py` module is correct"*. Every Read feeds the design judgment. **FP.** |
+| 53 | `general-purpose` | `a86990d…` (33 calls: 12 Read, 12 Edit, 9 Bash) | Implement-and-test loop: Reads inform Edits, Bash runs tests whose output drives the next fix. No disposable plumbing; the whole loop is the work. **FP.** |
+| 160 | `explore` (simplify review) | `a4c6ddb…` (21 calls: 7 Read, 14 Bash) | Reads + `git diff`/grep outputs all feed a simplification review; final text is the judgment over exactly that content. **FP.** |
+
+The structural reason generalizes: **`tokens_per_tool_use = total_tokens / tool_uses`,
+where `total_tokens` is the invocation's *entire* token consumption (large cached
+context re-sent each turn + reasoning output + tool I/O), not the size of intermediate
+tool *results* specifically.** For context-heavy reasoning agents the ratio is high
+regardless of whether any result-plumbing occurs. The proxy therefore measures
+"token-heavy invocation," which is not the same thing as "orchestration chain."
+
+## Per-detection classifications (sample of 30)
+
+All rows classified **FP**. `[*]` = deep-read anchor.
+
+| # | corpus | agent | calls | tok/call | turns | task | class |
+|---|---|---|---:|---:|---:|---|---|
+| 9 | af | architect | 28 | 2241 | (no trace) | design review C-004 (read code+issues → comment) | FP |
+| 14 | af | architect | 20 | 3889 | (no trace) | review Phase 3 PRD → feedback comment | FP |
+| 80 | af | architect | 22 | 2159 | 9 | review #346 plan `[*]` | FP |
+| 88 | af | architect | 21 | 2920 | 16 | review #285 plan | FP |
+| 99 | af | architect | 18 | 2846 | 9 | review #191 glossary plan | FP |
+| 103 | af | architect | 24 | 4283 | 15 | review #269 plan | FP |
+| 109 | af | architect | 24 | 3245 | 12 | review #271 plan | FP |
+| 136 | af | architect | 23 | 2985 | 14 | review #454 threshold-split design | FP |
+| 155 | af | architect | 22 | 3269 | 13 | review #172 plan | FP |
+| 177 | cf | architect | 19 | 2891 | 11 | review #242 scoring-prompt plan | FP |
+| 73 | af | explore | 29 | 2733 | 30 | map config/warning/discovery code | FP |
+| 138 | af | explore | 26 | 2011 | 18 | map parent-thread tool-use extraction | FP |
+| 160 | af | explore | 21 | 2418 | 13 | simplification review of #465 diff `[*]` | FP |
+| 180 | cf | explore | 16 | 5016 | 10 | explore #218 data readiness | FP |
+| 28 | af | general-purpose | 13 | 5944 | 14 | code review angle E (wrapper correctness) | FP |
+| 39 | af | general-purpose | 11 | 6210 | 12 | code review angle D (language pitfalls) | FP |
+| 40 | af | general-purpose | 22 | 3917 | 23 | code review angle E | FP |
+| 53 | af | general-purpose | 33 | 2552 | 34 | implement #298 window metadata `[*]` | FP |
+| 82 | af | general-purpose | 22 | 2377 | 23 | quality review of PR #369 | FP |
+| 108 | af | general-purpose | 14 | 4263 | 9 | reuse review of #270 diff | FP |
+| 176 | cf | general-purpose | 22 | 2509 | 9 | research code-review agents | FP |
+| 179 | cf | general-purpose | 17 | 2058 | 13 | code quality review round 2 | FP |
+| 194 | cf | general-purpose | 10 | 5387 | 5 | code reuse review (E2E tests) | FP |
+| 195 | cf | general-purpose | 12 | 3730 | 5 | efficiency review (E2E tests) | FP |
+| 15 | af | pm | 17 | 5113 | (no trace) | scope Phase 3 stories under #439 | FP |
+| 70 | af | pm | 26 | 4574 | 19 | scope C-006b Track B stories under #433 | FP |
+| 98 | af | pm | 43 | 3640 | 25 | scope v0.6 release (read context → PRD+backlog) | FP |
+| 121 | af | pm | 36 | 3597 | 21 | scope quality-axis PRD into epic | FP |
+| 164 | af | pm | 38 | 2786 | 23 | PM brief: model-turn metric | FP |
+| 189 | cf | pm | 41 | 3492 | 14 | scope+prioritize v1.3 release | FP |
+
+## Tally
+
+- **TP**: 0
+- **FP**: 30
+
+**Baseline precision: 0 / 30 = 0%** — far below the 70% target, and below the PRD's
+60–70% estimate. The metadata-only proxy has **no discriminating power** on this corpus:
+it fires uniformly on token-heavy reasoning subagents whose intermediate results are
+genuinely consumed.
+
+Caveat on generalization: 30/195 sampled, but the four emitting types are homogeneous
+(all reasoning/review/scoping) and the FP mode is *structural* to how the ratio is
+computed, so we expect ~0% across the full 195, not just the sample.
+
+## Dominant FP pattern (single mode)
+
+**Token-heavy reasoning subagents.** Every emitting agent type (architect, explore,
+general-purpose code/reuse/quality review, pm scoping) Reads code / diffs / issues /
+PRDs and reasons over that content. The high `tokens_per_tool_use` reflects large
+context windows and substantial reasoning output, **not** large disposable
+intermediate tool results. There is no second FP mode to separate out — it's one mode.
+
+## Tuning simulation (one round, per AC)
+
+Does any threshold band isolate a TP subpopulation?
+
+| tool_calls | tokens/call | min_inv | detections | emitting types |
+|---:|---:|---:|---:|---|
+| **10** | **2000** | **3** *(current)* | 189 | architect, general-purpose, pm, explore |
+| 15 | 2000 | 3 | 149 | architect, general-purpose, pm, explore |
+| 20 | 2000 | 3 | 92 | architect, pm, general-purpose, explore |
+| 10 | 3000 | 3 | 121 | general-purpose, architect, pm, explore |
+| 10 | 4000 | 3 | 45 | architect, pm, general-purpose, explore |
+| 10 | 5000 | 3 | 17 | architect, pm, general-purpose, explore |
+| 20 | 4000 | 5 | 13 | pm, architect |
+| 10 | 7000 | 3 | 0 | *(none)* |
+
+**No band isolates a non-reasoning subpopulation** — because none exists in the corpus.
+Tightening only shrinks the (entirely-FP) population; the sole band that eliminates the
+FPs (`tokens/call > 7000`) eliminates *every* detection, i.e. it disables the signal
+rather than tuning it. **Threshold tuning cannot rescue precision here.** The limitation
+is the proxy itself, not its constants.
+
+## Recommendation
+
+The AC's tuning lever does not apply (no threshold band reaches 70% while retaining
+detections). The honest dispositions, in order of preference:
+
+1. **Do not ship `TOOL_ORCHESTRATION_CHAIN` as a rule-only INFO signal in v0.9.**
+   At 0% dogfood precision it is pure noise, and noise undermines the trust theme the
+   diagnostics output depends on. Gate its emission off (keep the code + tests) pending
+   Tier B or LLM augmentation. **This changes v0.9 signal scope → needs Fred/PM sign-off
+   and a `decisions.md` entry.**
+2. If it must ship, emit only with an explicit low-confidence caveat in the message and
+   keep `INFO` severity — but (1) is cleaner.
+
+This is **strong evidence for D035** (LLM-call augmentation candidate #1): the rule-based
+baseline FP rate is ~100%, far above the 30% threshold that the PRD set as the bar for
+"LLM augmentation would pay off." A viable signal needs trace-level inspection (compare
+summed tool-result token size vs. final-output size — Tier B) or an LLM relevance
+classifier; the metadata proxy alone cannot distinguish orchestration from reasoning.
+
+## Follow-ups to file (pending Fred's disposition call)
+
+- **Signal disposition issue** — gate Tier A emission off for v0.9; track Tier B /
+  D035 LLM-augmentation as the path to a shippable version. Capture the
+  "`anthropic-research` is the only plausibly-TP type but sits below the min-invocation
+  gate" observation.
+- **D035 candidate entry** (PRD §9) — annotate with this calibration's ~100% rule-based
+  FP rate as the measured baseline LLM augmentation would improve upon.
+
+## Forward note: automated-classifier candidate
+
+Per the standing stance from #402/#274/#321: when the automated-classification capability
+lands, evaluate a **classical ML path** (TF-IDF over task description + agent type +
+tool-mix features → LR/GBT) before reaching for an LLM judge — determinism and zero
+per-run cost fit "calibrate every release." For *this* signal specifically, the cleaner
+fix is upstream (Tier B result-size measurement), since the FP mode is a feature-quality
+problem — the proxy lacks the input it would need — not a classification problem the same
+features can solve.

--- a/.claude/specs/analysis/407-calibration/detections.tsv
+++ b/.claude/specs/analysis/407-calibration/detections.tsv
@@ -1,0 +1,196 @@
+idx	corpus	session	agent_type	tool_uses	total_tokens	tokens_per_call	has_trace	turns	description
+1	af	02e21310	pm	39	156234	4006	True	21	Plan v0.8 release: PRD + backlog
+2	af	02e21310	architect	22	99892	4541	True	11	Design review of #399 Tier 3 infra
+3	af	083c02d2	Explore	28	89698	3204	True	29	Map diagnostics module structure
+4	af	083c02d2	Explore	15	64363	4291	True	12	Reuse review of #406 diff
+5	af	083c02d2	Explore	15	55936	3729	True	14	Altitude review of #406 diff
+6	af	08b03d83	pm	42	114072	2716	False		Scope C-008 into epic + stories
+7	af	08b03d83	architect	29	83623	2884	False		Architect design review for C-001
+8	af	08b03d83	pm	23	74590	3243	False		Scope C-001 stories under epic #423
+9	af	08b03d83	architect	28	62743	2241	False		Architect design review for C-004
+10	af	08b03d83	pm	26	55657	2141	False		Scope C-004 stories under epic #427
+11	af	08b03d83	architect	33	80066	2426	False		Architect design review for C-006
+12	af	08b03d83	pm	17	64530	3796	False		Scope C-006a Track A stories under #431
+13	af	08b03d83	pm	26	118930	4574	False		Scope C-006b Track B stories under #433
+14	af	08b03d83	architect	20	77783	3889	False		Architect review of Phase 3 PRD
+15	af	08b03d83	pm	17	86925	5113	False		Scope Phase 3 stories under #439
+16	af	08b03d83	architect	15	55062	3671	True	11	Post-merge review of Phase 3 skill body
+17	af	09c92e44	pm	22	94366	4289	True	9	PM scope review for v0.4
+18	af	09c92e44	architect	16	57824	3614	True	6	Architect review wave 2 plan
+19	af	09c92e44	general-purpose	18	37821	2101	True	19	Efficiency review #217 cost
+20	af	1104bcc9	pm	54	168332	3117	True	35	Scope v0.9 PRD and backlog
+21	af	1c0c92ce	architect	22	96145	4370	True	13	Architect review of quality axis epic #268
+22	af	1c0c92ce	architect	21	84610	4029	True	14	Architect review of quality module skeleton #269
+23	af	1c0c92ce	architect	31	88217	2846	True	17	Architect review of date-range epic #293
+24	af	2a7397e4	pm	30	121523	4051	True	11	Draft v0.7 PRD + backlog
+25	af	2b898766	architect	17	57259	3368	True	8	Architect review of #399 implementation plan
+26	af	2b898766	general-purpose	25	88749	3550	True	26	Angle A: line-by-line scan
+27	af	2b898766	general-purpose	35	88366	2525	True	36	Angle B: removed-behavior auditor
+28	af	2b898766	general-purpose	13	77267	5944	True	14	Angle E: wrapper correctness
+29	af	2b898766	general-purpose	33	109284	3312	True	34	Phase 3 sweep: find gaps
+30	af	2b898766	architect	25	57987	2319	True	15	Architect review of #400 plan
+31	af	2b898766	general-purpose	21	84062	4003	True	22	Angle A: line-by-line scan
+32	af	2b898766	general-purpose	39	94190	2415	True	39	Angle B: removed-behavior auditor
+33	af	2b898766	general-purpose	17	64139	3773	True	18	Angle D: language pitfalls
+34	af	2b898766	general-purpose	21	83513	3977	True	22	Angle E: wrapper correctness
+35	af	2b898766	general-purpose	29	103394	3565	True	30	Phase 3 sweep
+36	af	2b898766	architect	19	51724	2722	True	11	Architect review of #401 plan
+37	af	2b898766	general-purpose	15	90369	6025	True	16	Angle A: line-by-line scan
+38	af	2b898766	general-purpose	23	83627	3636	True	24	Angle B: removed-behavior auditor
+39	af	2b898766	general-purpose	11	68305	6210	True	12	Angle D: language pitfalls
+40	af	2b898766	general-purpose	22	86178	3917	True	23	Angle E: wrapper correctness
+41	af	32f70032	pm	22	87434	3974	True	11	Kick off v0.7 planning
+42	af	32f70032	pm	49	185423	3784	True	26	Finalize v0.7 plan + open epics
+43	af	32f70032	architect	18	67690	3761	True	12	Architect review: #344 + #345 design
+44	af	32f70032	general-purpose	17	47659	2803	True	10	Code-reuse review of #344+#345 PR
+45	af	3b79b5de	architect	22	77346	3516	True	10	Architect review: #356 report docs plan
+46	af	3b79b5de	architect	17	53709	3159	True	7	Architect review: #355 report tests + golden fixture plan
+47	af	3b79b5de	general-purpose	10	39523	3952	True	11	Quality review on docs PR
+48	af	3b79b5de	general-purpose	15	59925	3995	True	12	Reuse review on tests PR
+49	af	3b79b5de	architect	18	64790	3599	True	8	Architect review of #357 scoping plan
+50	af	3d70fb77	architect	25	85911	3436	True	17	Architect review of #273 plan
+51	af	3d70fb77	architect	18	52472	2915	True	11	Architect review of #298 plan
+52	af	3d70fb77	general-purpose	60	140850	2348	True	54	Implement #273 axis labels
+53	af	3d70fb77	general-purpose	33	84204	2552	True	34	Implement #298 window metadata
+54	af	3d70fb77	general-purpose	21	56462	2689	True	22	Code reuse review for #315
+55	af	3d70fb77	general-purpose	11	48919	4447	True	12	Efficiency review for #315
+56	af	3d70fb77	general-purpose	14	52944	3782	True	15	Code reuse review for #316
+57	af	3d70fb77	general-purpose	11	46596	4236	True	12	Code quality review for #316
+58	af	5e92c86b	pm	35	154548	4416	True	22	Spec advanced tool-use diagnostics for v0.9
+59	af	5e92c86b	anthropic-research	25	69381	2775	True	13	First smoke test research pass
+60	af	5e92c86b	candidate-promoter	11	39182	3562	True	7	Live run batch 1: GitHub ops only
+61	af	5e92c86b	candidate-promoter	12	47818	3985	True	12	Live run batch 2a: pm-first for C-005
+62	af	5e92c86b	pm	27	100737	3731	True	16	Spec C-005 fork-loop detection
+63	af	5e92c86b	pm	42	114072	2716	True	20	Scope C-008 into epic + stories
+64	af	5e92c86b	architect	29	83623	2884	True	13	Architect design review for C-001
+65	af	5e92c86b	pm	23	74590	3243	True	17	Scope C-001 stories under epic #423
+66	af	5e92c86b	architect	28	62743	2241	True	16	Architect design review for C-004
+67	af	5e92c86b	pm	26	55657	2141	True	17	Scope C-004 stories under epic #427
+68	af	5e92c86b	architect	33	80066	2426	True	17	Architect design review for C-006
+69	af	5e92c86b	pm	17	64530	3796	True	13	Scope C-006a Track A stories under #431
+70	af	5e92c86b	pm	26	118930	4574	True	19	Scope C-006b Track B stories under #433
+71	af	5e92c86b	architect	20	77783	3889	True	11	Architect review of Phase 3 PRD
+72	af	5e92c86b	pm	17	86925	5113	True	12	Scope Phase 3 stories under #439
+73	af	746c02dd	Explore	29	79257	2733	True	30	Map config/warning/discovery code
+74	af	746c02dd	Explore	18	48133	2674	True	17	Reuse review of #481 diff
+75	af	746c02dd	Explore	17	50870	2992	True	12	Simplification review of #481 diff
+76	af	746c02dd	Explore	16	43059	2691	True	17	Efficiency review of #481 diff
+77	af	788b588f	architect	25	82305	3292	True	15	Architect review of #354 renderer plan
+78	af	788b588f	general-purpose	14	48896	3493	True	15	Code reuse review of PR #366
+79	af	788b588f	general-purpose	16	48337	3021	True	8	Code quality review of PR #366
+80	af	788b588f	architect	22	47496	2159	True	9	Architect review of #346 plan
+81	af	788b588f	general-purpose	14	45675	3262	True	15	Reuse review of PR #369
+82	af	788b588f	general-purpose	22	52284	2377	True	23	Quality review of PR #369
+83	af	788b588f	general-purpose	11	37483	3408	True	5	Research RAG-over-tool-descriptions
+84	af	788b588f	claude-code-guide	13	32712	2516	True	6	CC subagent tool-loading mechanics
+85	af	7cdb2e77	architect	27	66738	2472	True	17	Review plans for #321 and #322
+86	af	7cdb2e77	pm	10	63047	6305	True	8	Scope decision on #275
+87	af	7cdb2e77	architect	19	43984	2315	True	12	Review plan for #281
+88	af	7f2b8660	architect	21	61317	2920	True	16	Architect review for #285 plan
+89	af	7f2b8660	architect	24	63739	2656	True	12	Architect review for #274 plan
+90	af	7f2b8660	pm	11	56095	5100	True	7	PM review of #274 implementation plan
+91	af	7f2b8660	architect	13	37900	2915	True	10	Architect re-review of #274 plan
+92	af	812b126d	Explore	14	44240	3160	True	8	Reuse review of diff
+93	af	812b126d	Explore	14	42497	3036	True	13	Simplification review of diff
+94	af	82904b0f	architect	22	92664	4212	True	13	Architect review of #372 design
+95	af	82904b0f	general-purpose	16	58836	3677	True	17	Reuse review of #372 diff
+96	af	9b9b68fd	architect	11	62349	5668	True	7	Review FEAT_FIX_PROXIMITY tuning plan
+97	af	a18a138e	pm	42	136466	3249	True	27	Scope date-range filtering for v0.6
+98	af	a18a138e	pm	43	156505	3640	True	25	Scope v0.6 release
+99	af	a341eff5	architect	18	51226	2846	True	9	Architect review for issue 191
+100	af	a341eff5	Explore	10	27581	2758	True	7	Research uv_build package data inclusion
+101	af	a341eff5	Explore	16	36624	2289	True	6	Hatchling security implications research
+102	af	a341eff5	pm	11	30818	2802	True	6	PM scope review on issue 188
+103	af	b40dbafc	architect	24	102785	4283	True	15	Review #269 implementation plan
+104	af	b40dbafc	general-purpose	22	66097	3004	True	18	Code reuse review of #269 diff
+105	af	b40dbafc	architect	26	91243	3509	True	16	Review #270 implementation plan
+106	af	b40dbafc	architect	15	67432	4495	True	7	Review #294 implementation plan
+107	af	b40dbafc	general-purpose	16	43975	2748	True	7	Reuse review of #294 diff
+108	af	b40dbafc	general-purpose	14	59679	4263	True	9	Reuse review of #270 diff
+109	af	b40dbafc	architect	24	77891	3245	True	12	Review #271 implementation plan
+110	af	b40dbafc	architect	12	74529	6211	True	6	Review #295 implementation plan
+111	af	b40dbafc	general-purpose	17	53228	3131	True	10	Reuse review of #271 diff
+112	af	b40dbafc	general-purpose	17	55091	3241	True	12	Code reuse review for #310
+113	af	b40dbafc	general-purpose	17	35495	2088	True	8	Code reuse review for #311
+114	af	b40dbafc	general-purpose	16	47767	2985	True	7	Code reuse review for #312
+115	af	b40dbafc	general-purpose	17	47438	2790	True	8	Code reuse review for #313
+116	af	b40dbafc	general-purpose	11	36260	3296	True	12	Code quality review for #313
+117	af	bd54bc29	architect	19	122402	6442	True	10	Architect review for #405 PARAMETER_RETRY
+118	af	bd54bc29	Explore	20	55693	2785	True	14	Reuse review of PR493
+119	af	bd54bc29	Explore	20	54796	2740	True	18	Simplification review of PR493
+120	af	bd54bc29	Explore	10	77677	7768	True	7	Altitude review of PR493
+121	af	c266bcf2	pm	36	129505	3597	True	21	Scope quality-axis PRD into epic
+122	af	c266bcf2	architect	34	113535	3339	True	20	Architect review of quality axis epic
+123	af	c266bcf2	pm	44	122419	2782	True	37	PM: D021 formula + resequencing
+124	af	c266bcf2	general-purpose	16	55663	3479	True	17	Reuse review on #279
+125	af	c266bcf2	general-purpose	14	39846	2846	True	15	Quality review on #277
+126	af	ca3d881d	pm	31	125276	4041	True	12	v0.5 release planning
+127	af	ca3d881d	architect	37	106140	2869	True	23	Architect review of #230 and #186
+128	af	ca3d881d	architect	15	60892	4059	True	9	Architect review #2 on #230 with empirical evidence
+129	af	ca3d881d	general-purpose	33	84235	2553	True	34	Code reuse review
+130	af	ca3d881d	general-purpose	17	63686	3746	True	9	Code quality review
+131	af	ca3d881d	general-purpose	16	44012	2751	True	9	Code reuse review
+132	af	ca3d881d	general-purpose	12	46192	3849	True	13	Code quality review
+133	af	ca3d881d	architect	12	60599	5050	True	8	Architect review of #231 fix plan
+134	af	ca3d881d	general-purpose	14	39559	2826	True	15	Code reuse review
+135	af	dada0b20	pm	24	93492	3896	True	22	Re-scope #394 after empirical diagnosis
+136	af	dada0b20	architect	23	68660	2985	True	14	Architect review of #454 threshold-split design
+137	af	dc461ab4	general-purpose	18	37544	2086	True	6	Code reuse review
+138	af	e175c382	Explore	26	52297	2011	True	18	Map parent-thread tool-use extraction
+139	af	e175c382	Plan	20	78800	3940	True	21	Design plan for #189 decomposition
+140	af	e175c382	architect	18	82942	4608	True	11	Architect review of #189 plan
+141	af	e175c382	general-purpose	26	63565	2445	True	9	Code reuse review
+142	af	e175c382	general-purpose	26	88632	3409	True	13	Code reuse review
+143	af	e175c382	general-purpose	12	59858	4988	True	4	Code reuse review
+144	af	e175c382	architect	17	59833	3520	True	10	Architect review of #185 plan + _complexity.py
+145	af	e175c382	general-purpose	14	56737	4053	True	15	Code reuse review
+146	af	e175c382	general-purpose	12	59808	4984	True	13	Code quality review
+147	af	e175c382	architect	13	61140	4703	True	9	Review plan for issue #184
+148	af	e175c382	architect	18	64034	3557	True	9	Review plan for sub-issue D
+149	af	e175c382	architect	15	62833	4189	True	8	Review plan for sub-issue E
+150	af	e175c382	general-purpose	18	48170	2676	True	19	Code reuse review of PR #259
+151	af	e175c382	general-purpose	10	36922	3692	True	6	Code quality review of PR #259
+152	af	e175c382	architect	26	71601	2754	True	13	Review plan for sub-issue F
+153	af	e175c382	general-purpose	15	46193	3080	True	16	Code reuse review of PR #261
+154	af	e175c382	general-purpose	14	43119	3080	True	15	Code quality review of PR #261
+155	af	e175c382	architect	22	71923	3269	True	13	Review plan for #172
+156	af	e175c382	general-purpose	13	45969	3536	True	6	Code reuse review of PR #266
+157	af	e9c28f92	architect	20	71187	3559	True	10	Architect review of #333 proposal
+158	af	ef6f60dc	architect	25	90019	3601	True	12	Review issue #465 implementation plan
+159	af	ef6f60dc	Explore	21	46851	2231	True	15	Reuse review of #465 diff
+160	af	ef6f60dc	Explore	21	50769	2418	True	13	Simplification review of #465 diff
+161	af	ef6f60dc	Explore	12	43738	3645	True	12	Efficiency review of #465 diff
+162	af	ef6f60dc	Explore	11	65269	5934	True	9	Altitude review of #465 diff
+163	af	ef6f60dc	architect	18	62836	3491	True	9	Review #467 design plan
+164	af	f3019fdf	pm	38	105859	2786	True	23	PM brief: model-turn count metric
+165	af	f3019fdf	architect	35	97077	2774	True	15	Architect review: turn-count metrics
+166	af	f3019fdf	pm	24	79095	3296	True	13	PM follow-up: turn metrics batch
+167	af	fd25efb7	architect	15	53287	3552	True	9	Architect review of #199 diff plan
+168	af	fd25efb7	general-purpose	18	49802	2767	True	19	Code reuse review
+169	cf	0cb255a7	architect	35	71958	2056	True	19	Architect review of v1.3 render refactor
+170	cf	0cb255a7	architect	20	58680	2934	True	17	Architect review of PR 302 release tooling
+171	cf	0cb255a7	Explore	12	38092	3174	True	5	Verify renderer + test-infra state for v1.2.1 plan
+172	cf	0cb255a7	Plan	26	66614	2562	True	9	Plan v1.2.1 fix implementation
+173	cf	13607e2a	Explore	22	69431	3156	True	18	Investigate #217 fork patterns
+174	cf	13607e2a	Explore	25	70400	2816	True	22	Map #245 data structures
+175	cf	13607e2a	pm	24	99856	4161	True	14	PM agent roadmap review
+176	cf	13607e2a	general-purpose	22	55196	2509	True	9	Research code review agents
+177	cf	13607e2a	architect	19	54927	2891	True	11	Test architect agent on v1.2 plan
+178	cf	13607e2a	Explore	24	81080	3378	True	14	Explore error recovery frontend state
+179	cf	13607e2a	general-purpose	17	34982	2058	True	13	Code quality review (round 2)
+180	cf	13607e2a	Explore	16	80250	5016	True	10	Explore #218 data readiness
+181	cf	13607e2a	Explore	17	93459	5498	True	4	Explore scoring prompt + schema
+182	cf	13607e2a	Explore	15	57643	3843	True	9	Explore issue #128 agreement data
+183	cf	13607e2a	general-purpose	11	41461	3769	True	7	README and metadata review
+184	cf	13607e2a	pm	15	44109	2941	True	10	Scope secret-handling issue
+185	cf	13607e2a	Explore	29	68268	2354	True	10	Survey agentfluent project
+186	cf	13607e2a	pm	32	104916	3279	True	9	v1.2 vs v1.3 scope decision review
+187	cf	4646f62d	architect	13	79811	6139	True	9	Architect review of #238 implementation plan
+188	cf	4646f62d	architect	14	56880	4063	True	7	Architect review of #246 plan
+189	cf	5fa5f6f8	pm	41	143162	3492	True	14	Scope and prioritize v1.3 release
+190	cf	5fa5f6f8	pm	18	81883	4549	True	9	Resolve v1.3 PRD open questions
+191	cf	5fa5f6f8	pm	22	82780	3763	True	14	Scope E2E automation for v1.3
+192	cf	5fa5f6f8	architect	23	75099	3265	True	15	Review #312 E2E automation design
+193	cf	5fa5f6f8	Explore	18	47226	2624	True	19	Code reuse review of Phase A
+194	cf	c43f3149	general-purpose	10	53871	5387	True	5	Code reuse review
+195	cf	c43f3149	general-purpose	12	44765	3730	True	5	Efficiency review

--- a/.claude/specs/analysis/407-calibration/export.py
+++ b/.claude/specs/analysis/407-calibration/export.py
@@ -1,0 +1,126 @@
+"""Throwaway: export TOOL_ORCHESTRATION_CHAIN matching invocations for #407.
+
+Mirrors analytics.pipeline per-session loading + trace linking, applies the
+_is_orchestration_chain predicate, and dumps a TSV + per-detection context
+(trace turn count, distinct tools, task description) for manual TP/FP review.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentfluent.agents.extractor import extract_agent_invocations
+from agentfluent.core.parser import parse_session
+from agentfluent.diagnostics.tool_orchestration import (
+    _MIN_TOKENS_PER_TOOL_CALL,
+    _MIN_TOOL_CALLS,
+    _is_orchestration_chain,
+)
+from agentfluent.traces.discovery import discover_session_subagents
+from agentfluent.traces.linker import link_traces
+from agentfluent.traces.parser import parse_subagent_trace
+
+PROJECTS = Path.home() / ".claude" / "projects"
+DIRS = [
+    "-home-fdpearce-Documents-Projects-git-agentfluent",
+    "-home-fdpearce-Documents-Projects-git-codefluent-codefluent",
+]
+
+
+def link(invocations, session_path):
+    session_dir = session_path.parent / session_path.stem
+    path_map = {i.agent_id: i.path for i in discover_session_subagents(session_dir)}
+
+    def loader(agent_id):
+        fp = path_map.get(agent_id)
+        if fp is None:
+            return None
+        try:
+            return parse_subagent_trace(fp)
+        except (FileNotFoundError, ValueError):
+            return None
+
+    return link_traces(invocations, loader)
+
+
+def trace_tools(trace):
+    """Distinct tool names + count from a linked subagent trace, if any."""
+    if trace is None:
+        return None
+    names: dict[str, int] = {}
+    for msg in getattr(trace, "messages", []) or []:
+        content = getattr(getattr(msg, "message", None), "content", None)
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                names[block.get("name", "?")] = names.get(block.get("name", "?"), 0) + 1
+    return names
+
+
+rows = []
+for d in DIRS:
+    proj = PROJECTS / d
+    if not proj.exists():
+        print(f"MISSING: {proj}")
+        continue
+    for session_path in sorted(proj.glob("*.jsonl")):
+        try:
+            messages = parse_session(session_path)
+        except Exception as e:  # noqa: BLE001
+            print(f"parse fail {session_path.name}: {e}")
+            continue
+        invs = extract_agent_invocations(messages)
+        if not invs:
+            continue
+        invs = link(invs, session_path)
+        for inv in invs:
+            if _is_orchestration_chain(inv):
+                rows.append((d, session_path.stem, inv))
+
+print(f"\nThresholds: tool_calls>={_MIN_TOOL_CALLS}, tokens/call>{_MIN_TOKENS_PER_TOOL_CALL}")
+print(f"Total matching invocations: {len(rows)}\n")
+
+# Aggregate per agent_type (how the signal actually gates: >=3 to emit)
+by_type: dict[str, int] = {}
+for _, _, inv in rows:
+    by_type[inv.agent_type.lower()] = by_type.get(inv.agent_type.lower(), 0) + 1
+print("Matching invocations per agent_type (>=3 emits a signal):")
+for t, n in sorted(by_type.items(), key=lambda x: -x[1]):
+    flag = "  <-- EMITS" if n >= 3 else ""
+    print(f"  {t:20s} {n}{flag}")
+
+out = Path("/tmp/orchestration_407.tsv")
+with out.open("w") as f:
+    f.write("idx\tcorpus\tsession\tagent_type\ttool_uses\ttotal_tokens\ttokens_per_call\thas_trace\tturns\tdescription\n")
+    for i, (corpus, session, inv) in enumerate(rows, 1):
+        c = "af" if "agentfluent" in corpus else "cf"
+        turns = inv.model_turns if inv.model_turns is not None else ""
+        desc = (inv.description or "").replace("\t", " ").replace("\n", " ")[:90]
+        f.write(
+            f"{i}\t{c}\t{session[:8]}\t{inv.agent_type}\t{inv.tool_uses}\t"
+            f"{inv.total_tokens}\t{inv.tokens_per_tool_use:.0f}\t"
+            f"{(inv.trace is not None)}\t{turns}\t{desc}\n"
+        )
+print(f"\nWrote {out}")
+
+# Dump rich per-detection context for classification
+ctx = Path("/tmp/orchestration_407_context.json")
+detail = []
+for i, (corpus, session, inv) in enumerate(rows, 1):
+    detail.append({
+        "idx": i,
+        "corpus": "af" if "agentfluent" in corpus else "cf",
+        "session": session[:8],
+        "agent_type": inv.agent_type,
+        "tool_uses": inv.tool_uses,
+        "total_tokens": inv.total_tokens,
+        "tokens_per_call": round(inv.tokens_per_tool_use, 0),
+        "has_trace": (inv.trace is not None),
+        "model_turns": inv.model_turns,
+        "trace_tools": trace_tools(inv.trace),
+        "description": inv.description,
+        "prompt_head": (inv.prompt or "")[:500],
+    })
+ctx.write_text(json.dumps(detail, indent=2, default=str))
+print(f"Wrote {ctx}")

--- a/.claude/specs/analysis/407-calibration/sample.py
+++ b/.claude/specs/analysis/407-calibration/sample.py
@@ -1,0 +1,40 @@
+"""Stratified seeded sample of orchestration detections for #407 classification."""
+import json
+import random
+from collections import defaultdict
+
+data = json.loads(open("/tmp/orchestration_407_context.json").read())
+
+# Restrict to the agent types that actually emit a signal (>=3 matching).
+EMIT = {"architect", "general-purpose", "pm", "explore"}
+pool = [d for d in data if d["agent_type"].lower() in EMIT]
+
+by_type = defaultdict(list)
+for d in pool:
+    by_type[d["agent_type"].lower()].append(d)
+
+# Proportional stratified sample, ~30 total, seeded for reproducibility.
+random.seed(407)
+TARGET = 30
+total = len(pool)
+sample = []
+for t, items in by_type.items():
+    k = max(3, round(TARGET * len(items) / total))
+    k = min(k, len(items))
+    sample.extend(random.sample(items, k))
+
+sample.sort(key=lambda d: (d["agent_type"].lower(), d["idx"]))
+print(f"pool={total} sample={len(sample)}")
+for t in sorted(by_type):
+    print(f"  {t}: pool={len(by_type[t])} sampled={sum(1 for s in sample if s['agent_type'].lower()==t)}")
+
+for d in sample:
+    tools = d.get("trace_tools")
+    tools_str = ", ".join(f"{k}:{v}" for k, v in sorted((tools or {}).items(), key=lambda x:-x[1]))
+    print("\n" + "=" * 78)
+    print(f"[{d['idx']}] {d['agent_type']}  {d['corpus']}/{d['session']}  "
+          f"calls={d['tool_uses']} tok={d['total_tokens']} ratio={d['tokens_per_call']:.0f} "
+          f"trace={d['has_trace']} turns={d['model_turns']}")
+    print(f"  TOOLS: {tools_str or '(no trace)'}")
+    print(f"  DESC: {d['description']}")
+    print(f"  PROMPT: {d['prompt_head'][:300]}")

--- a/.claude/specs/analysis/407-calibration/tune.py
+++ b/.claude/specs/analysis/407-calibration/tune.py
@@ -1,0 +1,45 @@
+"""Tuning simulation for #407: does any threshold band isolate true positives?
+
+All sampled detections classified FP (intermediates genuinely consumed by
+reasoning). This sim shows how the emitting population responds to threshold
+changes — i.e. whether a tighter gate could ever isolate a TP subpopulation.
+"""
+import json
+from collections import Counter
+
+data = json.loads(open("/tmp/orchestration_407_context.json").read())
+EMIT_GATE = 3
+
+
+def emits(calls_min, ratio_min, inv_min):
+    matching = [d for d in data
+                if d["tool_uses"] >= calls_min and d["tokens_per_call"] > ratio_min]
+    by_type = Counter(d["agent_type"].lower() for d in matching)
+    emitting = {t: n for t, n in by_type.items() if n >= inv_min}
+    return matching, emitting
+
+
+print(f"{'tool_calls':>10} {'tokens/call':>12} {'min_inv':>8} | "
+      f"{'detections':>10} {'emit_types':>10} {'agent_types_emitting'}")
+for calls_min, ratio_min, inv_min in [
+    (10, 2000, 3),   # current defaults
+    (15, 2000, 3),
+    (20, 2000, 3),
+    (10, 3000, 3),
+    (10, 4000, 3),
+    (10, 5000, 3),
+    (10, 2000, 5),
+    (20, 4000, 5),
+    (10, 7000, 3),   # near the max ratio (7768)
+]:
+    matching, emitting = emits(calls_min, ratio_min, inv_min)
+    types = ", ".join(f"{t}({n})" for t, n in sorted(emitting.items(), key=lambda x: -x[1]))
+    n_emit = sum(emitting.values())
+    print(f"{calls_min:>10} {ratio_min:>12} {inv_min:>8} | "
+          f"{n_emit:>10} {len(emitting):>10}  {types or '(none)'}")
+
+print("\nAll emitting agent types across every band are reasoning/review/scoping")
+print("subagents (architect, general-purpose, pm, explore). No band isolates a")
+print("data-processing/orchestration subpopulation because none exists in the corpus.")
+print("\nNote: 'anthropic-research' (web-fetch heavy, the one plausibly-TP type)")
+print("has only 1 matching invocation — below any sane min_inv gate — so it never emits.")

--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -918,3 +918,22 @@ primary_axis = max(AXIS_TIEBREAKER, key=lambda a: axis_scores[a])
 **Reference:** Epic #403 body ("Out of Scope" section); `prd-advanced-tool-use-diagnostics.md` Section 3 (Non-Goals).
 
 ---
+
+## D043: TOOL_ORCHESTRATION_CHAIN ships live-with-caveat in v0.9 -- 0% dogfood precision is a corpus artifact; Tier B (#499) is the precision fix
+
+**Date:** 2026-06-02
+**Context:** The #407 calibration of the Tier A `TOOL_ORCHESTRATION_CHAIN` signal (#406) measured precision against the agentfluent + codefluent dogfood corpora: 195 matching invocations, a seeded stratified sample of 30, classified **0/30 true positives = 0% precision** -- below the 70% target and the PRD's 60-70% estimate. Root cause is structural, not a threshold miss: `tokens_per_tool_use` divides whole-invocation token burn (large cached context re-sent each turn + reasoning output) by tool count, **not** intermediate-tool-*result* size, so it fires uniformly on token-heavy reasoning/review/scoping subagents (architect, general-purpose, pm, explore) whose intermediates are genuinely consumed. The tuning simulation (the D042-anticipated response) confirmed no threshold band improves precision -- every band emits the same reasoning agents; the only band that drops the FPs drops all detections. See `.claude/specs/analysis/407-calibration/`.
+
+**Decision:** Ship the signal **live in v0.9, emitting at `INFO` with an explicit low-confidence caveat** in its message (`_LOW_CONFIDENCE_CAVEAT` in `tool_orchestration.py`). It is **not** gated off. The architect's #407 review recommended gating off; that recommendation is **superseded** by this decision, as is D042's assumption that "the response is threshold tuning, not Tier B."
+
+**Rationale:**
+- **The 0% precision is a corpus artifact, not a broken signal.** Today's dogfood corpus contains only reasoning agents -- no agents that run genuine tool-orchestration chains, so there are no true positives to find. Fred expects to run agents that *will* generate real orchestration-chain TPs in future dogfood sessions; gating the signal off would mean those future TPs never surface.
+- **The caveat manages present noise honestly** -- the signal is flagged a low-confidence lead, not asserted as a finding, and the caveat propagates into the recommendation observation so the fix text never presents the orchestration claim as fact.
+- **Tier B is the precision fix, not a precondition for shipping.** Trace-level detection (summed tool-result tokens vs. final-output size -- deterministic, inputs already exist on ~185/195 invocations) directly measures the quantity the metadata proxy lacks. Filed as **#499** (post-v0.9). D035 (LLM relevance classifier) remains candidate #1 as the complement; the calibration's ~100% rule-based FP rate on this corpus is the measured baseline it would improve upon.
+- **PRD §11 success criterion #3 (>=70% precision) is an accepted known limitation for v0.9** -- not met on the current corpus, tracked to Tier B (#499). It is explicitly *not* "deferred by removing the signal."
+
+**Supersedes:** the architect's #407 gate-off recommendation; D042's tuning-not-Tier-B assumption. **Complements:** D035 (LLM-augmentation tracking).
+
+**Reference:** `.claude/specs/analysis/407-calibration/calibration.md`; #407 (calibration) and its disposition comment; #499 (Tier B); #406 (signal); epic #403; PRD `prd-advanced-tool-use-diagnostics.md` §9 / §11.
+
+---

--- a/.claude/specs/prd-advanced-tool-use-diagnostics.md
+++ b/.claude/specs/prd-advanced-tool-use-diagnostics.md
@@ -234,9 +234,9 @@ This section establishes the tracking discipline proposed in D035. AgentFluent i
 | **What the rule-based version does** | Uses token-to-tool ratio as a proxy: high ratio = likely orchestration. Cannot distinguish cases where high intermediate tokens are legitimately needed for reasoning. |
 | **What an LLM call would do** | Given the final output and the intermediate tool results, classify whether each intermediate result materially affected the final output. If not, the intermediate could have been processed in a code-execution sandbox. |
 | **Approximate cost/call** | ~2k input tokens (final output + summarized intermediates) + ~200 output tokens = ~$0.02-0.05 per invocation at Haiku pricing |
-| **Expected precision delta** | Rule-based: estimated 60-70% precision. LLM-augmented: estimated 85-90% precision. The ~20pp lift comes from eliminating false positives where complex reasoning genuinely required all intermediates in context. |
+| **Expected precision delta** | Rule-based: estimated 60-70% precision. LLM-augmented: estimated 85-90% precision. **Measured (#407, 2026-06-02): ~0% precision / ~100% rule-based FP rate** on the agentfluent+codefluent dogfood corpus -- the estimated 60-70% never materialized because the proxy measures whole-invocation token burn, not intermediate-result size, so it fires only on token-heavy reasoning agents (a corpus with no genuine orchestration chains). |
 | **Expected recall delta** | Minimal. Both approaches detect the same candidates; the LLM only reclassifies FPs. |
-| **When to implement** | When dogfood data confirms the rule-based FP rate exceeds 30%, AND AgentFluent has a general-purpose "optional LLM call" infrastructure (env var for API key, cost tracking, opt-in flag). |
+| **When to implement** | The >30% FP-rate trigger is now **met** (#407: ~100%). The deterministic first move is **Tier B** trace-level detection (#499), which measures intermediate-result size directly (summed tool-result tokens vs. final-output size); the LLM call here is the *complement* for residual semantic cases, gated on a general-purpose "optional LLM call" infrastructure (env var for API key, cost tracking, opt-in flag). Per the standing stance (D035 / #402), evaluate a classical-ML path before an LLM judge. |
 
 ### Future candidates (placeholder entries -- detail TBD)
 
@@ -250,7 +250,7 @@ This section establishes the tracking discipline proposed in D035. AgentFluent i
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| TOOL_ORCHESTRATION_CHAIN Tier A precision is low (<60%) | Users dismiss the signal; trust damage | Severity is INFO, not WARNING. Calibration story (#TBD) runs before shipping defaults. FP rate documented in GLOSSARY. LLM-augmentation candidate tracked for future precision lift. |
+| TOOL_ORCHESTRATION_CHAIN Tier A precision is low (<60%) | Users dismiss the signal; trust damage | Severity is INFO, not WARNING. Calibration (#407) measured ~0% precision on the current corpus (a corpus artifact -- no orchestration agents). Mitigated by an explicit low-confidence caveat on every emission (D043); Tier B (#499) is the precision fix; LLM-augmentation (D035) the complement. |
 | PARAMETER_RETRY requires subagent traces (Tier A) | Signal only fires for agents with traces; non-trace agents get no coverage | Tier B metadata fallback (3+ calls to same tool in `toolStats`) provides coarse coverage. Tier A is the high-confidence path; Tier B is additive. |
 | Paste-ready example extraction produces misleading examples | User copies an example that works in one context but not another | Examples are presented as "suggested based on observed successful call" with a caveat. The user is responsible for reviewing. Not auto-applied (D002). |
 | #372 has been parked for a reason -- insufficient data to calibrate | Signal fires on everyone with >30 tools regardless of actual degradation | The utilization ratio gate (uses <50% of declared tools) is the second filter. Combined threshold (30 tools AND low utilization) is conservative. Calibration against real data is a follow-up. |
@@ -263,7 +263,7 @@ v0.9 advanced tool use diagnostics are successful when:
 
 1. **PARAMETER_RETRY fires on genuine parameter-retry patterns.** At least one instance detected in the agentfluent or CodeFluent dogfood corpus where the agent retried a tool with a different input shape after an error.
 2. **Paste-ready example extraction produces a valid `input_examples` entry.** The extracted JSON matches the tool's `input_schema` and is copy-pasteable.
-3. **TOOL_ORCHESTRATION_CHAIN fires on high-tool-count invocations.** The signal triggers on invocations with 10+ tool calls and >2k tokens/call, with calibration showing >=70% precision.
+3. **TOOL_ORCHESTRATION_CHAIN fires on high-tool-count invocations.** The signal triggers on invocations with 10+ tool calls and >2k tokens/call. The >=70% precision target is an **accepted known limitation for v0.9**: the #407 calibration measured ~0% precision on the current dogfood corpus, but this is a corpus artifact (it contains no agents running genuine orchestration chains, so there are no true positives to find) -- not a broken signal. The signal ships live at INFO with an explicit low-confidence caveat (D043); trace-level Tier B detection (#499) is the tracked path to meeting the precision bar. See `.claude/specs/analysis/407-calibration/`.
 4. **TOOL_INVENTORY_OVERSIZED fires on agents with >30 declared tools.** Updated recommendation references the article's benchmarks.
 5. **All three signals contribute to the correct axis.** TOOL_ORCHESTRATION_CHAIN -> cost, PARAMETER_RETRY -> speed, TOOL_INVENTORY_OVERSIZED -> cost.
 6. **LLM-augmentation candidates list is established.** D035 appended to `decisions.md`. Candidate #1 documented with the fields specified above.

--- a/src/agentfluent/diagnostics/tool_orchestration.py
+++ b/src/agentfluent/diagnostics/tool_orchestration.py
@@ -19,15 +19,31 @@ average, aggregated to 3+ matching invocations per agent type. Tier B
 **Known precision risk.** The proxy cannot distinguish true orchestration
 chains (intermediate results consumed and discarded) from agents that
 genuinely need each intermediate result in context for reasoning. Severity
-is therefore ``INFO``, not ``WARNING``. This is the first LLM-call
-augmentation candidate (D035): an LLM classifying intermediate-result
-relevance could lift precision from an estimated 60-70% to 85-90%. A
-calibration story validates the thresholds against dogfood data.
+is therefore ``INFO``, not ``WARNING``, and every emitted signal carries an
+explicit low-confidence caveat (``_LOW_CONFIDENCE_CAVEAT``).
 
-**Threshold calibration.** The three thresholds below are the PRD's
-starting defaults, exposed as module-level constants so the calibration
-story can tune them against real session data without touching the
-detection logic.
+**Calibration (v0.9, #407).** On the agentfluent + codefluent dogfood
+corpora (195 matching invocations; seeded stratified sample of 30) the
+signal scored **0% precision (0/30 true positives)**. The corpus contained
+only reasoning/review/scoping subagents (architect, general-purpose, pm,
+explore) whose intermediate results are genuinely consumed -- it had no
+agents running real orchestration chains. The root cause is structural:
+``tokens_per_tool_use`` divides whole-invocation token burn (large cached
+context re-sent each turn + reasoning output) by tool count, not
+intermediate-*result* size, so no threshold band separates the two (every
+band emits the same reasoning agents). The signal nonetheless ships **live
+with the caveat** (decision 2026-06-02): the 0% is a corpus artifact, and
+the detection surface is retained for future corpora that include real
+orchestration-chain agents. Trace-level detection (Tier B: summed
+tool-result tokens vs. final-output size) is the precision fix; D035 (LLM
+relevance classifier) is the complement -- the ~100% rule-based FP rate is
+the measured baseline it would improve upon. See
+``.claude/specs/analysis/407-calibration/`` for the rubric, classification,
+and tuning simulation.
+
+**Thresholds.** The three constants below are the PRD's starting defaults.
+The #407 calibration confirmed no threshold band improves precision on the
+current corpus, so they are unchanged pending Tier B.
 """
 
 from __future__ import annotations
@@ -65,6 +81,18 @@ _MIN_MATCHING_INVOCATIONS = 3
 # complex research tasks. Applied to the summed tokens of the matching
 # invocations as a rough projection, surfaced in the recommendation.
 TOKEN_REDUCTION_FACTOR = 0.37
+
+# Appended to every emitted signal's message. The #407 calibration measured
+# 0% precision on the dogfood corpus (a metadata-only proxy can't tell a real
+# orchestration chain from a token-heavy reasoning agent), so the signal is
+# shipped live but flagged low-confidence rather than presented as a finding.
+# Removed once trace-level (Tier B) detection lifts precision. Kept as a
+# module constant so it's greppable and assertable in tests.
+_LOW_CONFIDENCE_CAVEAT = (
+    "Low-confidence heuristic: this metadata-only proxy cannot yet distinguish "
+    "genuine orchestration chains from token-heavy reasoning agents, so verify "
+    "against the agent's trace before acting on this."
+)
 
 # Producer/consumer contract: this module stores the projected token
 # savings under this key in the signal's ``detail`` dict;
@@ -107,7 +135,8 @@ def _build_signal(
     message = (
         f"Agent '{agent_type}' made {total_tool_calls} tool calls consuming "
         f"{total_tokens:,} tokens across {invocation_count} invocations. "
-        f"Average token cost per tool call: {ratio:,.0f} tokens."
+        f"Average token cost per tool call: {ratio:,.0f} tokens. "
+        f"{_LOW_CONFIDENCE_CAVEAT}"
     )
     return DiagnosticSignal(
         signal_type=SignalType.TOOL_ORCHESTRATION_CHAIN,

--- a/tests/unit/test_tool_orchestration.py
+++ b/tests/unit/test_tool_orchestration.py
@@ -9,6 +9,7 @@ from agentfluent.config.models import AgentConfig, Scope, Severity
 from agentfluent.diagnostics.correlator import correlate
 from agentfluent.diagnostics.models import SignalType
 from agentfluent.diagnostics.tool_orchestration import (
+    _LOW_CONFIDENCE_CAVEAT,
     ESTIMATED_TOKEN_SAVINGS_KEY,
     TOKEN_REDUCTION_FACTOR,
     extract_tool_orchestration_signals,
@@ -163,6 +164,21 @@ def test_recommendation_without_config_cites_article_url() -> None:
     _signal, rec = pairs[0]
     assert "anthropic.com/engineering/advanced-tool-use" in rec.action
     assert rec.config_file == ""
+
+
+def test_signal_message_carries_low_confidence_caveat() -> None:
+    """Every emitted signal flags itself low-confidence (#407: 0% dogfood precision)."""
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    assert _LOW_CONFIDENCE_CAVEAT in signals[0].message
+
+
+def test_recommendation_observation_carries_caveat() -> None:
+    """The caveat propagates into the recommendation observation, so the fix
+    text never asserts the orchestration finding as fact."""
+    signals = extract_tool_orchestration_signals(_matching_invs(3))
+    pairs = correlate(signals, {"researcher": _config()})
+    _signal, rec = pairs[0]
+    assert _LOW_CONFIDENCE_CAVEAT in rec.observation
 
 
 def test_builtin_agent_gets_builtin_action() -> None:


### PR DESCRIPTION
## Summary
Closes the #407 precision calibration for the `TOOL_ORCHESTRATION_CHAIN` signal (#406) and lands the resulting v0.9 disposition.

- **Calibration (`.claude/specs/analysis/407-calibration/`):** ground-truth precision check against the agentfluent + codefluent dogfood corpora (195 matching invocations; seeded stratified sample of 30), mirroring #402. Result: **0/30 TP — 0% precision**. Root cause is structural — `tokens_per_tool_use` measures whole-invocation token burn, not intermediate-result size — so it fires uniformly on token-heavy *reasoning* subagents (architect, general-purpose, pm, explore) whose intermediates are genuinely consumed (3 traces deep-read to confirm). Threshold tuning cannot rescue it. Includes `calibration.md`, `detections.tsv` (full 195-row population), and `export.py`/`sample.py`/`tune.py` for reproducibility.
- **Disposition — ship live with a low-confidence caveat (D043):** the 0% is a *corpus artifact* (no agents running real orchestration chains → no true positives to find), so the signal is **not** gated off; the detection surface is retained for future corpora that include such agents. `tool_orchestration.py` now appends `_LOW_CONFIDENCE_CAVEAT` to every emission (it propagates into the recommendation observation, so the fix text never asserts the orchestration claim as fact) and the module docstring records the calibration. This supersedes the architect's gate-off recommendation (see #407) on the strength of the future-TP rationale.
- **Backlog/trail:** `decisions.md` D043; PRD §11 criterion #3 reframed as an accepted known limitation tracked to **Tier B (#499)**; PRD §9 / D035 annotated with the measured ~100% rule-based FP baseline. Tier B (#499) is the precision fix; D035 the complement.
- **Hook-path hardening (`.claude/settings.json`):** anchor the PreToolUse/PostToolUse hook commands to `$CLAUDE_PROJECT_DIR` instead of bare relative paths, so a shell `cd` into a subdirectory can no longer make the secret-blocking hooks unresolvable and wedge the session. (Discovered the hard way during this work.)

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — **1661 passed** (+2 new: caveat in signal message, caveat propagates to recommendation observation)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/` — 80 files, no issues
- [x] New/changed behavior has test coverage — `test_signal_message_carries_low_confidence_caveat`, `test_recommendation_observation_carries_caveat`
- [x] Manual smoke test — `uv run agentfluent analyze --project agentfluent --json` fires the signal and renders the caveat in real output

## Security review
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

Rationale: the `settings.json` change alters how the secret-blocking hooks (`block_secret_reads.py` / `detect_secrets_in_output.py`) are *invoked* (path resolution). It strictly hardens — makes them resolve cwd-independently rather than failing-to-wedge — but touches the security-hook surface. Label applied only when dev-complete.

## Breaking changes
None. The caveat is additive text on an existing `INFO` signal's message; no enum, `detail` schema, severity, CLI, or JSON-envelope contract changes. The `settings.json` change preserves identical hook behavior (same scripts, same matchers), only making path resolution robust to cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)