### PR TITLE
chore(research): representative Agent SDK data-generation agent (#522)

### DIFF
--- a/research/agent-sdk-probe/FINDINGS.md
+++ b/research/agent-sdk-probe/FINDINGS.md
@@ -115,3 +115,103 @@ captured SDK session.
   this single-call probe).
 - **Downstream parser story (unticketed):** add the three SDK line types to
   `SKIP_TYPES`, version-pinned to SDK 0.2.106.
+
+---
+
+# Representative-agent findings (#522)
+
+Captured from `agent.py` (three variants) on the **same versions pinned above**
+(`claude-agent-sdk==0.2.106`, CLI `2.1.185`, model `claude-haiku-4-5-20251001`).
+The agent is a **pure** SDK agent: `setting_sources=[]`, `mcp_servers={}`,
+`disallowed_tools=["WebFetch","WebSearch"]` -> corpus is trivially anonymizable.
+
+> **`setting_sources=[]` caveat (architect review):** only reliably suppresses
+> `~/.claude` env inheritance on Python SDK > 0.1.59 (older builds treated `[]`
+> as "omitted"). Verified clean on 0.2.106 -- the init event showed no inherited
+> subagents/skills/plugins/MCP. The env-*inheriting* representativeness run is a
+> #519 config-matrix axis, deliberately not captured here.
+
+## Delegation tool is `Agent`, not `Task` (and the init event mislabels it)
+
+The probe's `SystemMessage(init)` advertised `Task` in its `tools` array, but the
+model actually emitted `tool_use` blocks named **`Agent`** (with
+`input.subagent_type`). `Agent` matches CLAUDE.md's documented delegation block,
+so AgentFluent's existing assumption holds. **Takeaway:** key on the emitted
+`tool_use.name == "Agent"`, *not* on the init event's tool list (which is stale
+re: the Task->Agent rename). The probe allowed both names to avoid betting wrong.
+
+## Subagent layout -- SDK reproduces Claude Code's, plus a new sidecar
+
+A forced delegation produced, under the parent session dir:
+
+```
+<session-id>/subagents/agent-<agentId>.jsonl        # full child trace
+<session-id>/subagents/agent-<agentId>.meta.json    # NEW sidecar (see below)
+```
+
+- **Child trace matches CC:** `isSidechain: true`, `entrypoint: "sdk-py"`,
+  `userType: "external"`; same `user`/`assistant` schema as the main session.
+- **`.meta.json` sidecar is new** vs the CLAUDE.md format snapshot:
+  `{"agentType","description","toolUseId"}`. Per the human, this sidecar is a
+  **recent Claude Code addition too** -- i.e. a CC format evolution, not
+  SDK-specific. A future parser can use it as a direct `toolUseId -> agentId`
+  map without scanning the parent JSONL.
+- **Parent->child linkage holds three ways** (capture all, per architect):
+  - parent `tool_use.id` (`toolu_...`) == `tool_result.tool_use_id` == sidecar `toolUseId`
+  - `toolUseResult.agentId` (e.g. `a561d5c531c5f37cb`) == the `agent-<agentId>.jsonl` filename
+  - `toolUseResult` also carries `agentType`, `prompt`, `status`, `totalTokens`,
+    `totalToolUseCount`, `totalDurationMs`, `toolStats`, `usage`, **plus a new
+    `resolvedModel`** field (the concrete model the child ran).
+  AgentFluent's existing `agentId` indexing works unchanged.
+
+## Large tool result -- a *new* `tool-results/` spill subfolder
+
+Forcing an oversized Bash result (`seq 1 500000`, ~3.2 MB stdout) triggered a
+spill the CLAUDE.md format snapshot does not document:
+
+```
+<session-id>/tool-results/<rand9>.txt    # full output verbatim (3,388,895 bytes)
+```
+
+- The main JSONL line does **not** inline the full output. Instead:
+  - `tool_result.content` becomes a `<persisted-output>` block: a header
+    (`Output too large (3.2MB). Full output saved to: <abs path>`) + a ~2 KB
+    preview + `...`.
+  - `toolUseResult.stdout` is **truncated to 30,000 chars**.
+  - `toolUseResult` gains **`persistedOutputPath`** (absolute path to the spill
+    file) and **`persistedOutputSize`** (full byte count).
+- **Parser implication (downstream):** any content/token analysis that reads
+  `tool_result.content` or `toolUseResult.stdout` sees only a truncated view of
+  large results. To get the full bytes, follow `persistedOutputPath`. AgentFluent
+  does not need full content for current metrics, but a signal that keys on tool
+  *output size* must read `persistedOutputSize`, not `len(stdout)`.
+- **#521 anonymization landmine (architect flagged, now concrete):**
+  `persistedOutputPath` and the `<persisted-output>` header embed an **absolute
+  filesystem path** (`/home/<user>/.claude/projects/<slug>/<id>/tool-results/...`).
+  Fixtures must scrub these before committing.
+
+## Parser-assumptions delta vs #518
+
+Everything in #518's parser section still holds. New downstream items the
+representative corpus surfaces (documented, not fixed -- per epic scope):
+
+| New artifact | Where | Parser action (downstream) |
+|---|---|---|
+| `agent-<id>.meta.json` sidecar | `<id>/subagents/` | enumerate/skip; optional `toolUseId->agentId` shortcut |
+| `tool-results/<rand>.txt` spill | `<id>/tool-results/` | follow `persistedOutputPath` only if full content needed |
+| `persistedOutputPath`/`persistedOutputSize` | `toolUseResult` | use for output-size signals; absorbed by `extra="ignore"` today |
+| `resolvedModel` | `toolUseResult` | concrete child model; useful for #112 model routing |
+
+## Net result for the roadmap
+
+- **#522 AC fully met:** multi-tool/multi-turn run with a natural `is_error`;
+  forced subagent delegation with the `<id>/subagents/` layout + `agentId`
+  linkage confirmed; large-output spill subfolder captured; no MCP/network/secret
+  surface; SDK version pinned; variants documented in the README; SDK dep stays
+  dev-only.
+- **#519 (corpus matrix)** can drive `agent.py` repeatably -- each run emits a
+  `RESULT ...` manifest line. Suggested added axes: an env-*inheriting* run
+  (`setting_sources` populated) and a non-default `model`.
+- **#520/#521 (diff + fixtures)** inherit a concrete, version-pinned list of
+  format deltas (above) and the explicit anonymization landmine (absolute paths
+  in persisted-output references).

--- a/research/agent-sdk-probe/FINDINGS.md
+++ b/research/agent-sdk-probe/FINDINGS.md
@@ -137,8 +137,18 @@ The probe's `SystemMessage(init)` advertised `Task` in its `tools` array, but th
 model actually emitted `tool_use` blocks named **`Agent`** (with
 `input.subagent_type`). `Agent` matches CLAUDE.md's documented delegation block,
 so AgentFluent's existing assumption holds. **Takeaway:** key on the emitted
-`tool_use.name == "Agent"`, *not* on the init event's tool list (which is stale
-re: the Task->Agent rename). The probe allowed both names to avoid betting wrong.
+`tool_use.name == "Agent"`, *not* on the init event's tool list (which advertises
+`Task`). The probe allowed both names to avoid betting wrong.
+
+**Backwards-compat aliasing, not a bug (verified).** With enforced permissions
+(`permission_mode="default"`, `Task` allow-listed but *not* `Agent`), the
+delegation runs with **zero permission denials** -- allow-listing the
+*advertised* name (`Task`) permits the *emitted* `Agent`. So `Task`/`Agent` are
+aliased, almost certainly for backwards compatibility (cf. the TS SDK's
+`Options.toolAliases` and Python SDK request
+`anthropics/claude-agent-sdk-python#980`). **Not worth an upstream bug report**;
+recorded here only as a parser caveat (analysis tools that read `init.tools` must
+map `Task` -> `Agent` when matching emitted `tool_use` blocks).
 
 ## Subagent layout -- SDK reproduces Claude Code's, plus a new sidecar
 
@@ -151,11 +161,12 @@ A forced delegation produced, under the parent session dir:
 
 - **Child trace matches CC:** `isSidechain: true`, `entrypoint: "sdk-py"`,
   `userType: "external"`; same `user`/`assistant` schema as the main session.
-- **`.meta.json` sidecar is new** vs the CLAUDE.md format snapshot:
-  `{"agentType","description","toolUseId"}`. Per the human, this sidecar is a
-  **recent Claude Code addition too** -- i.e. a CC format evolution, not
-  SDK-specific. A future parser can use it as a direct `toolUseId -> agentId`
-  map without scanning the parent JSONL.
+- **`.meta.json` sidecar** (`{"agentType","description","toolUseId"}`) -- a CC
+  format evolution (not SDK-specific), **already documented in the
+  `claude-code-sessions` reference** (`reference/subagent-traces.md`,
+  `reference/data-dictionary.md`). It simply postdates agentfluent's CLAUDE.md
+  JSONL snapshot, which should be synced (downstream item below). A parser can
+  use it as a direct `toolUseId -> agentId` map without scanning the parent JSONL.
 - **Parent->child linkage holds three ways** (capture all, per architect):
   - parent `tool_use.id` (`toolu_...`) == `tool_result.tool_use_id` == sidecar `toolUseId`
   - `toolUseResult.agentId` (e.g. `a561d5c531c5f37cb`) == the `agent-<agentId>.jsonl` filename
@@ -164,10 +175,12 @@ A forced delegation produced, under the parent session dir:
     `resolvedModel`** field (the concrete model the child ran).
   AgentFluent's existing `agentId` indexing works unchanged.
 
-## Large tool result -- a *new* `tool-results/` spill subfolder
+## Large tool result -- the `tool-results/` spill subfolder
 
-Forcing an oversized Bash result (`seq 1 500000`, ~3.2 MB stdout) triggered a
-spill the CLAUDE.md format snapshot does not document:
+Forcing an oversized Bash result (`seq 1 500000`, ~3.2 MB stdout) triggered the
+spill layout **already documented in `claude-code-sessions`**
+(`reference/data-dictionary.md`) but absent from agentfluent's CLAUDE.md snapshot
+(sync it -- downstream item below):
 
 ```
 <session-id>/tool-results/<rand9>.txt    # full output verbatim (3,388,895 bytes)
@@ -188,19 +201,28 @@ spill the CLAUDE.md format snapshot does not document:
 - **#521 anonymization landmine (architect flagged, now concrete):**
   `persistedOutputPath` and the `<persisted-output>` header embed an **absolute
   filesystem path** (`/home/<user>/.claude/projects/<slug>/<id>/tool-results/...`).
-  Fixtures must scrub these before committing.
+  Fixtures must scrub these before committing. **Solved by the
+  `claude-code-sessions` `ccs-sanitize` tool** -- validated against this corpus:
+  it rewrote the home path *and* the dash-encoded project slug
+  (`-home-<user>-...`) to `/home/user` (15 -> 0 username occurrences). #521
+  fixtures run through `ccs-sanitize` rather than bespoke scrubbing.
 
 ## Parser-assumptions delta vs #518
 
 Everything in #518's parser section still holds. New downstream items the
 representative corpus surfaces (documented, not fixed -- per epic scope):
 
-| New artifact | Where | Parser action (downstream) |
-|---|---|---|
-| `agent-<id>.meta.json` sidecar | `<id>/subagents/` | enumerate/skip; optional `toolUseId->agentId` shortcut |
-| `tool-results/<rand>.txt` spill | `<id>/tool-results/` | follow `persistedOutputPath` only if full content needed |
-| `persistedOutputPath`/`persistedOutputSize` | `toolUseResult` | use for output-size signals; absorbed by `extra="ignore"` today |
-| `resolvedModel` | `toolUseResult` | concrete child model; useful for #112 model routing |
+| Artifact | Where | In `claude-code-sessions`? | Parser action (downstream) |
+|---|---|---|---|
+| `agent-<id>.meta.json` sidecar | `<id>/subagents/` | yes (`subagent-traces.md`) | enumerate/skip; optional `toolUseId->agentId` shortcut |
+| `tool-results/<rand>.txt` spill | `<id>/tool-results/` | yes (`data-dictionary.md`) | follow `persistedOutputPath` only if full content needed |
+| `persistedOutputPath`/`persistedOutputSize` | `toolUseResult` | yes | use for output-size signals; absorbed by `extra="ignore"` today |
+| `resolvedModel` | `toolUseResult` | **no (as of 2026-06-22)** | concrete child model; useful for #112 model routing |
+
+The first three are already documented upstream; agentfluent's CLAUDE.md JSONL
+snapshot is simply **stale** and should be synced. `resolvedModel` was **not
+found** in `claude-code-sessions` -- a candidate for a brief issue there (or it
+will surface on a routine format scan).
 
 ## Net result for the roadmap
 
@@ -214,4 +236,18 @@ representative corpus surfaces (documented, not fixed -- per epic scope):
   (`setting_sources` populated) and a non-default `model`.
 - **#520/#521 (diff + fixtures)** inherit a concrete, version-pinned list of
   format deltas (above) and the explicit anonymization landmine (absolute paths
-  in persisted-output references).
+  in persisted-output references), now solved via `ccs-sanitize`.
+
+## Upstream / cross-repo follow-ups
+
+- **Sync agentfluent's CLAUDE.md JSONL snapshot** with the three artifacts above
+  (subagent `.meta.json` sidecar, `tool-results/` spill, `persistedOutputPath`/
+  `persistedOutputSize`). They are documented in `claude-code-sessions` but the
+  agentfluent reference predates them. Downstream doc task, not this epic.
+- **`resolvedModel`** on `toolUseResult` is not yet in `claude-code-sessions` --
+  candidate for a brief format-watch issue there.
+- **Fixture anonymization (#521)** uses `claude-code-sessions`' `ccs-sanitize`
+  CLI (validated here). It is a standalone tool invoked ad-hoc against captured
+  corpus files; agentfluent does **not** take it as a packaged dependency (it is
+  an unpublished sibling-repo CLI, and a local-path dep would break
+  reproducibility for CI/other contributors).

--- a/research/agent-sdk-probe/README.md
+++ b/research/agent-sdk-probe/README.md
@@ -6,15 +6,31 @@ This is **not** part of the published `agentfluent` package.
 
 ## What this is
 
-A ~15-line hello-world Claude Agent SDK script (`probe.py`) that spins up an
-agent, makes **exactly one** tool call (a single `Read` of a synthetic,
-secret-free `fixture.txt`), and exits. The goal is not the agent -- it is to
-learn, **with real bytes on disk**, where the SDK writes its session file and
-what an SDK session looks like, before investing in the representative
-data-generation agent ([#522](https://github.com/frederick-douglas-pearce/agentfluent/issues/522)).
+Two throwaway Claude Agent SDK scripts:
+
+- **`probe.py`** (#518) -- a ~15-line hello-world: spins up an agent, makes
+  **exactly one** tool call (a single `Read` of a synthetic, secret-free
+  `fixture.txt`), and exits. Answered where the SDK writes sessions and what an
+  SDK session looks like.
+- **`agent.py`** (#522) -- the representative **data-generation** agent, chosen
+  purely to maximize the JSONL **format surface** later stories inspect. Its
+  *answer* is irrelevant; we grade the bytes it emits. Three variants:
+
+  | Variant | What it exercises | Run |
+  |---------|-------------------|-----|
+  | `flat` | multi-tool (Glob/Grep/Read/Bash), multi-turn, one natural `is_error: true` | `uv run --group research python research/agent-sdk-probe/agent.py flat` |
+  | `subagent` | forces a delegation -> `<id>/subagents/agent-*.jsonl` + `isSidechain` + `agentId` linkage | `... agent.py subagent` |
+  | `large` | oversized tool result -> `<id>/tool-results/` spill subfolder | `... agent.py large` |
+
+  Each run prints a machine-readable `RESULT variant=... session_id=... file=...`
+  line so #519 can build its config->file manifest mechanically. `agent.py` is a
+  **pure** SDK agent (`setting_sources=[]`, no MCP, web tools disallowed) so its
+  corpus is trivially anonymizable. The synthetic targets live in `sampledata/`
+  (committed; secret-free).
 
 See [`FINDINGS.md`](./FINDINGS.md) for the recorded answers to #112's three open
-questions (location, discriminator, options metadata).
+questions (#518) and the representative-agent format findings (#522: subagent
+layout, parent->child linkage, large-output spill).
 
 ## Dependency isolation
 
@@ -27,11 +43,17 @@ wheel's `Requires-Dist` (no `claude-agent-sdk` entry).
 ## Run
 
 ```bash
+# #518 hello-world probe
 uv run --group research python research/agent-sdk-probe/probe.py
+
+# #522 representative agent -- one variant per run
+uv run --group research python research/agent-sdk-probe/agent.py flat
+uv run --group research python research/agent-sdk-probe/agent.py subagent
+uv run --group research python research/agent-sdk-probe/agent.py large
 ```
 
 Requires an authenticated `claude` CLI on `PATH` (the SDK drives it under the
-hood; `apiKeySource` was `none` in the captured run -- it used the CLI's own
+hood; `apiKeySource` was `none` in the captured runs -- it used the CLI's own
 auth).
 
 ## Corpus is never committed

--- a/research/agent-sdk-probe/agent.py
+++ b/research/agent-sdk-probe/agent.py
@@ -1,0 +1,130 @@
+"""Representative Agent SDK data-generation agent (#522).
+
+Builds on the #518 probe findings: SDK sessions land in
+``~/.claude/projects/<cwd-slug>/<id>.jsonl``, are marked ``entrypoint == "sdk-py"``,
+and inherit the developer's local ``~/.claude`` environment unless constrained.
+
+This agent is chosen purely to maximize the JSONL **format surface** S3 (#520)
+can study -- the agent's *answer* is irrelevant; we grade the bytes it emits.
+Three variants:
+
+* ``flat``     -- multi-tool (Glob/Grep/Read/Bash), multi-turn, one natural
+                 ``is_error: true`` tool result.
+* ``subagent`` -- forces a delegation to a programmatically-defined subagent, to
+                 observe whether the SDK reproduces Claude Code's
+                 ``<id>/subagents/agent-*.jsonl`` + ``isSidechain`` layout and how
+                 the parent points at the child (``toolUseResult.agentId`` vs
+                 ``parent_tool_use_id`` vs an ``agentId:`` text trailer -- a #522
+                 discovery question, so capture all candidates).
+* ``large``    -- emits an oversized tool result (``Bash: seq 1 500000``) to test
+                 whether the SDK spills large tool output to a separate on-disk
+                 location (the "tool output subfolder") and how the JSONL line
+                 references it.
+
+Pure SDK agent: ``setting_sources=[]`` (no inherited config/MCP/skills/agents),
+no MCP servers, web tools disallowed -> corpus is trivially anonymizable. The
+env-inheriting representativeness run is a #519 config-matrix axis, not here.
+
+NOTE (architect review, #522): ``setting_sources=[]`` only reliably suppresses
+env inheritance on Python SDK > 0.1.59 (older builds treated ``[]`` as "omitted"
+and loaded the full local env). Verified clean on the version pinned in README;
+re-check the init event if the SDK is downgraded.
+
+Run:
+    uv run --group research python research/agent-sdk-probe/agent.py flat
+    uv run --group research python research/agent-sdk-probe/agent.py subagent
+    uv run --group research python research/agent-sdk-probe/agent.py large
+
+Each run prints a machine-readable ``RESULT ...`` line (variant, session_id,
+resolved JSONL path) so #519 can build its config->file manifest mechanically.
+
+Throwaway research scaffolding. Not part of the published ``agentfluent`` package.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from claude_agent_sdk import (
+    AgentDefinition,
+    ClaudeAgentOptions,
+    ResultMessage,
+    project_key_for_directory,
+    query,
+)
+
+PROBE_DIR = Path(__file__).parent
+MODEL = "claude-haiku-4-5-20251001"  # explicit non-default; cheap for multi-turn
+
+FLAT_PROMPT = """\
+Explore the synthetic directory ./sampledata one tool call at a time, in order:
+1. Glob all files under sampledata/.
+2. Grep for the line containing 'MARKER' in sampledata/notes.txt.
+3. Read sampledata/data.csv.
+4. Run Bash: wc -l sampledata/does-not-exist.txt
+   (this file is intentionally missing -- note the error and continue).
+5. Run Bash: wc -l sampledata/data.csv
+Then give a one-paragraph summary. Do not use any network tools."""
+
+# Name the AGENT, not the delegation tool -- the tool's name has changed across
+# CLI versions (Task vs Agent), so we let the model pick and allow both below.
+SUBAGENT_PROMPT = """\
+Delegate to the 'file-summarizer' subagent to summarize the file
+sampledata/notes.txt, then report the subagent's summary verbatim."""
+
+LARGE_PROMPT = """\
+Run this exact Bash command. Do NOT add pipes, redirects, head/tail, wc, or any
+filtering -- the full multi-megabyte output must come back as the tool result:
+seq 1 500000
+After it runs, reply with just the word DONE."""
+
+SUMMARIZER = AgentDefinition(
+    description="Summarizes a single text file in two sentences.",
+    prompt=(
+        "You are a file summarizer. Read the file you are asked about and return "
+        "a two-sentence summary. Use only the Read tool."
+    ),
+    tools=["Read"],
+    model=MODEL,
+)
+
+PROMPTS = {"flat": FLAT_PROMPT, "subagent": SUBAGENT_PROMPT, "large": LARGE_PROMPT}
+
+
+def build_options(variant: str) -> ClaudeAgentOptions:
+    allowed = ["Read", "Grep", "Glob", "Bash"]
+    agents = None
+    if variant == "subagent":
+        allowed += ["Task", "Agent"]  # tool renamed across CLI versions; allow both
+        agents = {"file-summarizer": SUMMARIZER}
+    return ClaudeAgentOptions(
+        model=MODEL,
+        allowed_tools=allowed,
+        disallowed_tools=["WebFetch", "WebSearch"],  # AC: no network surface
+        mcp_servers={},  # AC: no MCP surface
+        setting_sources=[],  # pure SDK agent -- no inherited ~/.claude env
+        agents=agents,
+        cwd=str(PROBE_DIR),
+        permission_mode="bypassPermissions",
+        max_turns=12,
+    )
+
+
+def resolved_path(session_id: str) -> Path:
+    slug = project_key_for_directory(str(PROBE_DIR))
+    return Path.home() / ".claude" / "projects" / slug / f"{session_id}.jsonl"
+
+
+async def main(variant: str) -> None:
+    async for message in query(prompt=PROMPTS[variant], options=build_options(variant)):
+        print(type(message).__name__, message)
+        if isinstance(message, ResultMessage):
+            path = resolved_path(message.session_id)
+            print(f"RESULT variant={variant} session_id={message.session_id} file={path}")
+
+
+if __name__ == "__main__":
+    variant = sys.argv[1] if len(sys.argv) > 1 else "flat"
+    if variant not in PROMPTS:
+        sys.exit("usage: agent.py [flat|subagent|large]")
+    asyncio.run(main(variant))

--- a/research/agent-sdk-probe/sampledata/code.py
+++ b/research/agent-sdk-probe/sampledata/code.py
@@ -1,0 +1,7 @@
+"""Synthetic module so Glob/Grep have a .py target. Not imported anywhere."""
+
+
+def summarize(rows: list[dict[str, str]]) -> str:
+    """Return a one-line summary of sample rows. MARKER: grep target."""
+    tools = sorted({r["tool"] for r in rows})
+    return f"{len(rows)} rows across tools: {', '.join(tools)}"

--- a/research/agent-sdk-probe/sampledata/data.csv
+++ b/research/agent-sdk-probe/sampledata/data.csv
@@ -1,0 +1,6 @@
+id,tool,turns,is_error
+1,Read,2,false
+2,Grep,1,false
+3,Glob,1,false
+4,Bash,3,true
+5,Task,2,false

--- a/research/agent-sdk-probe/sampledata/notes.txt
+++ b/research/agent-sdk-probe/sampledata/notes.txt
@@ -1,0 +1,12 @@
+Project notes for the Agent SDK data-generation agent (#522).
+
+These files are synthetic and secret-free. They exist only to give the
+representative SDK agent real targets for Read / Grep / Glob / Bash so the
+captured JSONL exercises a realistic tool-use surface.
+
+MARKER: the agent is asked to grep for this line.
+
+Roadmap thoughts:
+- the corpus must be trivially anonymizable
+- no network, no MCP, no real credentials anywhere
+- the agent's answer does not matter; only the bytes it emits matter


### PR DESCRIPTION
## Summary
- Adds `research/agent-sdk-probe/agent.py` (#522) — the representative SDK data-generation agent, a **pure** SDK agent (`setting_sources=[]`, no MCP, web tools disallowed) chosen to maximize JSONL **format surface** for S3 (#520). Three variants: `flat`, `subagent`, `large`.
- Records the format findings in `FINDINGS.md` (#522 section), version-pinned to SDK `0.2.106` / CLI `2.1.185`.
- Architect-reviewed before build ([#522 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/522#issuecomment-4765710387)); all blocking feedback applied.

### Findings (feed #519/#520/#521 + #112)
- **Subagent layout matches Claude Code:** forced delegation produced `<id>/subagents/agent-<agentId>.jsonl` with `isSidechain: true` / `entrypoint: sdk-py`. Parent→child linkage holds three ways (`tool_use.id` == `tool_result.tool_use_id` == sidecar `toolUseId`; `toolUseResult.agentId` == child filename). Existing `agentId` indexing works unchanged.
- **New `tool-results/` spill subfolder:** an oversized Bash result (~3.2 MB) spilled to `<id>/tool-results/<rand>.txt`; the JSONL keeps a `<persisted-output>` pointer + `stdout` truncated to 30 KB, with **`persistedOutputPath`/`persistedOutputSize`** on `toolUseResult`. Undocumented in the CLAUDE.md snapshot.
- **Delegation tool emits as `Agent`** (matches CLAUDE.md), even though the init event still advertises `Task` — key on the emitted `tool_use.name`, not the init tool list.
- **New fields:** `agent-<id>.meta.json` sidecar (a recent Claude Code addition, not SDK-specific), `resolvedModel` on `toolUseResult`.
- **#521 anonymization landmine (concrete):** `persistedOutputPath` + the `<persisted-output>` header embed absolute filesystem paths — must be scrubbed before fixtures graduate.

Each variant prints a machine-readable `RESULT variant=… session_id=… file=…` line so #519's manifest is mechanical.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1685 passed, no regressions
- [x] Lint clean: `uv run ruff check research/agent-sdk-probe/ src/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [ ] New/changed behavior has test coverage — N/A: research scaffolding, exempt per #522 (the artifact under study is the session data, not the agent)
- [x] Manual smoke test — all three variants run end-to-end; subagent + tool-results layouts captured and inspected

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

  Research scaffolding only: a throwaway SDK agent under `research/` + synthetic secret-free `sampledata/` + docs. No `src/`, `pyproject.toml`, or runtime change. Raw corpus (incl. the spill file with absolute paths) is gitignored; nothing sensitive is committed.

## Breaking changes
None. No public contract change — research scaffolding under `research/`, no `src/` or CLI changes; SDK stays dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)