### PR TITLE
chore(security): add project-specific custom security-patterns (#524)

### DIFF
--- a/.claude/security-patterns.json
+++ b/.claude/security-patterns.json
@@ -1,0 +1,40 @@
+{
+  "_comment": "Project-specific custom patterns for the security-guidance plugin's free pattern layer. Complements (does not duplicate) the 25 built-in rules. Authored from the architect review on issue #524. JSON (not YAML) so the plugin's hook runtime never needs PyYAML. Globs use a leading wildcard because the hook matches against the absolute path with its leading slash stripped (file_path.lstrip('/') in check_patterns), and fnmatch anchors at the start.",
+  "patterns": [
+    {
+      "rule_name": "no-shell-true",
+      "regex": "shell\\s*=\\s*True",
+      "paths": ["*src/agentfluent/*.py"],
+      "exclude_paths": ["*/tests/*"],
+      "reminder": "AgentFluent never invokes a shell. Use list-form subprocess.run([...], shell=False); never shell=True. CLI args (--project/--agent/--session) must not reach a shell."
+    },
+    {
+      "rule_name": "no-dynamic-subprocess-args",
+      "regex": "subprocess\\.(run|Popen|call|check_output|check_call)\\(\\s*f[\"']",
+      "paths": ["*src/agentfluent/*.py"],
+      "exclude_paths": ["*/tests/*"],
+      "reminder": "Pass subprocess args as a list of literals/typed values, never an f-string or string-concatenated command. Building the command from interpolated input reintroduces injection even with shell=False."
+    },
+    {
+      "rule_name": "no-inprocess-http-client",
+      "regex": "(?:^|\\n)\\s*(import|from)\\s+(requests|httpx|urllib\\.request|urllib3|http\\.client|socket|aiohttp|ftplib|smtplib)\\b",
+      "paths": ["*src/agentfluent/*.py"],
+      "exclude_paths": ["*/tests/*", "*src/agentfluent/github/*"],
+      "reminder": "AgentFluent's only network egress is the gh CLI (Tier 3 GitHub signals). Do not import an in-process HTTP client. If you are adding a network feature, route it through the gh subprocess path or open a design discussion first."
+    },
+    {
+      "rule_name": "no-archive-extractall",
+      "substrings": [".extractall(", "tarfile.open(", "zipfile.ZipFile("],
+      "paths": ["*src/agentfluent/*.py"],
+      "exclude_paths": ["*/tests/*"],
+      "reminder": "AgentFluent reads JSONL, never archives. extractall() is a zip-slip / tar-slip path-traversal sink. If you genuinely need extraction, validate every member path stays within the target dir."
+    },
+    {
+      "rule_name": "no-render-secret-shaped-values",
+      "regex": "(print|log(ger)?\\.\\w+|console\\.print)\\([^)]*(api_key|api-key|secret|password)",
+      "paths": ["*src/agentfluent/*.py"],
+      "exclude_paths": ["*/tests/*"],
+      "reminder": "Session transcripts can contain secret-shaped values. Never print/log a variable named api_key/secret/password un-redacted. Redact at the boundary; see docs/SECURITY.md."
+    }
+  ]
+}

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -48,7 +48,10 @@ jobs:
           custom-security-scan-instructions: |
             AgentFluent is a local-first Python CLI that reads user session data and
             agent definitions from `~/.claude/projects/` and `~/.claude/agents/`.
-            It does NOT make network requests, store credentials, or transmit user data.
+            It stores no credentials and transmits no user data. Its only network
+            egress and subprocess use is the `gh`/`git` CLI (the Tier 3 GitHub-signals
+            feature in `src/agentfluent/github/` and `diagnostics/`), invoked list-form
+            with shell=False; no in-process HTTP client is imported elsewhere.
 
             Attack surfaces to focus on:
             1. JSONL parser (`src/agentfluent/core/parser.py`) — reads arbitrary user
@@ -64,5 +67,9 @@ jobs:
             4. CLI argument parsing (`src/agentfluent/cli/`) — user strings from
                `--project`, `--agent`, `--session` are matched against discovered
                data. Ensure none are passed to shell, subprocess, or eval-like APIs.
+            5. Subprocess/network boundary (`src/agentfluent/github/`,
+               `diagnostics/_git_helpers.py`) — shells out to `gh`/`git`. Verify
+               list-form argv (never shell=True), no f-string/concatenated commands,
+               and that no in-process HTTP client is introduced outside `github/`.
 
             Low priority (non-issues): no web server, no HTML rendering, no webview.


### PR DESCRIPTION
## Summary
- Add `.claude/security-patterns.json` — 5 project-tuned rules for the `security-guidance` plugin's free pattern layer, from the architect review on #524. They complement (don't duplicate) the 25 built-in rules and act as **regression tripwires** for AgentFluent-specific invariants (the codebase is clean today): `no-shell-true`, `no-dynamic-subprocess-args`, `no-inprocess-http-client` (excludes the sanctioned `github/` egress boundary), `no-archive-extractall` (zip-slip), `no-render-secret-shaped-values`.
- Correct the stale "no network requests" claim in the CI workflow's `custom-security-scan-instructions` and add a 5th focus area for the `gh`/`git` subprocess boundary, so the PR-time reviewer matches the real threat model (AgentFluent shells out to `gh`/`git` for Tier 3 GitHub signals).
- Two implementation details that matter: **JSON not YAML** (the plugin's hook runs under system Python, which may lack PyYAML), and globs use a **leading wildcard** + the HTTP regex uses `(?:^|\n)` not `^` (the hook matches `file_path.lstrip("/")` and runs `re.search` without `re.MULTILINE`).

## Test plan
- [ ] Unit tests pass: `uv run pytest -m "not integration"` — N/A, no `src/` change (config + CI prose only)
- [ ] Lint clean: `uv run ruff check src/ tests/` — N/A, no Python source touched
- [ ] Type check clean: `uv run mypy src/agentfluent/` — N/A, no Python source touched
- [ ] New/changed behavior has test coverage — N/A, no shipped code path changed
- [x] Manual verification — validated against the plugin's own `extensibility` loader: all 5 rules pass the ReDoS validator; 12 positive/negative match cases pass (incl. `github/` exclusion, `urllib.parse` non-match, `output_tokens` non-match, commented-import non-match); plus a **live end-to-end** hook fire of `user:no-inprocess-http-client`. JSON + workflow YAML both validated.

## Security review
- [ ] **Skip review**
- [x] **Needs review** — touches `.github/workflows/security-review.yml`. (Change is prose-only inside `custom-security-scan-instructions`; no `run:` interpolation, triggers, permissions, or action SHA changed. `needs-security-review` label will be applied when dev-complete per CONTRIBUTING.)

## Breaking changes
None. `.claude/` config + CI reviewer instructions only; nothing ships in the PyPI package.

Closes #524. Follow-up to #523.