### PR TITLE
chore(security): enable security-guidance plugin (pattern-only, Sonnet-pinned)

### DIFF
--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -1,0 +1,64 @@
+# Security Guidance — AgentFluent
+
+Threat model and review checklist for the `security-guidance` plugin's
+LLM-backed review layers (end-of-turn diff review and commit/push review).
+
+> **Status:** Currently dormant. The LLM layers are disabled
+> (`ENABLE_CODE_SECURITY_REVIEW=0` in `.claude/settings.json`), so only the
+> free deterministic pattern layer runs today. This file activates the moment
+> those layers are turned on — keep it in sync with the CI workflow's
+> `custom-security-scan-instructions` in `.github/workflows/security-review.yml`
+> so the in-session review and the PR-time review share one threat model.
+
+## What AgentFluent is
+
+A local-first Python CLI that reads user session data and agent definitions
+from `~/.claude/projects/` and `~/.claude/agents/`. It does **not** make network
+requests, store credentials, or transmit user data. There is no web server, no
+HTML rendering, and no webview.
+
+## Attack surfaces to focus on
+
+1. **JSONL parser** (`src/agentfluent/core/parser.py`) — reads arbitrary
+   user-controlled content. Check for unsafe deserialization, resource-exhaustion
+   on malformed/oversized input (unbounded reads, pathological nesting), and any
+   code path that evaluates or executes parsed strings.
+2. **Agent definition parser** (`src/agentfluent/config/scanner.py`) — parses
+   YAML frontmatter. Must use `yaml.safe_load` (never `yaml.load`) to prevent
+   arbitrary code execution via YAML tags.
+3. **Path handling in discovery** (`src/agentfluent/core/discovery.py`) —
+   iterates user directories. Check for path traversal, symlink following that
+   escapes the projects root, and TOCTOU races between stat and open.
+4. **CLI argument parsing** (`src/agentfluent/cli/`) — user strings from
+   `--project`, `--agent`, `--session` are matched against discovered data.
+   Ensure none reach a shell, `subprocess`, or any eval-like API.
+
+## Project-specific sensitivities
+
+- **Secret hygiene in output.** AgentFluent reads session transcripts that may
+  contain credential-looking values. Flag any new code path that echoes raw tool
+  output, renders un-redacted file contents, or logs values matching
+  `KEY|TOKEN|SECRET|PASSWORD`. (Two enforcement hooks already guard secret reads
+  and output — see `docs/SECURITY.md`.)
+- **Untrusted strings into rendering.** Sanitize user-controlled strings before
+  passing them to Rich/terminal formatting; never interpolate them into shell
+  commands.
+
+## Low priority (typically non-issues here)
+
+No web server, no HTML rendering, no webview, no authentication surface, no
+outbound network calls. Findings that assume a web/network attack surface are
+almost certainly false positives for this project — note them but rank low.
+
+## Review checklist
+
+- [ ] No `eval`, `exec`, `os.system`, `subprocess(..., shell=True)`, or
+      `compile()` on parsed/user-derived strings.
+- [ ] YAML loaded only via `yaml.safe_load`; no `pickle.load` /
+      `pickle.loads` on file or session content.
+- [ ] User-supplied paths are resolved and confined to their expected root
+      (no `..` escape, no symlink escape).
+- [ ] Parser bounds memory/CPU on malformed input — no unbounded buffering.
+- [ ] No credential-shaped value is logged, printed, or rendered un-redacted.
+- [ ] New external calls (file I/O, any future network) are wrapped in
+      try/except with user-friendly, non-leaking error messages.

--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -13,9 +13,13 @@ LLM-backed review layers (end-of-turn diff review and commit/push review).
 ## What AgentFluent is
 
 A local-first Python CLI that reads user session data and agent definitions
-from `~/.claude/projects/` and `~/.claude/agents/`. It does **not** make network
-requests, store credentials, or transmit user data. There is no web server, no
-HTML rendering, and no webview.
+from `~/.claude/projects/` and `~/.claude/agents/`. It stores no credentials and
+transmits no user data, and runs no web server, HTML rendering, or webview. Its
+**only** network egress and subprocess use is the `gh` / `git` CLI (the Tier 3
+GitHub-signals feature in `src/agentfluent/github/` and `diagnostics/`), invoked
+list-form with `shell=False`. No in-process HTTP client
+(`requests`/`httpx`/`urllib`/`socket`) is imported anywhere outside
+`src/agentfluent/github/`.
 
 ## Attack surfaces to focus on
 
@@ -46,9 +50,10 @@ HTML rendering, and no webview.
 
 ## Low priority (typically non-issues here)
 
-No web server, no HTML rendering, no webview, no authentication surface, no
-outbound network calls. Findings that assume a web/network attack surface are
-almost certainly false positives for this project — note them but rank low.
+No web server, no HTML rendering, no webview, no authentication surface. The only
+sanctioned network egress is the `gh` / `git` CLI (`src/agentfluent/github/`,
+`diagnostics/`); findings that assume an in-process HTTP or web attack surface
+elsewhere are almost certainly false positives — note them but rank low.
 
 ## Review checklist
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,5 +32,13 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  },
+  "env": {
+    "ENABLE_CODE_SECURITY_REVIEW": "0",
+    "SECURITY_REVIEW_MODEL": "claude-sonnet-4-6",
+    "SG_AGENTIC_MODEL": "claude-sonnet-4-6"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,24 @@ The CLI entry point is `agentfluent` (via `src/agentfluent/cli/main.py`). Comman
 - `agentfluent analyze --project <slug>` — token/cost/tool/agent analytics + diagnostics
 - `agentfluent config-check` — score agent definitions in `~/.claude/agents/` and `.claude/agents/`
 
+## Claude Code plugins
+
+This repo enables Claude Code plugins via the tracked `.claude/settings.json` (`enabledPlugins`). Enabling a plugin in settings does **not** install it for you — each contributor must install it once, then it activates automatically for this project. If you work on the repo with Claude Code, install the plugins below.
+
+| Plugin | Marketplace | What it does here | How it's configured |
+| --- | --- | --- | --- |
+| `security-guidance` | `claude-plugins-official` | Inline, in-session vulnerability detection. Flags dangerous patterns (e.g. `eval`, `yaml.load`, `pickle.load`) the moment Claude writes them — shifting detection left of the PR-time CI security review. | **Pattern-only** (`ENABLE_CODE_SECURITY_REVIEW=0`): runs the free, deterministic pattern layer only; the token-costing LLM review layers are off. Model pins (`SECURITY_REVIEW_MODEL`, `SG_AGENTIC_MODEL`) default to Sonnet for if/when those layers are enabled. The shared threat model lives in `.claude/claude-security-guidance.md`. |
+
+Install:
+
+```bash
+# inside a Claude Code session
+/plugin install security-guidance@claude-plugins-official
+/reload-plugins   # or restart the session
+```
+
+This is a convenience layer, not a merge gate — the authoritative security check remains the CI workflow (`.github/workflows/security-review.yml`, run via the `needs-security-review` label). See [`docs/SECURITY.md`](docs/SECURITY.md) for the full defense model.
+
 ## Project layout
 
 ```


### PR DESCRIPTION
## Summary
- Enable the official `security-guidance@claude-plugins-official` Claude Code plugin via `.claude/settings.json` for inline, in-session vulnerability detection — shifting detection left of the PR-time CI security review.
- Configure it conservatively to match the project's existing cost philosophy: **pattern-only** (`ENABLE_CODE_SECURITY_REVIEW=0`, free deterministic layer; LLM review layers off) with `SECURITY_REVIEW_MODEL`/`SG_AGENTIC_MODEL` pinned to Sonnet 4.6 for if/when those layers are enabled.
- Add `.claude/claude-security-guidance.md` (shared threat model, ported from the CI workflow's `custom-security-scan-instructions`) and document the enabled plugins + per-contributor install step in `CONTRIBUTING.md`.

## Test plan
- [ ] Unit tests pass: `uv run pytest -m "not integration"` — N/A, no `src/` change (config + docs only)
- [ ] Lint clean: `uv run ruff check src/ tests/` — N/A, no Python source touched
- [ ] Type check clean: `uv run mypy src/agentfluent/` — N/A, no Python source touched
- [ ] New/changed behavior has test coverage — N/A, no shipped code path changed
- [x] Manual smoke test — wrote `eval()`/`yaml.load()` to a scratch file; plugin's inline pattern warning fired for both, and no LLM review ran (pattern-only confirmed). Settings JSON validated with `python -m json.tool`.

## Security review
- [x] **Skip review** — no security-sensitive surface. Config + docs only: enables a security *tool* and adds a threat-model doc; does not modify `.claude/hooks/`, secret-handling code, workflows, CLI parsing, path resolution, or JSONL parsing.
- [ ] **Needs review**

## Breaking changes
None. No public contract changes — `.claude/` tooling config and contributor docs only; nothing ships in the PyPI package.