### PR TITLE
feat(diagnostics): recommend a duration_ms timing hook in DurationOutlierRule (#425)

### DIFF
--- a/src/agentfluent/diagnostics/correlator.py
+++ b/src/agentfluent/diagnostics/correlator.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import ClassVar, Protocol
 
 from agentfluent.agents.models import is_builtin_agent
-from agentfluent.config.models import AgentConfig, Severity
+from agentfluent.config.models import AgentConfig, HookFieldCoverage, Severity
 from agentfluent.diagnostics._complexity import (
     faster_tier,
     select_target_model,
@@ -252,8 +252,32 @@ class TokenOutlierRule:
         )
 
 
+_DURATION_HOOK_EVENT = "PostToolUse"
+_DURATION_HOOK_FIELD = "duration_ms"
+
+
+def _duration_ms_covered(
+    hook_coverage: dict[str, list[HookFieldCoverage]] | None,
+    agent_type: str | None,
+) -> bool | None:
+    """Whether ``agent_type`` has a ``(PostToolUse, duration_ms)`` hook.
+
+    Returns the coverage ``bool`` when an explicit result for that pair exists,
+    else ``None`` meaning *unknown* — no coverage map, no agent name, the agent
+    was not inspected, or the map carries no matching entry. ``None`` is treated
+    as "don't emit the hook rec" (default-deny), matching the
+    ``hook_coverage=None`` backward-compat contract.
+    """
+    if not hook_coverage or not agent_type:
+        return None
+    for cov in hook_coverage.get(agent_type.lower(), []):
+        if cov.hook_event == _DURATION_HOOK_EVENT and cov.field_name == _DURATION_HOOK_FIELD:
+            return cov.covered
+    return None
+
+
 class DurationOutlierRule:
-    """Duration outlier -> check model selection or task scoping."""
+    """Duration outlier -> check hook coverage, model selection, or scoping."""
 
     _builtin_target = "prompt"
     _builtin_concern: BuiltinConcern = "scope"
@@ -262,13 +286,26 @@ class DurationOutlierRule:
         return signal.signal_type == SignalType.DURATION_OUTLIER
 
     def recommend(
-        self, signal: DiagnosticSignal, config: AgentConfig | None,
+        self,
+        signal: DiagnosticSignal,
+        config: AgentConfig | None,
+        *,
+        hook_coverage: dict[str, list[HookFieldCoverage]] | None = None,
     ) -> DiagnosticRecommendation:
         observation = signal.message
         reason = "Slow invocations may indicate an overqualified model or unclear task scope."
 
         if rec := _check_builtin(self, signal, reason):
             return rec
+
+        # Hook-coverage branch (#425): the most actionable fix is "you have no
+        # timing hook, so slow calls go undetected at runtime." Emit it only on
+        # explicit not-covered evidence AND when we can cite the agent's config
+        # file — unknown coverage falls through to the model/prompt branches.
+        if config is not None and (
+            _duration_ms_covered(hook_coverage, signal.agent_type) is False
+        ):
+            return self._hook_recommendation(signal, config)
 
         # Resolve the model the agent runs on: the editable declaration
         # (config.model) wins, else the model the slow invocation actually
@@ -302,6 +339,34 @@ class DurationOutlierRule:
 
         return DiagnosticRecommendation(
             target=target,
+            severity=Severity.WARNING,
+            message=f"{observation} {reason} {action}",
+            observation=observation,
+            reason=reason,
+            action=action,
+            agent_type=signal.agent_type,
+            invocation_id=signal.invocation_id,
+            config_file=str(config.file_path) if config else "",
+            signal_types=[signal.signal_type],
+        )
+
+    @staticmethod
+    def _hook_recommendation(
+        signal: DiagnosticSignal, config: AgentConfig | None,
+    ) -> DiagnosticRecommendation:
+        """Recommend adding a ``duration_ms`` PostToolUse hook (``target=hooks``)."""
+        observation = signal.message
+        reason = (
+            "Slow tool calls go undetected at runtime when no PostToolUse hook "
+            "gates on `duration_ms`."
+        )
+        action = (
+            "Add a PostToolUse hook that logs or gates on `duration_ms` to surface "
+            "slow tool calls before they compound. Note: project-level hooks in "
+            "`.claude/settings.json` are not currently inspected."
+        )
+        return DiagnosticRecommendation(
+            target="hooks",
             severity=Severity.WARNING,
             message=f"{observation} {reason} {action}",
             observation=observation,
@@ -1315,6 +1380,7 @@ RULES: list[CorrelationRule] = [
 def correlate(
     signals: list[DiagnosticSignal],
     configs: dict[str, AgentConfig] | None = None,
+    hook_coverage: dict[str, list[HookFieldCoverage]] | None = None,
 ) -> list[tuple[DiagnosticSignal, DiagnosticRecommendation]]:
     """Map signals to config surfaces and produce recommendations.
 
@@ -1322,6 +1388,15 @@ def correlate(
         signals: Detected behavior signals from signal extraction.
         configs: Optional dict of agent_type (lowercase) -> AgentConfig.
             When available, recommendations reference specific config files.
+        hook_coverage: Optional dict of agent_type (lowercase) ->
+            HookFieldCoverage results, parallel to ``configs`` (#425). Only
+            ``DurationOutlierRule`` consumes it; when a ``DURATION_OUTLIER``
+            agent has an explicit not-covered ``(PostToolUse, duration_ms)``
+            entry the rule recommends adding a timing hook. **Contract with the
+            caller (#426):** to make the load-bearing "zero-hook agent" case
+            fire, emit a ``covered=False`` entry for *every* inspected custom
+            agent, including those declaring no hooks. Absent agents are treated
+            as "not inspected" (default-deny) — no hook rec.
 
     Returns:
         Paired ``(signal, recommendation)`` tuples — one per matched
@@ -1341,7 +1416,11 @@ def correlate(
 
         for rule in RULES:
             if rule.matches(signal, config):
-                pairs.append((signal, rule.recommend(signal, config)))
+                if isinstance(rule, DurationOutlierRule):
+                    rec = rule.recommend(signal, config, hook_coverage=hook_coverage)
+                else:
+                    rec = rule.recommend(signal, config)
+                pairs.append((signal, rec))
                 break
 
     return pairs

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.config.models import (
+    AgentConfig,
+    HookFieldCoverage,
+    Scope,
+    Severity,
+)
 from agentfluent.diagnostics.correlator import (
     _relpath,
 )
@@ -21,11 +26,12 @@ from agentfluent.diagnostics.models import (
 def correlate(
     signals: list[DiagnosticSignal],
     configs: dict[str, AgentConfig] | None = None,
+    hook_coverage: dict[str, list[HookFieldCoverage]] | None = None,
 ) -> list[DiagnosticRecommendation]:
     """Test wrapper: drops the signal side of ``correlate``'s paired return
     so per-rule assertions can stay focused on recommendation content.
     Pairing semantics are exercised by the aggregation tests."""
-    return [rec for _, rec in _correlate_pairs(signals, configs)]
+    return [rec for _, rec in _correlate_pairs(signals, configs, hook_coverage)]
 
 
 def _signal(
@@ -219,6 +225,117 @@ class TestDurationOutlierCorrelation:
         assert len(recs) == 1
         assert "estimated savings" not in recs[0].action
         assert "claude-sonnet-4-6" in recs[0].action
+
+
+def _coverage(covered: bool, agent: str = "pm") -> dict[str, list[HookFieldCoverage]]:
+    """One-agent coverage map with a single (PostToolUse, duration_ms) result."""
+    return {
+        agent: [
+            HookFieldCoverage(
+                hook_event="PostToolUse",
+                field_name="duration_ms",
+                covered=covered,
+                source="script.py" if covered else "",
+            )
+        ]
+    }
+
+
+class TestDurationOutlierHookCoverage:
+    _HOOK_REASON = (
+        "Slow tool calls go undetected at runtime when no PostToolUse hook "
+        "gates on `duration_ms`."
+    )
+    _HOOK_ACTION = (
+        "Add a PostToolUse hook that logs or gates on `duration_ms` to surface "
+        "slow tool calls before they compound. Note: project-level hooks in "
+        "`.claude/settings.json` are not currently inspected."
+    )
+
+    def test_no_coverage_yields_hooks_recommendation(self) -> None:
+        # AC: DURATION_OUTLIER + no PostToolUse/duration_ms hook -> hooks rec,
+        # pre-empting the model/prompt branches.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs, _coverage(covered=False))
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec.target == "hooks"
+        assert rec.severity == Severity.WARNING
+        assert rec.observation == signals[0].message
+        assert rec.reason == self._HOOK_REASON
+        assert rec.action == self._HOOK_ACTION
+        assert "pm.md" in rec.config_file
+
+    def test_has_coverage_falls_through_to_model_branch(self) -> None:
+        # AC: has PostToolUse/duration_ms coverage -> existing model branch fires.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs, _coverage(covered=True))
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+        assert "claude-sonnet-4-6" in recs[0].action
+
+    def test_none_coverage_preserves_existing_behavior(self) -> None:
+        # AC: hook_coverage=None -> no hook rec, existing model branch unchanged.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs, None)
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+
+    def test_builtin_agent_unaffected_by_missing_coverage(self) -> None:
+        # AC: built-in agent -> built-in rec, even with not-covered coverage
+        # present. The built-in check runs before the hook branch.
+        signals = [_duration_signal(agent_type="general-purpose")]
+        recs = correlate(signals, None, _coverage(covered=False, agent="general-purpose"))
+        assert len(recs) == 1
+        assert recs[0].target != "hooks"
+
+    def test_agent_absent_from_coverage_falls_through(self) -> None:
+        # Default-deny (architect Q3): an agent with no coverage entry is
+        # "not inspected", not "no hook" -> fall through, no hooks rec.
+        signals = [_duration_signal(agent_type="pm")]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        recs = correlate(signals, configs, _coverage(covered=False, agent="other"))
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+
+    def test_posttooluse_key_entirely_absent_falls_through(self) -> None:
+        # Architect finding 1: coverage map present but carrying only an
+        # unrelated field -> no (PostToolUse, duration_ms) entry -> fall through.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        coverage = {
+            "pm": [
+                HookFieldCoverage(
+                    hook_event="PostToolUse",
+                    field_name="tool_name",
+                    covered=False,
+                )
+            ]
+        }
+        recs = correlate(signals, configs, coverage)
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+
+    def test_no_coverage_but_no_config_falls_through(self) -> None:
+        # Hook branch is gated on config (config_file must cite the .md path).
+        # No config -> cannot emit a hooks rec -> existing behavior.
+        signals = [_duration_signal(detail={"current_model": "claude-opus-4-6"})]
+        recs = correlate(signals, None, _coverage(covered=False))
+        assert len(recs) == 1
+        assert recs[0].target == "model"
+
+    def test_sequential_calls_do_not_leak_coverage(self) -> None:
+        # Architect finding 2: a stateless param must not leak a prior call's
+        # coverage into a later None call.
+        signals = [_duration_signal()]
+        configs = {"pm": _config(model="claude-opus-4-6")}
+        first = correlate(signals, configs, _coverage(covered=False))
+        assert first[0].target == "hooks"
+        second = correlate(signals, configs, None)
+        assert second[0].target == "model"
 
 
 class TestCorrelateGeneral:


### PR DESCRIPTION
## Summary
- Add a hook-coverage branch to `DurationOutlierRule` that fires **before** the model/prompt branches: when a `DURATION_OUTLIER` signal fires and the agent has no `PostToolUse` hook covering `duration_ms`, recommend adding one (`target="hooks"`), activating the previously dormant `hooks` target surface.
- Extend `correlate()` with an optional `hook_coverage` param (parallel to `configs`, keyed by `agent_type.lower()`); `DurationOutlierRule.recommend()` consumes it via a **stateless keyword-only param** wired through the dispatch loop — no mutable singleton state can leak across calls.
- Coverage is **default-deny**: the rec is emitted only on explicit not-covered evidence for `(PostToolUse, duration_ms)` and only when the agent's config file can be cited; unknown/absent coverage falls through, preserving the `hook_coverage=None` backward-compat contract. The downstream caller (#426) builds and passes the coverage dict.

Closes #425.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1774 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (`TestDurationOutlierHookCoverage`, 8 tests: no-coverage→hooks, has-coverage→model, None→existing, built-in→built-in, agent-absent, field-absent, no-config gating, sequential no-leak)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI output change; internal correlation logic, exercised by unit tests)

## Security review
- [x] **Skip review** — no security-sensitive surface. Internal diagnostics correlation logic reading already-parsed `HookFieldCoverage` (bool/str) and `signal.message`; no JSONL parsing, path resolution (handled upstream in #424's `hook_inspector`), CLI parsing, or rendering of untrusted strings.
- [ ] **Needs review**

## Breaking changes
None. Both new parameters are optional with defaults (`correlate(..., hook_coverage=None)`, `recommend(..., *, hook_coverage=None)`); existing callers and the `CorrelationRule` protocol are unaffected. `target` remains a free-form `str`, so no downstream serializer/formatter change is required.