### PR TITLE
chore: gitignore the loop-engineering ledger directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ data/
 .claude/settings.local.json
 .claude/*.lock
 .claude/worktrees/
+# Loop-engineering harness ledger: local working state (queue/progress/plans),
+# never committed -- committing collides with branch protection (see
+# .claude/specs/prd-loop-engineering.md section 6.4).
+.claude/loop/
 
 # IDE
 .vscode/


### PR DESCRIPTION
## Summary
- Adds `.claude/loop/` to `.gitignore` — the loop-engineering harness's per-run ledger (queue/progress/per-issue plans) is local working state and is never committed (collides with branch protection; see `.claude/specs/prd-loop-engineering.md` §6.4). This is build step **C2** of the harness.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (unchanged — no code)
- [x] Lint clean: `uv run ruff check src/ tests/` (unchanged — no code)
- [x] Type check clean: `uv run mypy src/agentfluent/` (unchanged — no code)
- [x] New/changed behavior has test coverage — N/A, gitignore-only
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A, no code change

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. Ignore-rule only.