### PR TITLE
docs(specs): add v0.9 dogfood portfolio analysis

### DIFF
--- a/.claude/specs/analysis/2026-06-05-v09-dogfood/analysis.md
+++ b/.claude/specs/analysis/2026-06-05-v09-dogfood/analysis.md
@@ -1,0 +1,164 @@
+# Agent Portfolio Analysis — v0.9 dogfood run
+
+**Date:** 2026-06-05
+**Author:** Claude (Opus 4.8, 1M context) with Fred Pearce
+**Source:** `uv run agentfluent analyze --project agentfluent --diagnostics --git --github --json`
+**Sessions analyzed:** 46
+**agentfluent version:** v0.9.0 (published 2026-06-06 02:11 UTC; analyzed from editable install at the v0.9.0 release commit `8422ec3`)
+**Baseline:** [`2026-05-30-v08-dogfood/analysis.md`](../2026-05-30-v08-dogfood/analysis.md)
+**Raw outputs:** [`analyze.json`](analyze.json), [`analyze.table.txt`](analyze.table.txt)
+
+## Purpose
+
+Fourth dogfood run, first one with the v0.9 "Count Every Turn" surface live. Four goals:
+
+1. **Validate v0.9 ships clean on real data** — model-turn counts populate at every level, the three Advanced Tool Use signals fire (or stay correctly silent), no parse-time exceptions, `tier3_degraded: false`.
+2. **Pressure-test the marquee metric (model turns).** Does the new turn-level denominator produce a *diagnostic* on the corpus, or just a number? Does `avg_tool_calls_per_turn` finger the serialization anti-pattern the release was built to expose?
+3. **Calibrate the Advanced Tool Use signals in production** — `PARAMETER_RETRY` (#405), `TOOL_ORCHESTRATION_CHAIN` (#406/#407), `TOOL_INVENTORY_OVERSIZED` (#404/#372). These shipped with thin or zero corpus validation; this is their first real-data exposure.
+4. **Re-check the v0.8 follow-ups that landed in v0.9** — architect prompt tightening (#479), `active_duration` in the summary table (#480), `cleanupPeriodDays` warning (#481), tester removal (#477).
+
+## Headline — delta across three baselines
+
+| Metric | v0.7 (05-17, 25 sess) | v0.8 (05-30, 32 sess) | **v0.9 (06-05, 46 sess)** | Δ vs v0.8 |
+|---|---|---|---|---|
+| Total cost | $1,729 | $1,271 | **$1,286** | +$15 (+1%) |
+| Total tokens | 2.52B | 1.71B | **1.92B** | +12% |
+| API calls | 8,116 | 6,287 | **7,533** | +20% |
+| Cache efficiency | 97.8% | 97.3% | **97.2%** | −0.1pp |
+| Total agent invocations | 377 | 255 | **301** | +18% |
+| Agent token % | 0.6% | 0.80% | **0.90%** | +0.1pp |
+| Subagent traces parsed | — | 242 | **286** | +18% |
+| **Parent-session model turns** | — | — | **7,533** | (new) |
+| **Subagent model turns** | — | — | **3,413** | (new) |
+| **`<synthetic>` messages** | — | — | **25** | (new) |
+| Cost per session | $69 | $40 | **$28** | −$12 |
+
+**The corpus rolled again, and bigger.** 46 sessions is the largest window yet — Claude Code's `cleanupPeriodDays` is now `3650` globally (the #481 fix), so sessions stopped aging out of `~/.claude/projects/` mid-cycle. This is *not* a strict superset of the v0.8 32; it's a wider, less-truncated snapshot of recent activity. **Cost per session fell again to $28** — the post-v0.8 work was the v0.9 feature batch (model turns + 3 signals + dogfood fixes), shipped as many small PRs (#485–#509) rather than a few large features. The +12% token / +20% API-call rise is volume (14 more sessions), not per-unit inflation: cost/session kept dropping.
+
+**Cache efficiency held at 97.2%.** Four release cycles, four readings within 0.6pp. The parent-thread cache economics that make naive offloading a losing trade (see below) are stable.
+
+## The marquee: model turns produce a real diagnostic on first contact
+
+This is the result the v0.9 theme was built to produce, and it landed.
+
+`total_model_turns` (parent session) is **7,533** — and equals `api_call_count` exactly. The 25 `<synthetic>` ghost responses (Claude Code's locally-fabricated filler, no API round-trip) are tallied separately in `total_synthetic_messages` and excluded from the turn count, per #507/#509. **One thing to verify (see follow-ups):** `model_turns == api_call_count` to the unit is either by-construction or a coincidence worth confirming — and a user (Fred) raised exactly this mid-development (a `user_correction` signal fired in-thread: *"does api calls include synthetic messages... I thought both model turns and api calls..."*). The definitions should be documented as deliberately-equal or deliberately-distinct so the next reader isn't left guessing.
+
+### Per-agent turn efficiency — the headline finding
+
+`avg_tool_calls_per_turn` is the v0.9 ratio that matters: high = the agent batches tool calls within a turn (efficient); low (~1.0) = it serializes one tool call per round-trip (the waste the release targets).
+
+| Agent | Calls | Turns/inv | **Tool calls/turn** | Tokens/turn | $/turn |
+|---|---|---|---|---|---|
+| claude-code-guide (builtin) | 6 | 8.5 | **2.18** | 5,359 | $0.0051 |
+| pm (custom) | 35 | 17.3 | **1.86** | 6,684 | $0.0064 |
+| architect (custom) | 72 | 11.4 | **1.78** | 5,842 | $0.0043 |
+| anthropic-research (custom) | 4 | 7.3 | 1.64 | 7,714 | $0.0080 |
+| Explore (builtin) | 29 | 13.2 | 1.29 | 3,913 | $0.0007 |
+| candidate-promoter (custom) | 3 | 7.0 | 1.14 | 5,314 | $0.0055 |
+| **general-purpose (builtin)** | **150** | 11.0 | **0.96** | 3,938 | $0.0028 |
+
+**The dominant agent is the least turn-efficient.** `general-purpose` — 150 invocations, the single biggest token consumer (6.5M) — runs at **0.96 tool calls per turn**. That's the serialized anti-pattern stated as a number: it does roughly one tool call, takes a model turn, does the next, takes another turn. The custom agents (`architect`, `pm`) batch at ~1.8 — nearly double the tool-calls-per-turn. On its very first dogfood, the model-turn metric independently fingered the exact agent the prior three dogfoods flagged for retry-loops and tool-error-sequences — but now with a crisp efficiency framing instead of a raw error count.
+
+**The lever is unchanged, the evidence is sharper.** `general-purpose` is built-in; its prompt isn't user-editable. The fix is the one Fred's been executing for three releases — wrap narrow tasks in custom subagents — and the turn metric now *quantifies why it works*: the custom agents he's introduced (`architect`, `pm`, `candidate-verifier`) batch tool calls more tightly than the built-in `general-purpose` they displace. "Count turns, cut waste" is no longer a slogan; it's a column that ranks the portfolio.
+
+## Advanced Tool Use signals: one fires loud, two stay silent
+
+### `PARAMETER_RETRY` (#405) — works, but practically inert on this corpus
+
+**25 fires.** The headline feature — extracting a paste-ready `input_examples` entry from the observed successful call — **works exactly as designed**. Example output:
+
+> *"Subagent 'Explore' retried tool 'Read' 3 times with different parameter shapes before succeeding... Suggested `input_examples` entry for tool 'Read' based on the observed successful call: `{"file_path": "/tmp/simplify_481.diff", "offset": 219, "limit": 60}`"*
+
+The dominant true positive is a textbook one: an agent passed `Read`'s `offset` as an array `[447, 525]` instead of a number, got `InputValidationError: The parameter offset type is expected as number but provided as array`, then retried correctly. 23 of 25 fires reference a real `is_error: true` first attempt; spot-checks confirm genuine validation retries.
+
+**But the corpus exposes a scoping limit: 23 of 25 fires are on the built-in `Read` tool — where the recommendation is not user-actionable.** You cannot add an `input_examples` array to Claude Code's built-in `Read`; the tool definition isn't yours to edit. The signal's value proposition (paste-ready examples that lift complex-parameter accuracy 72%→90%) only *pays off for custom SDK/MCP tool definitions*. On this single-developer, built-in-tool-heavy corpus, the signal is technically correct but practically inert — it's correctly detecting a pattern whose fix the user can't apply. The signal will earn its keep on a corpus with custom MCP tools that have fiddly parameter shapes; this corpus isn't that.
+
+**Two clear false positives (2/25 = 8%).** Both fired with *zero* `is_error` calls in the sequence:
+- `architect` "retried `Read` 8 times" — actually reading eight different line-ranges of a notebook-builder script in sequence (legitimate paging, every call `is_error: false`).
+- `claude-code-guide` "retried `WebSearch` 2 times" — actually refining a search query (`hooks reference` → `"duration_ms" PostToolUse`), not recovering from a validation error.
+
+In both, the rendered message still reads *"First attempt failed with: '<successful output>'"* — quoting file content or search results as if it were an error string. That's a message-template correctness bug independent of the calibration question: a no-error sequence should not be described as "failed with."
+
+**Recommendation:** file a v0.9.x calibration issue — (a) require at least the first attempt to be `is_error: true` before firing (kills the paging/query-refinement FPs), and (b) when scoring/sorting, deprioritize fires on built-in tools whose definitions the user can't edit, or annotate them as "informational — built-in tool, not user-tunable." The headline `input_examples` extraction is good; it just needs an actionability gate.
+
+### `TOOL_ORCHESTRATION_CHAIN` (#406/#407) — silent-by-design, behaving as shipped
+
+**4 fires, all INFO, all carrying the low-confidence caveat** (D043, #498). Each is the metadata-only proxy flagging a high token-per-tool-call agent (`architect`: 1,244 tool calls / 4.19M tokens; `general-purpose`: 1,072 / 3.48M). As documented at release, this corpus has **no genuine orchestration agents** (no Programmatic-Tool-Calling chains), so these are the expected token-heavy-reasoning false positives the caveat warns about — *not* true positives. The signal is doing exactly what #498 said it would: firing at INFO with an explicit "verify against the agent" hedge. Trace-level precision remains tracked as **#499**; nothing here changes that plan. This matches the `[[project-orchestration-signal-kept-live]]` decision — ship live-with-caveat, fix precision in Tier B.
+
+### `TOOL_INVENTORY_OVERSIZED` (#404/#372) — zero fires, correct silence
+
+**0 fires.** No agent in the portfolio declares >30 tools while exercising under half. The custom agents are tightly scoped (architect, pm, the research agents all have curated tool lists); the built-ins that *do* have broad tool access (`general-purpose`) actually exercise a wide spread. This is **healthy silence** — the same shape as v0.8's Tier 3 signals: the pattern the signal targets doesn't exist in this well-pruned config, so zero is the right answer, not a missing-data symptom. It will fire the day someone points AgentFluent at an agent with a 40-tool MCP bundle it barely touches.
+
+## v0.8 follow-ups that shipped in v0.9 — did they land?
+
+| Issue | Shipped | Dogfood verdict |
+|---|---|---|
+| **#477** remove `tester` | Yes | ✅ Gone. `tester` no longer appears in the agent table or `unused_agent` signals. (`marketer` is the lone `unused_agent` fire now — user-scope, cross-project, not actionable here, same as v0.8.) |
+| **#480** `active_duration` in summary table | Yes | ✅ Present in `analyze.table.txt`. The 49-min/call `pm` framing trap from v0.8 is mitigated — wall-clock and active duration now sit side by side. |
+| **#481** `cleanupPeriodDays` warning | Yes | ✅ Correctly *silent* — `cleanupPeriodDays: 3650`, `warnings: []`. The warning path didn't fire because the setting is safe; the corpus growth to 46 sessions is the downstream proof the underlying trap is closed. |
+| **#479** architect prompt tightening | Yes (closed) | ⚠️ **No measurable effect yet.** architect→`Read` retries are **29** (was 30 in v0.8); architect→`mcp__github__get_issue` retries are **3** (was 3). Essentially flat. **Caveat:** the corpus is a rolling window spanning *before and after* #479 merged, so most of these 46 sessions predate the fix. This is not a clean post-fix measurement. Re-evaluate at v0.10.0 when the window is fully post-#479 — same corpus-rolling caveat the v0.8 report made. |
+
+Note: the get_issue retry hot spot **migrated** — in v0.8 it was architect (3); in v0.9 the heavier offender is **`pm`→`mcp__github__get_issue` (7 retries)**. The v0.7/v0.8 "confirm the issue number before retrying" prompt fix was applied to architect (#479) but pm carries the same un-tightened pattern. Cheap parallel fix candidate.
+
+## Calibration signals holding steady
+
+- **`ERROR_PATTERN`: 1 fire** — the same lone true positive as v0.8: `anthropic-research` output contains "not found" (self-bootstrap registration string). #333's per-invocation trace gating continues to hold precision at the floor. No drift across two release cycles.
+- **`FEAT_FIX_PROXIMITY`: 31 fires** — up from 24 (corpus is larger). Spot-checks reference real commit pairs from the v0.9 feature-then-fix wave (#498, #509 fixing #491/#465). The #402 2-file threshold continues to suppress trivial coincidences. No re-calibration needed.
+- **`reviewer_caught`: 62** (was 54), all on `architect`. The v0.6 quality signal firing as designed — architect reviews catching findings on PRs. Healthy and growing with PR volume.
+
+## File rework — README is the documentation-thrash signal the v0.8 report predicted
+
+`file_rework: 31 fires`. Top targets by edit count:
+
+| File | Edits |
+|---|---|
+| **README.md** | **64** |
+| table.py | 53 |
+| pipeline.py | 50 |
+| models.py | 49 |
+| analyze.py | 45 |
+| aggregation.py | 44 |
+| terms.yaml | 38 |
+| quality_signals.py | 38 |
+
+**The v0.8 report called this shot:** *"if a future dogfood shows README.md near the top again, that's a documentation-thrash signal worth investigating."* It's now **#1, at 64 edits** — ahead of every source file. This is the v0.9 docs catch-up (#483/#506) plus the README roadmap churn across the release. It's not a correctness red flag (docs *should* change at a release), but two consecutive dogfoods with README at/near the top suggests the README is absorbing release-note prose that might live more durably in `CHANGELOG.md` or `docs/`. Worth a glance at *what* keeps rewriting the same README sections — if it's the roadmap table re-edited every release, that's a structural fix (link out, don't inline).
+
+## Critical-severity recommendations — same shape, built-in-bound
+
+Four `critical` aggregated recommendations, all `tool_error_sequence`-driven, all on the heavy agents:
+
+| Agent | tool_error_seq | retry_loops (Read) | Actionable? |
+|---|---|---|---|
+| general-purpose | 14 | 46 | Built-in — wrap-in-subagent only |
+| architect | 4 | 29 | Custom — #479 landed, effect TBD (corpus caveat) |
+| candidate-verifier | 2 | (low vol) | Custom — 1 invocation, 2 error-seqs in a 33-turn run |
+| candidate-promoter | 2 | (low vol) | Skill-converted residual |
+
+`general-purpose`→`Read` (46 retries) remains the largest single (agent, tool) retry pair in the corpus, exactly as in v0.8 — and the new turn metric reframes *why*: at 0.96 tool-calls/turn, general-purpose's serialized Read-then-reason loop is structurally retry-prone. No new built-in fix lever; the wrap-in-custom-subagent path is the answer the engine keeps (correctly) recommending.
+
+## Offload candidates — negative-savings, third cycle running
+
+10 offload candidates, **all ≤ $0 savings** (largest: `architect-pm` −$86, `wave-bash` −$74, `id-task` −$28, `pm-claude` −$27; the rest $0). **Third consecutive dogfood with the same verdict:** naive offloading loses to parent-thread cache efficiency (97.2%) on this workload. The default behavior correctly hides these; "no actionable offloads" is the right answer, not a missing-data symptom. This is now a load-tested invariant of the workload, not a finding.
+
+## v0.10.0 candidate work, ranked by dogfood evidence
+
+All five filed against the **v0.10.0** milestone after this analysis was drafted. Listed in priority order with issue numbers for traceability.
+
+1. **[#510](https://github.com/frederick-douglas-pearce/agentfluent/issues/510) — `PARAMETER_RETRY` actionability gate + message fix (HIGH).** (a) Require ≥1 `is_error: true` attempt before firing — kills the 8% paging/query-refinement false positives. (b) Fix the "First attempt failed with: '<output>'" message when no attempt errored. (c) Deprioritize or annotate fires on built-in tools (`Read`, `WebSearch`) whose definitions the user can't edit — 23/25 fires this cycle were practically inert for that reason. The `input_examples` extraction itself is good; it needs a relevance filter.
+2. **[#511](https://github.com/frederick-douglas-pearce/agentfluent/issues/511) — Document `model_turns` vs `api_call_count` relationship (MEDIUM).** They're equal to the unit (7,533) on this corpus. Document whether that's by-construction (both count merged assistant messages) or coincidental, and where `<synthetic>` exclusion applies to each. A user already hit this confusion mid-development; the docs should pre-empt it.
+3. **[#512](https://github.com/frederick-douglas-pearce/agentfluent/issues/512) — Apply the architect get_issue/Read prompt tightening to `pm` (LOW-MED).** pm now owns the heaviest `mcp__github__get_issue` retry pair (7), the exact pattern #479 fixed for architect. Cheap, durable, parallel to a fix that already exists.
+4. **[#513](https://github.com/frederick-douglas-pearce/agentfluent/issues/513) — Re-measure #479 at v0.10.0 on a fully-post-fix window (LOW).** architect Read/get_issue retries are flat (29/3), but the corpus straddles the #479 merge. Not a clean read. Defer judgment one cycle rather than concluding the prompt fix failed.
+5. **[#514](https://github.com/frederick-douglas-pearce/agentfluent/issues/514) — README documentation-thrash investigation (LOW).** Two dogfoods with README as a top `file_rework` target. Check whether release-note/roadmap prose inlined in README should link out to CHANGELOG/docs instead.
+
+**Not filed (inline observation only):**
+- `TOOL_ORCHESTRATION_CHAIN` 4 INFO fires — expected corpus artifact, already tracked as #499. No new issue.
+- `TOOL_INVENTORY_OVERSIZED` 0 fires — correct silence. No action.
+- Offload negative-savings — correct, not a bug. Third confirmation.
+
+## What v0.9 proved
+
+The release shipped clean: model turns populate at every level, the three Advanced Tool Use signals either fired with their documented caveats or stayed correctly silent, `tier3_degraded: false`, no parse exceptions, and every v0.8 follow-up that targeted a reporting gap (active_duration, cleanup warning, tester removal) is verifiably in place. **The marquee metric earned its theme on first contact** — `avg_tool_calls_per_turn` independently surfaced `general-purpose` as the serialization hotspot, turning three releases of raw retry-counts into a single efficiency ranking.
+
+The one genuinely actionable calibration finding is `PARAMETER_RETRY`'s actionability problem: it works, it extracts good examples, but on a built-in-tool-heavy single-dev corpus, 92% of its fires recommend a fix the user can't apply, and 8% fire on non-errors. That's a v0.9.x tune, not a release blocker — exactly the kind of "land the calibration before the *next* cut" the dogfood ritual exists to catch.
+
+The next dogfood will be at v0.10.0 cut. Items 1–3 above should land before then so they show up in the v0.10.0 changelog rather than as backfilled notes.

--- a/.claude/specs/analysis/2026-06-05-v09-dogfood/analyze.table.txt
+++ b/.claude/specs/analysis/2026-06-05-v09-dogfood/analyze.table.txt
@@ -1,0 +1,2823 @@
+               Token Usage               
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ Metric                ┃         Value ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ Input tokens          │       434,500 │
+│ Output tokens         │     7,370,728 │
+│ Cache creation tokens │    53,048,101 │
+│ Cache read tokens     │ 1,857,023,635 │
+│ Total tokens          │ 1,917,876,964 │
+│ Total cost (API rate) │      $1285.95 │
+│ Cache efficiency      │         97.2% │
+│ API calls             │          7536 │
+│ Model turns           │          7536 │
+│ Synthetic responses   │            25 │
+└───────────────────────┴───────────────┘
+                     Cost by Model (API rate)                      
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Model                     ┃ Origin   ┃        Tokens ┃     Cost ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ claude-haiku-4-5-20251001 │ subagent │    17,172,947 │    $3.68 │
+│ claude-opus-4-6           │ subagent │    74,474,075 │  $102.92 │
+│ claude-opus-4-7           │ parent   │ 1,557,226,222 │ $1086.37 │
+│ claude-opus-4-7           │ subagent │    83,152,517 │   $90.29 │
+│ claude-opus-4-8           │ parent   │   178,844,067 │  $0.0000 │
+│ claude-opus-4-8           │ subagent │     3,401,533 │  $0.0000 │
+│ claude-sonnet-4-6         │ subagent │     3,605,603 │    $2.67 │
+└───────────────────────────┴──────────┴───────────────┴──────────┘
+                       Tool Usage                       
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
+┃ Tool                            ┃ Calls ┃ % of Total ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
+│ Bash                            │  4467 │      50.5% │
+│ Edit                            │  1377 │      15.6% │
+│ Read                            │  1172 │      13.3% │
+│ TaskUpdate                      │   664 │       7.5% │
+│ TaskCreate                      │   351 │       4.0% │
+│ Agent                           │   301 │       3.4% │
+│ Write                           │   188 │       2.1% │
+│ AskUserQuestion                 │    87 │       1.0% │
+│ ToolSearch                      │    86 │       1.0% │
+│ mcp__github__create_issue       │    30 │       0.3% │
+│ mcp__github__add_issue_comment  │    23 │       0.3% │
+│ mcp__github__get_issue          │    23 │       0.3% │
+│ Grep                            │    22 │       0.2% │
+│ WebFetch                        │    12 │       0.1% │
+│ Skill                           │     8 │       0.1% │
+│ mcp__github__list_issues        │     6 │       0.1% │
+│ mcp__github__update_issue       │     6 │       0.1% │
+│ ScheduleWakeup                  │     5 │       0.1% │
+│ TaskList                        │     4 │       0.0% │
+│ ExitPlanMode                    │     2 │       0.0% │
+│ mcp__github__search_issues      │     2 │       0.0% │
+│ Monitor                         │     1 │       0.0% │
+│ TaskGet                         │     1 │       0.0% │
+│ TaskStop                        │     1 │       0.0% │
+│ mcp__github__get_file_contents  │     1 │       0.0% │
+│ mcp__github__get_pull_request   │     1 │       0.0% │
+│ mcp__github__list_pull_requests │     1 │       0.0% │
+│ mcp__ide__executeCode           │     1 │       0.0% │
+│                                 │       │            │
+│ Total                           │  8843 │            │
+│ Unique tools                    │    28 │            │
+└─────────────────────────────────┴───────┴────────────┘
+                               Agent Invocations                                
+┏━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃               ┃       ┃           ┃           ┃           Avg ┃          Avg ┃
+┃ Agent Type    ┃ Count ┃ Avg Turns ┃    Tokens ┃   Tokens/Call ┃ Duration/Ca… ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ anthropic-re… │     4 │       7.3 │   169,699 │        42,424 │       146.9s │
+│               │       │           │           │               │      (256.3s │
+│               │       │           │           │               │       wall)† │
+│ architect     │    72 │      11.4 │ 4,445,450 │        61,742 │       106.5s │
+│               │       │           │           │               │      (177.7s │
+│               │       │           │           │               │       wall)† │
+│ candidate-pr… │     3 │       7.0 │   111,590 │        37,196 │      203.3s† │
+│ candidate-ve… │     1 │      33.0 │    77,237 │        77,237 │       365.6s │
+│               │       │           │           │               │     (1130.3s │
+│               │       │           │           │               │        wall) │
+│ claude-code-… │     6 │       8.5 │   182,215 │        30,369 │       64.5s† │
+│ (builtin)     │       │           │           │               │              │
+│ Explore       │    29 │      13.2 │ 1,498,800 │        51,682 │        79.7s │
+│ (builtin)     │       │           │           │               │      (119.3s │
+│               │       │           │           │               │        wall) │
+│ general-purp… │   150 │      11.0 │ 6,513,264 │        43,421 │       108.2s │
+│ (builtin)     │       │           │           │               │      (148.6s │
+│               │       │           │           │               │       wall)† │
+│ Plan          │     1 │      21.0 │    78,800 │        78,800 │       217.3s │
+│ (builtin)     │       │           │           │               │     (1080.1s │
+│               │       │           │           │               │        wall) │
+│ pm            │    35 │      17.3 │ 3,235,292 │        92,436 │       295.8s │
+│               │       │           │           │               │     (3533.4s │
+│               │       │           │           │               │       wall)† │
+│               │       │           │           │               │              │
+│ Total         │   301 │           │           │               │              │
+│ Agent token % │  0.9% │           │           │               │              │
+└───────────────┴───────┴───────────┴───────────┴───────────────┴──────────────┘
+† Active duration covers only the trace-linked invocations; the average and 
+active/wall split use that subset.
+API rate — pay-per-token equivalent. Subscription plans 
+(Pro/Max/Team/Enterprise) have fixed monthly cost independent of usage.
+                               Diagnostic Signals                               
+┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Agent              ┃ Type                 ┃ Severity ┃ Message               ┃
+┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
+│ anthropic-research │ error_pattern        │ warning  │ Agent                 │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ output contains 'not  │
+│                    │                      │          │ found'.               │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 7,792                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.1×IQR above Q3 of   │
+│                    │                      │          │ 4,059.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 6,442                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 4,059.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 6,211                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.8×IQR above Q3 of   │
+│                    │                      │          │ 4,059.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 7,130                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 4,059.                │
+│ Explore            │ token_outlier        │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 11,578                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 4,823.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38,454                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.8×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 41,648                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 5.3×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,264                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 31,296                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.6×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,305                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.4×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,194                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.4×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38,782                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.8×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 37,953                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.7×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,857                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,338                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.4×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 33,048                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.9×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 33,425                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.9×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,830                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,802                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,102                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.7×IQR above Q3 of   │
+│                    │                      │          │ 9,554.                │
+│ pm                 │ token_outlier        │ warning  │ Agent 'pm' has 6,305  │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 4,384.                │
+│ claude-code-guide  │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'claude-code-guide'   │
+│                    │                      │          │ has 9,705             │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.8×IQR above Q3 of   │
+│                    │                      │          │ 4,423.                │
+│ architect          │ duration_outlier     │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 10.7s/tool_use,       │
+│                    │                      │          │ 1.9×IQR above Q3 of   │
+│                    │                      │          │ 6.1s.                 │
+│ architect          │ duration_outlier     │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 16.1s/tool_use,       │
+│                    │                      │          │ 4.2×IQR above Q3 of   │
+│                    │                      │          │ 6.1s.                 │
+│ Explore            │ duration_outlier     │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 45.0s/tool_use,       │
+│                    │                      │          │ 24.1×IQR above Q3 of  │
+│                    │                      │          │ 4.3s.                 │
+│ Explore            │ duration_outlier     │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 36.6s/tool_use,       │
+│                    │                      │          │ 19.1×IQR above Q3 of  │
+│                    │                      │          │ 4.3s.                 │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 37.9s/tool_use,       │
+│                    │                      │          │ 4.3×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 22.6s/tool_use,       │
+│                    │                      │          │ 1.7×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.6s/tool_use,       │
+│                    │                      │          │ 4.4×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.8s/tool_use,       │
+│                    │                      │          │ 4.4×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 25.4s/tool_use,       │
+│                    │                      │          │ 2.2×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 29.7s/tool_use,       │
+│                    │                      │          │ 2.9×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24.1s/tool_use,       │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 474.5s/tool_use,      │
+│                    │                      │          │ 78.4×IQR above Q3 of  │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 461.8s/tool_use,      │
+│                    │                      │          │ 76.3×IQR above Q3 of  │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 29.2s/tool_use,       │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.7s/tool_use,       │
+│                    │                      │          │ 4.4×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 27.5s/tool_use,       │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 21.8s/tool_use,       │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 34.0s/tool_use,       │
+│                    │                      │          │ 3.6×IQR above Q3 of   │
+│                    │                      │          │ 12.5s.                │
+│ pm                 │ duration_outlier     │ warning  │ Agent 'pm' has        │
+│                    │                      │          │ 29.7s/tool_use,       │
+│                    │                      │          │ 1.7×IQR above Q3 of   │
+│                    │                      │          │ 14.6s.                │
+│ pm                 │ duration_outlier     │ warning  │ Agent 'pm' has        │
+│                    │                      │          │ 46.4s/tool_use,       │
+│                    │                      │          │ 3.5×IQR above Q3 of   │
+│                    │                      │          │ 14.6s.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 3   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Detect    │
+│                    │                      │          │ retry sequences       │
+│                    │                      │          │ within a subagent's   │
+│                    │                      │          │ tool_calls. 2 3 A     │
+│                    │                      │          │ retry sequence is two │
+│                    │                      │          │ or more consecutive   │
+│                    │                      │          │ tool calls ('.        │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read'   │
+│                    │                      │          │ 10 times with         │
+│                    │                      │          │ different parameter   │
+│                    │                      │          │ shapes before         │
+│                    │                      │          │ succeeding. First     │
+│                    │                      │          │ attempt failed with:  │
+│                    │                      │          │ '645 class            │
+│                    │                      │          │ ParameterRetryRule:   │
+│                    │                      │          │ 646                   │
+│                    │                      │          │ """PARAMETER_RETRY -> │
+│                    │                      │          │ recommend             │
+│                    │                      │          │ `input_examples` on   │
+│                    │                      │          │ the tool definition.  │
+│                    │                      │          │ 647 648 The a'.       │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'EISDIR:        │
+│                    │                      │          │ illegal operation on  │
+│                    │                      │          │ a directory, read     │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 3 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 7 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '855            │
+│                    │                      │          │ **Reference:** Issue  │
+│                    │                      │          │ #333; calibration     │
+│                    │                      │          │ data at               │
+│                    │                      │          │ `.claude/specs/analy… │
+│                    │                      │          │ architect revi'.      │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 6 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 5 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 6 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '76 def         │
+│                    │                      │          │ compute_error_rate(i… │
+│                    │                      │          │ AgentInvocation) ->   │
+│                    │                      │          │ float: 77 """Observed │
+│                    │                      │          │ error rate for a      │
+│                    │                      │          │ single invocation. 78 │
+│                    │                      │          │ 79 Trace'.            │
+│ architect          │ tool_error_sequence  │ critical │ Subagent 'architect'  │
+│                    │                      │          │ had 5 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 5 times.  │
+│ anthropic-research │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'WebFetch' 3 times.   │
+│ anthropic-research │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-verifier │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Behavior  │
+│                    │                      │          │ signal extraction     │
+│                    │                      │          │ from agent            │
+│                    │                      │          │ invocations. 2 3      │
+│                    │                      │          │ Detects error         │
+│                    │                      │          │ patterns in output    │
+│                    │                      │          │ text, token           │
+│                    │                      │          │ consumption out'.     │
+│ candidate-verifier │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ retried tool 'Edit' 8 │
+│                    │                      │          │ times.                │
+│ candidate-verifier │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ had 3 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-verifier │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ had 6 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-promoter │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ retried tool 'Edit' 3 │
+│                    │                      │          │ times.                │
+│ candidate-promoter │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-promoter │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ had 4 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Grep' 4 times.  │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1              │
+│                    │                      │          │ """Diagnostics        │
+│                    │                      │          │ orchestration. 2 3    │
+│                    │                      │          │ Owns the              │
+│                    │                      │          │ `run_diagnostics`     │
+│                    │                      │          │ pipeline: extracts    │
+│                    │                      │          │ metadata-level and 4  │
+│                    │                      │          │ trace-level signa'.   │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1              │
+│                    │                      │          │ """Diagnostics        │
+│                    │                      │          │ orchestration. 2 3    │
+│                    │                      │          │ Owns the              │
+│                    │                      │          │ `run_diagnostics`     │
+│                    │                      │          │ pipeline: extracts    │
+│                    │                      │          │ metadata-level and 4  │
+│                    │                      │          │ trace-level signa'.   │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ claude-code-guide  │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'claude-code-guide'   │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'WebSearch' 2 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'Web search     │
+│                    │                      │          │ results for query:    │
+│                    │                      │          │ "site:code.claude.com │
+│                    │                      │          │ hooks reference       │
+│                    │                      │          │ PostToolUse input     │
+│                    │                      │          │ schema" Links:        │
+│                    │                      │          │ [{"title":"Hooks re'. │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__add_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Glob' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File does not  │
+│                    │                      │          │ exist. Note: your     │
+│                    │                      │          │ current working       │
+│                    │                      │          │ directory is          │
+│                    │                      │          │ /home/fdpearce/Docum… │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 6 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File content   │
+│                    │                      │          │ (26154 tokens)        │
+│                    │                      │          │ exceeds maximum       │
+│                    │                      │          │ allowed tokens        │
+│                    │                      │          │ (25000). Use offset   │
+│                    │                      │          │ and limit parameters  │
+│                    │                      │          │ to read specific      │
+│                    │                      │          │ por'.                 │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit'   │
+│                    │                      │          │ 10 times.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Behavior  │
+│                    │                      │          │ signal extraction     │
+│                    │                      │          │ from agent            │
+│                    │                      │          │ invocations. 2 3      │
+│                    │                      │          │ Detects error         │
+│                    │                      │          │ patterns in output    │
+│                    │                      │          │ text, token           │
+│                    │                      │          │ consumption out'.     │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 5 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__update… │
+│                    │                      │          │ 7 times.              │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 8 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'EISDIR:        │
+│                    │                      │          │ illegal operation on  │
+│                    │                      │          │ a directory, read     │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 7 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Plan               │ retry_loop           │ warning  │ Subagent 'Plan'       │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ Plan               │ retry_loop           │ warning  │ Subagent 'Plan'       │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 8 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Build the │
+│                    │                      │          │ threshold-calibration │
+│                    │                      │          │ notebook              │
+│                    │                      │          │ programmatically. 2 3 │
+│                    │                      │          │ This script is the    │
+│                    │                      │          │ canonical source for  │
+│                    │                      │          │ 4 ``scripts/'.        │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 8 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File does not  │
+│                    │                      │          │ exist. Note: your     │
+│                    │                      │          │ current working       │
+│                    │                      │          │ directory is          │
+│                    │                      │          │ /home/fdpearce/Docum… │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 3 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 4 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 7 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ architect          │ tool_orchestration_… │ info     │ Agent 'architect'     │
+│                    │                      │          │ made 1244 tool calls  │
+│                    │                      │          │ consuming 4,187,917   │
+│                    │                      │          │ tokens across 58      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,366 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ Explore            │ tool_orchestration_… │ info     │ Agent 'Explore' made  │
+│                    │                      │          │ 363 tool calls        │
+│                    │                      │          │ consuming 1,099,921   │
+│                    │                      │          │ tokens across 20      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,030 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ general-purpose    │ tool_orchestration_… │ info     │ Agent                 │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ made 1072 tool calls  │
+│                    │                      │          │ consuming 3,482,399   │
+│                    │                      │          │ tokens across 57      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,249 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ pm                 │ tool_orchestration_… │ info     │ Agent 'pm' made 894   │
+│                    │                      │          │ tool calls consuming  │
+│                    │                      │          │ 3,196,582 tokens      │
+│                    │                      │          │ across 31             │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,576 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ marketer           │ unused_agent         │ info     │ Agent 'marketer' is   │
+│                    │                      │          │ defined in            │
+│                    │                      │          │ /home/fdpearce/.clau… │
+│                    │                      │          │ but has 0 invocations │
+│                    │                      │          │ across 46 analyzed    │
+│                    │                      │          │ sessions.             │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: wait   │
+│                    │                      │          │ does api calls        │
+│                    │                      │          │ include synthetic     │
+│                    │                      │          │ messages as the       │
+│                    │                      │          │ comment you just      │
+│                    │                      │          │ showed said? I        │
+│                    │                      │          │ thought both model    │
+│                    │                      │          │ turns and api calls   │
+│                    │                      │          │ excluded synthe…      │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread:        │
+│                    │                      │          │ `/simplify → 4        │
+│                    │                      │          │ cleanup agents in     │
+│                    │                      │          │ parallel → apply the  │
+│                    │                      │          │ fixes`                │
+│                    │                      │          │                       │
+│                    │                      │          │ You are improving the │
+│                    │                      │          │ quality of the        │
+│                    │                      │          │ changed code, not     │
+│                    │                      │          │ hunting for bugs.     │
+│                    │                      │          │ Revie…                │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: sorry, │
+│                    │                      │          │ I meant the architect │
+│                    │                      │          │ agent should review   │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 64 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/.cla… │
+│                    │                      │          │ edited 31 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 38 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 31 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 27 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 53 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 17 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 14 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 45 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 49 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 44 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 34 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 50 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 17 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 25 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 20 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 18 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 18 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 18 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 22 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 16 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 38 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 35 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 36 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 23 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 33 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 13 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 24 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/.cla… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 6            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 5            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 13e567c followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat f74c773 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 155cb1a followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 3a81554 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat d2c040d followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 942578e followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a274b3f followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a37c172 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 3147314 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c742b2b followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 0d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat b1b63a5 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 985d1a4 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 2fe7f65 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a9502fb followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 0ccc759 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat d4ba779 followed │
+│                    │                      │          │ by 3 fixes on shared  │
+│                    │                      │          │ file(s) within 6d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat c5fdc80 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 6d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat b0cf957 followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat ee0d98c followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat c73f94b followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat ef80c4f followed │
+│                    │                      │          │ by 3 fixes on shared  │
+│                    │                      │          │ file(s) within 0d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat adfd205 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat baf81c4 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c680db0 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 158dfb8 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c08c873 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat b516e53 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 75238df followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 204b759 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat 2b5737e followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat b042976 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 1d     │
+└────────────────────┴──────────────────────┴──────────┴───────────────────────┘
+
+Top 5 priority fixes (see Recommendations table below for detail):
+ #1  critical  general-purpose     14×  target: prompt    [speed]   
+ #2  critical  architect            4×  target: prompt    [speed]   
+ #3  critical  candidate-verifier   2×  target: prompt    [speed]   
+ #4  critical  candidate-promoter   2×  target: prompt    [speed]   
+ #5  warning   (global)            31×  target: subagent  [quality] 
+                                Recommendations                                 
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃  # ┃ Agent              ┃ Target      ┃ Severity ┃ Count ┃ Recommendation    ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│  1 │ general-purpose    │ prompt      │ critical │    14 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│  2 │ architect          │ prompt      │ critical │     4 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│  3 │ candidate-verifier │ prompt      │ critical │     2 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│  4 │ candidate-promoter │ prompt      │ critical │     2 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the agent's       │
+│    │                    │             │          │       │ prompt so it      │
+│    │                    │             │          │       │ recovers from     │
+│    │                    │             │          │       │ repeated tool     │
+│    │                    │             │          │       │ failures.         │
+│  5 │ (global)           │ subagent    │ warning  │    31 │ [quality]         │
+│    │                    │             │          │       │ file_rework:      │
+│    │                    │             │          │       │ Consider an       │
+│    │                    │             │          │       │ architect         │
+│    │                    │             │          │       │ subagent for      │
+│    │                    │             │          │       │ design review     │
+│    │                    │             │          │       │ before starting   │
+│    │                    │             │          │       │ implementation in │
+│    │                    │             │          │       │ this area, or a   │
+│    │                    │             │          │       │ tester subagent   │
+│    │                    │             │          │       │ to verify         │
+│    │                    │             │          │       │ completion        │
+│    │                    │             │          │       │ claims.           │
+│  6 │ (global)           │ subagent    │ warning  │    31 │ [quality]         │
+│    │                    │             │          │       │ feat_fix_proximi… │
+│    │                    │             │          │       │ Consider routing  │
+│    │                    │             │          │       │ similar feature   │
+│    │                    │             │          │       │ work through an   │
+│    │                    │             │          │       │ architect or      │
+│    │                    │             │          │       │ code-reviewer     │
+│    │                    │             │          │       │ subagent before   │
+│    │                    │             │          │       │ commit.           │
+│  7 │ general-purpose    │ prompt      │ warning  │    15 │ [cost]            │
+│    │                    │             │          │       │ token_outlier     │
+│    │                    │             │          │       │ (2.4×–5.3×IQR     │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│  8 │ general-purpose    │ prompt      │ warning  │    14 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.6×–78.4×IQR    │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│  9 │ general-purpose    │ tools       │ warning  │     8 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ Add an            │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'Read' tool       │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'Read' based on   │
+│    │                    │             │          │       │ the observed      │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "offset": 170,  │
+│    │                    │             │          │       │   "limit": 60     │
+│    │                    │             │          │       │ }                 │
+│ 10 │ architect          │ tools       │ warning  │     7 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ Add an            │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'Read' tool       │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'Read' based on   │
+│    │                    │             │          │       │ the observed      │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "limit": 150    │
+│    │                    │             │          │       │ }                 │
+│ 11 │ pm                 │ prompt      │ warning  │     5 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│ 12 │ Explore            │ tools       │ warning  │     5 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ Add an            │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'Read' tool       │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'Read' based on   │
+│    │                    │             │          │       │ the observed      │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/tmp/simplify_4… │
+│    │                    │             │          │       │   "offset": 219,  │
+│    │                    │             │          │       │   "limit": 60     │
+│    │                    │             │          │       │ }                 │
+│ 13 │ Explore            │ prompt      │ warning  │     3 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 14 │ pm                 │ tools       │ warning  │     3 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ Add an            │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'Read' tool       │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'Read' based on   │
+│    │                    │             │          │       │ the observed      │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "offset": 0,    │
+│    │                    │             │          │       │   "limit": 605    │
+│    │                    │             │          │       │ }                 │
+│ 15 │ (global)           │ subagent    │ warning  │     3 │ [quality]         │
+│    │                    │             │          │       │ user_correction:  │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ delegating to a   │
+│    │                    │             │          │       │ review-style      │
+│    │                    │             │          │       │ subagent          │
+│    │                    │             │          │       │ (architect,       │
+│    │                    │             │          │       │ code-reviewer)    │
+│    │                    │             │          │       │ for design checks │
+│    │                    │             │          │       │ before            │
+│    │                    │             │          │       │ implementation.   │
+│ 16 │ architect          │ prompt      │ warning  │     4 │ [cost]            │
+│    │                    │             │          │       │ token_outlier     │
+│    │                    │             │          │       │ (1.8×–3.1×IQR     │
+│    │                    │             │          │       │ above Q3): Add    │
+│    │                    │             │          │       │ more specific     │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ to reduce         │
+│    │                    │             │          │       │ exploration.      │
+│ 17 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'WebFetch' 3      │
+│    │                    │             │          │       │ times. Repeated   │
+│    │                    │             │          │       │ retries on the    │
+│    │                    │             │          │       │ same tool         │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. Add │
+│    │                    │             │          │       │ explicit retry /  │
+│    │                    │             │          │       │ fallback guidance │
+│    │                    │             │          │       │ to the prompt in  │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│ 18 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ had 2 consecutive │
+│    │                    │             │          │       │ tool errors.      │
+│    │                    │             │          │       │ Multiple          │
+│    │                    │             │          │       │ consecutive tool  │
+│    │                    │             │          │       │ errors suggest    │
+│    │                    │             │          │       │ the agent lacks   │
+│    │                    │             │          │       │ fallback          │
+│    │                    │             │          │       │ instructions for  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails. Add        │
+│    │                    │             │          │       │ fallback          │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│ 19 │ candidate-verifier │ tools       │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-verif… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Read' 3 times    │
+│    │                    │             │          │       │ with different    │
+│    │                    │             │          │       │ parameter shapes. │
+│    │                    │             │          │       │ First attempt     │
+│    │                    │             │          │       │ failed with: '1   │
+│    │                    │             │          │       │ """Behavior       │
+│    │                    │             │          │       │ signal extraction │
+│    │                    │             │          │       │ from agent        │
+│    │                    │             │          │       │ invocations. 2 3  │
+│    │                    │             │          │       │ Detects error     │
+│    │                    │             │          │       │ patterns in       │
+│    │                    │             │          │       │ output text,      │
+│    │                    │             │          │       │ token consumption │
+│    │                    │             │          │       │ out'.             │
+│    │                    │             │          │       │ Parameter-retry   │
+│    │                    │             │          │       │ patterns indicate │
+│    │                    │             │          │       │ the agent is      │
+│    │                    │             │          │       │ guessing at input │
+│    │                    │             │          │       │ formats. Adding   │
+│    │                    │             │          │       │ concrete examples │
+│    │                    │             │          │       │ to the tool       │
+│    │                    │             │          │       │ definition (an    │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array) improves   │
+│    │                    │             │          │       │ accuracy from 72% │
+│    │                    │             │          │       │ to 90% on complex │
+│    │                    │             │          │       │ parameter         │
+│    │                    │             │          │       │ handling          │
+│    │                    │             │          │       │ (Anthropic        │
+│    │                    │             │          │       │ benchmark). Add   │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'Read' tool       │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'Read' based on   │
+│    │                    │             │          │       │ the observed      │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "limit": 100    │
+│    │                    │             │          │       │ }                 │
+│ 20 │ candidate-verifier │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-verif… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Edit' 8 times.   │
+│    │                    │             │          │       │ Repeated retries  │
+│    │                    │             │          │       │ on the same tool  │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. The │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 21 │ candidate-promoter │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-promo… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Edit' 3 times.   │
+│    │                    │             │          │       │ Repeated retries  │
+│    │                    │             │          │       │ on the same tool  │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. Add │
+│    │                    │             │          │       │ explicit retry /  │
+│    │                    │             │          │       │ fallback guidance │
+│    │                    │             │          │       │ to the agent's    │
+│    │                    │             │          │       │ prompt body.      │
+│ 22 │ claude-code-guide  │ tools       │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'claude-code-gui… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'WebSearch' 2     │
+│    │                    │             │          │       │ times with        │
+│    │                    │             │          │       │ different         │
+│    │                    │             │          │       │ parameter shapes  │
+│    │                    │             │          │       │ before            │
+│    │                    │             │          │       │ succeeding. First │
+│    │                    │             │          │       │ attempt failed    │
+│    │                    │             │          │       │ with: 'Web search │
+│    │                    │             │          │       │ results for       │
+│    │                    │             │          │       │ query:            │
+│    │                    │             │          │       │ "site:code.claud… │
+│    │                    │             │          │       │ hooks reference   │
+│    │                    │             │          │       │ PostToolUse input │
+│    │                    │             │          │       │ schema" Links:    │
+│    │                    │             │          │       │ [{"title":"Hooks  │
+│    │                    │             │          │       │ re'.              │
+│    │                    │             │          │       │ Parameter-retry   │
+│    │                    │             │          │       │ patterns indicate │
+│    │                    │             │          │       │ the agent is      │
+│    │                    │             │          │       │ guessing at input │
+│    │                    │             │          │       │ formats. Adding   │
+│    │                    │             │          │       │ concrete examples │
+│    │                    │             │          │       │ to the tool       │
+│    │                    │             │          │       │ definition (an    │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array) improves   │
+│    │                    │             │          │       │ accuracy from 72% │
+│    │                    │             │          │       │ to 90% on complex │
+│    │                    │             │          │       │ parameter         │
+│    │                    │             │          │       │ handling          │
+│    │                    │             │          │       │ (Anthropic        │
+│    │                    │             │          │       │ benchmark). Add   │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to the      │
+│    │                    │             │          │       │ 'WebSearch' tool  │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Suggested         │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ entry for tool    │
+│    │                    │             │          │       │ 'WebSearch' based │
+│    │                    │             │          │       │ on the observed   │
+│    │                    │             │          │       │ successful call:  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "query":        │
+│    │                    │             │          │       │ "\"duration_ms\"  │
+│    │                    │             │          │       │ PostToolUse hook  │
+│    │                    │             │          │       │ \"all tools\" OR  │
+│    │                    │             │          │       │ \"every tool\" OR │
+│    │                    │             │          │       │ universal OR      │
+│    │                    │             │          │       │ scope",           │
+│    │                    │             │          │       │   "allowed_domai… │
+│    │                    │             │          │       │ [                 │
+│    │                    │             │          │       │     "code.claude… │
+│    │                    │             │          │       │     "github.com"  │
+│    │                    │             │          │       │   ]               │
+│    │                    │             │          │       │ }                 │
+│ 23 │ architect          │ model       │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.9×–4.2×IQR     │
+│    │                    │             │          │       │ above Q3): If     │
+│    │                    │             │          │       │ this agent's task │
+│    │                    │             │          │       │ is routine,       │
+│    │                    │             │          │       │ consider          │
+│    │                    │             │          │       │ switching from    │
+│    │                    │             │          │       │ claude-opus-4-8   │
+│    │                    │             │          │       │ to a faster model │
+│    │                    │             │          │       │ in                │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 24 │ Explore            │ prompt      │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (19.1×–24.1×IQR   │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 25 │ pm                 │ model       │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.7×–3.5×IQR     │
+│    │                    │             │          │       │ above Q3): If     │
+│    │                    │             │          │       │ this agent's task │
+│    │                    │             │          │       │ is routine,       │
+│    │                    │             │          │       │ consider          │
+│    │                    │             │          │       │ switching from    │
+│    │                    │             │          │       │ claude-opus-4-8   │
+│    │                    │             │          │       │ to a faster model │
+│    │                    │             │          │       │ in                │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 26 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Agent     │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ output contains   │
+│    │                    │             │          │       │ 'not found'.      │
+│    │                    │             │          │       │ Repeated errors   │
+│    │                    │             │          │       │ suggest the agent │
+│    │                    │             │          │       │ lacks error       │
+│    │                    │             │          │       │ handling          │
+│    │                    │             │          │       │ guidance. Add     │
+│    │                    │             │          │       │ error handling    │
+│    │                    │             │          │       │ guidance to the   │
+│    │                    │             │          │       │ prompt body in    │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│ 27 │ Explore            │ prompt      │ warning  │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'Explore' has     │
+│    │                    │             │          │       │ 11,578            │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 2.8×IQR above Q3  │
+│    │                    │             │          │       │ of 4,823. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Built-in │
+│    │                    │             │          │       │ agent — prompt is │
+│    │                    │             │          │       │ not               │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 28 │ pm                 │ prompt      │ warning  │     1 │ [cost] Agent 'pm' │
+│    │                    │             │          │       │ has 6,305         │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 1.6×IQR above Q3  │
+│    │                    │             │          │       │ of 4,384. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Add more │
+│    │                    │             │          │       │ specific          │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ to reduce         │
+│    │                    │             │          │       │ exploration.      │
+│ 29 │ claude-code-guide  │ prompt      │ warning  │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'claude-code-gui… │
+│    │                    │             │          │       │ has 9,705         │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 1.8×IQR above Q3  │
+│    │                    │             │          │       │ of 4,423. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Built-in │
+│    │                    │             │          │       │ agent — prompt is │
+│    │                    │             │          │       │ not               │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 30 │ architect          │ subagent    │ info     │    62 │ [quality]         │
+│    │                    │             │          │       │ reviewer_caught:  │
+│    │                    │             │          │       │ No action needed: │
+│    │                    │             │          │       │ this rate sits in │
+│    │                    │             │          │       │ the healthy band  │
+│    │                    │             │          │       │ (25%-75%).        │
+│    │                    │             │          │       │ Investigate only  │
+│    │                    │             │          │       │ if it falls below │
+│    │                    │             │          │       │ that band.        │
+│ 31 │ pm                 │ prompt      │ warning  │    27 │ [speed]           │
+│    │                    │             │          │       │ retry_loop: The   │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 32 │ general-purpose    │ prompt      │ warning  │    63 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+│ 33 │ architect          │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'architect' made  │
+│    │                    │             │          │       │ 1244 tool calls   │
+│    │                    │             │          │       │ consuming         │
+│    │                    │             │          │       │ 4,187,917 tokens  │
+│    │                    │             │          │       │ across 58         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,366       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ migrating the     │
+│    │                    │             │          │       │ tools this agent  │
+│    │                    │             │          │       │ calls to          │
+│    │                    │             │          │       │ `allowed_callers: │
+│    │                    │             │          │       │ ["code_execution… │
+│    │                    │             │          │       │ so intermediate   │
+│    │                    │             │          │       │ results are       │
+│    │                    │             │          │       │ processed in the  │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ sandbox           │
+│    │                    │             │          │       │ (estimated        │
+│    │                    │             │          │       │ savings:          │
+│    │                    │             │          │       │ ~1,549,529 tokens │
+│    │                    │             │          │       │ at the 37%        │
+│    │                    │             │          │       │ benchmark) — edit │
+│    │                    │             │          │       │ the tool          │
+│    │                    │             │          │       │ definitions       │
+│    │                    │             │          │       │ referenced by     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 34 │ Explore            │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'Explore' made    │
+│    │                    │             │          │       │ 363 tool calls    │
+│    │                    │             │          │       │ consuming         │
+│    │                    │             │          │       │ 1,099,921 tokens  │
+│    │                    │             │          │       │ across 20         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,030       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ tool list is not  │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Route this task   │
+│    │                    │             │          │       │ to a custom       │
+│    │                    │             │          │       │ subagent with     │
+│    │                    │             │          │       │ explicit tool     │
+│    │                    │             │          │       │ grants, or        │
+│    │                    │             │          │       │ confirm the       │
+│    │                    │             │          │       │ built-in agent's  │
+│    │                    │             │          │       │ fixed tool set is │
+│    │                    │             │          │       │ actually          │
+│    │                    │             │          │       │ required.         │
+│ 35 │ general-purpose    │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'general-purpose' │
+│    │                    │             │          │       │ made 1072 tool    │
+│    │                    │             │          │       │ calls consuming   │
+│    │                    │             │          │       │ 3,482,399 tokens  │
+│    │                    │             │          │       │ across 57         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,249       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ tool list is not  │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Route this task   │
+│    │                    │             │          │       │ to a custom       │
+│    │                    │             │          │       │ subagent with     │
+│    │                    │             │          │       │ explicit tool     │
+│    │                    │             │          │       │ grants, or        │
+│    │                    │             │          │       │ confirm the       │
+│    │                    │             │          │       │ built-in agent's  │
+│    │                    │             │          │       │ fixed tool set is │
+│    │                    │             │          │       │ actually          │
+│    │                    │             │          │       │ required.         │
+│ 36 │ pm                 │ tools       │ info     │     1 │ [cost] Agent 'pm' │
+│    │                    │             │          │       │ made 894 tool     │
+│    │                    │             │          │       │ calls consuming   │
+│    │                    │             │          │       │ 3,196,582 tokens  │
+│    │                    │             │          │       │ across 31         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,576       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ migrating the     │
+│    │                    │             │          │       │ tools this agent  │
+│    │                    │             │          │       │ calls to          │
+│    │                    │             │          │       │ `allowed_callers: │
+│    │                    │             │          │       │ ["code_execution… │
+│    │                    │             │          │       │ so intermediate   │
+│    │                    │             │          │       │ results are       │
+│    │                    │             │          │       │ processed in the  │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ sandbox           │
+│    │                    │             │          │       │ (estimated        │
+│    │                    │             │          │       │ savings:          │
+│    │                    │             │          │       │ ~1,182,735 tokens │
+│    │                    │             │          │       │ at the 37%        │
+│    │                    │             │          │       │ benchmark) — edit │
+│    │                    │             │          │       │ the tool          │
+│    │                    │             │          │       │ definitions       │
+│    │                    │             │          │       │ referenced by     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 37 │ marketer           │ description │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'marketer' is     │
+│    │                    │             │          │       │ defined in        │
+│    │                    │             │          │       │ /home/fdpearce/.… │
+│    │                    │             │          │       │ but has 0         │
+│    │                    │             │          │       │ invocations       │
+│    │                    │             │          │       │ across 46         │
+│    │                    │             │          │       │ analyzed          │
+│    │                    │             │          │       │ sessions. An      │
+│    │                    │             │          │       │ agent defined but │
+│    │                    │             │          │       │ never delegated   │
+│    │                    │             │          │       │ to is either      │
+│    │                    │             │          │       │ misaligned with   │
+│    │                    │             │          │       │ how the parent    │
+│    │                    │             │          │       │ frames tasks, or  │
+│    │                    │             │          │       │ the triggering    │
+│    │                    │             │          │       │ context isn't     │
+│    │                    │             │          │       │ present in this   │
+│    │                    │             │          │       │ analysis window.  │
+│    │                    │             │          │       │ Compare the       │
+│    │                    │             │          │       │ description       │
+│    │                    │             │          │       │ against           │
+│    │                    │             │          │       │ parent-thread     │
+│    │                    │             │          │       │ phrasing. Current │
+│    │                    │             │          │       │ description:      │
+│    │                    │             │          │       │ "Invoke when      │
+│    │                    │             │          │       │ drafting          │
+│    │                    │             │          │       │ marketing or      │
+│    │                    │             │          │       │ communications    │
+│    │                    │             │          │       │ content — blog    │
+│    │                    │             │          │       │ posts, case       │
+│    │                    │             │          │       │ studies,          │
+│    │                    │             │          │       │ LinkedIn/X/dev.to │
+│    │                    │             │          │       │ posts, project    │
+│    │                    │             │          │       │ announcements, or │
+│    │                    │             │          │       │ other             │
+│    │                    │             │          │       │ public-facing     │
+│    │                    │             │          │       │ writing in Fred's │
+│    │                    │             │          │       │ voice. Also       │
+│    │                    │             │          │       │ handles           │
+│    │                    │             │          │       │ series-planning   │
+│    │                    │             │          │       │ work: turning a   │
+│    │                    │             │          │       │ topic shortlist   │
+│    │                    │             │          │       │ the parent has    │
+│    │                    │             │          │       │ already chosen    │
+│    │                    │             │          │       │ into a sharpened  │
+│    │                    │             │          │       │ outline (titles,  │
+│    │                    │             │          │       │ scope, audience   │
+│    │                    │             │          │       │ hooks, bridges)   │
+│    │                    │             │          │       │ ready for         │
+│    │                    │             │          │       │ issue-filing.     │
+│    │                    │             │          │       │ Returns either a  │
+│    │                    │             │          │       │ proposed filename │
+│    │                    │             │          │       │ + post body       │
+│    │                    │             │          │       │ (single piece) or │
+│    │                    │             │          │       │ a structured      │
+│    │                    │             │          │       │ outline (series   │
+│    │                    │             │          │       │ planning),        │
+│    │                    │             │          │       │ depending on the  │
+│    │                    │             │          │       │ request shape. Do │
+│    │                    │             │          │       │ NOT invoke for:   │
+│    │                    │             │          │       │ code comments,    │
+│    │                    │             │          │       │ docstrings,       │
+│    │                    │             │          │       │ README updates,   │
+│    │                    │             │          │       │ commit messages,  │
+│    │                    │             │          │       │ PR descriptions,  │
+│    │                    │             │          │       │ internal/private  │
+│    │                    │             │          │       │ docs, or          │
+│    │                    │             │          │       │ technical         │
+│    │                    │             │          │       │ documentation     │
+│    │                    │             │          │       │ that lives in the │
+│    │                    │             │          │       │ codebase — those  │
+│    │                    │             │          │       │ stay with the     │
+│    │                    │             │          │       │ parent agent.".   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ broadening the    │
+│    │                    │             │          │       │ description,      │
+│    │                    │             │          │       │ rewriting it, or  │
+│    │                    │             │          │       │ accepting that    │
+│    │                    │             │          │       │ 'marketer' is     │
+│    │                    │             │          │       │ unused for this   │
+│    │                    │             │          │       │ workload. File:   │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 38 │ Explore            │ prompt      │ warning  │    18 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+│ 39 │ architect          │ prompt      │ warning  │    42 │ [speed]           │
+│    │                    │             │          │       │ retry_loop: The   │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 40 │ Plan               │ prompt      │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+└────┴────────────────────┴─────────────┴──────────┴───────┴───────────────────┘
+
+Deep Diagnostics: 211 trace signal(s) across 9 subagent(s). Use --verbose for 
+per-call evidence.
+
+Suggested Subagents
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┓
+┃ Name         ┃ Model        ┃ Confidence ┃ Cluster size ┃ Tools       ┃ Note ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━┩
+│ subagent-dr… │ claude-opus… │ medium     │            6 │ Bash, Read  │      │
+│ efficiency-… │ claude-opus… │ low        │           26 │ Bash, Read  │      │
+│ py-delegati… │ claude-opus… │ medium     │            7 │ Bash, Read  │      │
+│ calibration… │ claude-opus… │ medium     │           12 │ Bash, Read  │      │
+│ table-agg    │ claude-opus… │ medium     │            8 │ Bash, Edit, │      │
+│              │              │            │              │ Read, Write │      │
+│ py-angle     │ claude-opus… │ medium     │           17 │ Bash, Read  │      │
+│ text--detec… │ claude-opus… │ medium     │            6 │ Bash, Read  │      │
+│ py-existing  │ claude-opus… │ medium     │           31 │ Bash, Read  │      │
+│ comments-qu… │ claude-opus… │ medium     │           31 │ Bash, Read  │      │
+│ tools-membe… │ claude-opus… │ medium     │            6 │ Bash, Read  │      │
+└──────────────┴──────────────┴────────────┴──────────────┴─────────────┴──────┘
+
+Offload Candidates
+No offload candidates surfaced (10 negative-savings rows hidden — pass 
+--show-negative-savings to inspect).
+See docs/GLOSSARY.md for term definitions.
+
+Sessions analyzed: 46

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Adds the fourth dogfood analysis (`.claude/specs/analysis/2026-06-05-v09-dogfood/`) for the v0.9.0 release: writeup + raw `analyze.json`/`analyze.table.txt`.
- Validates v0.9 shipped clean — model-turn metrics at every level, all three Advanced Tool Use signals behaving, `tier3_degraded: false`, every v0.8 follow-up landed; cost/session down to $28.
- Records the key calibration finding (PARAMETER_RETRY is practically inert on a built-in-tool-heavy corpus) and the 5 v0.10.0 follow-ups filed from it (#510–#514).
- Syncs `uv.lock`'s editable self-version to 0.9.0 (the release commit bumped `pyproject.toml` but left the lockfile at 0.8.0).

## Test plan
- [ ] Unit tests pass: `uv run pytest -m "not integration"`
- [ ] Lint clean: `uv run ruff check src/ tests/`
- [ ] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — n/a, docs + lockfile only, no source change
- [x] Manual smoke test via `uv run agentfluent ...` — the analysis IS the smoke test (`analyze --diagnostics --git --github --json` ran clean on 46 sessions)

## Security review
- [x] **Skip review** — no security-sensitive surface (maintainer-only analysis doc under `.claude/specs/` + lockfile self-version sync; ships nothing to the PyPI package).
- [ ] **Needs review**

## Breaking changes
None. Docs and lockfile metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)