### PR TITLE
feat(diagnostics): name a concrete target model in model-routing recommendations

### DIFF
--- a/src/agentfluent/diagnostics/_complexity.py
+++ b/src/agentfluent/diagnostics/_complexity.py
@@ -48,6 +48,36 @@ _TIER_TO_MODEL: dict[ComplexityTier, str] = {
     "complex": MODEL_OPUS,
 }
 
+# Tiers ordered cheapest/fastest → most capable. The single source for
+# "what's one tier faster/slower" (``faster_tier``) — an explicit tuple
+# rather than relying on ``_TIER_TO_MODEL`` dict ordering.
+_TIER_ORDER: tuple[ComplexityTier, ...] = ("simple", "moderate", "complex")
+
+# Complexity tier by Claude model family. Model IDs follow the pattern
+# `claude-<family>-<version>[-<date>]`, so a prefix match covers both
+# short aliases (`claude-opus-4-7`) and dated pinned forms
+# (`claude-haiku-4-5-20251001`) that subagent traces record at runtime.
+# Lives here (not in the pricing module) so all model↔tier knowledge is
+# co-located with the tier→model mapping above (#170).
+_TIER_BY_FAMILY: dict[ComplexityTier, tuple[str, ...]] = {
+    "simple": ("claude-haiku",),
+    "moderate": ("claude-sonnet",),
+    "complex": ("claude-opus",),
+}
+
+
+def classify_model_tier(model: str) -> ComplexityTier:
+    """Classify a Claude model ID into a complexity tier by family prefix.
+
+    Returns "moderate" for anything that doesn't match a known family —
+    a safe default that doesn't emit MODEL_MISMATCH signals against
+    unrecognized models.
+    """
+    for tier, prefixes in _TIER_BY_FAMILY.items():
+        if any(model.startswith(p) for p in prefixes):
+            return tier
+    return "moderate"
+
 
 class AgentStats(BaseModel):
     """Aggregated stats consumed by complexity classification.
@@ -134,6 +164,44 @@ def classify_complexity(stats: AgentStats) -> ComplexityTier:
 def recommend_model_for_complexity(tier: ComplexityTier) -> str:
     """Map a complexity tier to its recommended model id."""
     return _TIER_TO_MODEL[tier]
+
+
+def select_target_model(
+    current_model: str | None,
+    target_tier: ComplexityTier,
+) -> str | None:
+    """Pick a concrete target model for ``target_tier`` — the shared
+    "pick a target model for this agent" helper (#170).
+
+    Both ``target: model`` recommendation paths (duration-outlier and
+    complexity-mismatch) route through this so they produce concrete,
+    deduplicated suggestions from one place. Returns the tier-matched
+    model id, or ``None`` when there's no actionable switch:
+
+    - ``current_model`` is unknown (caller has no model to name), or
+    - the current model already classifies into ``target_tier`` — the
+      "suggested target == current → no recommendation" guard (AC3).
+    """
+    if not current_model:
+        return None
+    if classify_model_tier(current_model) == target_tier:
+        return None
+    return recommend_model_for_complexity(target_tier)
+
+
+def faster_tier(current_model: str | None) -> ComplexityTier | None:
+    """The complexity tier one step faster/cheaper than ``current_model``.
+
+    Returns ``None`` when the model is unknown or already at the fastest
+    tier (Haiku) — callers fall back to a non-model recommendation in
+    that case.
+    """
+    if not current_model:
+        return None
+    idx = _TIER_ORDER.index(classify_model_tier(current_model))
+    if idx == 0:
+        return None
+    return _TIER_ORDER[idx - 1]
 
 
 def aggregate_cluster_stats(

--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -14,11 +14,18 @@ from typing import ClassVar, Protocol
 
 from agentfluent.agents.models import is_builtin_agent
 from agentfluent.config.models import AgentConfig, Severity
+from agentfluent.diagnostics._complexity import (
+    faster_tier,
+    select_target_model,
+)
 from agentfluent.diagnostics.builtin_actions import (
     BuiltinConcern,
     builtin_recommendation,
 )
-from agentfluent.diagnostics.model_routing import SAVINGS_USD_KEY
+from agentfluent.diagnostics.model_routing import (
+    SAVINGS_USD_KEY,
+    estimate_model_savings,
+)
 from agentfluent.diagnostics.models import (
     DiagnosticRecommendation,
     DiagnosticSignal,
@@ -263,11 +270,22 @@ class DurationOutlierRule:
         if rec := _check_builtin(self, signal, reason):
             return rec
 
-        if config and config.model and "opus" in config.model.lower():
-            action = (
-                f"If this agent's task is routine, consider switching "
-                f"from {config.model} to a faster model in {_relpath(config.file_path)}."
-            )
+        # Resolve the model the agent runs on: the editable declaration
+        # (config.model) wins, else the model the slow invocation actually
+        # used (carried on the signal from its trace). `faster_tier` +
+        # `select_target_model` name a concrete one-tier-down target, or
+        # return None when the model is unknown or already at the fastest
+        # tier — in which case we fall back to a task-scoping suggestion
+        # rather than emit an unnamed "a faster model" rec (#170).
+        current_model = config.model if (config and config.model) else None
+        if current_model is None:
+            detail_model = signal.detail.get("current_model")
+            current_model = detail_model if isinstance(detail_model, str) else None
+        tier = faster_tier(current_model)
+        target_model = select_target_model(current_model, tier) if tier else None
+
+        if target_model is not None:
+            action = self._model_action(signal, config, current_model, target_model)
             target = "model"
         elif config:
             action = (
@@ -277,10 +295,10 @@ class DurationOutlierRule:
             target = "prompt"
         else:
             action = (
-                "Consider using a faster model or adding clearer task "
-                "boundaries to the agent's prompt."
+                "Add clearer task boundaries to the agent's prompt to help "
+                "it work more efficiently."
             )
-            target = "model"
+            target = "prompt"
 
         return DiagnosticRecommendation(
             target=target,
@@ -294,6 +312,35 @@ class DurationOutlierRule:
             config_file=str(config.file_path) if config else "",
             signal_types=[signal.signal_type],
         )
+
+    @staticmethod
+    def _model_action(
+        signal: DiagnosticSignal,
+        config: AgentConfig | None,
+        current_model: str | None,
+        target_model: str,
+    ) -> str:
+        """Compose the concrete current → target switch suggestion.
+
+        Latency leads (it's the duration signal); cost is a parenthetical
+        scoped to *this invocation* — a single slow outlier's tokens are
+        atypically high, so framing them as per-agent savings would
+        overstate the typical case (architect review, #170).
+        """
+        tokens = signal.detail.get("total_tokens")
+        savings, _ = estimate_model_savings(
+            current_model, target_model,
+            tokens if isinstance(tokens, int | float) else None,
+            count=1,
+        )
+        where = f" in {_relpath(config.file_path)}" if config else ""
+        action = (
+            f"If this agent's task is routine, consider switching from "
+            f"{current_model} to {target_model}{where}."
+        )
+        if savings is not None and savings > 0:
+            action += f" (estimated savings: ${savings:.2f} for this invocation)"
+        return action
 
 
 class PermissionFailureRule:

--- a/src/agentfluent/diagnostics/model_routing.py
+++ b/src/agentfluent/diagnostics/model_routing.py
@@ -33,13 +33,13 @@ from typing import TYPE_CHECKING, Literal
 from agentfluent.analytics.pricing import compute_cost, get_pricing
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics._complexity import (
-    MODEL_HAIKU,
-    MODEL_SONNET,
     AgentStats,
     ComplexityTier,
     classify_complexity,
+    classify_model_tier,
     compute_error_rate,
     has_write_tools_in_trace,
+    select_target_model,
 )
 from agentfluent.diagnostics.models import DiagnosticSignal, SignalType
 
@@ -59,6 +59,7 @@ __all__ = [
     "aggregate_agent_stats",
     "classify_complexity",
     "classify_model_tier",
+    "estimate_model_savings",
     "extract_model_routing_signals",
 ]
 
@@ -78,31 +79,6 @@ _MIN_INVOCATIONS_FOR_ANALYSIS = 3
 # The error-rate threshold below is reused for the underspec gate; kept
 # local here so the gate stays close to its consumer.
 _UNDERSPEC_ERROR_RATE_GATE = 0.20
-
-# Complexity tier by Claude model family. Model IDs follow the pattern
-# `claude-<family>-<version>[-<date>]`, so a prefix match covers both
-# short aliases (`claude-opus-4-7`) and dated pinned forms
-# (`claude-haiku-4-5-20251001`) that subagent traces record at runtime.
-# Avoids duplicating the model catalog with `analytics.pricing._PRICING`.
-_TIER_BY_FAMILY: dict[ComplexityTier, tuple[str, ...]] = {
-    "simple": ("claude-haiku",),
-    "moderate": ("claude-sonnet",),
-    "complex": ("claude-opus",),
-}
-
-
-def classify_model_tier(model: str) -> ComplexityTier:
-    """Classify a Claude model ID into a complexity tier by family prefix.
-
-    Returns "moderate" for anything that doesn't match a known family —
-    a safe default that doesn't emit MODEL_MISMATCH signals against
-    unrecognized models.
-    """
-    for tier, prefixes in _TIER_BY_FAMILY.items():
-        if any(model.startswith(p) for p in prefixes):
-            return tier
-    return "moderate"
-
 
 def _resolve_current_model(
     group: list[AgentInvocation],
@@ -172,34 +148,49 @@ def aggregate_agent_stats(
     return stats_by_type
 
 
-def _compute_savings(
-    stats: AgentStats,
+def estimate_model_savings(
+    current_model: str | None,
     alt_model: str,
+    total_tokens: float | None,
+    count: int,
 ) -> tuple[float | None, float | None]:
-    """Estimate (savings_usd, current_cost_usd) for switching current → alt.
+    """Estimate ``(savings_usd, current_cost_usd)`` for ``current → alt``.
 
-    Returns ``(None, None)`` when pricing is unavailable for either
-    model — the recommendation still ships, just without the dollar
-    figure. Token in/out split is approximated 50/50; real ratio
-    tracked in #143.
+    Shared by both ``target: model`` paths (#170): the complexity-mismatch
+    path prices ``mean_tokens × invocation_count``; the duration-outlier
+    path prices a single outlier's ``total_tokens × 1``. Returns
+    ``(None, None)`` when the current model is unknown, token data is
+    missing, or pricing is unavailable for either model — the
+    recommendation still ships, just without the dollar figure. Token
+    in/out split is approximated 50/50; real ratio tracked in #143.
     """
-    if stats.current_model is None:
+    if not current_model or total_tokens is None:
         return None, None
-    current_pricing = get_pricing(stats.current_model)
+    current_pricing = get_pricing(current_model)
     alt_pricing = get_pricing(alt_model)
     if current_pricing is None or alt_pricing is None:
         return None, None
-    half = stats.mean_tokens / 2.0
+    half = total_tokens / 2.0
     current_per_inv = compute_cost(
         current_pricing, input_tokens=int(half), output_tokens=int(half),
     )
     alt_per_inv = compute_cost(
         alt_pricing, input_tokens=int(half), output_tokens=int(half),
     )
-    current_cost = current_per_inv * stats.invocation_count
-    alt_cost = alt_per_inv * stats.invocation_count
+    current_cost = current_per_inv * count
+    alt_cost = alt_per_inv * count
     savings = max(0.0, current_cost - alt_cost)
     return savings, current_cost
+
+
+def _compute_savings(
+    stats: AgentStats,
+    alt_model: str,
+) -> tuple[float | None, float | None]:
+    """Per-agent savings for the mismatch path: ``mean_tokens × count``."""
+    return estimate_model_savings(
+        stats.current_model, alt_model, stats.mean_tokens, stats.invocation_count,
+    )
 
 
 def _build_mismatch_signal(
@@ -259,18 +250,28 @@ def _detect_mismatch(stats: AgentStats) -> DiagnosticSignal | None:
     current_tier = classify_model_tier(stats.current_model)
     complexity = classify_complexity(stats)
 
+    # Both gates resolve their target through the shared selector (#170);
+    # it returns None when the target tier equals the current tier, so
+    # the same-as-current guard lives in one place. Overspec aims at the
+    # complexity-matched tier (simple → Haiku); underspec deliberately
+    # steps just one tier up to Sonnet rather than the complexity-matched
+    # Opus — a conservative, cheaper recommendation.
     if complexity == "simple" and current_tier in ("moderate", "complex"):
-        return _build_mismatch_signal(
-            stats, "overspec", complexity, recommended_model=MODEL_HAIKU,
-        )
+        recommended = select_target_model(stats.current_model, "simple")
+        if recommended is not None:
+            return _build_mismatch_signal(
+                stats, "overspec", complexity, recommended_model=recommended,
+            )
     if (
         complexity == "complex"
         and current_tier == "simple"
         and stats.error_rate > _UNDERSPEC_ERROR_RATE_GATE
     ):
-        return _build_mismatch_signal(
-            stats, "underspec", complexity, recommended_model=MODEL_SONNET,
-        )
+        recommended = select_target_model(stats.current_model, "moderate")
+        if recommended is not None:
+            return _build_mismatch_signal(
+                stats, "underspec", complexity, recommended_model=recommended,
+            )
     return None
 
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -161,6 +161,7 @@ def _detect_outliers(
     accessor: Callable[[AgentInvocation], float | None],
     signal_type: SignalType,
     format_message: Callable[[AgentInvocation, float, float, float], str],
+    extra_detail: Callable[[AgentInvocation], dict[str, object]] | None = None,
 ) -> list[DiagnosticSignal]:
     """Generic per-agent-type outlier detector (Tukey IQR rule).
 
@@ -170,7 +171,10 @@ def _detect_outliers(
     ``len(group) < OUTLIER_MIN_SAMPLE`` or where ``IQR <= 0`` (degenerate
     distribution — can't establish "outlier" sensibly).
 
-    Callers supply ``format_message(inv, value, q3, iqr)``.
+    Callers supply ``format_message(inv, value, q3, iqr)`` and may supply
+    ``extra_detail(inv)`` to merge per-invocation keys into the signal's
+    ``detail`` (e.g. the duration path attaches the current model + token
+    count the correlator needs to name + price a concrete model switch).
     """
     signals: list[DiagnosticSignal] = []
 
@@ -200,22 +204,25 @@ def _detect_outliers(
             if val is None or val <= threshold:
                 continue
             excess_iqrs = (val - q3) / iqr
+            detail: dict[str, object] = {
+                "actual_value": val,
+                "median_value": median_val,
+                "q3_value": q3,
+                "iqr_value": iqr,
+                "p95_value": p95,
+                "threshold_value": threshold,
+                "excess_iqrs": round(excess_iqrs, 2),
+                "tool_use_id": inv.tool_use_id,
+            }
+            if extra_detail is not None:
+                detail.update(extra_detail(inv))
             signals.append(DiagnosticSignal(
                 signal_type=signal_type,
                 severity=Severity.WARNING,
                 agent_type=inv.agent_type,
                 invocation_id=inv.invocation_id,
                 message=format_message(inv, val, q3, iqr),
-                detail={
-                    "actual_value": val,
-                    "median_value": median_val,
-                    "q3_value": q3,
-                    "iqr_value": iqr,
-                    "p95_value": p95,
-                    "threshold_value": threshold,
-                    "excess_iqrs": round(excess_iqrs, 2),
-                    "tool_use_id": inv.tool_use_id,
-                },
+                detail=detail,
             ))
 
     return signals
@@ -252,6 +259,14 @@ def _extract_duration_outliers(invocations: list[AgentInvocation]) -> list[Diagn
             f"Agent '{inv.agent_type}' has {val / 1000:.1f}s/tool_use, "
             f"{(val - q3) / iqr:.1f}×IQR above Q3 of {q3 / 1000:.1f}s."
         ),
+        # The correlator's DurationOutlierRule can't reach the invocation
+        # (its interface is (signal, config)), so carry the model it ran
+        # on and this invocation's token count — enough to name and price
+        # a concrete faster-model switch (#170).
+        extra_detail=lambda inv: {
+            "current_model": inv.trace.model if inv.trace else None,
+            "total_tokens": inv.total_tokens,
+        },
     )
 
 

--- a/tests/unit/test_complexity.py
+++ b/tests/unit/test_complexity.py
@@ -1,0 +1,51 @@
+"""Tests for the shared model-selection helpers in ``_complexity`` (#170)."""
+
+from __future__ import annotations
+
+from agentfluent.diagnostics._complexity import (
+    MODEL_HAIKU,
+    MODEL_OPUS,
+    MODEL_SONNET,
+    classify_model_tier,
+    faster_tier,
+    select_target_model,
+)
+
+
+class TestSelectTargetModel:
+    def test_downgrade_overspec_simple(self) -> None:
+        # complexity-mismatch overspec path: aim at the simple tier.
+        assert select_target_model(MODEL_OPUS, "simple") == MODEL_HAIKU
+
+    def test_upgrade_underspec_moderate(self) -> None:
+        # complexity-mismatch underspec path: deliberate one-step-up.
+        assert select_target_model(MODEL_HAIKU, "moderate") == MODEL_SONNET
+
+    def test_same_tier_returns_none(self) -> None:
+        # AC3: suggested target == current → no recommendation.
+        assert select_target_model(MODEL_SONNET, "moderate") is None
+        assert select_target_model("claude-sonnet-4-5-20250929", "moderate") is None
+
+    def test_unknown_current_returns_none(self) -> None:
+        assert select_target_model(None, "simple") is None
+        assert select_target_model("", "simple") is None
+
+
+class TestFasterTier:
+    def test_opus_steps_to_moderate(self) -> None:
+        assert faster_tier(MODEL_OPUS) == "moderate"
+
+    def test_sonnet_steps_to_simple(self) -> None:
+        assert faster_tier(MODEL_SONNET) == "simple"
+
+    def test_haiku_at_floor_returns_none(self) -> None:
+        assert faster_tier(MODEL_HAIKU) is None
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert faster_tier(None) is None
+        assert faster_tier("") is None
+
+    def test_unrecognized_family_defaults_moderate_then_steps(self) -> None:
+        # Unknown family classifies "moderate" → one tier down is simple.
+        assert classify_model_tier("claude-experimental-9000") == "moderate"
+        assert faster_tier("claude-experimental-9000") == "simple"

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -140,27 +140,85 @@ class TestTokenOutlierCorrelation:
         assert len(recs) == 1
 
 
+def _duration_signal(
+    detail: dict[str, object] | None = None,
+    agent_type: str = "pm",
+) -> DiagnosticSignal:
+    return _signal(
+        signal_type=SignalType.DURATION_OUTLIER,
+        agent_type=agent_type,
+        keyword="",
+        detail=detail if detail is not None else {},
+    )
+
+
 class TestDurationOutlierCorrelation:
-    def test_with_opus_model(self) -> None:
-        signals = [_signal(signal_type=SignalType.DURATION_OUTLIER, keyword="")]
+    def test_opus_config_names_concrete_sonnet_target(self) -> None:
+        # AC1: every target:model rec names current + proposed model.
+        signals = [_duration_signal()]
         configs = {"pm": _config(model="claude-opus-4-6")}
         recs = correlate(signals, configs)
         assert len(recs) == 1
         assert recs[0].target == "model"
+        assert "claude-opus-4-6" in recs[0].action
+        assert "claude-sonnet-4-6" in recs[0].action
+        assert "a faster model" not in recs[0].action
 
-    def test_with_sonnet_model(self) -> None:
-        signals = [_signal(signal_type=SignalType.DURATION_OUTLIER, keyword="")]
+    def test_sonnet_config_names_concrete_haiku_target(self) -> None:
+        # One tier down from Sonnet is Haiku — still a concrete model rec.
+        signals = [_duration_signal()]
         configs = {"pm": _config(model="claude-sonnet-4-6")}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+        assert "claude-sonnet-4-6" in recs[0].action
+        assert "claude-haiku-4-5" in recs[0].action
+
+    def test_haiku_config_falls_back_to_prompt(self) -> None:
+        # AC3: Haiku is the fastest tier — no faster model to name, so we
+        # suggest task scoping instead of an unnamed model rec.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-haiku-4-5")}
         recs = correlate(signals, configs)
         assert len(recs) == 1
         assert recs[0].target == "prompt"
 
-    def test_without_config(self) -> None:
-        signals = [_signal(signal_type=SignalType.DURATION_OUTLIER, keyword="")]
+    def test_current_model_resolved_from_signal_when_no_config(self) -> None:
+        # config → trace precedence: trace model on the signal still yields
+        # a concrete model rec when there's no AgentConfig.
+        signals = [_duration_signal(detail={"current_model": "claude-opus-4-6"})]
         recs = correlate(signals, None)
         assert len(recs) == 1
         assert recs[0].target == "model"
+        assert "claude-opus-4-6" in recs[0].action
+        assert "claude-sonnet-4-6" in recs[0].action
         assert recs[0].config_file == ""
+
+    def test_without_config_or_model_falls_back_to_prompt(self) -> None:
+        # No editable model and no trace model → can't name a target, so no
+        # unnamed target:model rec is emitted (AC1).
+        signals = [_duration_signal()]
+        recs = correlate(signals, None)
+        assert len(recs) == 1
+        assert recs[0].target == "prompt"
+        assert "a faster model" not in recs[0].action
+
+    def test_savings_included_when_tokens_and_pricing_available(self) -> None:
+        # AC4: cost-savings estimate present when pricing + tokens available.
+        signals = [_duration_signal(detail={"total_tokens": 500_000})]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert "estimated savings" in recs[0].action
+
+    def test_savings_omitted_when_tokens_missing(self) -> None:
+        # AC4: degrades gracefully — concrete target, no dollar figure.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs)
+        assert len(recs) == 1
+        assert "estimated savings" not in recs[0].action
+        assert "claude-sonnet-4-6" in recs[0].action
 
 
 class TestCorrelateGeneral:


### PR DESCRIPTION
## Summary
- Every `target: model` recommendation now names a **current and proposed model** instead of the generic "consider using a faster model" — closes #170.
- Both the duration-outlier and complexity-mismatch paths route through one shared `select_target_model` helper (the tier→model SSOT in `_complexity.py`), so targets stay concrete and consistent and the "no rec when proposed == current" guard lives in one place.
- The duration-outlier signal is enriched with `current_model` + `total_tokens` so `DurationOutlierRule` can name a one-tier-down target and attach a per-invocation cost-savings estimate (shared `estimate_model_savings`). Unknown/floor models fall back to a task-scoping suggestion rather than an unnamed model rec.

Before: `…consider switching from claude-opus-4-8 to a faster model in ~/.claude/agents/pm.md.`
After: `…consider switching from claude-opus-4-8 to claude-sonnet-4-6 in ~/.claude/agents/pm.md. (estimated savings: $0.56 for this invocation)`

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1758 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (new `tests/unit/test_complexity.py`; extended `TestDurationOutlierCorrelation` for overspec/underspec/floor/savings)
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent --diagnostics --json` — every `target:model` row now names a concrete current → proposed model

## Security review
- [x] **Skip review** — internal diagnostics logic only. No new CLI parsing, JSONL-parsing, path-resolution, or untrusted-string rendering surface; recommendation strings are built from internal model identifiers and existing home-dir-redacted paths (`_relpath`).
- [ ] **Needs review**

## Breaking changes
None. No public JSON envelope, CLI flag, or Pydantic model field changed — recommendation `action`/`message` text is advisory and not a versioned contract. The MODEL_MISMATCH path's overspec→Haiku / underspec→Sonnet behavior is preserved (now derived via the shared helper).