### PR TITLE
fix(#500): guard decisions.md against entry-dropping writes

### DIFF
--- a/.claude/hooks/guard_append_only.py
+++ b/.claude/hooks/guard_append_only.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: protect append-only spec logs from entry-dropping writes.
+
+Receives the PreToolUse event JSON on stdin. For a `Write` targeting a
+registered append-only file (currently `.claude/specs/decisions.md`), it
+compares the set of decision-entry IDs (`## Dxxx` headings) already on disk
+against the set in the proposed `content`. If the write would drop any
+existing entry, the call is denied.
+
+Background: an append-only decision log was once clobbered by an agent whose
+`Write` tool does full-file replacement -- a pm intending to append one
+`Dxxx` entry replaced the entire file, dropping D001-D042 in the working copy
+(GitHub issue #500). This hook is the durable, agent-agnostic guard.
+
+Scope and bypass surface (deliberately bounded):
+- Guards the `Write` tool only. `Edit` is surgical (it cannot easily drop the
+  whole file) and simulating its result to detect drops is fragile, so it is
+  not guarded.
+- It does NOT cover `Bash` redirection (`cat > file`, `tee`, `sed -i`), which
+  an agent with Bash could use to clobber the file. This hook therefore
+  protects *entry existence against full-file Writes*, not body content, and
+  is not an absolute "any tool" guarantee. A Bash-command scan is the natural
+  follow-up extension if that guarantee is needed.
+
+Emits a JSON decision on stdout and exits 0 (the modern pattern); exit 2 +
+stderr is the fail-closed fallback for an unparseable event, matching
+`block_secret_reads.py`.
+
+Cross-platform: stdlib only, no shell dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path, PurePath
+from typing import Any
+
+# Registry of append-only files to protect, keyed by path SUFFIX (not bare
+# basename, to avoid false positives on unrelated `decisions.md` files
+# elsewhere in the tree). Each value is the anchored, multiline regex that
+# captures the entry IDs whose existence must be preserved across a write.
+# To protect another append-only spec, add its suffix + ID pattern here.
+DECISION_ID_PATTERN = re.compile(r"^##\s+(D\d+)", re.MULTILINE)
+
+APPEND_ONLY_FILES: dict[str, re.Pattern[str]] = {
+    ".claude/specs/decisions.md": DECISION_ID_PATTERN,
+}
+
+DENY_REASON = (
+    "Blocked by AgentFluent append-only guard hook "
+    "(.claude/hooks/guard_append_only.py). "
+    "This Write would drop one or more existing entries from an append-only "
+    "log, which is a data-loss risk (see issue #500). "
+    "The guard protects entry existence (`## Dxxx` headings), not body text -- "
+    "editing the body of an existing entry is fine as long as no entry is "
+    "removed. To add an entry, append to the file (e.g. read the current "
+    "content and write it back with the new entry appended, or use Edit), "
+    "preserving every existing `## Dxxx` heading."
+)
+
+
+def normalize(path_str: str) -> str:
+    """Return a forward-slash path string for suffix matching."""
+    return PurePath(path_str).as_posix()
+
+
+def match_registered_file(path_str: str) -> re.Pattern[str] | None:
+    """Return the ID pattern for a registered append-only file, else None."""
+    if not path_str:
+        return None
+    normalized = normalize(path_str)
+    for suffix, pattern in APPEND_ONLY_FILES.items():
+        if normalized.endswith(suffix):
+            return pattern
+    return None
+
+
+def extract_ids(text: str, pattern: re.Pattern[str]) -> set[str]:
+    """Extract the set of entry IDs from text using the registered pattern."""
+    return set(pattern.findall(text))
+
+
+def evaluate(
+    existing_content: str, proposed_content: str, pattern: re.Pattern[str]
+) -> tuple[bool, str]:
+    """Decide whether a write should be blocked. Pure (no I/O).
+
+    Returns (blocked, reason). Blocks when any ID present in the existing
+    content is absent from the proposed content.
+    """
+    existing_ids = extract_ids(existing_content, pattern)
+    if not existing_ids:
+        # Nothing to protect yet (file exists but has no recognized entries).
+        return False, ""
+    proposed_ids = extract_ids(proposed_content, pattern)
+    missing = sorted(existing_ids - proposed_ids)
+    if missing:
+        return True, f"{DENY_REASON} (would drop: {', '.join(missing)})"
+    return False, ""
+
+
+def check(event: dict[str, Any]) -> tuple[bool, str]:
+    """Inspect a PreToolUse event; return (blocked, reason)."""
+    if event.get("tool_name", "") != "Write":
+        return False, ""
+
+    tool_input = event.get("tool_input") or {}
+    path = tool_input.get("file_path") or ""
+    pattern = match_registered_file(path)
+    if pattern is None:
+        return False, ""
+
+    proposed_content = tool_input.get("content") or ""
+
+    try:
+        existing_content = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        # New file: there is nothing to drop.
+        return False, ""
+    except (OSError, UnicodeDecodeError) as e:
+        # A real read error on an existing protected file means we cannot
+        # verify the write is safe. Fail closed -- deny rather than risk a
+        # silent clobber. (Such errors on a local file are vanishingly rare.)
+        return True, (
+            f"{DENY_REASON} (could not read the existing file to verify no "
+            f"entries are dropped: {e})"
+        )
+
+    return evaluate(existing_content, proposed_content, pattern)
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        # Fail closed: if we can't parse the event we can't confirm the write
+        # is safe, so deny rather than allow through a malformed event.
+        print(
+            f"guard_append_only: failed to parse hook event JSON, "
+            f"denying by default: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    blocked, reason = check(event)
+    if blocked:
+        emit_decision("deny", reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/guard_append_only.py
+++ b/.claude/hooks/guard_append_only.py
@@ -42,7 +42,12 @@ from typing import Any
 # elsewhere in the tree). Each value is the anchored, multiline regex that
 # captures the entry IDs whose existence must be preserved across a write.
 # To protect another append-only spec, add its suffix + ID pattern here.
-DECISION_ID_PATTERN = re.compile(r"^##\s+(D\d+)", re.MULTILINE)
+#
+# The ID capture includes an optional `-<suffix>` segment so suffixed entries
+# (e.g. `## D038-A:`) are tracked as distinct IDs. Without it, `D\d+` would
+# truncate `D038-A` to `D038`, collapsing it with a sibling `## D038:` entry
+# and silently allowing one of them to be dropped (the exact #500 hazard).
+DECISION_ID_PATTERN = re.compile(r"^##\s+(D\d+(?:-[A-Za-z0-9]+)?)", re.MULTILINE)
 
 APPEND_ONLY_FILES: dict[str, re.Pattern[str]] = {
     ".claude/specs/decisions.md": DECISION_ID_PATTERN,
@@ -72,7 +77,10 @@ def match_registered_file(path_str: str) -> re.Pattern[str] | None:
         return None
     normalized = normalize(path_str)
     for suffix, pattern in APPEND_ONLY_FILES.items():
-        if normalized.endswith(suffix):
+        # Require a path-component boundary so an unrelated file whose tail
+        # merely ends in the suffix string (e.g. `.../vendor.claude/specs/
+        # decisions.md`) is not mistaken for the protected log.
+        if normalized == suffix or normalized.endswith("/" + suffix):
             return pattern
     return None
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block_secret_reads.py\""
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_append_only.py\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/unit/test_append_only_guard.py
+++ b/tests/unit/test_append_only_guard.py
@@ -1,0 +1,218 @@
+"""Tests for the append-only guard hook (#500).
+
+Covers ``.claude/hooks/guard_append_only.py``: the subset-of-IDs detection
+(drop, append, body-edit, count-preserving swap), the anchored ID regex
+(prose mentions are not entries), suffix-based file matching, the fail
+directions (FileNotFoundError -> allow, other read errors -> deny, malformed
+event -> deny), and benign passes.
+
+The hook lives in ``.claude/hooks/`` (maintainer-only Claude Code tooling,
+outside the ``agentfluent`` package), so it is loaded here by file path via
+importlib rather than imported as a module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_HOOK_PATH = (
+    Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "guard_append_only.py"
+)
+
+
+def _load_hook() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("guard_append_only", _HOOK_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_hook()
+
+REGISTERED_SUFFIX = ".claude/specs/decisions.md"
+
+
+def _entry(num: str, body: str = "Some decision body.") -> str:
+    return f"## D{num}: a decision\n\n{body}\n"
+
+
+def _doc(*nums: str, body: str = "Some decision body.") -> str:
+    return "\n".join(_entry(n, body) for n in nums)
+
+
+# --- evaluate(): pure detection logic -------------------------------------
+
+
+def test_pure_append_is_allowed() -> None:
+    existing = _doc("001", "002")
+    proposed = _doc("001", "002", "003")
+    blocked, _ = guard.evaluate(existing, proposed, guard.DECISION_ID_PATTERN)
+    assert blocked is False
+
+
+def test_dropping_an_entry_is_blocked() -> None:
+    existing = _doc("001", "002")
+    proposed = _doc("001")
+    blocked, reason = guard.evaluate(existing, proposed, guard.DECISION_ID_PATTERN)
+    assert blocked is True
+    assert "D002" in reason
+
+
+def test_editing_existing_body_is_allowed() -> None:
+    existing = _doc("001", "002", body="Original rationale.")
+    proposed = _doc("001", "002", body="Rewritten, clearer rationale.")
+    blocked, _ = guard.evaluate(existing, proposed, guard.DECISION_ID_PATTERN)
+    assert blocked is False
+
+
+def test_count_preserving_id_swap_is_blocked() -> None:
+    existing = _doc("001", "002", "003")
+    proposed = _doc("001", "002", "099")  # same count, D003 silently dropped
+    blocked, reason = guard.evaluate(existing, proposed, guard.DECISION_ID_PATTERN)
+    assert blocked is True
+    assert "D003" in reason
+
+
+def test_empty_proposed_content_is_blocked() -> None:
+    existing = _doc("001", "002")
+    blocked, reason = guard.evaluate(existing, "", guard.DECISION_ID_PATTERN)
+    assert blocked is True
+    assert "D001" in reason and "D002" in reason
+
+
+def test_existing_with_no_ids_is_allowed() -> None:
+    existing = "# Decision log\n\nNo entries yet.\n"
+    blocked, _ = guard.evaluate(existing, "anything", guard.DECISION_ID_PATTERN)
+    assert blocked is False
+
+
+# --- extract_ids(): anchored regex ----------------------------------------
+
+
+def test_prose_mentions_are_not_counted_as_entries() -> None:
+    text = (
+        "## D001: real entry\n\nThis decision supersedes D012 and relates to "
+        "D999 mentioned inline.\n"
+    )
+    ids = guard.extract_ids(text, guard.DECISION_ID_PATTERN)
+    assert ids == {"D001"}
+
+
+# --- match_registered_file(): suffix matching -----------------------------
+
+
+def test_registered_suffix_matches() -> None:
+    path = f"/home/u/project/{REGISTERED_SUFFIX}"
+    assert guard.match_registered_file(path) is guard.DECISION_ID_PATTERN
+
+
+def test_unrelated_decisions_md_does_not_match() -> None:
+    assert guard.match_registered_file("/home/u/notes/decisions.md") is None
+
+
+def test_empty_path_does_not_match() -> None:
+    assert guard.match_registered_file("") is None
+
+
+# --- check(): event-level behavior + I/O ----------------------------------
+
+
+def _write_event(path: str, content: str) -> dict:
+    return {"tool_name": "Write", "tool_input": {"file_path": path, "content": content}}
+
+
+def _registered_path(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "specs" / "decisions.md"
+
+
+def test_check_ignores_non_write_tools() -> None:
+    event = {"tool_name": "Edit", "tool_input": {"file_path": "x/decisions.md"}}
+    assert guard.check(event) == (False, "")
+
+
+def test_check_ignores_unregistered_files(tmp_path: Path) -> None:
+    target = tmp_path / "decisions.md"
+    target.write_text(_doc("001"), encoding="utf-8")
+    blocked, _ = guard.check(_write_event(str(target), ""))
+    assert blocked is False
+
+
+def test_check_allows_new_file(tmp_path: Path) -> None:
+    target = _registered_path(tmp_path)  # parent dirs absent; file does not exist
+    blocked, _ = guard.check(_write_event(str(target), _doc("001")))
+    assert blocked is False
+
+
+def test_check_blocks_dropping_entries_on_existing_file(tmp_path: Path) -> None:
+    target = _registered_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(_doc("001", "002", "003"), encoding="utf-8")
+    blocked, reason = guard.check(_write_event(str(target), _doc("001")))
+    assert blocked is True
+    assert "D002" in reason and "D003" in reason
+
+
+def test_check_allows_valid_append_on_existing_file(tmp_path: Path) -> None:
+    target = _registered_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(_doc("001", "002"), encoding="utf-8")
+    blocked, _ = guard.check(_write_event(str(target), _doc("001", "002", "003")))
+    assert blocked is False
+
+
+def test_check_fails_closed_on_read_error(tmp_path: Path) -> None:
+    # A directory at the target path makes read_text raise IsADirectoryError
+    # (an OSError that is not FileNotFoundError) -> deny.
+    target = _registered_path(tmp_path)
+    target.mkdir(parents=True)
+    blocked, reason = guard.check(_write_event(str(target), _doc("001")))
+    assert blocked is True
+    assert "could not read" in reason
+
+
+# --- main(): stdin parsing + decision emission ----------------------------
+
+
+def test_main_fails_closed_on_malformed_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+    assert guard.main() == 2
+
+
+def test_main_emits_deny_decision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = _registered_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(_doc("001", "002"), encoding="utf-8")
+    event = _write_event(str(target), _doc("001"))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
+
+    rc = guard.main()
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_main_allows_valid_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = _registered_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(_doc("001"), encoding="utf-8")
+    event = _write_event(str(target), _doc("001", "002"))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
+
+    rc = guard.main()
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # no decision emitted == allow

--- a/tests/unit/test_append_only_guard.py
+++ b/tests/unit/test_append_only_guard.py
@@ -16,14 +16,15 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import re
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-_HOOK_PATH = (
-    Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "guard_append_only.py"
-)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PATH = _REPO_ROOT / ".claude" / "hooks" / "guard_append_only.py"
+_REAL_DECISIONS = _REPO_ROOT / ".claude" / "specs" / "decisions.md"
 
 
 def _load_hook() -> ModuleType:
@@ -93,6 +94,21 @@ def test_existing_with_no_ids_is_allowed() -> None:
     assert blocked is False
 
 
+def test_suffixed_id_is_distinct_from_numeric_sibling() -> None:
+    # Regression: `## D038-A:` must not collapse onto `## D038:`. Dropping the
+    # suffixed entry while keeping the numeric one must be detected.
+    existing = _doc("038", "038-A")
+    proposed = _doc("038")  # D038-A silently dropped
+    blocked, reason = guard.evaluate(existing, proposed, guard.DECISION_ID_PATTERN)
+    assert blocked is True
+    assert "D038-A" in reason
+
+
+def test_suffixed_and_numeric_ids_both_extracted() -> None:
+    ids = guard.extract_ids(_doc("038", "038-A"), guard.DECISION_ID_PATTERN)
+    assert ids == {"D038", "D038-A"}
+
+
 # --- extract_ids(): anchored regex ----------------------------------------
 
 
@@ -119,6 +135,16 @@ def test_unrelated_decisions_md_does_not_match() -> None:
 
 def test_empty_path_does_not_match() -> None:
     assert guard.match_registered_file("") is None
+
+
+def test_relative_registered_path_matches() -> None:
+    assert guard.match_registered_file(REGISTERED_SUFFIX) is guard.DECISION_ID_PATTERN
+
+
+def test_suffix_requires_path_boundary() -> None:
+    # Regression: a tail that merely ends in the suffix STRING, without a `/`
+    # boundary before `.claude`, must NOT be treated as the protected log.
+    assert guard.match_registered_file(f"/repo/vendor{REGISTERED_SUFFIX}") is None
 
 
 # --- check(): event-level behavior + I/O ----------------------------------
@@ -216,3 +242,26 @@ def test_main_allows_valid_append(
     rc = guard.main()
     assert rc == 0
     assert capsys.readouterr().out == ""  # no decision emitted == allow
+
+
+# --- drift guard against the real decisions.md ----------------------------
+
+
+def test_pattern_tracks_the_real_decision_log() -> None:
+    # Couples the guard to the live file: if decisions.md's heading style ever
+    # drifts away from `## Dxxx`, the pattern would silently stop matching and
+    # the guard would degrade to a no-op (the #500 hazard, reintroduced
+    # quietly). This test turns that silent failure into a red build.
+    assert _REAL_DECISIONS.exists(), "real decisions.md not found at expected path"
+    text = _REAL_DECISIONS.read_text(encoding="utf-8")
+
+    ids = list(guard.DECISION_ID_PATTERN.findall(text))
+    heading_lines = re.findall(r"^##\s+D\d", text, re.MULTILINE)
+
+    assert ids, "pattern captured no decision IDs from the real log"
+    # Every decision-shaped heading is captured exactly once (no drift, no
+    # collision such as D038-A collapsing onto D038).
+    assert len(ids) == len(heading_lines)
+    assert len(ids) == len(set(ids))
+    # The known suffixed/numeric sibling pair stays distinct.
+    assert {"D038", "D038-A"} <= set(ids)


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/guard_append_only.py`, a PreToolUse hook that denies a `Write` to `.claude/specs/decisions.md` when it would drop any existing `## Dxxx` entry — closing the append-only data-loss risk in #500 (a full-file `Write` that replaces the decision log, as happened during #407).
- Detection is a **subset check on entry IDs**: every `## Dxxx` ID on disk must remain present in the proposed content. Editing an existing entry's body is allowed; removing any entry is denied. New-file writes are allowed (nothing to drop); a non-ENOENT read error on an existing protected file fails closed.
- Wires the hook into `.claude/settings.json` (PreToolUse, `Write` matcher) and adds unit tests (`tests/unit/test_append_only_guard.py`).

**Scope / residual (per architect review on #500):** guards the `Write` tool only. `Edit` is surgical and not guarded; `Bash` redirection (`cat >`, `tee`, `sed -i`) is a documented residual bypass — so the guard protects *entry existence against full-file Writes*, not body content under every tool. A Bash-command scan is the natural follow-up if an absolute guarantee is wanted.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1732 passed; 19 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/` (unchanged; hook also passes `mypy --strict`)
- [x] New/changed behavior has test coverage (drop/append/body-edit/count-preserving-swap, anchored-regex prose case, suffix matching, fail-open-on-ENOENT vs fail-closed-on-read-error, malformed-event exit 2)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI change). Hook smoke-tested directly by piping PreToolUse event JSON: clobber→deny, valid append/new-file/unrelated→allow, malformed→exit 2.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Adds a new maintainer-only guard hook; no public contract, CLI, or model change. `.claude/` tooling is not shipped in the PyPI package.

Fixes #500.