### PR TITLE
fix(diagnostics): gate PARAMETER_RETRY on first-attempt error, annotate built-in tools

### DIFF
--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -30,7 +30,7 @@ from agentfluent.diagnostics.quality_signals import (
 )
 from agentfluent.diagnostics.tool_orchestration import ESTIMATED_TOKEN_SAVINGS_KEY
 from agentfluent.diagnostics.trace_signals import PARAMETER_RETRY_EXAMPLE_KEY
-from agentfluent.glossary.loader import builtin_tool_names, load_glossary
+from agentfluent.glossary.loader import builtin_tool_names_cached
 
 
 def _relpath(path: Path) -> str:
@@ -676,7 +676,12 @@ class ParameterRetryRule:
     ) -> DiagnosticRecommendation:
         tool_name = str(signal.detail.get("tool_name", "the tool"))
         observation = signal.message
-        is_builtin_tool = tool_name in builtin_tool_names(load_glossary())
+        # Exact-match (no case-folding) is correct here: trace tool names are
+        # machine-emitted canonical identifiers (``Read``, ``Edit``) that match
+        # terms.yaml verbatim. This intentionally differs from
+        # ``is_builtin_agent``, which lower-cases because agent types are
+        # user-authored and free-cased.
+        is_builtin_tool = tool_name in builtin_tool_names_cached()
 
         if is_builtin_tool:
             # The `input_examples` fix lives on the tool definition, which a

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -30,6 +30,7 @@ from agentfluent.diagnostics.quality_signals import (
 )
 from agentfluent.diagnostics.tool_orchestration import ESTIMATED_TOKEN_SAVINGS_KEY
 from agentfluent.diagnostics.trace_signals import PARAMETER_RETRY_EXAMPLE_KEY
+from agentfluent.glossary.loader import builtin_tool_names, load_glossary
 
 
 def _relpath(path: Path) -> str:
@@ -651,8 +652,18 @@ class ParameterRetryRule:
     tool, or custom tool), not the agent's own prompt/tools config. This
     rule therefore does NOT branch on built-in agents the way
     prompt/tools/model rules do: ``input_examples`` helps whoever calls
-    the tool regardless of whether the caller is a built-in agent. When
-    the trace captured a subsequent successful call, its ``input`` dict
+    the tool regardless of whether the caller is a built-in agent.
+
+    Two *different* "built-in" axes apply here, and must not be conflated:
+    built-in **agent** (``is_builtin_agent``) — NOT branched on, above — and
+    built-in **tool** (the glossary ``builtin_tool`` category, via
+    ``builtin_tool_names``) — which this rule DOES branch on. A retry on a
+    built-in tool like ``Read`` is annotated *informational*: you cannot edit
+    a built-in tool's definition to add ``input_examples``, so the fix is not
+    user-actionable (#510). A built-in *tool* can still be called from inside a
+    custom *agent*, so the two axes are orthogonal.
+
+    When the trace captured a subsequent successful call, its ``input`` dict
     is surfaced as a paste-ready example (D002: informational, never
     auto-applied).
     """
@@ -665,24 +676,49 @@ class ParameterRetryRule:
     ) -> DiagnosticRecommendation:
         tool_name = str(signal.detail.get("tool_name", "the tool"))
         observation = signal.message
-        reason = (
-            "Parameter-retry patterns indicate the agent is guessing at "
-            "input formats. Adding concrete examples to the tool definition "
-            "(an `input_examples` array) improves accuracy from 72% to 90% "
-            "on complex parameter handling (Anthropic benchmark)."
-        )
+        is_builtin_tool = tool_name in builtin_tool_names(load_glossary())
 
-        action_parts = [
-            f"Add an `input_examples` array to the '{tool_name}' tool "
-            "definition showing the expected parameter shape.",
-        ]
+        if is_builtin_tool:
+            # The `input_examples` fix lives on the tool definition, which a
+            # user cannot edit for a Claude Code built-in -- so annotate the
+            # fire as informational rather than emit a non-actionable action
+            # (#510). Severity/target are left unchanged: this is annotation,
+            # not scoring deprioritization (the latter is a tracked follow-up).
+            reason = (
+                f"'{tool_name}' is a built-in Claude Code tool, so its "
+                "definition cannot be edited to add an `input_examples` array "
+                "-- this finding is informational, not directly user-tunable. "
+                "The retry pattern still indicates input-format guessing; the "
+                "fix applies only if it recurs on a custom SDK/MCP tool you own."
+            )
+            action_parts = [
+                f"No action on the built-in '{tool_name}' itself. For any "
+                "custom SDK/MCP tool showing the same pattern, add an "
+                "`input_examples` array to its definition showing the expected "
+                "parameter shape.",
+            ]
+        else:
+            reason = (
+                "Parameter-retry patterns indicate the agent is guessing at "
+                "input formats. Adding concrete examples to the tool definition "
+                "(an `input_examples` array) improves accuracy from 72% to 90% "
+                "on complex parameter handling (Anthropic benchmark)."
+            )
+            action_parts = [
+                f"Add an `input_examples` array to the '{tool_name}' tool "
+                "definition showing the expected parameter shape.",
+            ]
+
         example = signal.detail.get(PARAMETER_RETRY_EXAMPLE_KEY)
         if isinstance(example, dict):
             rendered = json.dumps(example, indent=2, ensure_ascii=False)
-            action_parts.append(
-                f"Suggested `input_examples` entry for tool '{tool_name}' "
-                f"based on the observed successful call:\n{rendered}",
+            label = (
+                "Observed successful call shape (informational)"
+                if is_builtin_tool
+                else f"Suggested `input_examples` entry for tool '{tool_name}' "
+                "based on the observed successful call"
             )
+            action_parts.append(f"{label}:\n{rendered}")
         action = "\n".join(action_parts)
 
         return DiagnosticRecommendation(

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -49,7 +49,6 @@ import re
 
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
-from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
 from agentfluent.traces.models import (
     RESULT_SUMMARY_MAX_CHARS,
     RetrySequence,
@@ -64,26 +63,6 @@ from agentfluent.traces.models import (
 # ``input_examples`` block. Absent when no successful call followed the
 # retries or its input exceeded the capture cap.
 PARAMETER_RETRY_EXAMPLE_KEY = "input_example"
-
-# Validation-flavored error keywords that signal parameter/schema
-# confusion specifically (a superset trigger for PARAMETER_RETRY beyond
-# the generic ``is_error`` flag). Kept separate from
-# ``signals.ERROR_PATTERNS`` (which governs the metadata ERROR_PATTERN
-# signal): these terms are too narrow to flag a generic failure but are
-# strong evidence the agent supplied a malformed ``input``. Matched
-# against the leading window only, reusing the FP-defense bound that
-# ``signals.detect_is_error_from_text`` applies.
-_PARAM_ERROR_KEYWORDS = (
-    "invalid",
-    "validation",
-    "missing required",
-    "type error",
-    "schema",
-)
-_PARAM_ERROR_REGEX = re.compile(
-    "|".join(re.escape(k) for k in _PARAM_ERROR_KEYWORDS),
-    re.IGNORECASE,
-)
 
 # Minimum consecutive same-tool calls to consider a parameter-retry run.
 _PARAMETER_RETRY_MIN_ATTEMPTS = 2
@@ -212,21 +191,6 @@ def _extract_permission_failures(
     return signals
 
 
-def _is_param_error(call: SubagentToolCall) -> bool:
-    """Whether ``call`` looks like a parameter/validation failure.
-
-    The parser-supplied ``is_error`` flag (generic error detection) OR a
-    validation-flavored keyword in the leading window of the result. The
-    window bound mirrors ``signals.detect_is_error_from_text``'s
-    FP-defense — keep keyword matches to the start of the result, where
-    real error messages lead.
-    """
-    if call.is_error:
-        return True
-    window = call.result_summary[:ERROR_DETECTION_WINDOW_CHARS]
-    return bool(_PARAM_ERROR_REGEX.search(window))
-
-
 def _value_shape(value: object) -> object:
     """Recursively reduce a JSON value to its structural shape.
 
@@ -288,9 +252,16 @@ def _build_parameter_retry_signal(
     invocation_id: str | None,
 ) -> DiagnosticSignal | None:
     """Emit PARAMETER_RETRY for a same-tool run, or ``None`` if it doesn't
-    qualify (first call not an error, or no input-shape change)."""
+    qualify (first call not an error, or no input-shape change).
+
+    The first attempt must carry ``is_error=True`` (the parser-supplied flag,
+    which already synthesizes errors from result text via
+    ``signals.detect_is_error_from_text``). A run that opens with a successful
+    call is sequential paging or query refinement, not a parameter retry, and
+    must not fire (#510) — describing a successful first result as "failed
+    with" was the message bug that motivated this gate."""
     run_calls = [calls[i] for i in run_indices]
-    if not _is_param_error(run_calls[0]):
+    if not run_calls[0].is_error:
         return None
     if not _input_shape_changed(run_calls):
         return None

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -254,12 +254,19 @@ def _build_parameter_retry_signal(
     """Emit PARAMETER_RETRY for a same-tool run, or ``None`` if it doesn't
     qualify (first call not an error, or no input-shape change).
 
-    The first attempt must carry ``is_error=True`` (the parser-supplied flag,
-    which already synthesizes errors from result text via
-    ``signals.detect_is_error_from_text``). A run that opens with a successful
-    call is sequential paging or query refinement, not a parameter retry, and
-    must not fire (#510) — describing a successful first result as "failed
-    with" was the message bug that motivated this gate."""
+    The first attempt must carry ``is_error=True`` — the parser-supplied flag,
+    which the parser also synthesizes from result text via
+    ``signals.detect_is_error_from_text``. That synthesis covers generic error
+    vocabulary (``failed``/``error``/``unable to``/…), NOT every validation-only
+    phrasing; a first call that sets neither ``is_error`` nor a generic error
+    token is treated as paging/refinement, not a parameter retry. This is a
+    deliberate precision trade-off (#510): it drops the prior keyword-regex
+    fallback (``invalid``/``validation``/``schema``/…) that fired on
+    *successful* results whose text merely looked validation-flavored — the
+    false positives, including describing a successful first result as "failed
+    with", that motivated this gate. The message is keyed on ``run_calls[0]``,
+    so gating on the FIRST attempt (not any attempt) is what keeps that message
+    truthful."""
     run_calls = [calls[i] for i in run_indices]
     if not run_calls[0].is_error:
         return None

--- a/src/agentfluent/glossary/loader.py
+++ b/src/agentfluent/glossary/loader.py
@@ -155,3 +155,20 @@ def categories_in_use(entries: list[GlossaryEntry]) -> list[str]:
             seen.add(entry.category)
             out.append(cast(str, entry.category))
     return out
+
+
+def builtin_tool_names(entries: list[GlossaryEntry]) -> frozenset[str]:
+    """Names of the glossary's ``builtin_tool`` entries (Read, Edit, …).
+
+    The single source of truth for "is this a Claude Code built-in tool"
+    (as opposed to a custom SDK/MCP tool). Reuses the maintained
+    ``terms.yaml`` glossary rather than a hard-coded set, so newly added
+    built-ins are picked up centrally. Distinct from the ``builtin_agent_type``
+    category — a built-in *tool* (e.g. ``Read``) can be called from inside a
+    custom *agent*. Consumed by the PARAMETER_RETRY recommendation (#510),
+    which flags fires on built-in tools as informational because an
+    ``input_examples`` array cannot be added to a built-in tool definition.
+    """
+    return frozenset(
+        entry.name for entry in entries if entry.category == "builtin_tool"
+    )

--- a/src/agentfluent/glossary/loader.py
+++ b/src/agentfluent/glossary/loader.py
@@ -61,6 +61,7 @@ def _load_cached() -> tuple[GlossaryEntry, ...]:
 def reset_cache() -> None:
     """Clear the load cache. Tests use this to force a re-read."""
     _load_cached.cache_clear()
+    builtin_tool_names_cached.cache_clear()
 
 
 def _check_unique_names(entries: list[GlossaryEntry]) -> None:
@@ -172,3 +173,17 @@ def builtin_tool_names(entries: list[GlossaryEntry]) -> frozenset[str]:
     return frozenset(
         entry.name for entry in entries if entry.category == "builtin_tool"
     )
+
+
+@lru_cache(maxsize=1)
+def builtin_tool_names_cached() -> frozenset[str]:
+    """Memoized, zero-arg ``builtin_tool_names`` for hot-path callers.
+
+    The set is invariant across a run, so callers that consult it per item
+    (e.g. ``correlator.ParameterRetryRule`` per signal) should use this rather
+    than rebuilding via ``builtin_tool_names(load_glossary())`` each time. The
+    explicit-``entries`` form is kept for testability/parity with the other
+    accessors; this wrapper caches over the process-wide glossary. Cleared by
+    ``reset_cache``.
+    """
+    return builtin_tool_names(list(_load_cached()))

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -1139,9 +1139,13 @@ class TestParameterRetryRule:
         *,
         with_example: bool = True,
         agent_type: str = "general-purpose",
+        tool_name: str = "search_docs",
     ) -> DiagnosticSignal:
+        # Default ``tool_name`` is a CUSTOM (non-built-in) tool so these tests
+        # exercise the actionable input_examples path; built-in tools take the
+        # informational branch (#510) and are covered separately below.
         detail: dict[str, object] = {
-            "tool_name": "Edit",
+            "tool_name": tool_name,
             "retry_count": 2,
             "eventual_success": with_example,
         }
@@ -1155,7 +1159,7 @@ class TestParameterRetryRule:
             signal_type=SignalType.PARAMETER_RETRY,
             severity=Severity.WARNING,
             agent_type=agent_type,
-            message="Subagent 'general-purpose' retried tool 'Edit' 2 times.",
+            message=f"Subagent '{agent_type}' retried tool '{tool_name}' 2 times.",
             detail=detail,
         )
 
@@ -1165,7 +1169,7 @@ class TestParameterRetryRule:
         assert recs[0].target == "tools"
         assert recs[0].severity == Severity.WARNING
         assert "input_examples" in recs[0].action
-        assert "'Edit'" in recs[0].action
+        assert "'search_docs'" in recs[0].action
 
     def test_includes_paste_ready_example_when_available(self) -> None:
         recs = correlate([self._param_signal(with_example=True)], None)
@@ -1183,9 +1187,31 @@ class TestParameterRetryRule:
 
     def test_fires_for_builtin_agent_without_builtin_branch(self) -> None:
         # The fix targets the tool definition, not the agent config, so a
-        # built-in agent still gets the input_examples recommendation
-        # (not the generic "route to a custom subagent" built-in action).
+        # built-in AGENT (orthogonal to a built-in TOOL) still gets the
+        # input_examples recommendation for a custom tool.
         recs = correlate([self._param_signal(agent_type="Explore")], None)
         assert len(recs) == 1
         assert recs[0].target == "tools"
         assert "input_examples" in recs[0].action
+
+    def test_builtin_tool_fire_is_annotated_informational(self) -> None:
+        # #510 (c): a retry on a built-in tool (Read) cannot be fixed by adding
+        # input_examples (you can't edit a built-in's definition), so the
+        # recommendation is annotated informational rather than emitting a
+        # non-actionable "add an array to 'Read'" instruction.
+        recs = correlate([self._param_signal(tool_name="Read")], None)
+        assert len(recs) == 1
+        assert recs[0].target == "tools"
+        assert recs[0].severity == Severity.WARNING  # annotation only, not deprioritized
+        assert "built-in" in recs[0].reason
+        assert "informational" in recs[0].reason
+        assert "No action on the built-in 'Read'" in recs[0].action
+        # The non-actionable "add input_examples to 'Read'" instruction is gone.
+        assert "Add an `input_examples` array to the 'Read'" not in recs[0].action
+
+    def test_builtin_tool_example_labeled_informational(self) -> None:
+        recs = correlate([self._param_signal(tool_name="Read", with_example=True)], None)
+        action = recs[0].action
+        assert "Observed successful call shape (informational)" in action
+        assert "Suggested `input_examples` entry" not in action
+        assert '"file_path": "a.py"' in action  # shape still surfaced

--- a/tests/unit/test_glossary_loader.py
+++ b/tests/unit/test_glossary_loader.py
@@ -15,6 +15,7 @@ from agentfluent.glossary.loader import (
     _check_cross_references,
     _check_unique_aliases,
     _check_unique_names,
+    builtin_tool_names,
     find_term,
     fuzzy_match,
     reset_cache,
@@ -57,6 +58,32 @@ class TestPackagedGlossaryLoads:
     def test_every_entry_has_short(self) -> None:
         for entry in load_glossary():
             assert entry.short.strip(), f"{entry.name} missing short"
+
+
+class TestBuiltinToolNames:
+    """`builtin_tool_names` is the SSOT consumed by PARAMETER_RETRY (#510)."""
+
+    def test_tracks_the_builtin_tool_category(self) -> None:
+        # Drift guard: the accessor must equal exactly the names declared in
+        # the `builtin_tool` category, so adding/removing a built-in in
+        # terms.yaml flows through without code changes (and a miscategorized
+        # entry is caught here rather than silently mis-annotating findings).
+        entries = load_glossary()
+        expected = {e.name for e in entries if e.category == "builtin_tool"}
+        assert builtin_tool_names(entries) == expected
+
+    def test_core_builtins_present_custom_absent(self) -> None:
+        names = builtin_tool_names(load_glossary())
+        assert {"Read", "Edit", "Write", "Bash", "Grep", "Glob"} <= names
+        # A custom SDK/MCP tool name is NOT a built-in.
+        assert "search_docs" not in names
+
+    def test_distinct_from_builtin_agent_types(self) -> None:
+        # Built-in TOOL and built-in AGENT are orthogonal categories; the
+        # accessor must not leak agent-type names (e.g. "general-purpose").
+        entries = load_glossary()
+        agent_names = {e.name for e in entries if e.category == "builtin_agent_type"}
+        assert builtin_tool_names(entries).isdisjoint(agent_names)
 
 
 class TestSchemaValidation:

--- a/tests/unit/test_glossary_loader.py
+++ b/tests/unit/test_glossary_loader.py
@@ -16,6 +16,7 @@ from agentfluent.glossary.loader import (
     _check_unique_aliases,
     _check_unique_names,
     builtin_tool_names,
+    builtin_tool_names_cached,
     find_term,
     fuzzy_match,
     reset_cache,
@@ -84,6 +85,13 @@ class TestBuiltinToolNames:
         entries = load_glossary()
         agent_names = {e.name for e in entries if e.category == "builtin_agent_type"}
         assert builtin_tool_names(entries).isdisjoint(agent_names)
+
+    def test_cached_accessor_matches_entries_form(self) -> None:
+        # The hot-path memoized wrapper must agree with the explicit-entries
+        # accessor (and stay correct after a cache reset).
+        assert builtin_tool_names_cached() == builtin_tool_names(load_glossary())
+        reset_cache()
+        assert builtin_tool_names_cached() == builtin_tool_names(load_glossary())
 
 
 class TestSchemaValidation:

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -472,7 +472,12 @@ class TestParameterRetry:
         ]
         assert len(_param_signals(_trace(calls=calls))) == 1
 
-    def test_validation_keyword_triggers_without_is_error(self) -> None:
+    def test_validation_keyword_without_is_error_does_not_fire(self) -> None:
+        # #510: the first attempt must carry is_error=True. A non-error first
+        # call whose result text merely *looks* validation-flavored is NOT a
+        # parameter retry (the old text-regex branch fired here -- a false
+        # positive). The parser already synthesizes is_error from result text,
+        # so a genuine error would have is_error=True.
         calls = [
             _ptc(
                 "Run",
@@ -482,7 +487,37 @@ class TestParameterRetry:
             ),
             _ptc("Run", {"a": 1, "b": 2}, err=False),
         ]
-        assert len(_param_signals(_trace(calls=calls))) == 1
+        assert _param_signals(_trace(calls=calls)) == []
+
+    def test_all_success_paging_sequence_does_not_fire(self) -> None:
+        # #510 motivating case: an agent paging through one file (or refining a
+        # query) makes several same-tool calls with differing input shapes but
+        # every call is_error=False. With no first-attempt error this is
+        # sequential paging, not a parameter retry -> must not fire, and so no
+        # "First attempt failed with: '<successful output>'" message is built.
+        calls = [
+            _ptc("Read", {"file_path": "big.py", "offset": 1}, res="1\tline", err=False),
+            _ptc(
+                "Read",
+                {"file_path": "big.py", "offset": 100, "limit": 50},
+                res="100\tline",
+                err=False,
+            ),
+        ]
+        sigs = _param_signals(_trace(calls=calls))
+        assert sigs == []
+
+    def test_fired_message_reports_real_error_first_attempt(self) -> None:
+        # #510 (b): when the rule DOES fire, the first attempt is a real error,
+        # so "First attempt failed with" accurately quotes an error string.
+        calls = [
+            _ptc("Edit", {"path": "a.py"}, res="InputValidationError: bad", err=True),
+            _ptc("Edit", {"file_path": "a.py", "old_string": "x"}, err=False),
+        ]
+        sigs = _param_signals(_trace(calls=calls))
+        assert len(sigs) == 1
+        assert "First attempt failed with" in sigs[0].message
+        assert "InputValidationError" in sigs[0].message
 
     def test_no_shape_evidence_no_signal(self) -> None:
         # First errored but inputs uncaptured and keys empty -> can't


### PR DESCRIPTION
## Summary
- **AC(a)** `PARAMETER_RETRY` now requires the first attempt to be a real error (`if not run_calls[0].is_error: return None` in `trace_signals.py`). Deleted the looser `_is_param_error` gate (which OR'd `is_error` with a validation-keyword text regex — the false-positive source) plus its dead `_PARAM_ERROR_REGEX`/`_KEYWORDS` and the now-unused import. Fixes the no-error paging/query-refinement misfires (2/25 on the v0.9 dogfood).
- **AC(b)** The "First attempt failed with: '…'" message is built only after that gate, so it can no longer quote a successful result as an error.
- **AC(c)** Built-in-tool fires (23/25 were `Read`) are now annotated **informational / non-actionable** in `correlator.py`, via a new `builtin_tool_names()` accessor over the existing glossary `builtin_tool` SSOT (`terms.yaml`) — not a hard-coded set, and not the `is_builtin` *agent-type* field (orthogonal axis). `aggregation.py` scoring left unchanged by design (annotation satisfies the AC; scoring deprioritization is a tracked follow-up, sibling to #459).
- Architect-reviewed (issue #510 comment); independently AC-verified.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — **1744 passed**
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — all-success paging no-fire, real-error message wording, built-in-tool annotation (+ custom-tool path), and a glossary drift guard coupling `builtin_tool_names()` to the `builtin_tool` category.
- [N/A] Manual smoke test via `uv run agentfluent ...` — no CLI surface change; behavior is internal signal/recommendation logic covered by unit tests.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge.)
- [ ] **Skip review**
- [x] **Needs review** — touches the diagnostics path that renders session-derived strings (`tool_name`, example dicts) into recommendations (downstream of JSONL parsing). No new untrusted-input parsing or subprocess/path surface is introduced (the change narrows firing logic and adds an annotation branch using the same rendering pattern already present), but the surface is on the workflow's sensitive list, so a review pass is warranted. Label will be applied at dev-complete.

## Breaking changes
None. No public contract, CLI flag, JSON envelope, or Pydantic model changes. Behavior change is a precision improvement: `PARAMETER_RETRY` no longer fires on no-error sequences, and its recommendation is annotated (not removed) for built-in tools.

Fixes #510.