### PR TITLE
feat(diagnostics): wire hook_inspector into run_diagnostics pipeline (#426)

### DIFF
--- a/src/agentfluent/diagnostics/pipeline.py
+++ b/src/agentfluent/diagnostics/pipeline.py
@@ -23,8 +23,9 @@ from agentfluent.agents.models import AgentInvocation
 if TYPE_CHECKING:
     from agentfluent.analytics.pipeline import SessionAnalysis
     from agentfluent.github.models import GitHubRepo
+from agentfluent.config.hook_inspector import inspect_hook_field
 from agentfluent.config.mcp_discovery import discover_mcp_servers
-from agentfluent.config.models import AgentConfig
+from agentfluent.config.models import AgentConfig, HookFieldCoverage
 from agentfluent.config.scanner import scan_agents
 from agentfluent.core.session import SessionMessage
 from agentfluent.diagnostics.agent_audit import (
@@ -228,6 +229,32 @@ def run_diagnostics(
         {c.name.lower(): c for c in agent_configs} if agent_configs else None
     )
 
+    # Hook-field coverage (#426, C-001). Inspect every scanned agent for a
+    # PostToolUse hook that surfaces ``duration_ms``; the correlator's
+    # DurationOutlierRule turns an explicit not-covered result into a
+    # ``target="hooks"`` recommendation. Contract with correlate() (#425):
+    # emit a coverage entry for *every* inspected agent (incl. those with no
+    # hooks — inspect_hook_field returns covered=False for them) so the
+    # load-bearing "zero-hook agent" case fires; absent agents stay
+    # uninspected (default-deny). ``None`` when no configs were scanned, so
+    # correlate() receives hook_coverage=None (no crash). Guarded like the
+    # scan itself. project_dir resolves $CLAUDE_PROJECT_DIR / relative script
+    # paths (falls back to cwd inside the inspector when None).
+    hook_coverage_by_name: dict[str, list[HookFieldCoverage]] | None = None
+    if agent_configs:
+        try:
+            hook_coverage_by_name = {
+                c.name.lower(): [
+                    inspect_hook_field(
+                        c, "PostToolUse", "duration_ms", project_root=project_dir,
+                    )
+                ]
+                for c in agent_configs
+            }
+        except OSError:
+            logger.debug("Could not inspect hook coverage", exc_info=True)
+            hook_coverage_by_name = None
+
     # Aggregate-level signals (model-routing) use the same config lookup
     # the correlator will read from; fold them in before correlation.
     signals.extend(extract_model_routing_signals(invocations, configs_by_name))
@@ -370,7 +397,7 @@ def run_diagnostics(
         )
         tier3_degraded = True
 
-    correlated_pairs = correlate(signals, configs_by_name)
+    correlated_pairs = correlate(signals, configs_by_name, hook_coverage_by_name)
     recommendations = [rec for _, rec in correlated_pairs]
     aggregated = aggregate_recommendations(correlated_pairs)
 

--- a/tests/unit/test_diagnostics_pipeline.py
+++ b/tests/unit/test_diagnostics_pipeline.py
@@ -16,7 +16,7 @@ from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.mcp_discovery import _load_json
 from agentfluent.config.models import AgentConfig, Scope, Severity
 from agentfluent.core.session import ContentBlock, SessionMessage
-from agentfluent.diagnostics import TRACE_SIGNAL_TYPES
+from agentfluent.diagnostics import TRACE_SIGNAL_TYPES, pipeline
 from agentfluent.diagnostics.delegation import MODEL_OPUS
 from agentfluent.diagnostics.mcp_assessment import McpToolCall
 from agentfluent.diagnostics.models import (
@@ -1042,3 +1042,145 @@ class TestParameterRetryPipeline:
         assert param_recs[0].target == "tools"
         # Paste-ready example extracted from the successful call.
         assert '"file_path": "a.py"' in param_recs[0].action
+
+
+def _duration_group(
+    agent_type: str, *, outlier_ms: int = 500_000, n_peers: int = 8,
+) -> list[AgentInvocation]:
+    """Build a trace-linked invocation group that yields one DURATION_OUTLIER.
+
+    ``duration_reliable`` requires a linked trace, and outlier detection
+    compares ``active_duration_per_tool_use``; every invocation carries a
+    trace with ``idle_gap_ms=0`` so active duration equals wall-clock.
+    """
+    invs: list[AgentInvocation] = []
+    for i in range(n_peers):
+        dur = 10_000 + 1_000 * i
+        invs.append(
+            AgentInvocation(
+                agent_type=agent_type,
+                description="task",
+                prompt="do it",
+                tool_use_id=f"t{i}",
+                tool_uses=10,
+                duration_ms=dur,
+                trace=SubagentTrace(
+                    agent_id=f"ag-{i}",
+                    agent_type=agent_type,
+                    delegation_prompt="x",
+                    duration_ms=dur,
+                    idle_gap_ms=0,
+                ),
+            )
+        )
+    invs.append(
+        AgentInvocation(
+            agent_type=agent_type,
+            description="task",
+            prompt="do it",
+            tool_use_id="t-slow",
+            tool_uses=10,
+            duration_ms=outlier_ms,
+            trace=SubagentTrace(
+                agent_id="ag-slow",
+                agent_type=agent_type,
+                delegation_prompt="x",
+                duration_ms=outlier_ms,
+                idle_gap_ms=0,
+            ),
+        )
+    )
+    return invs
+
+
+def _agent_config(name: str, *, command: str, model: str | None = None) -> AgentConfig:
+    """An AgentConfig with one PostToolUse hook running ``command`` (nested shape)."""
+    return AgentConfig(
+        name=name,
+        file_path=Path(f"/home/user/.claude/agents/{name}.md"),
+        scope=Scope.USER,
+        model=model,
+        hooks={
+            "PostToolUse": [
+                {"matcher": "*", "hooks": [{"type": "command", "command": command}]},
+            ],
+        },
+    )
+
+
+class TestHookCoverageWiring:
+    """#426: run_diagnostics assembles per-agent hook coverage and threads it
+    to correlate() so a DURATION_OUTLIER on an agent whose PostToolUse hooks
+    don't reference ``duration_ms`` yields a ``target="hooks"`` recommendation.
+    """
+
+    def test_uncovered_agent_yields_hooks_recommendation(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_scan(_scope: str) -> list[AgentConfig]:
+            return [_agent_config("my-agent", command="echo done")]
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline.scan_agents", fake_scan,
+        )
+
+        result = run_diagnostics(_duration_group("my-agent"))
+
+        hook_recs = [
+            r
+            for r in result.recommendations
+            if r.target == "hooks" and r.agent_type == "my-agent"
+        ]
+        assert len(hook_recs) == 1
+        assert "duration_ms" in hook_recs[0].action
+
+    def test_covered_agent_targets_model_not_hooks(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_scan(_scope: str) -> list[AgentConfig]:
+            return [
+                _agent_config(
+                    "my-agent",
+                    command="echo \"slow: $duration_ms\"",
+                    model=MODEL_OPUS,
+                ),
+            ]
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline.scan_agents", fake_scan,
+        )
+
+        result = run_diagnostics(_duration_group("my-agent"))
+
+        my_agent_recs = [
+            r for r in result.recommendations if r.agent_type == "my-agent"
+        ]
+        assert my_agent_recs, "expected a duration recommendation for my-agent"
+        assert all(r.target != "hooks" for r in my_agent_recs)
+        # A covered agent declaring Opus falls through to the model branch.
+        assert any(r.target == "model" for r in my_agent_recs)
+
+    def test_no_configs_passes_hook_coverage_none(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def empty_scan(_scope: str) -> list[AgentConfig]:
+            return []
+
+        monkeypatch.setattr(
+            "agentfluent.diagnostics.pipeline.scan_agents", empty_scan,
+        )
+
+        captured: dict[str, object] = {}
+        real_correlate = pipeline.correlate
+
+        def spy_correlate(signals, configs=None, hook_coverage=None):  # type: ignore[no-untyped-def]
+            captured["hook_coverage"] = hook_coverage
+            return real_correlate(signals, configs, hook_coverage)
+
+        monkeypatch.setattr(pipeline, "correlate", spy_correlate)
+
+        result = run_diagnostics(_duration_group("my-agent"))
+
+        assert captured["hook_coverage"] is None
+        # No config → no hooks rec, but the pipeline still runs cleanly.
+        assert all(r.target != "hooks" for r in result.recommendations)


### PR DESCRIPTION
## Summary
- Wires `hook_inspector` into `run_diagnostics()`: after the config scan, assembles per-agent `("PostToolUse", "duration_ms")` coverage into `dict[str, list[HookFieldCoverage]]` (keyed lowercase, matching `configs_by_name`) and threads it to `correlate()` as `hook_coverage`.
- Closes the **C-001** chain end-to-end (#423): a `DURATION_OUTLIER` on an agent whose PostToolUse hooks don't reference `duration_ms` now yields a `target="hooks"` recommendation in real `agentfluent analyze --diagnostics` runs. Depends on #424 (inspector) and #425 (correlator wiring), both merged.
- Inspects **every** scanned agent (incl. hook-less ones — `inspect_hook_field` returns `covered=False`), honoring the `correlate()` caller contract from #425; passes `None` when no configs are scanned (guarded like the scan itself), so absent agents stay uninspected (default-deny) and the pipeline can't crash. No new field on `DiagnosticsResult` (coverage is consumed internally).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1777 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `TestHookCoverageWiring`: uncovered→hooks rec, covered→model (not hooks), no-configs→`hook_coverage=None`
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A: no CLI-surface change (the `Target` column already renders `target` as a free-form `str` via `escape()`; confirmed no enum gating)

## Security review
- [x] **Skip review** — no new security-sensitive surface. The path-resolution + hook-script file-read surface lives in #424's `hook_inspector` (already security-reviewed, PASS). This PR only wires it: passes the existing trusted `project_dir` param as `project_root` and consumes finished `HookFieldCoverage` results. No new path handling, JSONL parsing, subprocess, network, or user-string rendering introduced here. (Consistent with #425's wiring PR.)
- [ ] **Needs review**

## Breaking changes
None. Purely additive internal wiring — no public contract, JSON envelope, CLI flag, exit code, or Pydantic field changes. `correlate()`'s `hook_coverage` param already existed (#425) and defaults to `None`.