### PR TITLE
feat: surface active duration alongside wall-clock in agent summary table (#480)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1518,6 +1518,48 @@ Token Usage
 
 **Related:** [`output`](#output), [`total_cost`](#total_cost)
 
+### `active_duration`
+
+**Short:** Wall-clock duration with detected idle (user-wait) gaps subtracted --
+an estimate of time the agent was actually working.
+
+**Detail:** Added in v0.9 (#480; the underlying subtraction shipped in #230).
+Two duration measures exist for an agent invocation:
+
+- **wall-clock** (`duration_ms`) -- raw elapsed time from the parent's
+  `toolUseResult` metadata. It silently includes any stretch where a
+  tool call sat pending user approval while the user was away (the IDE
+  prompting to allow a `Write`, an MCP call, etc.).
+- **active** (`active_duration_ms`) -- wall-clock minus detected idle
+  gaps. AgentFluent flags a gap when it exceeds
+  `max(10 × median, 5 minutes)` within a subagent trace and subtracts
+  it. Available only when a subagent trace is linked (~80% of the
+  dogfood corpus); without one, only wall-clock exists.
+
+Why the distinction matters: for an interactive agent like `pm`, the
+wall-clock average can be tens of minutes per call while the active
+time is seconds -- almost all of the gap is the user thinking, not the
+agent working. The `analyze` summary table renders
+`active (wall)` per call over the trace-linked subset and highlights
+rows whose wall/active ratio exceeds 3×, so a high wall-clock number
+no longer reads as a duration problem.
+
+Note the denominator: the summary table reports duration **per call**,
+whereas `duration_outlier` detection operates on
+`active_duration_per_tool_use` -- active time **per tool call** -- a
+finer-grained basis that isolates slow individual tool calls. The two
+are not interchangeable; a high per-call active duration with a normal
+per-tool_use figure just means the invocation made many tool calls.
+
+**Example:**
+
+```
+Agent Invocations
+  pm   ...   470.0s (2918.0s wall)†   <- active 470s/call, wall 2918s/call
+```
+
+**Related:** [`model_turns`](#model_turns), [`duration_outlier`](#duration_outlier)
+
 
 ---
 

--- a/src/agentfluent/analytics/agent_metrics.py
+++ b/src/agentfluent/analytics/agent_metrics.py
@@ -58,6 +58,36 @@ class AgentTypeMetrics:
     avg_tokens_per_tool_use: float | None = None
     avg_duration_per_tool_use: float | None = None
 
+    # Active-duration aggregates (#480). ``total_duration_ms`` above is
+    # raw wall-clock summed over *all* invocations and silently includes
+    # user-wait time (the IDE sitting on an approval prompt while the user
+    # is AFK). The three fields below let the summary table show the
+    # idle-subtracted "active" duration next to wall-clock so an
+    # interactive agent like ``pm`` doesn't read as a duration problem.
+    #
+    # Honesty constraint (#480, architect review): active duration only
+    # exists for trace-linked invocations (~80% of the dogfood corpus).
+    # To make the wall/active ratio measure *only* idle subtraction --
+    # not trace-coverage skew -- ``total_wallclock_ms_trace_linked``
+    # sums wall-clock over the SAME subset that contributed active
+    # duration, so both averages share ``active_duration_invocation_count``
+    # as their denominator.
+    total_active_duration_ms: int = 0
+    """Sum of ``active_duration_ms`` over invocations that had a linked
+    trace (idle gaps subtracted)."""
+
+    total_wallclock_ms_trace_linked: int = 0
+    """Sum of raw ``duration_ms`` over the *same* trace-linked invocations
+    that contributed ``total_active_duration_ms``. The wall-clock
+    numerator for a coverage-matched wall/active ratio."""
+
+    active_duration_invocation_count: int = 0
+    """Count of invocations contributing to the two active totals
+    (``active_duration_ms is not None``). Shared denominator for the
+    active and trace-linked-wall per-call averages, and the coverage
+    figure against ``invocation_count``. Mirrors the
+    ``invocations_with_turns`` pattern."""
+
     total_model_turns: int = 0
     """Sum of ``model_turns`` across this agent type's invocations,
     counting only invocations where ``model_turns is not None`` (a
@@ -97,6 +127,38 @@ class AgentTypeMetrics:
     def estimated_avg_cost_per_invocation_usd(self) -> float | None:
         if self.invocation_count > 0 and self.estimated_total_cost_usd > 0:
             return self.estimated_total_cost_usd / self.invocation_count
+        return None
+
+    @property
+    def avg_active_duration_per_invocation(self) -> float | None:
+        """Average idle-subtracted duration (ms) per invocation, over the
+        trace-linked subset. ``None`` when no invocation had a trace."""
+        if self.active_duration_invocation_count > 0 and self.total_active_duration_ms > 0:
+            return self.total_active_duration_ms / self.active_duration_invocation_count
+        return None
+
+    @property
+    def avg_wallclock_per_trace_linked_invocation(self) -> float | None:
+        """Average raw wall-clock (ms) per invocation over the *same*
+        trace-linked subset as :attr:`avg_active_duration_per_invocation`,
+        so the two are directly comparable. ``None`` when no invocation
+        had a trace."""
+        if (
+            self.active_duration_invocation_count > 0
+            and self.total_wallclock_ms_trace_linked > 0
+        ):
+            return self.total_wallclock_ms_trace_linked / self.active_duration_invocation_count
+        return None
+
+    @property
+    def wallclock_active_ratio(self) -> float | None:
+        """Wall-clock / active over the coverage-matched trace-linked
+        subset. >1 means idle (user-wait) time inflated wall-clock;
+        a large ratio marks an interactive-pattern agent whose headline
+        wall-clock duration would otherwise mislead. ``None`` when no
+        active duration is available."""
+        if self.total_active_duration_ms > 0 and self.total_wallclock_ms_trace_linked > 0:
+            return self.total_wallclock_ms_trace_linked / self.total_active_duration_ms
         return None
 
 
@@ -158,6 +220,17 @@ def compute_agent_metrics(
             metrics.total_tool_uses += inv.tool_uses
         if inv.duration_ms is not None:
             metrics.total_duration_ms += inv.duration_ms
+        # Active duration exists only for trace-linked invocations. Sum
+        # active and its coverage-matched wall-clock over the same subset
+        # (#480) so a downstream wall/active ratio reflects idle
+        # subtraction, not which invocations happened to have a trace.
+        # ``duration_ms`` is guaranteed present here: a linked trace
+        # implies parent toolUseResult metadata, but guard anyway so a
+        # degenerate trace can't desync the two sums from their count.
+        if inv.active_duration_ms is not None and inv.duration_ms is not None:
+            metrics.total_active_duration_ms += inv.active_duration_ms
+            metrics.total_wallclock_ms_trace_linked += inv.duration_ms
+            metrics.active_duration_invocation_count += 1
         # ``is not None`` (not truthiness): a 0-turn trace still has turn
         # data, so it counts toward invocations_with_turns and yields a
         # legitimate 0.0 average, distinct from a trace-missing gap.

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -345,6 +345,9 @@ def _merge_agent_metrics(
                     estimated_total_cost_usd=m.estimated_total_cost_usd,
                     total_model_turns=m.total_model_turns,
                     invocations_with_turns=m.invocations_with_turns,
+                    total_active_duration_ms=m.total_active_duration_ms,
+                    total_wallclock_ms_trace_linked=m.total_wallclock_ms_trace_linked,
+                    active_duration_invocation_count=m.active_duration_invocation_count,
                 )
             else:
                 existing.invocation_count += m.invocation_count
@@ -354,6 +357,11 @@ def _merge_agent_metrics(
                 existing.estimated_total_cost_usd += m.estimated_total_cost_usd
                 existing.total_model_turns += m.total_model_turns
                 existing.invocations_with_turns += m.invocations_with_turns
+                existing.total_active_duration_ms += m.total_active_duration_ms
+                existing.total_wallclock_ms_trace_linked += m.total_wallclock_ms_trace_linked
+                existing.active_duration_invocation_count += (
+                    m.active_duration_invocation_count
+                )
 
     # estimated_total_cost_usd is summed at each session's blended rate
     # so the per-invocation average property reads correctly. Tool-use

--- a/src/agentfluent/cli/commands/report_renderers.py
+++ b/src/agentfluent/cli/commands/report_renderers.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from agentfluent.cli.formatters.helpers import (
     GLOBAL_AGENT_LABEL,
+    format_agent_duration_cell,
     format_cost,
     format_tokens,
 )
@@ -57,12 +58,6 @@ def _avg_tokens_per_invocation(row: dict[str, Any]) -> float | None:
     if count > 0 and tokens > 0:
         return float(tokens) / float(count)
     return None
-
-
-def _fmt_duration_seconds(duration_ms: int) -> str:
-    if duration_ms <= 0:
-        return "—"
-    return f"{duration_ms / 1000:.1f}s"
 
 
 def _md_table(
@@ -184,30 +179,56 @@ def render_agent_metrics(data: dict[str, Any]) -> str:
     if total_invocations == 0 or not by_type:
         return "## Agent Metrics\n\nNo agent invocations.\n"
 
-    headers = ["Agent Type", "Count", "Tokens", "Avg Tokens/Call", "Duration"]
+    headers = ["Agent Type", "Count", "Tokens", "Avg Tokens/Call", "Avg Duration/Call"]
     align = ["l", "r", "r", "r", "r"]
     rows: list[list[str]] = []
+    any_unreliable = False
+    any_partial = False
     for _key, m in sorted(by_type.items()):
         agent_type = m.get("agent_type", "")
         if m.get("is_builtin"):
             agent_type = f"{agent_type} (builtin)"
         avg = _avg_tokens_per_invocation(m)
         avg_label = format_tokens(int(avg)) if avg is not None else "—"
+        cell = format_agent_duration_cell(
+            total_duration_ms=m.get("total_duration_ms", 0),
+            invocation_count=m.get("invocation_count", 0),
+            total_active_duration_ms=m.get("total_active_duration_ms", 0),
+            total_wallclock_ms_trace_linked=m.get("total_wallclock_ms_trace_linked", 0),
+            active_duration_invocation_count=m.get("active_duration_invocation_count", 0),
+        )
+        any_unreliable = any_unreliable or cell.unreliable
+        any_partial = any_partial or cell.partial
+        # No Rich color in Markdown; bold the interactive-pattern cell so
+        # the wall/active divergence is still visible in a PR comment.
+        dur = f"**{cell.text}**" if cell.highlight else cell.text
         rows.append([
             agent_type,
             str(m.get("invocation_count", 0)),
             format_tokens(m.get("total_tokens", 0)),
             avg_label,
-            _fmt_duration_seconds(m.get("total_duration_ms", 0)),
+            dur,
         ])
 
     rows.append(["**Total**", f"**{total_invocations}**", "", "", ""])
 
     agent_pct = am.get("agent_token_percentage", 0.0)
     table = _md_table(headers, rows, align)
+    footnotes = ""
+    if any_partial:
+        footnotes += (
+            "\n† Active duration covers only the trace-linked invocations; "
+            "the average and active/wall split use that subset.\n"
+        )
+    if any_unreliable:
+        footnotes += (
+            "\n\\* Duration estimated from wall-clock; no subagent trace "
+            "available (may include user-wait time).\n"
+        )
     return (
         "## Agent Metrics\n\n"
         + table
+        + footnotes
         + f"\nAgent token share of session total: **{agent_pct}%**\n"
     )
 

--- a/src/agentfluent/cli/formatters/helpers.py
+++ b/src/agentfluent/cli/formatters/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from rich.console import Console
 from rich.markup import escape
@@ -130,3 +130,89 @@ def average_score(scores: list[ConfigScore]) -> int:
 def truncate(text: str, max_len: int) -> str:
     """Truncate with a trailing ellipsis when the text exceeds max_len."""
     return text if len(text) <= max_len else text[: max_len - 1] + "…"
+
+
+# Wall/active ratio at or above which an agent type's duration cell is
+# flagged as interactive-pattern (#480). The ``pm`` dogfood case sat
+# around 6x (2,918s wall vs ~470s active per call); 3x cleanly separates
+# genuinely interactive agents from the ms-level jitter between the
+# parent-side wall clock and trace-derived active duration.
+DURATION_RATIO_HIGHLIGHT = 3.0
+
+# Minimum wall-over-active gap before the cell shows the combined
+# "active (wall)" form rather than a bare active figure. Below this the
+# two are effectively equal (the ~ms disagreement noted in table.py's
+# verbose path) and a second number would be noise.
+_DURATION_DIVERGENCE = 1.05
+
+
+class DurationCell(NamedTuple):
+    """Rendered agent-type duration cell plus the flags a caller needs to
+    style it and decide which footnotes to print (#480).
+
+    ``text`` is plain (no Rich markup) so both the analyze table and the
+    Markdown report share it. ``highlight`` is set when the wall/active
+    ratio crosses :data:`DURATION_RATIO_HIGHLIGHT`. ``unreliable`` marks
+    the wall-only fallback (no invocation of this type had a linked
+    trace). ``partial`` marks partial trace coverage (the active/wall
+    averages reflect only the trace-linked subset)."""
+
+    text: str
+    highlight: bool
+    unreliable: bool
+    partial: bool
+
+
+def format_agent_duration_cell(
+    *,
+    total_duration_ms: int,
+    invocation_count: int,
+    total_active_duration_ms: int,
+    total_wallclock_ms_trace_linked: int,
+    active_duration_invocation_count: int,
+) -> DurationCell:
+    """Format an agent type's summary-table duration as active (wall) per call.
+
+    Renders the idle-subtracted active duration next to raw wall-clock so
+    an interactive agent (whose wall-clock includes user-wait time) does
+    not read as a duration problem -- the misread #480 exists to fix.
+
+    Both per-call averages are taken over the *same* trace-linked subset
+    (denominator ``active_duration_invocation_count``) so the wall/active
+    ratio measures only idle subtraction, not trace-coverage skew. When no
+    invocation of this type had a trace, falls back to a bare wall-only
+    average over all invocations, marked unreliable.
+    """
+    if total_duration_ms <= 0 or invocation_count <= 0:
+        return DurationCell("-", highlight=False, unreliable=False, partial=False)
+
+    if active_duration_invocation_count <= 0:
+        # No trace anywhere in this agent type: only parent-side
+        # wall-clock is available, and it silently includes user-wait.
+        avg_wall = total_duration_ms / invocation_count
+        return DurationCell(
+            f"~{avg_wall / 1000:.1f}s*",
+            highlight=False,
+            unreliable=True,
+            partial=False,
+        )
+
+    active_avg = total_active_duration_ms / active_duration_invocation_count
+    wall_avg = total_wallclock_ms_trace_linked / active_duration_invocation_count
+    partial = active_duration_invocation_count < invocation_count
+
+    if active_avg > 0 and wall_avg > active_avg * _DURATION_DIVERGENCE:
+        text = f"{active_avg / 1000:.1f}s ({wall_avg / 1000:.1f}s wall)"
+        ratio = wall_avg / active_avg
+    else:
+        text = f"{active_avg / 1000:.1f}s"
+        ratio = 1.0
+    if partial:
+        text += "†"
+
+    return DurationCell(
+        text,
+        highlight=ratio >= DURATION_RATIO_HIGHLIGHT,
+        unreliable=False,
+        partial=partial,
+    )

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -20,6 +20,7 @@ from agentfluent.cli.formatters.helpers import (
     SEVERITY_COLORS,
     average_score,
     axis_label,
+    format_agent_duration_cell,
     format_cost,
     format_date,
     format_size,
@@ -201,7 +202,9 @@ def format_analysis_table(
         agent_table.add_column("Avg Turns", justify="right")
         agent_table.add_column("Tokens", justify="right")
         agent_table.add_column("Avg Tokens/Call", justify="right")
-        agent_table.add_column("Duration", justify="right")
+        agent_table.add_column("Avg Duration/Call", justify="right")
+        any_dur_unreliable = False
+        any_dur_partial = False
         for _key, m in sorted(am.by_agent_type.items()):
             label = f"{m.agent_type} {'(builtin)' if m.is_builtin else ''}"
             avg_turns = (
@@ -214,7 +217,16 @@ def format_analysis_table(
                 if m.avg_tokens_per_invocation
                 else "-"
             )
-            duration = f"{m.total_duration_ms / 1000:.1f}s" if m.total_duration_ms else "-"
+            cell = format_agent_duration_cell(
+                total_duration_ms=m.total_duration_ms,
+                invocation_count=m.invocation_count,
+                total_active_duration_ms=m.total_active_duration_ms,
+                total_wallclock_ms_trace_linked=m.total_wallclock_ms_trace_linked,
+                active_duration_invocation_count=m.active_duration_invocation_count,
+            )
+            any_dur_unreliable = any_dur_unreliable or cell.unreliable
+            any_dur_partial = any_dur_partial or cell.partial
+            duration = f"[yellow]{cell.text}[/yellow]" if cell.highlight else cell.text
             agent_table.add_row(
                 label.strip(),
                 str(m.invocation_count),
@@ -234,6 +246,22 @@ def format_analysis_table(
             "",
         )
         console.print(agent_table)
+        # Duration column shows active (idle-subtracted) wall-clock per
+        # call; the parenthetical raw wall-clock and yellow highlight mark
+        # interactive agents whose wall-clock would otherwise mislead
+        # (#480). Footnotes mirror the verbose Per-Invocation table.
+        if any_dur_partial:
+            console.print(
+                "† Active duration covers only the trace-linked invocations; "
+                "the average and active/wall split use that subset.",
+                style="dim",
+            )
+        if any_dur_unreliable:
+            console.print(
+                "* Duration estimated from wall-clock; no subagent trace available "
+                "(may include user-wait time).",
+                style="dim",
+            )
 
     if verbose and len(result.sessions) > 1:
         session_table = Table(title="Per-Session Breakdown", show_header=True)

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1360,6 +1360,44 @@
       Model turns    20
   related: [output, total_cost]
 
+- name: active_duration
+  category: session_metric
+  short: |
+    Wall-clock duration with detected idle (user-wait) gaps subtracted --
+    an estimate of time the agent was actually working.
+  long: |
+    Added in v0.9 (#480; the underlying subtraction shipped in #230).
+    Two duration measures exist for an agent invocation:
+
+    - **wall-clock** (`duration_ms`) -- raw elapsed time from the parent's
+      `toolUseResult` metadata. It silently includes any stretch where a
+      tool call sat pending user approval while the user was away (the IDE
+      prompting to allow a `Write`, an MCP call, etc.).
+    - **active** (`active_duration_ms`) -- wall-clock minus detected idle
+      gaps. AgentFluent flags a gap when it exceeds
+      `max(10 × median, 5 minutes)` within a subagent trace and subtracts
+      it. Available only when a subagent trace is linked (~80% of the
+      dogfood corpus); without one, only wall-clock exists.
+
+    Why the distinction matters: for an interactive agent like `pm`, the
+    wall-clock average can be tens of minutes per call while the active
+    time is seconds -- almost all of the gap is the user thinking, not the
+    agent working. The `analyze` summary table renders
+    `active (wall)` per call over the trace-linked subset and highlights
+    rows whose wall/active ratio exceeds 3×, so a high wall-clock number
+    no longer reads as a duration problem.
+
+    Note the denominator: the summary table reports duration **per call**,
+    whereas `duration_outlier` detection operates on
+    `active_duration_per_tool_use` -- active time **per tool call** -- a
+    finer-grained basis that isolates slow individual tool calls. The two
+    are not interchangeable; a high per-call active duration with a normal
+    per-tool_use figure just means the invocation made many tool calls.
+  example: |
+    Agent Invocations
+      pm   ...   470.0s (2918.0s wall)†   <- active 470s/call, wall 2918s/call
+  related: [model_turns, duration_outlier]
+
 # =============================================================================
 # Comparison row status (agentfluent diff)
 # =============================================================================

--- a/tests/fixtures/report/analyze_snapshot.json
+++ b/tests/fixtures/report/analyze_snapshot.json
@@ -66,7 +66,10 @@
           "invocation_count": 6,
           "total_tokens": 78000,
           "total_tool_uses": 42,
-          "total_duration_ms": 510000
+          "total_duration_ms": 510000,
+          "total_active_duration_ms": 90000,
+          "total_wallclock_ms_trace_linked": 510000,
+          "active_duration_invocation_count": 6
         },
         "tester": {
           "agent_type": "tester",
@@ -74,7 +77,10 @@
           "invocation_count": 3,
           "total_tokens": 24000,
           "total_tool_uses": 18,
-          "total_duration_ms": 145000
+          "total_duration_ms": 145000,
+          "total_active_duration_ms": 140000,
+          "total_wallclock_ms_trace_linked": 145000,
+          "active_duration_invocation_count": 3
         }
       }
     },

--- a/tests/fixtures/report/expected_report.md
+++ b/tests/fixtures/report/expected_report.md
@@ -20,12 +20,14 @@
 
 ## Agent Metrics
 
-| Agent Type | Count | Tokens | Avg Tokens/Call | Duration |
+| Agent Type | Count | Tokens | Avg Tokens/Call | Avg Duration/Call |
 | :--- | ---: | ---: | ---: | ---: |
-| Explore (builtin) | 8 | 42,000 | 5,250 | 320.0s |
-| pm | 6 | 78,000 | 13,000 | 510.0s |
-| tester | 3 | 24,000 | 8,000 | 145.0s |
+| Explore (builtin) | 8 | 42,000 | 5,250 | ~40.0s* |
+| pm | 6 | 78,000 | 13,000 | **15.0s (85.0s wall)** |
+| tester | 3 | 24,000 | 8,000 | 46.7s |
 | **Total** | **17** |  |  |  |
+
+\* Duration estimated from wall-clock; no subagent trace available (may include user-wait time).
 
 Agent token share of session total: **38.5%**
 

--- a/tests/unit/cli/test_active_duration_display.py
+++ b/tests/unit/cli/test_active_duration_display.py
@@ -139,3 +139,69 @@ def test_missing_duration_renders_dash() -> None:
     # Look for "interrupted" row's Duration column showing "-"
     rows = [line for line in output.splitlines() if "interrupted" in line]
     assert any(" - " in row or row.rstrip().endswith("-") for row in rows)
+
+
+# ---- Non-verbose summary (Agent Invocations) table, #480 ------------------
+
+
+def _summary_render(invocations: list[AgentInvocation]) -> str:
+    """Render the non-verbose summary table from real invocations so the
+    active-duration aggregates are computed end-to-end."""
+    from agentfluent.analytics.agent_metrics import compute_agent_metrics
+
+    am = compute_agent_metrics(invocations)
+    session = SessionAnalysis(
+        session_path=Path("session-1.jsonl"),
+        token_metrics=TokenMetrics(),
+        tool_metrics=ToolMetrics(),
+        agent_metrics=am,
+        invocations=invocations,
+    )
+    result = AnalysisResult(sessions=[session], agent_metrics=am)
+    console = Console(record=True, width=200, force_terminal=False)
+    format_analysis_table(console, result, verbose=False)
+    return console.export_text()
+
+
+def test_summary_table_shows_active_wall_and_header() -> None:
+    inv = _invocation(
+        "pm",
+        description="interactive",
+        parent_duration_ms=1_834_000,
+        trace=_trace(duration_ms=1_834_000, idle_gap_ms=1_452_000),
+    )
+    output = _summary_render([inv])
+    assert "Avg Duration/Call" in output
+    # 382s active vs 1834s wall per call -> combined cell in the summary.
+    assert "382.0s (1834.0s wall)" in output
+
+
+def test_summary_table_traceless_shows_unreliable_footnote() -> None:
+    inv = _invocation(
+        "pm",
+        description="no-trace",
+        parent_duration_ms=120_000,
+        trace=None,
+    )
+    output = _summary_render([inv])
+    # Wall-only avg per call, marked unreliable.
+    assert "~120.0s*" in output
+    assert "no subagent trace available" in output
+
+
+def test_summary_table_partial_coverage_footnote() -> None:
+    linked = _invocation(
+        "pm",
+        description="linked",
+        parent_duration_ms=1_834_000,
+        trace=_trace(duration_ms=1_834_000, idle_gap_ms=1_452_000),
+    )
+    bare = _invocation(
+        "pm",
+        description="bare",
+        parent_duration_ms=120_000,
+        trace=None,
+    )
+    output = _summary_render([linked, bare])
+    assert "†" in output
+    assert "the average and active/wall split use that subset" in output

--- a/tests/unit/cli/test_agent_duration_cell.py
+++ b/tests/unit/cli/test_agent_duration_cell.py
@@ -1,0 +1,128 @@
+"""Tests for the shared agent-duration cell formatter (#480).
+
+``format_agent_duration_cell`` renders an agent type's summary-table
+duration as active (idle-subtracted) wall-clock per call, so an
+interactive agent like ``pm`` -- whose raw wall-clock includes user-wait
+time -- does not read as a duration problem. Both the analyze table and
+the Markdown report share it.
+"""
+
+from agentfluent.cli.formatters.helpers import (
+    DURATION_RATIO_HIGHLIGHT,
+    format_agent_duration_cell,
+)
+
+
+def _cell(**kwargs: int):
+    base = {
+        "total_duration_ms": 0,
+        "invocation_count": 0,
+        "total_active_duration_ms": 0,
+        "total_wallclock_ms_trace_linked": 0,
+        "active_duration_invocation_count": 0,
+    }
+    base.update(kwargs)
+    return format_agent_duration_cell(**base)
+
+
+class TestNoData:
+    def test_zero_duration_renders_dash(self) -> None:
+        cell = _cell(total_duration_ms=0, invocation_count=4)
+        assert cell.text == "-"
+        assert not cell.highlight
+        assert not cell.unreliable
+        assert not cell.partial
+
+    def test_zero_invocations_renders_dash(self) -> None:
+        cell = _cell(total_duration_ms=1000, invocation_count=0)
+        assert cell.text == "-"
+
+
+class TestWallOnlyFallback:
+    def test_no_trace_falls_back_to_wall_per_call_marked_unreliable(self) -> None:
+        # 60s wall over 4 invocations, no trace anywhere -> ~15.0s* avg.
+        cell = _cell(total_duration_ms=60000, invocation_count=4)
+        assert cell.text == "~15.0s*"
+        assert cell.unreliable
+        assert not cell.highlight
+        assert not cell.partial
+
+
+class TestCombinedCell:
+    def test_divergent_renders_active_then_wall(self) -> None:
+        # 2.0s active / 15.0s wall per call over 4 trace-linked calls.
+        cell = _cell(
+            total_duration_ms=60000,
+            invocation_count=4,
+            total_active_duration_ms=8000,
+            total_wallclock_ms_trace_linked=60000,
+            active_duration_invocation_count=4,
+        )
+        assert cell.text == "2.0s (15.0s wall)"
+        assert cell.highlight  # 7.5x >= 3x
+        assert not cell.unreliable
+        assert not cell.partial
+
+    def test_near_equal_renders_bare_active_no_highlight(self) -> None:
+        # Active ~= wall (no meaningful idle) -> single figure, no flag.
+        cell = _cell(
+            total_duration_ms=40000,
+            invocation_count=4,
+            total_active_duration_ms=40000,
+            total_wallclock_ms_trace_linked=40000,
+            active_duration_invocation_count=4,
+        )
+        assert cell.text == "10.0s"
+        assert not cell.highlight
+
+    def test_ratio_just_below_threshold_not_highlighted(self) -> None:
+        # 2.5x divergence -> combined cell, but below the 3x highlight.
+        cell = _cell(
+            total_duration_ms=25000,
+            invocation_count=2,
+            total_active_duration_ms=10000,
+            total_wallclock_ms_trace_linked=25000,
+            active_duration_invocation_count=2,
+        )
+        assert cell.text == "5.0s (12.5s wall)"
+        assert not cell.highlight
+
+    def test_ratio_at_threshold_is_highlighted(self) -> None:
+        # Exactly 3x -> highlighted (boundary is inclusive).
+        cell = _cell(
+            total_duration_ms=30000,
+            invocation_count=2,
+            total_active_duration_ms=10000,
+            total_wallclock_ms_trace_linked=30000,
+            active_duration_invocation_count=2,
+        )
+        ratio = 30000 / 10000
+        assert ratio == DURATION_RATIO_HIGHLIGHT
+        assert cell.highlight
+
+
+class TestPartialCoverage:
+    def test_partial_coverage_appends_dagger_and_flag(self) -> None:
+        # 4 invocations, only 3 trace-linked.
+        cell = _cell(
+            total_duration_ms=80000,
+            invocation_count=4,
+            total_active_duration_ms=6000,
+            total_wallclock_ms_trace_linked=45000,
+            active_duration_invocation_count=3,
+        )
+        assert cell.partial
+        assert cell.text.endswith("†")
+        # 2.0s active / 15.0s wall over the 3 linked calls.
+        assert "2.0s (15.0s wall)†" == cell.text
+
+    def test_full_coverage_no_dagger(self) -> None:
+        cell = _cell(
+            total_duration_ms=60000,
+            invocation_count=4,
+            total_active_duration_ms=8000,
+            total_wallclock_ms_trace_linked=60000,
+            active_duration_invocation_count=4,
+        )
+        assert not cell.partial
+        assert "†" not in cell.text

--- a/tests/unit/cli/test_report_golden.py
+++ b/tests/unit/cli/test_report_golden.py
@@ -104,6 +104,7 @@ def _analyze_envelope_data() -> dict[str, Any]:
             "total_invocations": 17,
             "agent_token_percentage": 38.5,
             "by_agent_type": {
+                # Explore: no trace -> wall-only fallback (unreliable, #480).
                 "Explore": {
                     "agent_type": "Explore",
                     "is_builtin": True,
@@ -112,6 +113,8 @@ def _analyze_envelope_data() -> dict[str, Any]:
                     "total_tool_uses": 56,
                     "total_duration_ms": 320_000,
                 },
+                # pm: interactive pattern -- 15s active / 85s wall per call
+                # (5.7x) -> highlighted combined cell (#480).
                 "pm": {
                     "agent_type": "pm",
                     "is_builtin": False,
@@ -119,7 +122,11 @@ def _analyze_envelope_data() -> dict[str, Any]:
                     "total_tokens": 78_000,
                     "total_tool_uses": 42,
                     "total_duration_ms": 510_000,
+                    "total_active_duration_ms": 90_000,
+                    "total_wallclock_ms_trace_linked": 510_000,
+                    "active_duration_invocation_count": 6,
                 },
+                # tester: trace-linked, negligible idle -> bare active.
                 "tester": {
                     "agent_type": "tester",
                     "is_builtin": False,
@@ -127,6 +134,9 @@ def _analyze_envelope_data() -> dict[str, Any]:
                     "total_tokens": 24_000,
                     "total_tool_uses": 18,
                     "total_duration_ms": 145_000,
+                    "total_active_duration_ms": 140_000,
+                    "total_wallclock_ms_trace_linked": 145_000,
+                    "active_duration_invocation_count": 3,
                 },
             },
         },

--- a/tests/unit/cli/test_report_renderers.py
+++ b/tests/unit/cli/test_report_renderers.py
@@ -63,6 +63,12 @@ def _data(**overrides: Any) -> dict[str, Any]:
                     "total_tokens": 12000,
                     "total_tool_uses": 20,
                     "total_duration_ms": 60_000,
+                    # All 4 trace-linked, heavily idle-inflated: 2.0s
+                    # active / 15.0s wall per call (7.5x) -> highlighted
+                    # interactive-pattern row.
+                    "total_active_duration_ms": 8_000,
+                    "total_wallclock_ms_trace_linked": 60_000,
+                    "active_duration_invocation_count": 4,
                 },
                 "explore": {
                     "agent_type": "Explore",
@@ -71,6 +77,7 @@ def _data(**overrides: Any) -> dict[str, Any]:
                     "total_tokens": 5000,
                     "total_tool_uses": 8,
                     "total_duration_ms": 15_000,
+                    # No active fields -> wall-only fallback (unreliable).
                 },
             },
             "total_invocations": 6,
@@ -168,9 +175,28 @@ class TestRenderAgentMetrics:
         assert "pm" in out
         assert "Explore (builtin)" in out
         assert "12,000" in out
-        assert "60.0s" in out
+        # Per-call active (wall) duration, bolded because the wall/active
+        # ratio (7.5x) crosses the interactive-pattern highlight (#480).
+        assert "**2.0s (15.0s wall)**" in out
+        # Explore had no trace -> wall-only fallback + unreliable footnote.
+        assert "~7.5s*" in out
+        assert "no subagent trace available" in out
         # Footer line with agent token share.
         assert "42.5%" in out
+
+    def test_partial_coverage_marks_cell_and_footnote(self) -> None:
+        d = _data()
+        # 4 invocations, only 3 trace-linked -> partial coverage dagger.
+        d["agent_metrics"]["by_agent_type"]["pm"][
+            "active_duration_invocation_count"
+        ] = 3
+        d["agent_metrics"]["by_agent_type"]["pm"]["total_active_duration_ms"] = 6_000
+        d["agent_metrics"]["by_agent_type"]["pm"][
+            "total_wallclock_ms_trace_linked"
+        ] = 45_000
+        out = render_agent_metrics(d)
+        assert "†" in out
+        assert "trace-linked invocations" in out
 
     def test_zero_invocations_emits_fallback(self) -> None:
         out = render_agent_metrics(

--- a/tests/unit/test_agent_metrics.py
+++ b/tests/unit/test_agent_metrics.py
@@ -135,6 +135,91 @@ class TestAverages:
         assert pm.avg_tokens_per_tool_use is None
 
 
+def _trace_linked_invocation(
+    agent_type: str = "pm",
+    duration_ms: int = 60000,
+    idle_gap_ms: int = 56000,
+    tool_uses: int = 5,
+) -> AgentInvocation:
+    """Invocation whose linked trace yields an active duration
+    (``duration_ms - idle_gap_ms``). ``inv.active_duration_ms`` reads
+    the trace; ``inv.duration_ms`` is the parent-side wall-clock summed
+    into ``total_wallclock_ms_trace_linked``."""
+    inv = AgentInvocation(
+        agent_type=agent_type,
+        description="test",
+        prompt="do something",
+        tool_use_id="toolu_active",
+        tool_uses=tool_uses,
+        duration_ms=duration_ms,
+    )
+    inv.trace = SubagentTrace(
+        agent_id="a",
+        delegation_prompt="x",
+        duration_ms=duration_ms,
+        idle_gap_ms=idle_gap_ms,
+    )
+    return inv
+
+
+class TestActiveDuration:
+    """#480: active-duration aggregates on AgentTypeMetrics."""
+
+    def test_trace_linked_invocations_accumulate_active_totals(self) -> None:
+        # Two trace-linked pm invocations: 4s active / 60s wall each.
+        invocations = [
+            _trace_linked_invocation(duration_ms=60000, idle_gap_ms=56000),
+            _trace_linked_invocation(duration_ms=60000, idle_gap_ms=56000),
+        ]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.total_active_duration_ms == 8000
+        assert pm.total_wallclock_ms_trace_linked == 120000
+        assert pm.active_duration_invocation_count == 2
+
+    def test_traceless_invocations_excluded_from_active_totals(self) -> None:
+        # One trace-linked, one trace-less: only the linked one counts
+        # toward active aggregates, but both count toward total_duration.
+        invocations = [
+            _trace_linked_invocation(duration_ms=60000, idle_gap_ms=56000),
+            _invocation(duration_ms=30000),  # no trace
+        ]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.active_duration_invocation_count == 1
+        assert pm.total_active_duration_ms == 4000
+        assert pm.total_wallclock_ms_trace_linked == 60000
+        # total_duration_ms spans all invocations (the misleading number).
+        assert pm.total_duration_ms == 90000
+
+    def test_active_per_invocation_properties(self) -> None:
+        invocations = [
+            _trace_linked_invocation(duration_ms=60000, idle_gap_ms=56000),
+            _trace_linked_invocation(duration_ms=60000, idle_gap_ms=56000),
+        ]
+        pm = compute_agent_metrics(invocations).by_agent_type["pm"]
+        assert pm.avg_active_duration_per_invocation == 4000.0
+        assert pm.avg_wallclock_per_trace_linked_invocation == 60000.0
+        assert pm.wallclock_active_ratio == 15.0
+
+    def test_ratio_none_without_active_data(self) -> None:
+        pm = compute_agent_metrics([_invocation(duration_ms=30000)]).by_agent_type["pm"]
+        assert pm.active_duration_invocation_count == 0
+        assert pm.avg_active_duration_per_invocation is None
+        assert pm.wallclock_active_ratio is None
+
+    def test_active_fields_serialize_into_json(self) -> None:
+        # Stored fields (not properties) so they survive model_dump into
+        # the JSON envelope (AC#2).
+        import dataclasses
+
+        pm = compute_agent_metrics(
+            [_trace_linked_invocation()],
+        ).by_agent_type["pm"]
+        dumped = dataclasses.asdict(pm)
+        assert dumped["total_active_duration_ms"] == 4000
+        assert dumped["total_wallclock_ms_trace_linked"] == 60000
+        assert dumped["active_duration_invocation_count"] == 1
+
+
 class TestAgentTokenPercentage:
     def test_percentage_of_session(self) -> None:
         invocations = [_invocation(total_tokens=30000)]

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -179,3 +179,38 @@ class TestMergeAgentMetricsTurns:
         pm = _merge_agent_metrics([self._metrics(6, 2, 12)]).by_agent_type["pm"]
         assert pm.total_model_turns == 6
         assert pm.invocations_with_turns == 2
+
+
+class TestMergeAgentMetricsActiveDuration:
+    """#480: _merge_agent_metrics carries active-duration aggregates
+    across sessions through both the first-seen and accumulate branches."""
+
+    @staticmethod
+    def _metrics(active_ms: int, wall_linked_ms: int, linked: int) -> AgentMetrics:
+        t = AgentTypeMetrics(
+            agent_type="pm",
+            is_builtin=False,
+            invocation_count=linked,
+            total_active_duration_ms=active_ms,
+            total_wallclock_ms_trace_linked=wall_linked_ms,
+            active_duration_invocation_count=linked,
+        )
+        return AgentMetrics(by_agent_type={"pm": t}, total_invocations=linked)
+
+    def test_active_fields_summed_across_sessions(self) -> None:
+        merged = _merge_agent_metrics(
+            [self._metrics(4000, 60000, 1), self._metrics(8000, 120000, 2)],
+        ).by_agent_type["pm"]
+        assert merged.total_active_duration_ms == 12000
+        assert merged.total_wallclock_ms_trace_linked == 180000
+        assert merged.active_duration_invocation_count == 3
+        # Ratio computed from merged totals.
+        assert merged.wallclock_active_ratio == 15.0
+
+    def test_first_seen_branch_preserves_active_fields(self) -> None:
+        pm = _merge_agent_metrics(
+            [self._metrics(4000, 60000, 1)],
+        ).by_agent_type["pm"]
+        assert pm.total_active_duration_ms == 4000
+        assert pm.total_wallclock_ms_trace_linked == 60000
+        assert pm.active_duration_invocation_count == 1


### PR DESCRIPTION
## Summary
- Replaces the per-agent summary table's single raw-wall-clock "Duration" column with an honest **per-call `active (wall)`** rendering, so interactive agents (notably `pm`) no longer read as a duration problem when the gap is just user-input wait time.
- Adds three additive aggregate fields to `AgentTypeMetrics` (`total_active_duration_ms`, `total_wallclock_ms_trace_linked`, `active_duration_invocation_count`); wall and active averages share the trace-linked denominator so the wall/active ratio measures only idle-gap subtraction, not trace-coverage skew. Serialized into the JSON envelope (additive — no schema break).
- Shared `format_agent_duration_cell` helper used by both the analyze table and the `report` Markdown renderer (prevents drift); highlights rows with wall/active ≥ 3× (yellow in the table, **bold** in Markdown), daggers partial coverage, and marks a wall-only fallback when no subagent trace is linked.
- New `active_duration` glossary term explaining wall-vs-active and the per-call vs per-tool_use denominator distinction; `docs/GLOSSARY.md` regenerated.

Architect-reviewed before implementation ([#480 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/480#issuecomment-4620200305)): per-call basis, shared denominator for honesty, combined-cell over a 7th column.

Closes #480.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1681 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (helper branch matrix in `test_agent_duration_cell.py`; metrics accumulation + properties in `test_agent_metrics.py`; cross-session merge in `test_pipeline.py`; summary-table + report rendering + golden snapshot)
- [x] Manual smoke test: `agentfluent analyze --project agentfluent` renders `pm` as `295.8s (3533.4s wall)†`; `report` and `diff` confirmed on the new envelope; `explain active_duration` renders.

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface. The new duration cell is pure numeric formatting; agent-type labels were already `escape()`d. No new user-controlled-string rendering, parsing, path, network, or subprocess surface.
- [ ] **Needs review**

## Breaking changes
None to the JSON envelope (fields are additive; `diff` reads named keys and ignores new ones). User-visible presentation changes, by design:
- The table/report duration column is relabeled **Duration → Avg Duration/Call** and now reports a per-call average (active, idle-subtracted) rather than a raw wall-clock total — this is the misread #480 exists to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)