### PR TITLE
docs(glossary): add api_call_count term, cross-link model_turns (#511)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1504,6 +1504,52 @@ cleanly and skips the warning.
 
 ## Session metrics
 
+### `api_call_count`
+
+**Short:** The number of real API round-trips in a session -- one per
+non-synthetic assistant message that carries a `usage` block.
+
+**Detail:** Surfaced as the "API calls" row in the Token Usage table and as
+`api_call_count` in `analyze --json`. An *API call* is one assistant
+message that records a `usage` block (input/output/cache token
+counts) -- i.e. a real request/response round-trip the model was
+billed for. Counted once per such message after the parser's
+fragment-merging step.
+
+**`<synthetic>` responses are excluded (#507, D044).** Claude Code
+emits `<synthetic>`-model assistant messages -- locally fabricated
+filler (e.g. "No response requested.") with zero usage and no API
+round-trip. They never carry a `usage` block, so they are never
+counted as API calls. The exclusion is the same one
+[`model_turns`](#model_turns) applies; both counters net out
+synthetic ghost turns.
+
+**Relationship to [`model_turns`](#model_turns).** Both exclude
+synthetic messages, so they are **equal in the common case** -- on
+the v0.9 dogfood corpus both were 7,533 to the unit. They diverge
+only on the (so far unobserved) edge case of a *real-model*
+assistant message that carries no `usage` block: it counts as a
+model turn but **not** as an API call, making
+`model_turns >= api_call_count`. Keeping both metrics surfaces
+exactly that case if it ever occurs. The two are different lenses on
+the same messages: `model_turns` counts the model's *responses*,
+`api_call_count` counts the *billed round-trips* -- they coincide
+whenever every real response was a billed call.
+
+**Example:**
+
+```
+Token Usage
+  ...
+  API calls            350
+  Model turns          350   <- == API calls (both exclude synthetic)
+  Synthetic responses    2   <- ghost turns netted out, not API calls
+```
+
+**Aliases:** `api_calls`
+
+**Related:** [`model_turns`](#model_turns), [`total_cost`](#total_cost)
+
 ### `model_turns`
 
 **Short:** The number of model turns in a session -- one merged, non-synthetic
@@ -1562,7 +1608,7 @@ Token Usage
   Synthetic responses    2   <- ghost turns netted out, tallied here
 ```
 
-**Related:** [`output`](#output), [`total_cost`](#total_cost)
+**Related:** [`api_call_count`](#api_call_count), [`output`](#output), [`total_cost`](#total_cost)
 
 ### `active_duration`
 

--- a/src/agentfluent/glossary/terms.yaml
+++ b/src/agentfluent/glossary/terms.yaml
@@ -1350,6 +1350,47 @@
 # Session metrics
 # =============================================================================
 
+- name: api_call_count
+  category: session_metric
+  short: |
+    The number of real API round-trips in a session -- one per
+    non-synthetic assistant message that carries a `usage` block.
+  long: |
+    Surfaced as the "API calls" row in the Token Usage table and as
+    `api_call_count` in `analyze --json`. An *API call* is one assistant
+    message that records a `usage` block (input/output/cache token
+    counts) -- i.e. a real request/response round-trip the model was
+    billed for. Counted once per such message after the parser's
+    fragment-merging step.
+
+    **`<synthetic>` responses are excluded (#507, D044).** Claude Code
+    emits `<synthetic>`-model assistant messages -- locally fabricated
+    filler (e.g. "No response requested.") with zero usage and no API
+    round-trip. They never carry a `usage` block, so they are never
+    counted as API calls. The exclusion is the same one
+    [`model_turns`](#model_turns) applies; both counters net out
+    synthetic ghost turns.
+
+    **Relationship to [`model_turns`](#model_turns).** Both exclude
+    synthetic messages, so they are **equal in the common case** -- on
+    the v0.9 dogfood corpus both were 7,533 to the unit. They diverge
+    only on the (so far unobserved) edge case of a *real-model*
+    assistant message that carries no `usage` block: it counts as a
+    model turn but **not** as an API call, making
+    `model_turns >= api_call_count`. Keeping both metrics surfaces
+    exactly that case if it ever occurs. The two are different lenses on
+    the same messages: `model_turns` counts the model's *responses*,
+    `api_call_count` counts the *billed round-trips* -- they coincide
+    whenever every real response was a billed call.
+  example: |
+    Token Usage
+      ...
+      API calls            350
+      Model turns          350   <- == API calls (both exclude synthetic)
+      Synthetic responses    2   <- ghost turns netted out, not API calls
+  aliases: [api_calls]
+  related: [model_turns, total_cost]
+
 - name: model_turns
   category: session_metric
   short: |
@@ -1404,7 +1445,7 @@
       API calls            350
       Model turns          350   <- == API calls (both exclude synthetic)
       Synthetic responses    2   <- ghost turns netted out, tallied here
-  related: [output, total_cost]
+  related: [api_call_count, output, total_cost]
 
 - name: active_duration
   category: session_metric


### PR DESCRIPTION
## Summary
- Adds a standalone `api_call_count` ("API calls") glossary term to the `terms.yaml` SSOT so the **model_turns vs api_call_count relationship** and the `<synthetic>` exclusion are discoverable from the *API-calls* side — the side the user confusion in #511 came from (previously these facts lived only inside the `model_turns` entry).
- New term documents: an API call = a non-synthetic assistant message carrying a `usage` block; the `<synthetic>` exclusion applies to this counter too; `model_turns >= api_call_count` (equal in the common case, diverging only when a real-model message lacks a `usage` block). Adds an `api_calls` alias and a **bidirectional `related` cross-ref** between the two terms.
- Regenerates `docs/GLOSSARY.md` from the SSOT (the markdown is generated; a drift test enforces byte-match).

Closes #511.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1745 passed, 39 deselected)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — glossary drift + loader (alias-uniqueness, `related`-validation) + render tests exercise the new term; `test_glossary_drift.py` guards SSOT↔markdown sync
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change; docs/glossary content only)

Prose accuracy independently verified against `src/agentfluent/analytics/tokens.py:170-179` (the `api_call_count` computation): counts one per non-synthetic assistant message with a `usage` block, so the documented relationship direction is correct.

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface (docs/glossary content; the markdown is generated from a static YAML SSOT, no user-controlled string rendering).
- [ ] **Needs review**

## Breaking changes
None. Documentation-only; no public contract, CLI flag, JSON envelope, or model field changes.