### PR TITLE
feat(config): add HookFieldCoverage model and hook_inspector module (#424)

### DIFF
--- a/src/agentfluent/config/hook_inspector.py
+++ b/src/agentfluent/config/hook_inspector.py
@@ -1,0 +1,145 @@
+"""Inspect agent hook scripts for references to specific hook-input fields.
+
+The config scanner (``scanner.py``) inventories hook script *paths* from agent
+frontmatter but never inspects their *content*. This module adds that capability:
+given an ``AgentConfig``, a hook event, and a field name, it reports whether any
+hook script wired to that event references the field.
+
+The first consumer (story #425) checks ``PostToolUse`` for ``duration_ms`` so the
+``DURATION_OUTLIER`` diagnostic can tell whether the agent already has a timing
+hook. The interface generalizes to other fields via ``KNOWN_HOOK_FIELDS`` without
+code changes.
+
+Design notes:
+
+- **Substring search, not AST.** Hook scripts are polyglot (Python, bash, jq).
+  The question is "does this script reference ``duration_ms``?", not "does it use
+  the value correctly." A literal-field-name substring search answers that
+  reliably; false positives (a comment) are acceptable, false negatives are the
+  real risk and near-zero. Transitive imports
+  (``python3 -c "import m; m.run()"``) are an accepted false-negative limitation.
+- **Agent-frontmatter hooks only.** Project-level hooks in
+  ``.claude/settings.json`` are not inspected; recommendation copy (story #425)
+  surfaces this caveat.
+- **Single-pair result.** ``inspect_hook_field`` answers one ``(event, field)``
+  question and returns one ``HookFieldCoverage`` -- exactly what the correlator
+  needs. Callers that want a list (story #426) invoke this per pair.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from .models import AgentConfig, HookFieldCoverage
+
+logger = logging.getLogger(__name__)
+
+KNOWN_HOOK_FIELDS: dict[str, set[str]] = {
+    "PostToolUse": {"duration_ms", "tool_input", "tool_response", "tool_name"},
+    "Stop": {"background_tasks", "session_crons"},
+}
+"""Authoritative registry of hook-input fields each hook event supports.
+
+Seeded with documented fields. ``Stop`` fields come from C-002 and are included
+for forward-compatibility; no diagnostic chain exercises them yet. Future fields
+add *data* here, not code.
+"""
+
+_SCRIPT_RE = re.compile(r"""[^\s"']+\.(?:py|sh|js)\b""")
+"""Matches a script path token inside a hook command, tolerant of surrounding
+quotes (real commands look like ``python3 "$CLAUDE_PROJECT_DIR/.../x.py"``)."""
+
+_INLINE = "(inline)"
+
+
+def _references_field(script_content: str, field: str) -> bool:
+    """Return True if ``field`` appears literally in ``script_content``."""
+    return field in script_content
+
+
+def _resolve_script_path(command: str, root: Path) -> Path | None:
+    """Extract a script path from a hook ``command`` and resolve it under ``root``.
+
+    Handles quoted paths and ``$CLAUDE_PROJECT_DIR`` / ``${CLAUDE_PROJECT_DIR}``
+    expansion. Returns ``None`` for pure inline commands (no script-file token).
+    """
+    match = _SCRIPT_RE.search(command)
+    if match is None:
+        return None
+    candidate = match.group(0)
+    candidate = candidate.replace("${CLAUDE_PROJECT_DIR}", str(root)).replace(
+        "$CLAUDE_PROJECT_DIR", str(root)
+    )
+    path = Path(candidate)
+    return path if path.is_absolute() else root / path
+
+
+def _iter_commands(groups: object) -> list[str]:
+    """Yield every ``command`` string from a hook event's matcher groups.
+
+    Claude Code's hook schema nests commands two levels deep:
+    ``event -> [{matcher, hooks: [{type, command}]}]``.
+    """
+    commands: list[str] = []
+    if not isinstance(groups, list):
+        return commands
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        for hook in group.get("hooks", []):
+            if isinstance(hook, dict):
+                command = hook.get("command")
+                if isinstance(command, str):
+                    commands.append(command)
+    return commands
+
+
+def inspect_hook_field(
+    config: AgentConfig,
+    hook_event: str,
+    field_name: str,
+    project_root: Path | None = None,
+) -> HookFieldCoverage:
+    """Report whether ``config``'s hooks for ``hook_event`` reference ``field_name``.
+
+    Inspects every hook command wired to ``hook_event``. External script files
+    (``.py``/``.sh``/``.js``) are read and searched; inline commands are searched
+    directly. Returns coverage for the first hook that references the field, else
+    a not-covered result. A missing external script file is logged and treated as
+    not covering (no crash). Does not modify ``config``.
+    """
+    root = project_root or Path.cwd()
+    last_source = ""
+    for command in _iter_commands(config.hooks.get(hook_event)):
+        script_path = _resolve_script_path(command, root)
+        if script_path is None:
+            last_source = _INLINE
+            if _references_field(command, field_name):
+                return HookFieldCoverage(
+                    hook_event=hook_event,
+                    field_name=field_name,
+                    covered=True,
+                    source=_INLINE,
+                )
+            continue
+        last_source = str(script_path)
+        try:
+            content = script_path.read_text(encoding="utf-8")
+        except OSError:
+            logger.debug("Hook script not readable: %s", script_path)
+            continue
+        if _references_field(content, field_name):
+            return HookFieldCoverage(
+                hook_event=hook_event,
+                field_name=field_name,
+                covered=True,
+                source=str(script_path),
+            )
+    return HookFieldCoverage(
+        hook_event=hook_event,
+        field_name=field_name,
+        covered=False,
+        source=last_source,
+    )

--- a/src/agentfluent/config/hook_inspector.py
+++ b/src/agentfluent/config/hook_inspector.py
@@ -111,11 +111,9 @@ def inspect_hook_field(
     not covering (no crash). Does not modify ``config``.
     """
     root = project_root or Path.cwd()
-    last_source = ""
     for command in _iter_commands(config.hooks.get(hook_event)):
         script_path = _resolve_script_path(command, root)
         if script_path is None:
-            last_source = _INLINE
             if _references_field(command, field_name):
                 return HookFieldCoverage(
                     hook_event=hook_event,
@@ -124,10 +122,9 @@ def inspect_hook_field(
                     source=_INLINE,
                 )
             continue
-        last_source = str(script_path)
         try:
             content = script_path.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             logger.debug("Hook script not readable: %s", script_path)
             continue
         if _references_field(content, field_name):
@@ -141,5 +138,5 @@ def inspect_hook_field(
         hook_event=hook_event,
         field_name=field_name,
         covered=False,
-        source=last_source,
+        source="",
     )

--- a/src/agentfluent/config/models.py
+++ b/src/agentfluent/config/models.py
@@ -172,6 +172,27 @@ class ConfigScore(BaseModel):
     """Actionable recommendations for improving the config."""
 
 
+class HookFieldCoverage(BaseModel):
+    """Whether an agent's hook scripts reference a specific hook-input field.
+
+    Result of inspecting one ``(hook_event, field_name)`` pair against an
+    agent's configured hooks (see ``hook_inspector``). Standalone result
+    model -- not nested inside ``AgentConfig``.
+    """
+
+    hook_event: str
+    """The hook event inspected (e.g. ``"PostToolUse"``)."""
+
+    field_name: str
+    """The hook-input field searched for (e.g. ``"duration_ms"``)."""
+
+    covered: bool = False
+    """True if a hook script for ``hook_event`` references ``field_name``."""
+
+    source: str = ""
+    """Where coverage was found: a script path, ``"(inline)"``, or ``""`` (none)."""
+
+
 class McpServerConfig(BaseModel):
     """A configured MCP server discovered from Claude Code config files."""
 

--- a/tests/fixtures/hooks/inline_bash_timing.yaml
+++ b/tests/fixtures/hooks/inline_bash_timing.yaml
@@ -1,0 +1,15 @@
+# Fixture: minimal agent frontmatter with an inline-bash PostToolUse hook that
+# references duration_ms directly in the command (no external script file).
+# Nested Claude Code matcher-group schema: event -> [{matcher, hooks: [{type, command}]}].
+hooks:
+  PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: |
+            bash -c '
+              DURATION=$(jq -r ".tool_response.duration_ms // empty")
+              if [ -n "$DURATION" ] && [ "$DURATION" -gt 5000 ]; then
+                echo "{\"systemMessage\": \"slow: ${DURATION}ms\"}"
+              fi
+            '

--- a/tests/fixtures/hooks/no_post_hook.yaml
+++ b/tests/fixtures/hooks/no_post_hook.yaml
@@ -1,0 +1,9 @@
+# Fixture: agent frontmatter with PreToolUse hooks only (no PostToolUse).
+# Inspecting the PostToolUse timing field against this must return not-covered.
+# Nested Claude Code matcher-group schema.
+hooks:
+  PreToolUse:
+    - matcher: "Edit"
+      hooks:
+        - type: command
+          command: 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/block_secret_reads.py"'

--- a/tests/fixtures/hooks/secrets_hook.py
+++ b/tests/fixtures/hooks/secrets_hook.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Fixture: a PostToolUse hook that reads tool_response only (no timing field).
+
+Used to assert a not-covered result when searching for the timing field.
+"""
+import json
+import sys
+
+
+def main() -> None:
+    event = json.load(sys.stdin)
+    output = event.get("tool_response", {}).get("stdout", "")
+    if "sk-ant-" in output:
+        print(json.dumps({"decision": "block", "reason": "secret detected"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/hooks/timing_hook.py
+++ b/tests/fixtures/hooks/timing_hook.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Fixture: a PostToolUse timing hook that reads duration_ms (covered=True)."""
+import json
+import sys
+
+
+def main() -> None:
+    event = json.load(sys.stdin)
+    duration_ms = event.get("tool_response", {}).get("duration_ms")
+    if duration_ms is not None and duration_ms > 5000:
+        print(json.dumps({"systemMessage": f"slow tool call: {duration_ms}ms"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_hook_inspector.py
+++ b/tests/unit/test_hook_inspector.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``config.hook_inspector``.
+
+Fixtures use the real nested Claude Code matcher-group hook schema
+(``event -> [{matcher, hooks: [{type, command}]}]``) so green tests reflect
+production shape (see #424 architect review).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agentfluent.config.hook_inspector import (
+    KNOWN_HOOK_FIELDS,
+    inspect_hook_field,
+)
+from agentfluent.config.models import AgentConfig, Scope
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "hooks"
+
+
+def _agent(hooks: dict[str, Any]) -> AgentConfig:
+    """Build a minimal AgentConfig carrying the given hooks dict."""
+    return AgentConfig(
+        name="test-agent",
+        file_path=Path("/tmp/test-agent.md"),
+        scope=Scope.PROJECT,
+        hooks=hooks,
+    )
+
+
+def _external_hook(script_name: str) -> dict[str, Any]:
+    """A PostToolUse hook group invoking an external script by name."""
+    return {
+        "PostToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": f"python3 {script_name}"}],
+            }
+        ]
+    }
+
+
+def _load_fixture_hooks(filename: str) -> dict[str, Any]:
+    data = yaml.safe_load((FIXTURES / filename).read_text())
+    hooks: dict[str, Any] = data["hooks"]
+    return hooks
+
+
+def test_external_script_with_duration_ms_is_covered() -> None:
+    config = _agent(_external_hook("timing_hook.py"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is True
+    assert result.source == str(FIXTURES / "timing_hook.py")
+    assert result.hook_event == "PostToolUse"
+    assert result.field_name == "duration_ms"
+
+
+def test_external_script_without_duration_ms_is_uncovered() -> None:
+    config = _agent(_external_hook("secrets_hook.py"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is False
+
+
+def test_inline_command_with_duration_ms_is_covered() -> None:
+    config = _agent(_load_fixture_hooks("inline_bash_timing.yaml"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is True
+    assert result.source == "(inline)"
+
+
+def test_no_post_tool_use_hooks_is_uncovered() -> None:
+    config = _agent(_load_fixture_hooks("no_post_hook.yaml"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is False
+    assert result.source == ""
+
+
+def test_missing_external_script_does_not_crash() -> None:
+    config = _agent(_external_hook("does_not_exist.py"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is False
+
+
+def test_claude_project_dir_expansion() -> None:
+    """A quoted ``$CLAUDE_PROJECT_DIR`` path resolves under project_root."""
+    hooks = {
+        "PostToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": 'python3 "$CLAUDE_PROJECT_DIR/timing_hook.py"',
+                    }
+                ],
+            }
+        ]
+    }
+    config = _agent(hooks)
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=FIXTURES
+    )
+    assert result.covered is True
+    assert result.source == str(FIXTURES / "timing_hook.py")
+
+
+def test_known_hook_fields_registry() -> None:
+    assert "duration_ms" in KNOWN_HOOK_FIELDS["PostToolUse"]
+    assert {"tool_input", "tool_response", "tool_name"} <= KNOWN_HOOK_FIELDS[
+        "PostToolUse"
+    ]
+    assert KNOWN_HOOK_FIELDS["Stop"] == {"background_tasks", "session_crons"}

--- a/tests/unit/test_hook_inspector.py
+++ b/tests/unit/test_hook_inspector.py
@@ -92,6 +92,18 @@ def test_missing_external_script_does_not_crash() -> None:
         config, "PostToolUse", "duration_ms", project_root=FIXTURES
     )
     assert result.covered is False
+    assert result.source == ""
+
+
+def test_non_utf8_external_script_does_not_crash(tmp_path: Path) -> None:
+    """A binary/non-UTF-8 hook script degrades to not-covered, no crash."""
+    bad = tmp_path / "binary_hook.py"
+    bad.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    config = _agent(_external_hook("binary_hook.py"))
+    result = inspect_hook_field(
+        config, "PostToolUse", "duration_ms", project_root=tmp_path
+    )
+    assert result.covered is False
 
 
 def test_claude_project_dir_expansion() -> None:


### PR DESCRIPTION
## Summary
- Add `config/hook_inspector.py` with `inspect_hook_field(config, hook_event, field_name, project_root=None)` — reports whether an agent's hooks for a given event reference a given hook-input field (first use: `PostToolUse` / `duration_ms`), returning a `HookFieldCoverage` result.
- Add the `HookFieldCoverage` Pydantic model (`config/models.py`) with a `KNOWN_HOOK_FIELDS` registry (fields add as data, not code).
- Reads the **real nested Claude Code matcher-group hook schema** (`event -> [{matcher, hooks: [{type, command}]}]`), tolerating quoted paths and `$CLAUDE_PROJECT_DIR` expansion. Substring search over hook-script content; agent-frontmatter hooks only. Foundational for the C-001 duration-outlier hook-coverage chain — **not yet wired** into the diagnostics pipeline (that is #425/#426).

> Note: the issue's *Implementation Notes* described a flat `[{"command": ...}]` hooks shape. An architect currency-review (comment on #424) found that shape stale vs. the real nested schema; implemented against the correct nested shape so the feature works on real agents. Checkbox ACs unchanged and all met.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — **1765 passed**
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `tests/unit/test_hook_inspector.py` (7 cases) + 4 nested-schema fixtures
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (new module, not yet wired to any CLI path; no user-visible output change)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

Rationale: resolves paths from config-derived hook commands (incl. `$CLAUDE_PROJECT_DIR` expansion) and reads those files; the resolved path is surfaced in `HookFieldCoverage.source`. Path-resolution + file-read of config-controlled paths → review warranted. Label to be applied when dev-complete.

## Breaking changes
None — purely additive. New `HookFieldCoverage` model and new `hook_inspector` module; no existing public contract changed.