### PR TITLE
chore(research): SDK session corpus across config matrix (#519)

### DIFF
--- a/research/agent-sdk-probe/FINDINGS.md
+++ b/research/agent-sdk-probe/FINDINGS.md
@@ -242,8 +242,10 @@ will surface on a routine format scan).
 
 - **Sync agentfluent's CLAUDE.md JSONL snapshot** with the three artifacts above
   (subagent `.meta.json` sidecar, `tool-results/` spill, `persistedOutputPath`/
-  `persistedOutputSize`). They are documented in `claude-code-sessions` but the
-  agentfluent reference predates them. Downstream doc task, not this epic.
+  `persistedOutputSize`) **plus the four line types missing from "Types to skip"**
+  (`queue-operation`, `attachment`, `last-prompt`, `ai-title` -- see #519 below).
+  Tracked in [#528](https://github.com/frederick-douglas-pearce/agentfluent/issues/528)
+  so all CLAUDE.md updates land in one pass. Downstream doc task, not this epic.
 - **`resolvedModel`** on `toolUseResult` is not yet in `claude-code-sessions` --
   candidate for a brief format-watch issue there.
 - **Fixture anonymization (#521)** uses `claude-code-sessions`' `ccs-sanitize`
@@ -251,3 +253,106 @@ will surface on a routine format scan).
   corpus files; agentfluent does **not** take it as a packaged dependency (it is
   an unpublished sibling-repo CLI, and a local-path dep would break
   reproducibility for CI/other contributors).
+
+---
+
+# Corpus matrix findings (#519)
+
+Captured by `run_matrix.py` on the **same versions pinned above**
+(`claude-agent-sdk==0.2.106`, CLI `2.1.185`, captured 2026-06-22). The runner
+drives `agent.py` across a 3-run matrix (one axis toggled per run -- the
+cross-product is gold-plating, per architect review), copies each run's raw
+session file(s) out of `~/.claude/projects/<slug>/` into the gitignored
+`corpus/`, and writes `corpus/manifest.json` (the config->file index #520
+consumes).
+
+| run | variant  | main model | subagent model | isolates |
+|-----|----------|------------|----------------|----------|
+| a | `flat` | haiku | -- | full `tool_use` / error surface |
+| b | `subagent` | **sonnet** | **haiku** | delegation + parent!=child model |
+| c | `flat` | sonnet | -- | model recording (2nd model value) |
+
+Satisfies the ACs: >=1 delegation run (b) + 2 without (a, c); 2 distinct models
+(haiku, sonnet). Variant 1 (#518 hello-world) and the #522 `large` spill are not
+re-run -- they are carried as `pre_existing` manifest entries so the manifest is
+the single index of all SDK corpus.
+
+## Model divergence is recorded three ways (the #112 artifact)
+
+Run (b) ran a **sonnet parent delegating to a haiku child** -- a genuine
+divergence sample. The split is recoverable from the bytes, three independent
+ways:
+
+- parent `message.model` on every assistant line == `claude-sonnet-4-6`
+- child trace `message.model` == `claude-haiku-4-5-20251001`
+- **`toolUseResult.resolvedModel` == the *child's* resolved model**
+  (`claude-haiku-4-5-20251001`), i.e. `resolvedModel` reports what the *subagent*
+  ran, not the parent. So #112 model-routing can verify a configured
+  `subagent_model` against `resolvedModel` with no JSONL cross-referencing. The
+  subagent model **must** be a threaded, recorded input for this to work -- it is
+  (architect-flagged; `agent.py` no longer hardcodes the child model).
+
+## Line type `ai-title` -- another stale-snapshot type, not a novel find
+
+The richer multi-turn sessions surfaced a line type the #518 single-call probe
+did not exercise: **`ai-title`** (`{"type","sessionId","aiTitle"}` -- the
+auto-generated session title). Like the `.meta.json` sidecar and the
+`tool-results/` spill, it is **already documented upstream in
+`claude-code-sessions`** (`reference/data-dictionary.md`,
+`reference/subagent-traces.md`) -- agentfluent's CLAUDE.md snapshot is simply
+stale, not missing a new discovery. The same is true of the three #518 already
+found absent from `SKIP_TYPES` (`queue-operation`, `attachment`, `last-prompt`):
+all four are upstream-documented. All four:
+
+- **do not crash the production parser** -- they fall through to the `else` branch
+  and are debug-logged as "Unknown message type" (verified: `parse_session` ran on
+  all three new sessions, 0 crashes).
+- should be added to `SKIP_TYPES` (`session.py`) **and** to CLAUDE.md's
+  "Types to skip" list. The CLAUDE.md doc edit is folded into
+  [#528](https://github.com/frederick-douglas-pearce/agentfluent/issues/528); the
+  `SKIP_TYPES` code change is a separate downstream parser item (unticketed, noted
+  in #518).
+
+**No *new persisted* `user`/`assistant` format fields** beyond what #522 already
+recorded -- #519 widens line-type and model coverage, it does not surface new
+`toolUseResult`/message schema.
+
+## Manifest schema (`corpus/manifest.json`, gitignored)
+
+Per architect review, each run entry carries enough to correlate format deltas to
+inputs **and** to hand #521 a scrub worklist:
+
+- `variant`, `main_model`, `subagent_model`, `session_id`
+- `source_jsonl` (absolute) **and** `corpus_jsonl` (corpus-relative) -- both paths
+- `sdk_version`, `cli_version` (read from the trace's `version` field), `prompt`,
+  and the full `config` snapshot (`allowed_tools`, `disallowed_tools`,
+  `setting_sources`, `permission_mode`, `max_turns`, `cwd`, `agents`)
+- `subagent_files` / `tool_results_files` lists
+- `files[]`: per-file `sha256`, `bytes`, `lines`, and a **`contains_abs_paths`**
+  flag (true when the real home path or dash-slug appears in the bytes -- #521's
+  mechanical scrub worklist). Observed: every `.jsonl` (main + child) is `true`;
+  the `.meta.json` sidecar is `false`.
+- `init`: the runtime-only `SystemMessage(init)` payload (keys include `tools`,
+  `mcp_servers`, `agents`, `skills`, `plugins`, `permissionMode`, `cwd`,
+  `apiKeySource`, `model`) -- the only place the non-model options surface, since
+  they are **not** persisted to the JSONL (reaffirms #518 Q3). With
+  `setting_sources=[]` the `agents`/`skills`/`plugins`/`mcp_servers` lists are
+  empty -- the pure-SDK isolation holds on 0.2.106.
+
+A **completeness post-condition** guards the copy: a `subagent` run that yields no
+`subagents/*.jsonl` raises rather than writing a misleading (empty-child) manifest
+entry. The copy runs after the subprocess exits, so the lazily-created sibling
+dirs are fully flushed.
+
+## Net result for the roadmap
+
+- **#519 AC met:** raw corpus across the matrix exists under the gitignored
+  `corpus/`; >=1 delegation + 2 non-delegation runs; 2 models; every file's
+  on-disk location recorded; `manifest.json` maps config -> file for #520.
+- **#520 (diff)** inherits the manifest as its correlation key and a confirmed
+  model-divergence sample.
+- **#521 (fixtures)** inherits the `contains_abs_paths` worklist (every `.jsonl`
+  needs scrubbing; `ccs-sanitize` already validated in #522).
+- **#528 (CLAUDE.md sync)** gains the four upstream-documented skip-types
+  (`ai-title`, `queue-operation`, `attachment`, `last-prompt`) for the
+  "Types to skip" list -- same stale-snapshot category as meta.json/spill.

--- a/research/agent-sdk-probe/README.md
+++ b/research/agent-sdk-probe/README.md
@@ -6,7 +6,7 @@ This is **not** part of the published `agentfluent` package.
 
 ## What this is
 
-Two throwaway Claude Agent SDK scripts:
+Three throwaway Claude Agent SDK scripts:
 
 - **`probe.py`** (#518) -- a ~15-line hello-world: spins up an agent, makes
   **exactly one** tool call (a single `Read` of a synthetic, secret-free
@@ -22,15 +22,42 @@ Two throwaway Claude Agent SDK scripts:
   | `subagent` | forces a delegation -> `<id>/subagents/agent-*.jsonl` + `isSidechain` + `agentId` linkage | `... agent.py subagent` |
   | `large` | oversized tool result -> `<id>/tool-results/` spill subfolder | `... agent.py large` |
 
-  Each run prints a machine-readable `RESULT variant=... session_id=... file=...`
-  line so #519 can build its config->file manifest mechanically. `agent.py` is a
-  **pure** SDK agent (`setting_sources=[]`, no MCP, web tools disallowed) so its
-  corpus is trivially anonymizable. The synthetic targets live in `sampledata/`
-  (committed; secret-free).
+  Each run prints a human `RESULT ...` line and a machine-readable `RESULT_JSON
+  {...}` line so `run_matrix.py` can build the config->file manifest mechanically.
+  An optional `[model] [subagent_model]` (e.g. `agent.py subagent
+  claude-sonnet-4-6 claude-haiku-4-5-20251001`) threads the model into both the
+  main agent and the subagent, so the child's `toolUseResult.resolvedModel` is a
+  recorded, controllable input. `agent.py` is a **pure** SDK agent
+  (`setting_sources=[]`, no MCP, web tools disallowed) so its corpus is trivially
+  anonymizable. The synthetic targets live in `sampledata/` (committed;
+  secret-free).
+
+- **`run_matrix.py`** (#519) -- the corpus matrix runner. Drives `agent.py` across
+  a 3-run matrix (one axis toggled per run), copies each run's raw session
+  file(s) into the gitignored `corpus/`, and writes `corpus/manifest.json` -- the
+  config->file index #520 consumes.
+
+  | Run | variant | main / subagent model | isolates |
+  |-----|---------|-----------------------|----------|
+  | a | `flat` | haiku | full tool_use / error surface |
+  | b | `subagent` | **sonnet / haiku** | delegation + parent!=child model |
+  | c | `flat` | sonnet | model recording (2nd model) |
+
+  Run (b) is a deliberate model-divergence sample: the parent runs sonnet, the
+  child runs haiku, and `toolUseResult.resolvedModel` reports the **child** model
+  -- the high-value artifact for #112 model-routing. Each manifest entry carries
+  the config snapshot, SDK/CLI versions, the runtime `init` event, and per-file
+  `sha256` + a `contains_abs_paths` scrub flag for #521. A completeness
+  post-condition fails the run if a `subagent` variant yields no child trace.
+
+  ```bash
+  uv run --group research python research/agent-sdk-probe/run_matrix.py
+  ```
 
 See [`FINDINGS.md`](./FINDINGS.md) for the recorded answers to #112's three open
-questions (#518) and the representative-agent format findings (#522: subagent
-layout, parent->child linkage, large-output spill).
+questions (#518), the representative-agent format findings (#522: subagent layout,
+parent->child linkage, large-output spill), and the corpus matrix findings (#519:
+model divergence, manifest schema, the `ai-title` stale-snapshot type).
 
 ## Dependency isolation
 
@@ -50,6 +77,9 @@ uv run --group research python research/agent-sdk-probe/probe.py
 uv run --group research python research/agent-sdk-probe/agent.py flat
 uv run --group research python research/agent-sdk-probe/agent.py subagent
 uv run --group research python research/agent-sdk-probe/agent.py large
+
+# #519 full corpus matrix (runs agent.py x3, writes corpus/manifest.json)
+uv run --group research python research/agent-sdk-probe/run_matrix.py
 ```
 
 Requires an authenticated `claude` CLI on `PATH` (the SDK drives it under the
@@ -61,10 +91,13 @@ auth).
 The SDK writes the raw session to `~/.claude/projects/<cwd-slug>/<id>.jsonl`.
 Raw sessions may carry secrets (per the CLAUDE.md secrets policy), so any copy
 landed under `research/agent-sdk-probe/corpus/` is **gitignored** and never
-committed. Only anonymized fixtures graduate to `tests/fixtures/` -- that is
-downstream work ([#521](https://github.com/frederick-douglas-pearce/agentfluent/issues/521)),
-not this story. The probe's fixture is synthetic, so its corpus is trivially
-safe, but the gitignore guard is unconditional.
+committed. `run_matrix.py`'s `corpus/manifest.json` is gitignored too -- it embeds
+absolute filesystem paths. Only anonymized fixtures graduate to `tests/fixtures/`
+-- that is downstream work
+([#521](https://github.com/frederick-douglas-pearce/agentfluent/issues/521)), and
+the manifest's per-file `contains_abs_paths` flag is the scrub worklist for it.
+The probe's fixture is synthetic, so its corpus is trivially safe, but the
+gitignore guard is unconditional.
 
 ## SDK version
 

--- a/research/agent-sdk-probe/agent.py
+++ b/research/agent-sdk-probe/agent.py
@@ -30,31 +30,41 @@ env inheritance on Python SDK > 0.1.59 (older builds treated ``[]`` as "omitted"
 and loaded the full local env). Verified clean on the version pinned in README;
 re-check the init event if the SDK is downgraded.
 
-Run:
+Run (``[model]`` and ``[subagent_model]`` are optional; both default to the cheap
+haiku tier -- the ``subagent_model`` axis only applies to the ``subagent`` variant):
     uv run --group research python research/agent-sdk-probe/agent.py flat
-    uv run --group research python research/agent-sdk-probe/agent.py subagent
+    uv run --group research python research/agent-sdk-probe/agent.py \
+        subagent claude-sonnet-4-6 claude-haiku-4-5-20251001
     uv run --group research python research/agent-sdk-probe/agent.py large
 
-Each run prints a machine-readable ``RESULT ...`` line (variant, session_id,
-resolved JSONL path) so #519 can build its config->file manifest mechanically.
+Each run prints a human ``RESULT ...`` line and a machine-readable ``RESULT_JSON
+{...}`` line (variant, models, session_id, source path, config snapshot, init
+event) so ``run_matrix.py`` (#519) can build the config->file corpus manifest
+mechanically. The model is threaded into both the main agent and the subagent so
+the child's ``toolUseResult.resolvedModel`` is a recorded, controllable input.
 
 Throwaway research scaffolding. Not part of the published ``agentfluent`` package.
 """
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 
+import claude_agent_sdk
 from claude_agent_sdk import (
     AgentDefinition,
     ClaudeAgentOptions,
     ResultMessage,
+    SystemMessage,
     project_key_for_directory,
     query,
 )
 
 PROBE_DIR = Path(__file__).parent
 MODEL = "claude-haiku-4-5-20251001"  # explicit non-default; cheap for multi-turn
+MAX_TURNS = 12
+SDK_VERSION = getattr(claude_agent_sdk, "__version__", "unknown")
 
 FLAT_PROMPT = """\
 Explore the synthetic directory ./sampledata one tool call at a time, in order:
@@ -78,27 +88,37 @@ filtering -- the full multi-megabyte output must come back as the tool result:
 seq 1 500000
 After it runs, reply with just the word DONE."""
 
-SUMMARIZER = AgentDefinition(
-    description="Summarizes a single text file in two sentences.",
-    prompt=(
-        "You are a file summarizer. Read the file you are asked about and return "
-        "a two-sentence summary. Use only the Read tool."
-    ),
-    tools=["Read"],
-    model=MODEL,
-)
+def make_summarizer(model: str) -> AgentDefinition:
+    # The subagent's model is a #519 matrix axis, NOT a frozen constant -- the
+    # child's `toolUseResult.resolvedModel` is the #112 model-routing artifact, so
+    # it must be a controllable, recorded input. Parameterize it (architect review,
+    # #519): a sonnet-parent / haiku-child run yields a genuine divergence sample.
+    return AgentDefinition(
+        description="Summarizes a single text file in two sentences.",
+        prompt=(
+            "You are a file summarizer. Read the file you are asked about and "
+            "return a two-sentence summary. Use only the Read tool."
+        ),
+        tools=["Read"],
+        model=model,
+    )
+
 
 PROMPTS = {"flat": FLAT_PROMPT, "subagent": SUBAGENT_PROMPT, "large": LARGE_PROMPT}
 
 
-def build_options(variant: str) -> ClaudeAgentOptions:
+def build_options(
+    variant: str, model: str, subagent_model: str
+) -> tuple[ClaudeAgentOptions, dict]:
+    """Return the SDK options plus a JSON-serializable config snapshot for the
+    #519 manifest (config -> file provenance)."""
     allowed = ["Read", "Grep", "Glob", "Bash"]
     agents = None
     if variant == "subagent":
         allowed += ["Task", "Agent"]  # tool renamed across CLI versions; allow both
-        agents = {"file-summarizer": SUMMARIZER}
-    return ClaudeAgentOptions(
-        model=MODEL,
+        agents = {"file-summarizer": make_summarizer(subagent_model)}
+    options = ClaudeAgentOptions(
+        model=model,
         allowed_tools=allowed,
         disallowed_tools=["WebFetch", "WebSearch"],  # AC: no network surface
         mcp_servers={},  # AC: no MCP surface
@@ -106,8 +126,19 @@ def build_options(variant: str) -> ClaudeAgentOptions:
         agents=agents,
         cwd=str(PROBE_DIR),
         permission_mode="bypassPermissions",
-        max_turns=12,
+        max_turns=MAX_TURNS,
     )
+    config = {
+        "allowed_tools": allowed,
+        "disallowed_tools": ["WebFetch", "WebSearch"],
+        "mcp_servers": [],
+        "setting_sources": [],
+        "agents": sorted(agents) if agents else [],
+        "permission_mode": "bypassPermissions",
+        "max_turns": MAX_TURNS,
+        "cwd": str(PROBE_DIR),
+    }
+    return options, config
 
 
 def resolved_path(session_id: str) -> Path:
@@ -115,16 +146,59 @@ def resolved_path(session_id: str) -> Path:
     return Path.home() / ".claude" / "projects" / slug / f"{session_id}.jsonl"
 
 
-async def main(variant: str) -> None:
-    async for message in query(prompt=PROMPTS[variant], options=build_options(variant)):
+def _jsonable(value: object) -> object:
+    """Best-effort coerce an SDK message payload to something json.dumps can emit."""
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
+async def run_one(variant: str, model: str, subagent_model: str) -> dict:
+    """Run a single variant and return a manifest-ready record. Captures the
+    runtime-only `SystemMessage(init)` event -- the only place the non-model
+    options surface (they are not persisted to the JSONL)."""
+    options, config = build_options(variant, model, subagent_model)
+    init: dict | None = None
+    session_id: str | None = None
+    async for message in query(prompt=PROMPTS[variant], options=options):
         print(type(message).__name__, message)
+        if isinstance(message, SystemMessage) and getattr(message, "subtype", None) == "init":
+            init = {k: _jsonable(v) for k, v in getattr(message, "data", {}).items()}
         if isinstance(message, ResultMessage):
-            path = resolved_path(message.session_id)
-            print(f"RESULT variant={variant} session_id={message.session_id} file={path}")
+            session_id = message.session_id
+    if session_id is None:
+        raise RuntimeError(f"variant {variant!r} produced no ResultMessage")
+    return {
+        "variant": variant,
+        "main_model": model,
+        "subagent_model": subagent_model if variant == "subagent" else None,
+        "session_id": session_id,
+        "source_jsonl": str(resolved_path(session_id)),
+        "prompt": PROMPTS[variant],
+        "config": config,
+        "sdk_version": SDK_VERSION,
+        "init": init,
+    }
+
+
+async def main(variant: str, model: str, subagent_model: str) -> None:
+    record = await run_one(variant, model, subagent_model)
+    # Human-readable line (standalone use) + machine-readable line (run_matrix.py
+    # parses RESULT_JSON to assemble the corpus manifest).
+    print(
+        f"RESULT variant={record['variant']} model={record['main_model']} "
+        f"session_id={record['session_id']} file={record['source_jsonl']}"
+    )
+    print("RESULT_JSON " + json.dumps(record))
 
 
 if __name__ == "__main__":
-    variant = sys.argv[1] if len(sys.argv) > 1 else "flat"
+    args = sys.argv[1:]
+    variant = args[0] if args else "flat"
     if variant not in PROMPTS:
-        sys.exit("usage: agent.py [flat|subagent|large]")
-    asyncio.run(main(variant))
+        sys.exit("usage: agent.py [flat|subagent|large] [model] [subagent_model]")
+    cli_model = args[1] if len(args) > 1 else MODEL
+    cli_subagent_model = args[2] if len(args) > 2 else cli_model
+    asyncio.run(main(variant, cli_model, cli_subagent_model))

--- a/research/agent-sdk-probe/run_matrix.py
+++ b/research/agent-sdk-probe/run_matrix.py
@@ -1,0 +1,208 @@
+"""#519 corpus matrix runner for the representative Agent SDK agent (`agent.py`).
+
+Runs `agent.py` across a small configuration matrix, copies each run's raw
+session file(s) out of `~/.claude/projects/<slug>/` into the gitignored
+`corpus/`, and writes `corpus/manifest.json` -- a config->file index so S3 (#520)
+can correlate observed format differences to the inputs that produced them.
+
+The matrix toggles ONE axis per run (running the cross-product is gold-plating,
+per architect review on #517/#519):
+
+  | run | variant  | main model | subagent model | isolates                        |
+  |-----|----------|------------|----------------|---------------------------------|
+  | a   | flat     | haiku      | --             | full tool_use / error surface   |
+  | b   | subagent | sonnet     | haiku          | delegation + parent!=child model|
+  | c   | flat     | sonnet     | --             | model recording (2nd model)     |
+
+This satisfies #519's ACs: >=1 delegation run + >=1 without; >=2 distinct models;
+and run (b) is a genuine model-divergence sample (parent sonnet, child haiku) --
+the highest-value artifact for #112 model-routing, since the child's
+`toolUseResult.resolvedModel` can be checked against a known config value.
+
+Variant 1 (#518 hello-world) and the #522 `large` spill capture are NOT re-run
+here; if their raw files are still present under `corpus/`, they are indexed as
+`pre_existing` entries so the manifest is the single index of all SDK corpus.
+
+RAW DATA ONLY. The corpus and this manifest embed absolute filesystem paths and
+are gitignored -- they are never committed. Anonymization + fixture graduation is
+#521's job. Each file entry carries a `contains_abs_paths` flag to hand #521 a
+mechanical scrubbing worklist.
+
+Run:
+    uv run --group research python research/agent-sdk-probe/run_matrix.py
+
+Throwaway research scaffolding. Not part of the published `agentfluent` package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from claude_agent_sdk import project_key_for_directory
+
+PROBE_DIR = Path(__file__).parent
+AGENT = PROBE_DIR / "agent.py"
+CORPUS = PROBE_DIR / "corpus"
+
+HAIKU = "claude-haiku-4-5-20251001"
+SONNET = "claude-sonnet-4-6"
+
+MATRIX = [
+    {"variant": "flat", "main_model": HAIKU, "subagent_model": HAIKU},
+    {"variant": "subagent", "main_model": SONNET, "subagent_model": HAIKU},
+    {"variant": "flat", "main_model": SONNET, "subagent_model": SONNET},
+]
+
+# Bytes that, if present in a captured file, mean it must be scrubbed before it
+# can graduate to a committed fixture (#521).
+_HOME = str(Path.home()).encode()
+_SLUG = project_key_for_directory(str(PROBE_DIR)).encode()
+
+
+def _run_agent(entry: dict) -> dict:
+    """Invoke agent.py as a subprocess (isolation against SDK/asyncio state bleed
+    and mid-matrix faults) and return its RESULT_JSON record."""
+    cmd = [
+        sys.executable,
+        str(AGENT),
+        entry["variant"],
+        entry["main_model"],
+        entry["subagent_model"],
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout + proc.stderr)
+        raise RuntimeError(f"agent.py {entry['variant']} exited {proc.returncode}")
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT_JSON "):
+            return json.loads(line[len("RESULT_JSON ") :])
+    raise RuntimeError(f"no RESULT_JSON line from agent.py {entry['variant']}")
+
+
+def _file_record(path: Path) -> dict:
+    data = path.read_bytes()
+    is_jsonl = path.suffix == ".jsonl"
+    return {
+        "path": str(path.relative_to(CORPUS)),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "bytes": len(data),
+        "lines": data.count(b"\n") if is_jsonl else None,
+        "contains_abs_paths": _HOME in data or _SLUG in data,
+    }
+
+
+def _cli_version(jsonl: Path) -> str | None:
+    """Read the `version` field (Claude Code CLI version) off the first trace line
+    that carries one."""
+    with jsonl.open() as fh:
+        for line in fh:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            version = obj.get("version") or obj.get("claude_code_version")
+            if version:
+                return str(version)
+    return None
+
+
+def _capture(record: dict) -> dict:
+    """Copy a run's session file(s) into corpus/, assert completeness, and return
+    the manifest run entry."""
+    session_id = record["session_id"]
+    src_jsonl = Path(record["source_jsonl"])
+    src_dir = src_jsonl.with_suffix("")  # sibling <id>/ holding subagents/, tool-results/
+
+    dst_jsonl = CORPUS / f"{session_id}.jsonl"
+    dst_dir = CORPUS / session_id
+    CORPUS.mkdir(exist_ok=True)
+    dst_jsonl.write_bytes(src_jsonl.read_bytes())
+
+    files = [_file_record(dst_jsonl)]
+    subagent_files: list[str] = []
+    tool_results_files: list[str] = []
+    if src_dir.is_dir():
+        for child in sorted(src_dir.rglob("*")):
+            if child.is_file():
+                dst = dst_dir / child.relative_to(src_dir)
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_bytes(child.read_bytes())
+                rel = str(dst.relative_to(CORPUS))
+                files.append(_file_record(dst))
+                if "subagents/" in rel:
+                    subagent_files.append(rel)
+                elif "tool-results/" in rel:
+                    tool_results_files.append(rel)
+
+    # Completeness post-condition: a subagent run MUST yield a child trace, else we
+    # captured a partial corpus and the manifest would lie. Fail loudly.
+    if record["variant"] == "subagent" and not subagent_files:
+        raise RuntimeError(
+            f"subagent run {session_id} produced no subagents/*.jsonl -- partial "
+            "capture; not recording a misleading manifest entry"
+        )
+
+    return {
+        "variant": record["variant"],
+        "main_model": record["main_model"],
+        "subagent_model": record["subagent_model"],
+        "session_id": session_id,
+        "source_jsonl": str(src_jsonl),
+        "corpus_jsonl": str(dst_jsonl.relative_to(CORPUS)),
+        "sdk_version": record["sdk_version"],
+        "cli_version": _cli_version(dst_jsonl),
+        "prompt": record["prompt"],
+        "config": record["config"],
+        "subagent_files": subagent_files,
+        "tool_results_files": tool_results_files,
+        "files": files,
+        "init": record["init"],
+    }
+
+
+def _pre_existing(produced_ids: set[str]) -> list[dict]:
+    """Index any raw *.jsonl already under corpus/ from prior ad-hoc runs (#518
+    hello-world, #522 large) so the manifest is the single index of all corpus.
+    Their config provenance was not recorded at capture time."""
+    out = []
+    for jsonl in sorted(CORPUS.glob("*.jsonl")):
+        if jsonl.stem in produced_ids:
+            continue
+        out.append(
+            {
+                **_file_record(jsonl),
+                "note": "ad-hoc capture (#518 probe / #522 large); config provenance not recorded",
+            }
+        )
+    return out
+
+
+def main() -> None:
+    runs = [_capture(_run_agent(entry)) for entry in MATRIX]
+    produced = {r["session_id"] for r in runs}
+    manifest = {
+        "captured_at": datetime.now(UTC).isoformat(),
+        "generator": "run_matrix.py (#519)",
+        "probe_dir": str(PROBE_DIR),
+        "project_slug": project_key_for_directory(str(PROBE_DIR)),
+        "runs": runs,
+        "pre_existing": _pre_existing(produced),
+    }
+    manifest_path = CORPUS / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"\nWrote {manifest_path} ({len(runs)} runs, "
+          f"{len(manifest['pre_existing'])} pre-existing).")
+    for r in runs:
+        models = r["main_model"] + (
+            f" -> {r['subagent_model']}" if r["variant"] == "subagent" else ""
+        )
+        print(f"  {r['variant']:9} {models:48} {r['session_id']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `research/agent-sdk-probe/run_matrix.py` (#519) — the corpus matrix runner. Drives `agent.py` across a 3-run matrix (one axis toggled per run, per [architect review](https://github.com/frederick-douglas-pearce/agentfluent/issues/519#issuecomment-4774009830)), copies each run's raw session file(s) out of `~/.claude/projects/<slug>/` into the gitignored `corpus/`, and writes `corpus/manifest.json` — the config→file index #520 consumes.
- Threads the model into **both** the main agent and the subagent (`make_summarizer` factory; the child model is no longer a frozen constant), so the child's `toolUseResult.resolvedModel` is a recorded, controllable input for #112 model-routing. `agent.py` gains `run_one()` (manifest-ready record + runtime `init` capture) and a machine-readable `RESULT_JSON` line.
- Records the findings in `FINDINGS.md` (#519 section); raw corpus + manifest stay gitignored.

### Matrix (one axis per run)
| run | variant | main / subagent model | isolates |
|-----|---------|-----------------------|----------|
| a | `flat` | haiku | full `tool_use` / error surface |
| b | `subagent` | **sonnet / haiku** | delegation + parent≠child model |
| c | `flat` | sonnet | model recording (2nd model) |

Satisfies #519's ACs: ≥1 delegation run (b) + 2 without (a, c); 2 distinct models; on-disk location recorded per run; `manifest.json` maps config→file.

### Findings (feed #520/#521 + #112)
- **Model divergence recorded three ways:** run (b) ran a sonnet parent delegating to a haiku child. Parent `message.model` = sonnet, child trace `message.model` = haiku, and **`toolUseResult.resolvedModel` = the *child* model** (haiku). So #112 can verify a configured `subagent_model` against `resolvedModel` with no cross-referencing.
- **`ai-title` is a stale-snapshot type, not a novel find:** the multi-turn corpus surfaced `ai-title`, but — like the `.meta.json` sidecar / `tool-results/` spill — it's already documented upstream in `claude-code-sessions`. It joins `queue-operation`/`attachment`/`last-prompt` as types missing from CLAUDE.md's "Types to skip" list. Synced to **#528** (the CLAUDE.md doc-sync umbrella). The parser does not crash on any of them (verified: `parse_session` on all 3 new sessions, 0 crashes).
- **No new persisted `user`/`assistant` format fields** beyond #522 — #519 widens line-type and model coverage.
- **Manifest carries the #521 scrub worklist:** per-file `sha256` + a `contains_abs_paths` flag (every `.jsonl` is `true`; the `.meta.json` sidecar is `false`).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1685 passed, no regressions
- [x] Lint clean: `uv run ruff check research/agent-sdk-probe/ src/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [ ] New/changed behavior has test coverage — N/A: research scaffolding, exempt per epic (the artifact under study is the session data, not the harness)
- [x] Manual smoke test — `run_matrix.py` ran end-to-end; 3 runs captured, manifest verified, model divergence + subagent layout inspected

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

  Research scaffolding only, under `research/` — no `src/`, `pyproject.toml`, or runtime change; SDK stays dev-only. `run_matrix.py` does invoke `subprocess` and resolve paths, but every input is **trusted/self-generated**: list-form args (no shell) built from a hardcoded model-name matrix; paths are SDK-emitted session UUIDs under `~/.claude` copied into `corpus/`; the JSONL it reads is its own freshly-generated corpus. No untrusted/external input, and nothing ships in the package. Raw corpus + manifest (which embed absolute paths) are gitignored.

## Breaking changes
None. No public contract change — research scaffolding under `research/`, no `src/` or CLI changes; SDK stays dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)