### PR TITLE
chore(loop): add /release-loop orchestrator skill (C3) + spec hardening

### DIFF
--- a/.claude/skills/release-loop/SKILL.md
+++ b/.claude/skills/release-loop/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: release-loop
+description: Run one routed iteration of the supervised dev loop over a backlog (milestone/label). Selects the next unblocked issue, routes it, drives plan→architect→implement→review→merge with human gates on uncertainty, and journals to the ledger. Invoke once per issue; re-invoke (or drive via /loop) for the next. Use when the user wants to work a backlog as a loop, "run the release loop", or "do the next issue".
+---
+
+# Release Loop — orchestrator (ONE issue per invocation)
+
+You are the orchestrator of a supervised dev loop. Each invocation handles exactly ONE
+issue end-to-end, journals, and stops. State lives in the ledger, not your context — so a
+fresh invocation resumes correctly. Read the project parameters in
+`.claude/specs/prd-loop-engineering.md` §4.0.
+
+## 0. Load or initialize state
+1. Identify the active run (most recent `LEDGER_ROOT/<run>/`). If it already carries a
+   `RUN COMPLETE` sentinel (§9), report done and STOP — do not re-scan. If no run exists, ask
+   the user which milestone/label to run, then INITIALIZE per §7.5 of the spec.
+2. Read `queue.md` (note its `mode:` header and any `hold` rows) and the tail of `progress.md`.
+3. **Resume before selecting (spec §7.6).** If any row sits in a non-terminal,
+   non-`queued`/`routed` status (`planning`/`plan-approved`/`implementing`/`in-pr`/
+   `in-review`/`hold`), a prior iteration was interrupted. Reconcile that row against LIVE
+   git/PR state as the source of truth — branch exists? PR open? already merged? CI status? —
+   plus the working tree, then re-enter the pipeline at the matching stage and FINISH that
+   issue BEFORE selecting a new one. This is what makes "one PR at a time" hold across
+   `/clear`/compaction. A `hold` row stays held until the human releases it.
+
+## 1. Select
+Among issues whose status is `queued`/`routed` and whose `Depends on` issues are all `done`,
+pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable: if
+EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE — <run-slug>`
+sentinel to `progress.md` (counts + any blocked/deferred items) and STOP (convergence).
+Otherwise (rows still blocked on open in-run dependencies) report what's pending and STOP
+without the sentinel.
+**Size guard:** before entering the pipeline, estimate scope from the issue body — if it
+plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
+fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
+go back to select. Aggressively offload reading/analysis to subagents (architect, AC-verifier)
+within an iteration to conserve the parent's context.
+
+## 2. Triage / route (if not already routed)
+Classify into `code | research | docs | stub-defer | blocked` using §7.3. Set the row's Route
+and advance its status to `routed`. If `stub-defer` or `blocked`, journal why and go back to
+§1 (do not implement).
+
+## 3. Plan
+Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
+`issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
+research/docs.
+
+## 4. Architect gate (conditional)
+If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
+the plan; address `blocking`/`important` concerns before coding. Skip for docs and trivial
+research.
+
+## 5. Human gate (conditional — supervised mode)
+Present the plan and STOP for approval when: acceptance criteria are ambiguous; the change is
+risky/irreversible; SCOPE/ DESIGN agents disagree or punt; or you are otherwise unsure.
+Otherwise proceed (note "auto-approved" + why in the journal). Route scope questions to
+SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
+(human or auto), advance the row to `plan-approved`.
+
+## 6. Implement (you, the parent thread)
+Advance the row to `implementing`. Create the branch (`BRANCH_FMT`). Implement code + tests +
+docs per the plan. TDD where it fits (write failing tests, commit, do not modify tests later).
+Run `LINT_CMD`, `TYPE_CMD`, `TEST_CMD` until green. Do NOT stage unrelated pre-existing
+working-tree changes.
+
+## 7. Verify done (independent, fresh context)
+Run the AC-verifier (spec §7.4): a fresh check that the diff satisfies EVERY acceptance
+criterion — verify state, not your claim. If gaps, fix and re-verify (max 2 rounds, else
+escalate).
+
+## 8. Commit + PR
+Commit with correct `COMMIT_CONV` scope. Open the PR; **replicate `PR_TEMPLATE` fully** in
+the body; make the Security-review choice up front. Advance the row to `in-pr` and record the
+PR number. Wait for CI; fix until green.
+
+## 9. Code review
+Advance the row to `in-review`. Run CODE_REVIEW on the diff. Implement viable findings;
+decline others with a one-line rationale; **verify recs were applied**. Bounded to 2 rounds —
+contested findings escalate to the human, do not loop. Commit fixes.
+
+## 10. Security review (by route)
+- `.claude/`-only change → run local `/security-review` (the labeled workflow excludes
+  `.claude/`; the local skill needs `git remote set-head origin -a` if it errors on
+  `origin/HEAD...`).
+- Otherwise, if a sensitive surface is touched → apply `needs-security-review` ONLY now
+  (dev-complete). Skip for docs/no-surface changes.
+Address findings ≥ the project's confidence bar.
+
+## 11. Merge
+Read the run `mode` from the `queue.md` header. If `mode: calibration` (the default until the
+human loosens it) OR the row is flagged `hold`: STOP and ask the human before merging — never
+auto-merge in calibration. Otherwise, when CI + security are green AND no merge-hold is
+recorded: squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
+`--delete-branch`. Confirm the issue closed. (A human merge-hold is recorded durably in the
+row — status `hold` or a `Notes: HOLD …` flag — so it survives `/clear`.)
+
+## 12. Journal + stop
+Append the iteration block to `progress.md`; set the `queue.md` row to `done` (or
+`blocked`/`deferred` with reason); note newly-unblocked issues. The ledger is gitignored —
+do NOT commit it (spec §6.4). STOP. (Driver re-invokes with fresh context for the next issue.)
+
+## Escalation rubric (when unsure)
+Scope/priority/requirements → SCOPE_AGENT. Design/implementation → DESIGN_AGENT. Escalate to
+the HUMAN only when those disagree/punt, ACs are unresolvable, an action is
+destructive/irreversible, a review finding is contested, or the same step failed twice.
+
+## Guardrails
+One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL
+`progress.md` (not just the tail) for the signature: an identical CI failure, or the same
+tool+args failing again — NOT merely re-entering a status (a legitimate `/clear`-resume
+re-enters `implementing` and must not be flagged). On a genuine repeat: stop, escalate, mark
+`blocked`, move on. Respect any iteration/budget cap (stored in the ledger; enforced by the
+driver — inert in manual re-invoke mode).
+
+## Tool surface — and what you must NOT do
+This skill intentionally runs with the full session toolset (no `allowed-tools` restriction):
+an orchestrator needs Write/Edit, Bash(git+gh+tests), Agent (pm/architect/AC-verifier), and
+the built-in review skills. With that power come hard limits — never force-push; never bypass
+failing CI (no `gh pr merge --admin`, never merge red); only `--delete-branch` the PR's own
+branch; never `git add` unrelated pre-existing working-tree changes; never edit the
+user-global SCOPE_AGENT/DESIGN_AGENT definitions. The C1 append-only guard and the
+human/merge gates are the enforced backstops; the rest of this list is your contract.

--- a/.claude/skills/release-loop/SKILL.md
+++ b/.claude/skills/release-loop/SKILL.md
@@ -15,21 +15,29 @@ fresh invocation resumes correctly. Read the project parameters in
    `RUN COMPLETE` sentinel (§9), report done and STOP — do not re-scan. If no run exists, ask
    the user which milestone/label to run, then INITIALIZE per §7.5 of the spec.
 2. Read `queue.md` (note its `mode:` header and any `hold` rows) and the tail of `progress.md`.
-3. **Resume before selecting (spec §7.6).** If any row sits in a non-terminal,
-   non-`queued`/`routed` status (`planning`/`plan-approved`/`implementing`/`in-pr`/
-   `in-review`/`hold`), a prior iteration was interrupted. Reconcile that row against LIVE
-   git/PR state as the source of truth — branch exists? PR open? already merged? CI status? —
-   plus the working tree, then re-enter the pipeline at the matching stage and FINISH that
-   issue BEFORE selecting a new one. This is what makes "one PR at a time" hold across
-   `/clear`/compaction. A `hold` row stays held until the human releases it.
+3. **Resume before selecting (spec §7.6).** If any row sits in an *interrupted* status —
+   non-terminal and NOT `queued`/`routed`/`hold` (i.e. `planning`/`plan-approved`/
+   `implementing`/`in-pr`/`in-review`) — a prior iteration was cut off. Reconcile it against
+   LIVE git/PR state as the source of truth — branch exists? PR open? already merged? CI
+   status? — plus the working tree (status is only a coarse anchor; git wins on conflict),
+   then re-enter the pipeline at the matching stage and FINISH that issue BEFORE selecting a
+   new one. This is what makes "one PR at a time" hold across `/clear`/compaction. A `hold`
+   row is NOT an interruption: skip it here, leave it held — it stays parked until the human
+   releases the hold and does not block working other issues.
 
 ## 1. Select
-Among issues whose status is `queued`/`routed` and whose `Depends on` issues are all `done`,
-pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable: if
-EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE — <run-slug>`
-sentinel to `progress.md` (counts + any blocked/deferred items) and STOP (convergence).
-Otherwise (rows still blocked on open in-run dependencies) report what's pending and STOP
-without the sentinel.
+A row is **selectable** if its status is `queued`/`routed`, OR it is `blocked` on an unmet
+dependency that has SINCE cleared (all its `Depends on` issues are now `done` — re-route it via
+§2; this does NOT apply to a `blocked: too-large` park, which waits on a split). Among
+selectable rows pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are
+selectable:
+- If EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE —
+  <run-slug>` sentinel to `progress.md` (counts + any blocked/deferred items) and STOP
+  (convergence).
+- Else if the only non-terminal rows are `hold`, report "<n> held — awaiting human
+  merge-release" and STOP **without** the sentinel (the run is not complete).
+- Else (rows still blocked on open in-run dependencies) report what's pending and STOP
+  without the sentinel.
 **Size guard:** before entering the pipeline, estimate scope from the issue body — if it
 plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
 fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
@@ -37,9 +45,12 @@ go back to select. Aggressively offload reading/analysis to subagents (architect
 within an iteration to conserve the parent's context.
 
 ## 2. Triage / route (if not already routed)
-Classify into `code | research | docs | stub-defer | blocked` using §7.3. Set the row's Route
-and advance its status to `routed`. If `stub-defer` or `blocked`, journal why and go back to
-§1 (do not implement).
+Run §7.3 to set the row's **Route** (`code`/`research`/`docs`/`stub-defer`) and its **initial
+Status** (Route and Status are distinct — §6.1): `stub-defer` → Status `deferred` (terminal);
+an unmet dependency → Status `blocked` (parked; record the dep, or `too-large`, in Notes — the
+Route is retained so the row resumes as that route when the dependency clears, §1); otherwise →
+Status `routed`. If the Status is `deferred` or `blocked`, journal why and go back to §1 — do
+not implement.
 
 ## 3. Plan
 Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
@@ -90,10 +101,13 @@ Address findings ≥ the project's confidence bar.
 ## 11. Merge
 Read the run `mode` from the `queue.md` header. If `mode: calibration` (the default until the
 human loosens it) OR the row is flagged `hold`: STOP and ask the human before merging — never
-auto-merge in calibration. Otherwise, when CI + security are green AND no merge-hold is
-recorded: squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
-`--delete-branch`. Confirm the issue closed. (A human merge-hold is recorded durably in the
-row — status `hold` or a `Notes: HOLD …` flag — so it survives `/clear`.)
+auto-merge in calibration. **If the human holds the merge (now or in any later invocation),
+WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
+it persists across `/clear`; resume (step 0.3), §1, and this gate all key on Status `hold` and
+honor it until the human clears it (restoring the row's prior status). Otherwise, when CI +
+security are green AND the row is not `hold`:
+squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
+`--delete-branch`. Confirm the issue closed.
 
 ## 12. Journal + stop
 Append the iteration block to `progress.md`; set the `queue.md` row to `done` (or

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -176,10 +176,16 @@ The orchestrator is the only writer except where noted.
 
 ### 6.1 `queue.md` — work list (authoritative status)
 Dependency-ordered. One row per issue. Statuses: `queued → routed → planning →
-plan-approved → implementing → in-pr → in-review → done | blocked | deferred`.
+plan-approved → implementing → in-pr → in-review → done | blocked | deferred | hold`.
+The orchestrator advances a row's status as it moves through the pipeline (§7.1), so an
+interrupted run leaves a **non-terminal status that resume keys on** (§7.6). `hold` is a
+durable, human-set merge-hold that survives `/clear`. The header carries a `mode:` field
+(`calibration` until the human loosens it to `escalation-only`) that gates auto-merge (§7.1
+step 11).
 
 ```markdown
 # Loop run: v0.10.0
+_mode: calibration_
 _Last updated: <ISO8601 by orchestrator>_
 
 | # | Issue | Route | Status | Depends on | PR | Notes |
@@ -267,14 +273,25 @@ fresh invocation resumes correctly. Read the project parameters in
 `.claude/specs/prd-loop-engineering.md` §4.0.
 
 ## 0. Load or initialize state
-1. Identify the active run (most recent `LEDGER_ROOT/<run>/`), or ask the user which
-   milestone/label to run if none exists, then INITIALIZE per §7.5 of the spec.
-2. Read `queue.md` and the tail of `progress.md`.
+1. Identify the active run (most recent `LEDGER_ROOT/<run>/`). If it already carries a
+   `RUN COMPLETE` sentinel (§9), report done and STOP — do not re-scan. If no run exists, ask
+   the user which milestone/label to run, then INITIALIZE per §7.5 of the spec.
+2. Read `queue.md` (note its `mode:` header and any `hold` rows) and the tail of `progress.md`.
+3. **Resume before selecting (spec §7.6).** If any row sits in a non-terminal,
+   non-`queued`/`routed` status (`planning`/`plan-approved`/`implementing`/`in-pr`/
+   `in-review`/`hold`), a prior iteration was interrupted. Reconcile that row against LIVE
+   git/PR state as the source of truth — branch exists? PR open? already merged? CI status? —
+   plus the working tree, then re-enter the pipeline at the matching stage and FINISH that
+   issue BEFORE selecting a new one. This is what makes "one PR at a time" hold across
+   `/clear`/compaction. A `hold` row stays held until the human releases it.
 
 ## 1. Select
 Among issues whose status is `queued`/`routed` and whose `Depends on` issues are all `done`,
-pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are unblocked:
-report status and STOP (convergence, or all remaining blocked/deferred — say which).
+pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable: if
+EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE — <run-slug>`
+sentinel to `progress.md` (counts + any blocked/deferred items) and STOP (convergence).
+Otherwise (rows still blocked on open in-run dependencies) report what's pending and STOP
+without the sentinel.
 **Size guard:** before entering the pipeline, estimate scope from the issue body — if it
 plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
 fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
@@ -282,12 +299,14 @@ go back to select. Aggressively offload reading/analysis to subagents (architect
 within an iteration to conserve the parent's context.
 
 ## 2. Triage / route (if not already routed)
-Classify into `code | research | docs | stub-defer | blocked` using §7.3. Update the row.
-If `stub-defer` or `blocked`, journal why and go back to §1 (do not implement).
+Classify into `code | research | docs | stub-defer | blocked` using §7.3. Set the row's Route
+and advance its status to `routed`. If `stub-defer` or `blocked`, journal why and go back to
+§1 (do not implement).
 
 ## 3. Plan
-Fetch the issue (`gh issue view <N>`). Write `issue-<N>.plan.md` (template in spec §6.3),
-copying acceptance criteria verbatim. Lighter for research/docs.
+Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
+`issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
+research/docs.
 
 ## 4. Architect gate (conditional)
 If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
@@ -298,12 +317,14 @@ research.
 Present the plan and STOP for approval when: acceptance criteria are ambiguous; the change is
 risky/irreversible; SCOPE/ DESIGN agents disagree or punt; or you are otherwise unsure.
 Otherwise proceed (note "auto-approved" + why in the journal). Route scope questions to
-SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human.
+SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
+(human or auto), advance the row to `plan-approved`.
 
 ## 6. Implement (you, the parent thread)
-Create the branch (`BRANCH_FMT`). Implement code + tests + docs per the plan. TDD where it
-fits (write failing tests, commit, do not modify tests later). Run `LINT_CMD`, `TYPE_CMD`,
-`TEST_CMD` until green. Do NOT stage unrelated pre-existing working-tree changes.
+Advance the row to `implementing`. Create the branch (`BRANCH_FMT`). Implement code + tests +
+docs per the plan. TDD where it fits (write failing tests, commit, do not modify tests later).
+Run `LINT_CMD`, `TYPE_CMD`, `TEST_CMD` until green. Do NOT stage unrelated pre-existing
+working-tree changes.
 
 ## 7. Verify done (independent, fresh context)
 Run the AC-verifier (spec §7.4): a fresh check that the diff satisfies EVERY acceptance
@@ -312,12 +333,13 @@ escalate).
 
 ## 8. Commit + PR
 Commit with correct `COMMIT_CONV` scope. Open the PR; **replicate `PR_TEMPLATE` fully** in
-the body; make the Security-review choice up front. Wait for CI; fix until green.
+the body; make the Security-review choice up front. Advance the row to `in-pr` and record the
+PR number. Wait for CI; fix until green.
 
 ## 9. Code review
-Run CODE_REVIEW on the diff. Implement viable findings; decline others with a one-line
-rationale; **verify recs were applied**. Bounded to 2 rounds — contested findings escalate to
-the human, do not loop. Commit fixes.
+Advance the row to `in-review`. Run CODE_REVIEW on the diff. Implement viable findings;
+decline others with a one-line rationale; **verify recs were applied**. Bounded to 2 rounds —
+contested findings escalate to the human, do not loop. Commit fixes.
 
 ## 10. Security review (by route)
 - `.claude/`-only change → run local `/security-review` (the labeled workflow excludes
@@ -328,9 +350,12 @@ the human, do not loop. Commit fixes.
 Address findings ≥ the project's confidence bar.
 
 ## 11. Merge
-When CI + security are green AND the human has not held the merge: squash-merge with an
-explicit `--subject` carrying the correct `COMMIT_CONV` scope, `--delete-branch`. Confirm the
-issue closed. In early calibration, STOP and ask the human before merging.
+Read the run `mode` from the `queue.md` header. If `mode: calibration` (the default until the
+human loosens it) OR the row is flagged `hold`: STOP and ask the human before merging — never
+auto-merge in calibration. Otherwise, when CI + security are green AND no merge-hold is
+recorded: squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
+`--delete-branch`. Confirm the issue closed. (A human merge-hold is recorded durably in the
+row — status `hold` or a `Notes: HOLD …` flag — so it survives `/clear`.)
 
 ## 12. Journal + stop
 Append the iteration block to `progress.md`; set the `queue.md` row to `done` (or
@@ -343,11 +368,21 @@ the HUMAN only when those disagree/punt, ACs are unresolvable, an action is
 destructive/irreversible, a review finding is contested, or the same step failed twice.
 
 ## Guardrails
-One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** (identical
-CI failure, or the same tool+args failing again) — NOT merely re-entering a status (a
-legitimate `/clear`-resume re-enters `implementing` and must not be flagged). On a genuine
-repeat: stop, escalate, mark `blocked`, move on. Respect any iteration/budget cap (stored in
-the ledger; enforced by the driver — inert in manual re-invoke mode).
+One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL
+`progress.md` (not just the tail) for the signature: an identical CI failure, or the same
+tool+args failing again — NOT merely re-entering a status (a legitimate `/clear`-resume
+re-enters `implementing` and must not be flagged). On a genuine repeat: stop, escalate, mark
+`blocked`, move on. Respect any iteration/budget cap (stored in the ledger; enforced by the
+driver — inert in manual re-invoke mode).
+
+## Tool surface — and what you must NOT do
+This skill intentionally runs with the full session toolset (no `allowed-tools` restriction):
+an orchestrator needs Write/Edit, Bash(git+gh+tests), Agent (pm/architect/AC-verifier), and
+the built-in review skills. With that power come hard limits — never force-push; never bypass
+failing CI (no `gh pr merge --admin`, never merge red); only `--delete-branch` the PR's own
+branch; never `git add` unrelated pre-existing working-tree changes; never edit the
+user-global SCOPE_AGENT/DESIGN_AGENT definitions. The C1 append-only guard and the
+human/merge gates are the enforced backstops; the rest of this list is your contract.
 ````
 
 ### 7.2 Architect-gate triggers (from CLAUDE.md)
@@ -385,15 +420,17 @@ Promote to a dedicated `ac-verifier` agent only if the composed approach proves 
 3. For each issue: determine route (§7.3) and dependencies (parse "Depends on"/"blocked by"
    refs in the body; respect epic ordering notes).
 4. Topologically order by dependency, then by `PRIORITY_LABELS` (tiebreak issue-number asc).
-   Write `queue.md` (§6.1).
+   Write `queue.md` (§6.1) with header `mode: calibration` (default; the human loosens to
+   `escalation-only` after calibration — step 11 reads this to gate auto-merge).
 5. Append an "init" block to `progress.md`. (Ledger is gitignored — not committed.)
 
 ### 7.6 Resume after `/clear` or compaction
-No special action: the next `/release-loop` invocation reads `queue.md` + tail of
-`progress.md` and continues. The on-disk ledger is reconciled against **live git/PR state**
-as the source of truth (the ledger is uncommitted, §6.4): for an in-flight row, check whether
-its branch exists, whether a PR is open, and the PR's CI status, and resume at the matching
-pipeline stage. **Working-tree reconciliation:** if a crashed prior attempt left uncommitted
+The next `/release-loop` invocation's §0 resume step (step 3) reads `queue.md` + tail of
+`progress.md` and, finding any in-flight (non-terminal, non-`queued`/`routed`) row, finishes
+it before selecting new work. The on-disk ledger row status is the cheap anchor (which stage);
+the **live git/PR state is the source of truth** for the details (the ledger is uncommitted,
+§6.4): for an in-flight row, check whether its branch exists, whether a PR is open (or already
+merged), and the PR's CI status, and resume at the matching pipeline stage. **Working-tree reconciliation:** if a crashed prior attempt left uncommitted
 changes, inspect them before proceeding — keep and continue if they match the plan, or
 `git restore`/stash if they're partial/unrelated. A resumed `implementing` row is NOT "stuck"
 (stuck keys on a repeated error signature, not status re-entry — see Guardrails).

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -175,13 +175,17 @@ Create `LEDGER_ROOT/<run-slug>/` (e.g. `.claude/loop/v0.10.0/`) containing three
 The orchestrator is the only writer except where noted.
 
 ### 6.1 `queue.md` — work list (authoritative status)
-Dependency-ordered. One row per issue. Statuses: `queued → routed → planning →
-plan-approved → implementing → in-pr → in-review → done | blocked | deferred | hold`.
-The orchestrator advances a row's status as it moves through the pipeline (§7.1), so an
-interrupted run leaves a **non-terminal status that resume keys on** (§7.6). `hold` is a
-durable, human-set merge-hold that survives `/clear`. The header carries a `mode:` field
-(`calibration` until the human loosens it to `escalation-only`) that gates auto-merge (§7.1
-step 11).
+Dependency-ordered. One row per issue. **`Route` and `Status` are separate columns** (a row
+can be Route `research`, Status `blocked`). **Pipeline statuses** — advanced by the
+orchestrator as the issue moves through §7.1, so an interrupted run leaves a non-terminal
+status resume keys on (§7.6): `queued → routed → planning → plan-approved → implementing →
+in-pr → in-review`. **Terminal statuses** — the run converges when every row is terminal:
+`done`; `deferred` (Route `stub-defer`); `blocked` (parked — an unmet dependency, or
+`blocked: too-large` awaiting a split). **`hold`** is a separate **non-terminal, parked**
+status: a durable, human-set merge-hold that survives `/clear`. While any `hold` row remains
+the run is NOT complete, but a held row does not block selecting other queued work (§7.1
+steps 0–1). The header carries a `mode:` field (`calibration` until the human loosens it to
+`escalation-only`) that gates auto-merge (§7.1 step 11).
 
 ```markdown
 # Loop run: v0.10.0
@@ -277,21 +281,29 @@ fresh invocation resumes correctly. Read the project parameters in
    `RUN COMPLETE` sentinel (§9), report done and STOP — do not re-scan. If no run exists, ask
    the user which milestone/label to run, then INITIALIZE per §7.5 of the spec.
 2. Read `queue.md` (note its `mode:` header and any `hold` rows) and the tail of `progress.md`.
-3. **Resume before selecting (spec §7.6).** If any row sits in a non-terminal,
-   non-`queued`/`routed` status (`planning`/`plan-approved`/`implementing`/`in-pr`/
-   `in-review`/`hold`), a prior iteration was interrupted. Reconcile that row against LIVE
-   git/PR state as the source of truth — branch exists? PR open? already merged? CI status? —
-   plus the working tree, then re-enter the pipeline at the matching stage and FINISH that
-   issue BEFORE selecting a new one. This is what makes "one PR at a time" hold across
-   `/clear`/compaction. A `hold` row stays held until the human releases it.
+3. **Resume before selecting (spec §7.6).** If any row sits in an *interrupted* status —
+   non-terminal and NOT `queued`/`routed`/`hold` (i.e. `planning`/`plan-approved`/
+   `implementing`/`in-pr`/`in-review`) — a prior iteration was cut off. Reconcile it against
+   LIVE git/PR state as the source of truth — branch exists? PR open? already merged? CI
+   status? — plus the working tree (status is only a coarse anchor; git wins on conflict),
+   then re-enter the pipeline at the matching stage and FINISH that issue BEFORE selecting a
+   new one. This is what makes "one PR at a time" hold across `/clear`/compaction. A `hold`
+   row is NOT an interruption: skip it here, leave it held — it stays parked until the human
+   releases the hold and does not block working other issues.
 
 ## 1. Select
-Among issues whose status is `queued`/`routed` and whose `Depends on` issues are all `done`,
-pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable: if
-EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE — <run-slug>`
-sentinel to `progress.md` (counts + any blocked/deferred items) and STOP (convergence).
-Otherwise (rows still blocked on open in-run dependencies) report what's pending and STOP
-without the sentinel.
+A row is **selectable** if its status is `queued`/`routed`, OR it is `blocked` on an unmet
+dependency that has SINCE cleared (all its `Depends on` issues are now `done` — re-route it via
+§2; this does NOT apply to a `blocked: too-large` park, which waits on a split). Among
+selectable rows pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are
+selectable:
+- If EVERY row is terminal (`done`/`deferred`/`blocked`), append the §9 `RUN COMPLETE —
+  <run-slug>` sentinel to `progress.md` (counts + any blocked/deferred items) and STOP
+  (convergence).
+- Else if the only non-terminal rows are `hold`, report "<n> held — awaiting human
+  merge-release" and STOP **without** the sentinel (the run is not complete).
+- Else (rows still blocked on open in-run dependencies) report what's pending and STOP
+  without the sentinel.
 **Size guard:** before entering the pipeline, estimate scope from the issue body — if it
 plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
 fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
@@ -299,9 +311,12 @@ go back to select. Aggressively offload reading/analysis to subagents (architect
 within an iteration to conserve the parent's context.
 
 ## 2. Triage / route (if not already routed)
-Classify into `code | research | docs | stub-defer | blocked` using §7.3. Set the row's Route
-and advance its status to `routed`. If `stub-defer` or `blocked`, journal why and go back to
-§1 (do not implement).
+Run §7.3 to set the row's **Route** (`code`/`research`/`docs`/`stub-defer`) and its **initial
+Status** (Route and Status are distinct — §6.1): `stub-defer` → Status `deferred` (terminal);
+an unmet dependency → Status `blocked` (parked; record the dep, or `too-large`, in Notes — the
+Route is retained so the row resumes as that route when the dependency clears, §1); otherwise →
+Status `routed`. If the Status is `deferred` or `blocked`, journal why and go back to §1 — do
+not implement.
 
 ## 3. Plan
 Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
@@ -352,10 +367,13 @@ Address findings ≥ the project's confidence bar.
 ## 11. Merge
 Read the run `mode` from the `queue.md` header. If `mode: calibration` (the default until the
 human loosens it) OR the row is flagged `hold`: STOP and ask the human before merging — never
-auto-merge in calibration. Otherwise, when CI + security are green AND no merge-hold is
-recorded: squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
-`--delete-branch`. Confirm the issue closed. (A human merge-hold is recorded durably in the
-row — status `hold` or a `Notes: HOLD …` flag — so it survives `/clear`.)
+auto-merge in calibration. **If the human holds the merge (now or in any later invocation),
+WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
+it persists across `/clear`; resume (step 0.3), §1, and this gate all key on Status `hold` and
+honor it until the human clears it (restoring the row's prior status). Otherwise, when CI +
+security are green AND the row is not `hold`:
+squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
+`--delete-branch`. Confirm the issue closed.
 
 ## 12. Journal + stop
 Append the iteration block to `progress.md`; set the `queue.md` row to `done` (or
@@ -392,15 +410,22 @@ correlation logic, or analytics pipeline; **or the orchestrator is unsure.** Bia
 calling it (read-only, cheap vs. a bad implementation). Skip for docs and trivial research.
 
 ### 7.3 Router — classification procedure
-Decide route from labels + body signals, in order:
+Set the row's **Route** (the semantic kind) and its **initial Status** *separately* — they are
+distinct columns (§6.1), so a dependency-blocked research issue is Route `research` / Status
+`blocked`, not Route `blocked`.
+
+**Route**, from labels + body signals, in order:
 1. Issue body says explicitly "NOT implementation-ready" / is a stub (e.g. #469, D041) →
    `stub-defer`.
-2. Any `Depends on` issue not `done` → `blocked`.
-3. Label `documentation` and change is confined to `docs/`/markdown → `docs`.
-4. Label `research` or epic `*-discovery`, throwaway scaffolding, "artifact under study is
+2. Label `documentation` and change is confined to `docs/`/markdown → `docs`.
+3. Label `research` or epic `*-discovery`, throwaway scaffolding, "artifact under study is
    data" → `research` (no test-coverage gate; placement outside `src/`; no runtime-dep
    leakage into the package).
-5. Otherwise (`bug`/`enhancement` touching `src/`) → `code` (full pipeline).
+4. Otherwise (`bug`/`enhancement` touching `src/`) → `code` (full pipeline).
+
+**Initial Status:** Route `stub-defer` → `deferred` (terminal). Else if any `Depends on` issue
+is not `done` → `blocked` (parked; record the dep in Notes; the semantic Route is retained so
+the row resumes as that route once the dependency clears, §1). Else → `routed`.
 
 ### 7.4 C5 — AC-verifier
 Default: **compose existing tools**, don't mint an agent.
@@ -426,14 +451,23 @@ Promote to a dedicated `ac-verifier` agent only if the composed approach proves 
 
 ### 7.6 Resume after `/clear` or compaction
 The next `/release-loop` invocation's §0 resume step (step 3) reads `queue.md` + tail of
-`progress.md` and, finding any in-flight (non-terminal, non-`queued`/`routed`) row, finishes
-it before selecting new work. The on-disk ledger row status is the cheap anchor (which stage);
-the **live git/PR state is the source of truth** for the details (the ledger is uncommitted,
-§6.4): for an in-flight row, check whether its branch exists, whether a PR is open (or already
-merged), and the PR's CI status, and resume at the matching pipeline stage. **Working-tree reconciliation:** if a crashed prior attempt left uncommitted
-changes, inspect them before proceeding — keep and continue if they match the plan, or
-`git restore`/stash if they're partial/unrelated. A resumed `implementing` row is NOT "stuck"
-(stuck keys on a repeated error signature, not status re-entry — see Guardrails).
+`progress.md` and, finding any *interrupted* row (non-terminal and NOT
+`queued`/`routed`/`hold`), finishes it before selecting new work. A `hold` row is **excluded**
+— it is a deliberate, durable human merge-hold, not an interruption; leave it parked (it stays
+held until the human clears it, §7.1 step 11) and it does not block other work. The on-disk
+ledger row status is only a **coarse anchor** (which stage); the **live git/PR state is the
+source of truth** for the details (the ledger is uncommitted, §6.4): for an in-flight row,
+check whether its branch exists, whether a PR is open (or already merged), and the PR's CI
+status, and resume at the matching pipeline stage — git wins on any conflict with a stale
+status. Stages 4/7/10 need no distinct status because the surrounding statuses bracket them:
+a `plan-approved` row re-enters at implement (§6), so the architect/human gates are NOT re-run.
+The one external-side-effect stage is the architect (§4) — it posts a comment to the issue —
+so on the rare resume of a `planning` row, check for an existing architect comment and skip
+re-invoking if present (do not double-post). AC-verify (§7) is side-effect-free; security (§10)
+re-labeling is a GitHub no-op. **Working-tree reconciliation:** if a crashed prior attempt left uncommitted changes, inspect them before
+proceeding — keep and continue if they match the plan, or `git restore`/stash if they're
+partial/unrelated. A resumed `implementing` row is NOT "stuck" (stuck keys on a repeated error
+signature, not status re-entry — see Guardrails).
 
 ---
 
@@ -444,8 +478,11 @@ changes, inspect them before proceeding — keep and continue if they match the 
 | `code` | full pipeline, all gates |
 | `research` | lighter plan; **no test-coverage gate**; architect optional; security only if deps added; place outside `src/` |
 | `docs` | skip architect + security; light review; `docs:` scope |
-| `stub-defer` | do NOT implement; journal why; leave in backlog |
-| `blocked` | skip; revisit when dependency closes |
+| `stub-defer` | do NOT implement; journal why; leave in backlog (Status `deferred`) |
+
+`blocked` is a **Status overlay, not a Route**: a row keeps its semantic Route (`code`/
+`research`/`docs`) while parked on an unmet dependency. Skip it; it returns to selection and
+runs as its Route when the dependency closes (§1, §7.3).
 
 **Mechanical rules (both learned in the #500 run — §11):**
 - `.claude/`-only change → local `/security-review`, not the label (workflow excludes


### PR DESCRIPTION
## Summary
- Builds **C3** of the loop-engineering harness: the `/release-loop` orchestrator skill (`.claude/skills/release-loop/SKILL.md`). One invocation runs ONE routed backlog issue end-to-end (select → route → plan → [architect] → [human] → implement → AC-verify → PR → code-review → [security] → merge → journal), then stops; the driver re-invokes with fresh context for the next. C4 (router, spec §7.3) and C5 (AC-verifier, §7.4) are embodied in the skill, not separate files.
- Skill body is spec §7.1 **verbatim** (verified in sync). Architect review of the skill caught one **blocking** gap + three **important** ones, fixed in BOTH the spec and the skill: (1) resume was unimplemented — §7.1 never invoked §7.6, so an in-flight row left by a `/clear`/crash was invisible to Select and the loop would start the next issue with a PR still open; added a resume-before-select step + per-stage status advancement; (2) added a run `mode: calibration|escalation-only` so a fresh-context orchestrator never silently auto-merges; (3) made human merge-holds durable across `/clear`; (4) added a "what you must NOT do" boundary for the full-access orchestrator. Plus convergence sentinel + full-`progress.md` stuck-detection.
- `.claude/**`-only change (maintainer tooling, not shipped to PyPI) → `chore` scope per CLAUDE.md.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (unaffected — no `src/`/`tests/` change)
- [x] Lint clean: `uv run ruff check src/ tests/` (unaffected)
- [x] Type check clean: `uv run mypy src/agentfluent/` (unaffected)
- [N/A] New/changed behavior has test coverage — the artifact is a markdown instruction file + spec; no testable code unit. A drift-check (skill body == spec §7.1) was run locally and passes.
- [N/A] Manual smoke test via `uv run agentfluent ...` — no CLI change. End-to-end smoke test of `/release-loop` on a real issue is the next calibration step (spec §10 items 6–7).

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface: `.claude/skills/` + `.claude/specs/` markdown only, not in the template's trigger list (which names `.claude/hooks/`). No code, parser, path handling, or secret surface. As a dogfood precaution (the skill *directs* git/merge operations), a local `/security-review` pass was run anyway — see review comments. The labeled `security-review.yml` workflow excludes `.claude/`, so the label would be a no-op here regardless.
- [ ] **Needs review**

## Breaking changes
None. Additive maintainer tooling; no public contract, CLI flag, JSON envelope, or Pydantic model affected.