### PR TITLE
fix: exclude <synthetic> ghost responses from model_turns, tally separately (#507)

### DIFF
--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -937,3 +937,27 @@ primary_axis = max(AXIS_TIEBREAKER, key=lambda a: axis_scores[a])
 **Reference:** `.claude/specs/analysis/407-calibration/calibration.md`; #407 (calibration) and its disposition comment; #499 (Tier B); #406 (signal); epic #403; PRD `prd-advanced-tool-use-diagnostics.md` §9 / §11.
 
 ---
+
+## D044: model_turns excludes <synthetic> ghost responses; tally them separately (Option A)
+
+**Date:** 2026-06-05
+**Context:** The v0.9 `model_turns` metric (#465, #466) was implemented as a raw count of `type:"assistant"` messages. Dogfooding the #483 docs PR surfaced that this includes Claude Code's `<synthetic>`-model assistant messages -- locally fabricated filler (observed payload: `"No response requested."`, `stop_reason: stop_sequence`, zero usage) emitted to keep user/assistant alternation valid when a user-role turn needs no model reply (local slash-commands, `!`-bash output, hook injection, resume preambles). On the agentfluent dogfood corpus this made `model_turns` (e.g. 7412) exceed `api_call_count` (7387) by exactly the synthetic count (25), even though `api_call_count` already excludes synthetic (`tokens.py`: requires `usage is not None` AND `model not in SYNTHETIC_MODELS`). The model did not take a turn for a synthetic message, so counting it as one is wrong. Filed as #507 (release blocker for v0.9.0, which is unreleased).
+
+**Decision:** Exclude `<synthetic>`-model assistant messages from `model_turns` and tally them separately. Specifically (**Option A**):
+- `model_turns = assistant_message_count - synthetic_message_count` -- every assistant message the model actually produced, with `<synthetic>` ghosts netted out. Applied at both count sites: parent session (`pipeline.py`) and subagent trace (`traces/parser.py`).
+- Keep `assistant_message_count` at its original all-inclusive meaning (it backs the integration invariant `message_count >= user + assistant` and is already in the JSON envelope).
+- Add `synthetic_message_count` (per session) and a computed `total_synthetic_messages` (aggregate, top-level), surfaced on a "Synthetic responses" row in the Token Usage table and in JSON.
+- Filter on the `SYNTHETIC_MODELS` sentinel, not on zero-token usage: a real turn always carries a real model name, so the sentinel is the robust discriminator.
+
+**Option A vs Option B:** Option B was to define `model_turns` as exactly `api_call_count` (usage-bearing non-synthetic messages), collapsing the two metrics. **Rejected.** Under Option A the two metrics are equal in the common case but diverge on the (so-far-unobserved) edge case of a real-model assistant message carrying no `usage` block -- which counts as a model turn (the model responded) but not as an API call (no billing recorded). Keeping both metrics distinct surfaces that case if it ever occurs; collapsing them would hide it. Semantically, "model turn" = "the model produced a response," which is not the same predicate as "Claude Code recorded usage."
+
+**Rationale:**
+- **Correctness of the headline metric.** `model_turns` is v0.9's headline efficiency metric and the denominator of the per-agent ratios (`avg_tokens_per_turn`, `avg_tool_calls_per_turn`, `estimated_avg_cost_per_turn_usd`). Inflating it with zero-cost ghost turns biases every ratio down by the synthetic fraction.
+- **Pre-ship, so no migration cost.** v0.9 is unreleased (release PR #486 open); fixing now means no user ever sees the inflated definition. `diff` reads turn fields with tolerant `.get(..., 0)`, and no pre-fix v0.9 baseline exists in any user's hands.
+- **Blast radius is small.** The per-agent ratio chain is additive off `inv.model_turns -> trace.model_turns`, so the single `traces/parser.py` fix auto-corrects all rollups; `diff` needs no change.
+
+**Follow-ups:** #508 (research) investigates the full taxonomy of `<synthetic>` scenarios and whether any sub-category warrants its own metric. The architect review on #507 endorsed Option A and this data-model shape (keep `assistant_message_count` all-inclusive, derive `model_turns` by subtraction) over redefining the field or storing `model_turns` directly.
+
+**Reference:** #507 (fix), #508 (synthetic taxonomy research), #465/#466 (model-turn introduction), #467 (efficiency ratios); architect review comment on #507. Supersedes the "(one API round-trip)" phrasing in the #465/#466 docstrings and the original `model_turns` glossary entry.
+
+---

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1506,14 +1506,14 @@ cleanly and skips the warning.
 
 ### `model_turns`
 
-**Short:** The number of model turns in a session -- one merged assistant
-message (one API round-trip).
+**Short:** The number of model turns in a session -- one merged, non-synthetic
+assistant message (a real model response).
 
-**Detail:** Added in v0.9 (#465). A *model turn* is one merged assistant
-message: a single API round-trip the model took. The parser's
-fragment-merging step can combine several raw JSONL lines into one
-logical assistant message, so a turn is **not** "one JSONL line" --
-it is the merged message.
+**Detail:** Added in v0.9 (#465; synthetic exclusion #507). A *model turn* is
+one merged assistant message that the model actually produced. The
+parser's fragment-merging step can combine several raw JSONL lines
+into one logical assistant message, so a turn is **not** "one JSONL
+line" -- it is the merged message.
 
 Distinct from `tool_uses` and from tokens:
 
@@ -1528,20 +1528,38 @@ tools in 10 turns serializes it (wasteful). Reducing turns for a
 fixed task while holding quality steady drops both cost and latency
 more than any single other change.
 
+**Synthetic responses are excluded (#507, D044).** Claude Code emits
+`<synthetic>`-model assistant messages -- locally fabricated filler
+(e.g. "No response requested.") with zero usage and no API
+round-trip -- to keep user/assistant alternation valid when a turn
+needs no model reply. The model did not turn, so these are NOT
+counted; they are tallied separately as `synthetic_message_count`
+(per session) and `total_synthetic_messages` (aggregate), and shown
+on a "Synthetic responses" row in the Token Usage table.
+
+**Relationship to `api_call_count` ("API calls").** Both exclude
+synthetic messages, so they are equal in the common case. They
+diverge only on the (so far unobserved) edge case of a real-model
+assistant message carrying no `usage` block: it counts as a model
+turn but not as an API call, making `model_turns >= api_call_count`.
+Keeping both metrics surfaces exactly that case if it ever occurs.
+
 Surfaced in the Token Usage table ("Model turns" row), in the
 verbose Per-Session Breakdown table ("Turns" column), and in
-`analyze --json` as `model_turns` per session plus
-`total_model_turns` aggregated across sessions at the envelope top
-level. Backed by the session's `assistant_message_count` field,
-which stays in the JSON output for backward compatibility.
+`analyze --json` as `model_turns` per session plus a top-level
+`total_model_turns` aggregated across sessions. Computed as
+`assistant_message_count - synthetic_message_count`; the
+all-inclusive `assistant_message_count` stays in the JSON output for
+backward compatibility.
 
 **Example:**
 
 ```
 Token Usage
   ...
-  API calls      42
-  Model turns    20
+  API calls            350
+  Model turns          350   <- == API calls (both exclude synthetic)
+  Synthetic responses    2   <- ghost turns netted out, tallied here
 ```
 
 **Related:** [`output`](#output), [`total_cost`](#total_cost)

--- a/src/agentfluent/agents/models.py
+++ b/src/agentfluent/agents/models.py
@@ -159,7 +159,8 @@ class AgentInvocation(BaseModel):
     @property
     def model_turns(self) -> int | None:
         """Number of model turns in this invocation's subagent trace --
-        one merged assistant message (one API round-trip) (#466).
+        one merged, non-synthetic assistant message (#466; synthetic
+        exclusion #507).
 
         ``None`` when no trace is linked (~20% of invocations in the
         dogfood corpus, see #468): turns can't be counted without the

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -19,6 +19,7 @@ from agentfluent.analytics.agent_metrics import (
     _recompute_turn_ratios,
     compute_agent_metrics,
 )
+from agentfluent.analytics.pricing import SYNTHETIC_MODELS
 from agentfluent.analytics.tokens import (
     ModelTokenBreakdown,
     TokenMetrics,
@@ -81,24 +82,40 @@ class SessionAnalysis(BaseModel):
     message_count: int = 0
     user_message_count: int = 0
     assistant_message_count: int = 0
+    """All ``type:"assistant"`` messages in the session, INCLUDING
+    Claude Code's ``<synthetic>`` ghost responses. Kept at its original
+    all-inclusive meaning for backward compat (the integration invariant
+    ``message_count >= user + assistant`` depends on it); ``model_turns``
+    nets out the synthetic subset (#507)."""
+
+    synthetic_message_count: int = 0
+    """``<synthetic>``-model assistant messages -- Claude Code-fabricated
+    filler (e.g. "No response requested.") emitted with zero usage and
+    no API round-trip, to keep user/assistant alternation valid when a
+    turn needs no model reply. Tallied separately and excluded from
+    ``model_turns`` because the model did not actually turn (#507, D044).
+    What populates this bucket is under investigation in #508."""
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def model_turns(self) -> int:
-        """Number of model turns in this session.
+        """Number of model turns in this session (#465, corrected in #507).
 
-        A *model turn* is one merged assistant message -- one API
-        round-trip. Fragment-merging in the parser may combine several
-        raw JSONL lines into one logical assistant message, so this is
-        the merged-message count, not the raw-line count. Distinct from
+        A *model turn* is one merged, **non-synthetic** assistant
+        message. Fragment-merging in the parser may combine several raw
+        JSONL lines into one logical assistant message, so this is the
+        merged-message count, not the raw-line count. Distinct from
         ``tool_uses`` (actions within a turn) and tokens (cost per turn).
 
-        Aliases the backing ``assistant_message_count`` field: the
-        semantic name communicates intent to downstream consumers while
-        the existing field stays in the JSON output for backward compat
-        (#465). Emitted in ``model_dump`` output as a computed field.
+        Computed as ``assistant_message_count - synthetic_message_count``
+        (D044, Option A): every assistant message the model actually
+        produced, with Claude Code's ``<synthetic>`` ghost responses
+        netted out. This equals ``api_call_count`` except on the (so far
+        unobserved) edge case of a real-model response carrying no
+        ``usage`` block -- see the ``model_turns`` glossary entry.
+        Emitted in ``model_dump`` output as a computed field.
         """
-        return self.assistant_message_count
+        return self.assistant_message_count - self.synthetic_message_count
 
 
 class AnalysisResult(BaseModel):
@@ -154,6 +171,20 @@ class AnalysisResult(BaseModel):
         #470 (diff integration) reads it from the top level."""
         return sum(s.model_turns for s in self.sessions)
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total_synthetic_messages(self) -> int:
+        """Aggregate ``<synthetic>`` ghost-response count across all
+        analyzed sessions (#507, D044).
+
+        Mirrors ``total_model_turns``: summed from each session's
+        ``synthetic_message_count``, recomputed-not-stored so it survives
+        JSON rehydration, ``0`` for an empty result. Surfaced at the
+        envelope top level (and in the Token Usage table) so the gap
+        between ``api_call_count`` and ``model_turns`` is explained
+        rather than mysterious. Additive field; ``diff`` ignores it."""
+        return sum(s.synthetic_message_count for s in self.sessions)
+
 
 def analyze_session(
     path: Path,
@@ -204,6 +235,7 @@ def analyze_session(
         message_count=len(messages),
         user_message_count=_count_type(messages, "user"),
         assistant_message_count=_count_type(messages, "assistant"),
+        synthetic_message_count=_count_synthetic(messages),
     )
 
 
@@ -445,3 +477,19 @@ def _link_subagent_traces(
 def _count_type(messages: list[SessionMessage], msg_type: str) -> int:
     """Count messages of a given type."""
     return sum(1 for m in messages if m.type == msg_type)
+
+
+def _count_synthetic(messages: list[SessionMessage]) -> int:
+    """Count ``<synthetic>``-model assistant messages (#507).
+
+    These are Claude Code-fabricated ghost responses (zero usage, no API
+    round-trip) that are netted out of ``model_turns``. Filters on the
+    ``SYNTHETIC_MODELS`` sentinel rather than zero-token usage: a real
+    turn always carries a real model name, so the sentinel is the robust
+    discriminator. Mirrors the same exclusion ``api_call_count`` applies
+    in :mod:`agentfluent.analytics.tokens`."""
+    return sum(
+        1
+        for m in messages
+        if m.type == "assistant" and m.model in SYNTHETIC_MODELS
+    )

--- a/src/agentfluent/cli/formatters/table.py
+++ b/src/agentfluent/cli/formatters/table.py
@@ -159,6 +159,17 @@ def format_analysis_table(
     token_table.add_row("Cache efficiency", f"{tm.cache_efficiency}%")
     token_table.add_row("API calls", str(tm.api_call_count))
     token_table.add_row("Model turns", str(result.total_model_turns))
+    # Both API calls and Model turns exclude <synthetic> ghost responses
+    # (#507), so they match unless a real-model turn is missing its usage
+    # block (the null-usage edge case). This row tallies the excluded
+    # ghosts -- reconciling Model turns against the total assistant-
+    # message count so the netted-out turns are visible, not silently
+    # dropped. Always shown (incl. 0) so "0" reads as "none", not "not
+    # computed".
+    token_table.add_row(
+        "Synthetic responses",
+        f"[dim]{result.total_synthetic_messages}[/dim]",
+    )
     console.print(token_table)
 
     if tm.by_model and (verbose or len(tm.by_model) > 1):

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1353,14 +1353,14 @@
 - name: model_turns
   category: session_metric
   short: |
-    The number of model turns in a session -- one merged assistant
-    message (one API round-trip).
+    The number of model turns in a session -- one merged, non-synthetic
+    assistant message (a real model response).
   long: |
-    Added in v0.9 (#465). A *model turn* is one merged assistant
-    message: a single API round-trip the model took. The parser's
-    fragment-merging step can combine several raw JSONL lines into one
-    logical assistant message, so a turn is **not** "one JSONL line" --
-    it is the merged message.
+    Added in v0.9 (#465; synthetic exclusion #507). A *model turn* is
+    one merged assistant message that the model actually produced. The
+    parser's fragment-merging step can combine several raw JSONL lines
+    into one logical assistant message, so a turn is **not** "one JSONL
+    line" -- it is the merged message.
 
     Distinct from `tool_uses` and from tokens:
 
@@ -1375,17 +1375,35 @@
     fixed task while holding quality steady drops both cost and latency
     more than any single other change.
 
+    **Synthetic responses are excluded (#507, D044).** Claude Code emits
+    `<synthetic>`-model assistant messages -- locally fabricated filler
+    (e.g. "No response requested.") with zero usage and no API
+    round-trip -- to keep user/assistant alternation valid when a turn
+    needs no model reply. The model did not turn, so these are NOT
+    counted; they are tallied separately as `synthetic_message_count`
+    (per session) and `total_synthetic_messages` (aggregate), and shown
+    on a "Synthetic responses" row in the Token Usage table.
+
+    **Relationship to `api_call_count` ("API calls").** Both exclude
+    synthetic messages, so they are equal in the common case. They
+    diverge only on the (so far unobserved) edge case of a real-model
+    assistant message carrying no `usage` block: it counts as a model
+    turn but not as an API call, making `model_turns >= api_call_count`.
+    Keeping both metrics surfaces exactly that case if it ever occurs.
+
     Surfaced in the Token Usage table ("Model turns" row), in the
     verbose Per-Session Breakdown table ("Turns" column), and in
-    `analyze --json` as `model_turns` per session plus
-    `total_model_turns` aggregated across sessions at the envelope top
-    level. Backed by the session's `assistant_message_count` field,
-    which stays in the JSON output for backward compatibility.
+    `analyze --json` as `model_turns` per session plus a top-level
+    `total_model_turns` aggregated across sessions. Computed as
+    `assistant_message_count - synthetic_message_count`; the
+    all-inclusive `assistant_message_count` stays in the JSON output for
+    backward compatibility.
   example: |
     Token Usage
       ...
-      API calls      42
-      Model turns    20
+      API calls            350
+      Model turns          350   <- == API calls (both exclude synthetic)
+      Synthetic responses    2   <- ghost turns netted out, tallied here
   related: [output, total_cost]
 
 - name: active_duration

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -138,10 +138,11 @@ class SubagentTrace(BaseModel):
     total_retries: int = 0
 
     model_turns: int = 0
-    """Number of model turns in this subagent trace -- one merged
-    assistant message (one API round-trip). Set at parse time by
-    counting ``type == "assistant"`` messages after fragment-merging
-    (#466). Independent of ``tool_calls``: a single turn can carry zero
+    """Number of model turns in this subagent trace -- one merged,
+    non-synthetic assistant message. Set at parse time by counting
+    ``type == "assistant"`` messages (excluding ``<synthetic>`` ghost
+    responses, #507) after fragment-merging (#466). Independent of
+    ``tool_calls``: a single turn can carry zero
     ``tool_use`` blocks (text/thinking/refusal) or many (parallel tool
     use), so neither count bounds the other. Always definitive for a
     trace (``0`` for an empty trace); ``AgentInvocation.model_turns`` is

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from agentfluent.analytics.pricing import SYNTHETIC_MODELS
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
 from agentfluent.diagnostics.signals import detect_is_error_from_text
@@ -258,7 +259,11 @@ def parse_subagent_trace(path: Path) -> SubagentTrace:
         retry_sequences=retry_sequences,
         total_errors=sum(1 for tc in tool_calls if tc.is_error),
         total_retries=sum(seq.attempts - 1 for seq in retry_sequences),
-        model_turns=sum(1 for m in messages if m.type == "assistant"),
+        model_turns=sum(
+            1
+            for m in messages
+            if m.type == "assistant" and m.model not in SYNTHETIC_MODELS
+        ),
         usage=_sum_usage(messages),
         duration_ms=_compute_duration_ms(messages),
         idle_gap_ms=_compute_idle_gap_ms(tool_calls),

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,6 +1,8 @@
 """Tests for the analytics pipeline orchestration."""
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from agentfluent.analytics.agent_metrics import AgentMetrics, AgentTypeMetrics
 from agentfluent.analytics.pipeline import (
@@ -12,16 +14,24 @@ from agentfluent.analytics.pipeline import (
 )
 from agentfluent.analytics.tokens import TokenMetrics
 from agentfluent.analytics.tools import ToolMetrics
+from tests._builders import assistant_message, user_message
+
+WriteJSONL = Callable[[str, list[dict[str, Any]]], Path]
 
 
-def _session(assistant_count: int) -> SessionAnalysis:
-    """Build a minimal SessionAnalysis with a given assistant-message count."""
+def _session(assistant_count: int, synthetic_count: int = 0) -> SessionAnalysis:
+    """Build a minimal SessionAnalysis with given assistant + synthetic counts.
+
+    ``assistant_count`` is the all-inclusive assistant-message count
+    (including synthetics); ``synthetic_count`` is the subset netted out
+    of ``model_turns`` (#507)."""
     return SessionAnalysis(
         session_path=Path("s.jsonl"),
         token_metrics=TokenMetrics(),
         tool_metrics=ToolMetrics(),
         agent_metrics=AgentMetrics(),
         assistant_message_count=assistant_count,
+        synthetic_message_count=synthetic_count,
     )
 
 
@@ -56,6 +66,41 @@ class TestAnalyzeSession:
         assert result.token_metrics.total_tokens == 0
         assert result.tool_metrics.total_tool_calls == 0
         assert result.agent_metrics.total_invocations == 0
+
+    def test_synthetic_excluded_from_model_turns(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # #507: a <synthetic> ghost response is counted in
+        # assistant_message_count but excluded from model_turns and
+        # tallied in synthetic_message_count.
+        path = write_jsonl(
+            "session_synthetic.jsonl",
+            [
+                user_message("do a thing"),
+                assistant_message(
+                    [{"type": "text", "text": "working"}],
+                    message_id="m1",
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                ),
+                assistant_message(
+                    [{"type": "text", "text": "done"}],
+                    message_id="m2",
+                    usage={"input_tokens": 8, "output_tokens": 4},
+                ),
+                assistant_message(
+                    [{"type": "text", "text": "No response requested."}],
+                    message_id="m3",
+                    model="<synthetic>",
+                ),
+            ],
+        )
+        result = analyze_session(path)
+        assert result.assistant_message_count == 3
+        assert result.synthetic_message_count == 1
+        assert result.model_turns == 2
+        # Both metrics exclude synthetic, and the two real turns carry
+        # usage, so model_turns == api_call_count (the common case).
+        assert result.model_turns == result.token_metrics.api_call_count
 
     def test_streaming_dupes_session(self, streaming_dupes_session_path: Path) -> None:
         result = analyze_session(streaming_dupes_session_path)
@@ -106,10 +151,15 @@ class TestAnalyzeSessions:
 
 
 class TestModelTurns:
-    """#465: model_turns aliases assistant_message_count; total_model_turns sums."""
+    """#465 + #507: model_turns = assistant_message_count - synthetic; the
+    synthetic subset is excluded and tallied separately; totals sum."""
 
-    def test_model_turns_aliases_assistant_count(self) -> None:
+    def test_model_turns_no_synthetic_equals_assistant_count(self) -> None:
         assert _session(5).model_turns == 5
+
+    def test_model_turns_excludes_synthetic(self) -> None:
+        # #507: 5 assistant messages, 2 of them <synthetic> ghosts -> 3 turns.
+        assert _session(5, synthetic_count=2).model_turns == 3
 
     def test_model_turns_empty_session(self) -> None:
         assert _session(0).model_turns == 0
@@ -118,14 +168,25 @@ class TestModelTurns:
         self, basic_session_path: Path,
     ) -> None:
         result = analyze_session(basic_session_path)
-        assert result.model_turns == result.assistant_message_count
+        assert result.model_turns == (
+            result.assistant_message_count - result.synthetic_message_count
+        )
 
     def test_total_model_turns_sums_sessions(self) -> None:
         result = AnalysisResult(sessions=[_session(5), _session(3), _session(0)])
         assert result.total_model_turns == 8
 
+    def test_total_model_turns_nets_out_synthetic(self) -> None:
+        # 5+3 assistant messages, 1+2 synthetic -> (5-1)+(3-2) = 5 turns.
+        result = AnalysisResult(
+            sessions=[_session(5, synthetic_count=1), _session(3, synthetic_count=2)],
+        )
+        assert result.total_model_turns == 5
+        assert result.total_synthetic_messages == 3
+
     def test_total_model_turns_empty_result(self) -> None:
         assert AnalysisResult().total_model_turns == 0
+        assert AnalysisResult().total_synthetic_messages == 0
 
     def test_total_model_turns_via_analyze_sessions(
         self, basic_session_path: Path, agent_session_path: Path,
@@ -136,10 +197,14 @@ class TestModelTurns:
         )
 
     def test_model_turns_in_json_dump(self) -> None:
-        dumped = AnalysisResult(sessions=[_session(5)]).model_dump(mode="json")
-        assert dumped["total_model_turns"] == 5
-        assert dumped["sessions"][0]["model_turns"] == 5
-        # Backing field stays for backward compat.
+        dumped = AnalysisResult(
+            sessions=[_session(5, synthetic_count=2)],
+        ).model_dump(mode="json")
+        assert dumped["total_model_turns"] == 3
+        assert dumped["total_synthetic_messages"] == 2
+        assert dumped["sessions"][0]["model_turns"] == 3
+        assert dumped["sessions"][0]["synthetic_message_count"] == 2
+        # Backing field stays all-inclusive for backward compat.
         assert dumped["sessions"][0]["assistant_message_count"] == 5
 
 

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -109,6 +109,25 @@ class TestToolCallPairing:
         assert len(trace.tool_calls) == 1
         assert trace.tool_calls[0].tool_name == "Bash"
 
+    def test_model_turns_excludes_synthetic(self, write_jsonl: WriteJSONL) -> None:
+        # #507: <synthetic> ghost responses are not model turns. Two real
+        # assistant messages + one synthetic -> model_turns == 2.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Read")], message_id="m1"),
+                _user([_tool_result("t1")]),
+                _assistant([{"type": "text", "text": "done"}], message_id="m2"),
+                _assistant(
+                    [{"type": "text", "text": "No response requested."}],
+                    message_id="m3",
+                    model="<synthetic>",
+                ),
+            ],
+        )
+        assert parse_subagent_trace(path).model_turns == 2
+
     def test_multiple_tool_use_in_one_message(self, write_jsonl: WriteJSONL) -> None:
         path = write_jsonl(
             "agent-x.jsonl",


### PR DESCRIPTION
## Summary
- `model_turns` counted every `type:"assistant"` message, including Claude Code's `<synthetic>`-model ghost responses (`"No response requested."`, zero usage, no API round-trip). The model never turned for these, so they inflated `model_turns` above `api_call_count` (which already excludes them) and biased every per-turn ratio down. **Closes #507 (v0.9.0 release blocker).**
- **Option A (D044):** `model_turns = assistant_message_count - synthetic_message_count`. Both `model_turns` and `api_call_count` now exclude synthetic, so they agree except on the (so-far-unobserved) edge case of a real-model turn carrying no `usage` block. Synthetic messages are tallied separately (`synthetic_message_count` per session, `total_synthetic_messages` aggregate) and shown on a new "Synthetic responses" row.
- On the dogfood corpus this collapses the discrepancy the docs PR surfaced: API calls == Model turns, with the ghost count broken out.

## Design review
Architect-reviewed before implementation — endorsed Option A and the data-model shape (keep `assistant_message_count` all-inclusive, derive `model_turns` by subtraction). Review: https://github.com/frederick-douglas-pearce/agentfluent/issues/507#issuecomment-4636325122

## Changes
- `analytics/pipeline.py` — `synthetic_message_count` field + `total_synthetic_messages` computed field; `model_turns` derives by subtraction; `_count_synthetic` helper.
- `traces/parser.py` — exclude synthetic from trace `model_turns` (auto-corrects the per-agent rollup + efficiency ratios, which are additive off `inv.model_turns → trace.model_turns`).
- `cli/formatters/table.py` — "Synthetic responses" row under Model turns (always shown).
- docstrings (`pipeline`/`traces/models`/`agents/models`) — drop the "one API round-trip" equation.
- GLOSSARY (`terms.yaml` + regenerated `docs/GLOSSARY.md`) — rewrite `model_turns`, document synthetic exclusion + `api_call_count` relationship, fix example.
- `.claude/specs/decisions.md` — D044.
- tests — synthetic excluded at session + trace level; tally + aggregation; JSON dump shape.

## Out of scope / sequencing
- **README + screenshots** are owned by the #483 docs PR (#506), which will rebase on this fix and regenerate screenshots once (so they show API calls == Model turns + the Synthetic row). Per the agreed merge order: **this PR merges first**, then #506.
- **CHANGELOG 0.9.0 prose** on the release branch (#486) is synced separately (different branch).
- Follow-up #508 investigates the full `<synthetic>` scenario taxonomy.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1685 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — session + trace synthetic exclusion, tally, aggregation, JSON shape
- [x] Manual smoke test — `agentfluent analyze` Token Usage now shows API calls == Model turns + a "Synthetic responses" row

## Security review
- [x] **Skip review** — internal metric-counting logic + docs; no parsing/network/argument/path/subprocess/secret surface introduced (reads an existing parsed field, `model`, against an existing constant).

## Breaking changes
None. `model_turns` is new in the unreleased v0.9 (release PR #486 not yet merged), so there is no published contract; `synthetic_message_count` / `total_synthetic_messages` are additive; `diff` reads turn fields tolerantly (`.get(..., 0)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)