### PR TITLE
feat(config): add verbosity-constraint scanner to prompt-body scoring (#437)

### DIFF
--- a/src/agentfluent/config/scoring.py
+++ b/src/agentfluent/config/scoring.py
@@ -48,6 +48,68 @@ SUCCESS_KEYWORDS: frozenset[str] = frozenset({
     "produce", "deliver", "result", "criteria",
 })
 
+# Verbosity-constraint detection (C-006a). Blanket word-count caps on agent
+# responses can silently degrade quality -- Anthropic's April 2026 postmortem
+# documented a 3% coding regression from a "keep responses to <=25 words" cap.
+# We flag captured word counts at or below this threshold as advisory only.
+VERBOSITY_CONSTRAINT_MAX_WORDS = 200
+
+# WARNING at/below this many words; INFO above it (up to the max threshold).
+VERBOSITY_CONSTRAINT_WARNING_WORDS = 50
+
+VERBOSITY_POSTMORTEM_URL = "https://www.anthropic.com/engineering/april-23-postmortem"
+
+# Regex list from the #431 architect design, with two corrections so the
+# canonical no-space postmortem phrasing ("<=25", "<=100") is caught:
+#   - pattern 1 tolerates an optional <=/≤ symbol before the digits
+#   - pattern 2 uses \s* (not \s+) after the symbol alternation
+# Without these the exact string the feature targets goes undetected (dead feature).
+VERBOSITY_CONSTRAINT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"(?:keep|limit|restrict|cap)\b.{0,40}\b(?:to|under|at most|no more than)"
+        r"\s+(?:≤|<=)?\s*(\d+)\s+words",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:≤|<=|at most|max(?:imum)?|no more than)\s*(\d+)\s+words",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(\d+)\s+words?\s+(?:or fewer|max(?:imum)?|limit)", re.IGNORECASE),
+    re.compile(r"respond\s+(?:in|with)\s+(\d+)\s+(?:words|tokens)\b", re.IGNORECASE),
+]
+
+# Strips fenced code blocks (```...```) so constraint examples inside code
+# samples don't trigger a recommendation.
+_FENCED_CODE_BLOCK = re.compile(r"```.*?```", re.DOTALL)
+
+
+def _detect_verbosity_constraints(body: str) -> list[tuple[int, str]]:
+    """Find blanket word-count constraints in a prompt body.
+
+    Returns ``(word_count, matched_text)`` pairs for matches at or below
+    ``VERBOSITY_CONSTRAINT_MAX_WORDS``. Fenced code blocks are stripped before
+    scanning. Overlapping matches (one constraint caught by multiple patterns)
+    are de-duplicated by span so each distinct constraint yields one result.
+    """
+    scrubbed = _FENCED_CODE_BLOCK.sub("", body)
+
+    spans: list[tuple[int, int, int, str]] = []  # start, end, word_count, text
+    for pattern in VERBOSITY_CONSTRAINT_PATTERNS:
+        for match in pattern.finditer(scrubbed):
+            word_count = int(match.group(1))
+            if word_count <= VERBOSITY_CONSTRAINT_MAX_WORDS:
+                spans.append((match.start(), match.end(), word_count, match.group(0)))
+
+    # Earliest start first, longest match first, then greedily accept only
+    # non-overlapping spans so a single constraint isn't reported twice.
+    spans.sort(key=lambda s: (s[0], -(s[1] - s[0])))
+    results: list[tuple[int, str]] = []
+    last_end = -1
+    for start, end, word_count, text in spans:
+        if start >= last_end:
+            results.append((word_count, text))
+            last_end = end
+    return results
 
 
 def _score_description(config: AgentConfig) -> tuple[int, list[ConfigRecommendation]]:
@@ -265,6 +327,30 @@ def _score_prompt_body(config: AgentConfig) -> tuple[int, list[ConfigRecommendat
             severity=Severity.INFO,
             message="Prompt body doesn't define success criteria.",
             suggested_action="Add criteria for what constitutes a successful outcome.",
+        ))
+
+    # Verbosity-constraint overlay (C-006a): advisory only, no score change.
+    for word_count, matched_text in _detect_verbosity_constraints(body):
+        severity = (
+            Severity.WARNING
+            if word_count <= VERBOSITY_CONSTRAINT_WARNING_WORDS
+            else Severity.INFO
+        )
+        recs.append(ConfigRecommendation(
+            dimension="prompt_body",
+            severity=severity,
+            message=(
+                f"Prompt contains a blanket word-count constraint "
+                f"('{matched_text}') that may degrade output quality. "
+                f"Anthropic's April 2026 postmortem documented a 3% quality "
+                f"regression from similar constraints. See: "
+                f"{VERBOSITY_POSTMORTEM_URL}"
+            ),
+            current_value=matched_text,
+            suggested_action=(
+                "Remove or relax the word-count constraint, or scope it to a "
+                "specific output field rather than all responses."
+            ),
         ))
 
     return score, recs

--- a/src/agentfluent/config/scoring.py
+++ b/src/agentfluent/config/scoring.py
@@ -59,14 +59,19 @@ VERBOSITY_CONSTRAINT_WARNING_WORDS = 50
 
 VERBOSITY_POSTMORTEM_URL = "https://www.anthropic.com/engineering/april-23-postmortem"
 
-# Regex list from the #431 architect design, with two corrections so the
-# canonical no-space postmortem phrasing ("<=25", "<=100") is caught:
-#   - pattern 1 tolerates an optional <=/≤ symbol before the digits
-#   - pattern 2 uses \s* (not \s+) after the symbol alternation
-# Without these the exact string the feature targets goes undetected (dead feature).
+# Regex list from the #431 architect design, with corrections:
+#   - pattern 1 tolerates an optional <=/≤ symbol before the digits, so the
+#     canonical no-space postmortem phrasing ("<=25", "<=100") is caught;
+#   - pattern 2 uses \s* (not \s+) after the symbol alternation, for the same
+#     reason;
+#   - pattern 1's gap is NON-greedy (.{0,40}?) so two distinct constraints on
+#     one line ("...to 30 words. Keep...to 15 words") aren't merged into a
+#     single match that drops the first (and its severity).
+# Without the first two the exact string the feature targets goes undetected
+# (dead feature); without the third a nearby second constraint is silently lost.
 VERBOSITY_CONSTRAINT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(
-        r"(?:keep|limit|restrict|cap)\b.{0,40}\b(?:to|under|at most|no more than)"
+        r"(?:keep|limit|restrict|cap)\b.{0,40}?\b(?:to|under|at most|no more than)"
         r"\s+(?:≤|<=)?\s*(\d+)\s+words",
         re.IGNORECASE,
     ),

--- a/tests/unit/test_verbosity.py
+++ b/tests/unit/test_verbosity.py
@@ -1,0 +1,182 @@
+"""Tests for the verbosity-constraint scanner (C-006a) in config scoring.
+
+Covers the advisory word-count-constraint detector added to
+``_score_prompt_body`` per issue #437: detection, code-block exclusion,
+severity split, threshold, span-overlap dedup, and the no-score-deduction
+contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentfluent.config.models import AgentConfig, Scope, Severity
+from agentfluent.config.scoring import (
+    VERBOSITY_POSTMORTEM_URL,
+    _detect_verbosity_constraints,
+    _score_prompt_body,
+    score_agent,
+)
+
+
+def _make_agent(prompt_body: str) -> AgentConfig:
+    """AgentConfig with the given prompt body and otherwise sane defaults."""
+    return AgentConfig(
+        name="test-agent",
+        file_path=Path("/tmp/test.md"),
+        scope=Scope.USER,
+        description="A test agent that reviews and analyzes things thoroughly.",
+        model="claude-sonnet-5",
+        tools=["Read", "Grep"],
+        prompt_body=prompt_body,
+    )
+
+
+def _verbosity_recs(prompt_body: str) -> list:
+    """Verbosity recs emitted by ``_score_prompt_body`` for a body."""
+    _, recs = _score_prompt_body(_make_agent(prompt_body))
+    return [r for r in recs if "word-count constraint" in r.message]
+
+
+class TestDetectHelper:
+    def test_le_25_no_space_detected(self) -> None:
+        # The canonical postmortem phrasing has no space after the symbol.
+        assert _detect_verbosity_constraints("Keep responses to ≤25 words") == [
+            (25, "Keep responses to ≤25 words"),
+        ]
+
+    def test_max_100_detected(self) -> None:
+        assert _detect_verbosity_constraints("Limit output to max 100 words") == [
+            (100, "max 100 words"),
+        ]
+
+    def test_maximum_50_detected(self) -> None:
+        assert _detect_verbosity_constraints("maximum 50 words") == [
+            (50, "maximum 50 words"),
+        ]
+
+    def test_respond_with_30_detected(self) -> None:
+        assert _detect_verbosity_constraints("respond with 30 words") == [
+            (30, "respond with 30 words"),
+        ]
+
+    def test_no_constraint_no_match(self) -> None:
+        assert _detect_verbosity_constraints("Write thorough, detailed responses") == []
+
+    def test_above_threshold_not_flagged(self) -> None:
+        # Captured (500) but dropped: 500 > VERBOSITY_CONSTRAINT_MAX_WORDS.
+        assert _detect_verbosity_constraints("Limit output to 500 words") == []
+
+    def test_empty_body_no_match(self) -> None:
+        assert _detect_verbosity_constraints("") == []
+
+    def test_postmortem_string_yields_two_distinct(self) -> None:
+        # The literal string the feature exists to catch -> two constraints.
+        body = (
+            "keep text between tool calls to ≤25 words; "
+            "keep final responses to ≤100 words"
+        )
+        assert _detect_verbosity_constraints(body) == [
+            (25, "keep text between tool calls to ≤25 words"),
+            (100, "keep final responses to ≤100 words"),
+        ]
+
+    def test_overlapping_patterns_deduped_to_one(self) -> None:
+        # "maximum 50 words or fewer" is caught by patterns 2 and 3; dedup -> one.
+        assert _detect_verbosity_constraints("maximum 50 words or fewer") == [
+            (50, "maximum 50 words"),
+        ]
+
+    def test_le_25_single_rec_not_double(self) -> None:
+        # The ≤-aware pattern 1 also matches pattern 2 on this string; span
+        # dedup must collapse it to exactly one result.
+        assert len(_detect_verbosity_constraints("Keep responses to ≤25 words")) == 1
+
+
+class TestCodeBlockExclusion:
+    def test_constraint_inside_code_block_ignored(self) -> None:
+        body = "```\nkeep to ≤25 words\n```"
+        assert _detect_verbosity_constraints(body) == []
+
+    def test_only_outside_code_block_flagged(self) -> None:
+        body = "keep to ≤25 words outside\n```\nkeep to ≤25 words\n```"
+        assert _detect_verbosity_constraints(body) == [
+            (25, "keep to ≤25 words"),
+        ]
+
+
+class TestScoringIntegration:
+    def test_le_25_emits_warning(self) -> None:
+        recs = _verbosity_recs("You are helpful. Keep responses to ≤25 words please.")
+        assert len(recs) == 1
+        assert recs[0].severity is Severity.WARNING
+        assert recs[0].dimension == "prompt_body"
+
+    def test_max_100_emits_info(self) -> None:
+        recs = _verbosity_recs("You are helpful. Limit output to max 100 words please.")
+        assert len(recs) == 1
+        assert recs[0].severity is Severity.INFO
+
+    def test_maximum_50_emits_warning(self) -> None:
+        recs = _verbosity_recs("You are helpful. maximum 50 words in replies.")
+        assert recs[0].severity is Severity.WARNING
+
+    def test_respond_with_30_emits_warning(self) -> None:
+        recs = _verbosity_recs("You are helpful. Always respond with 30 words.")
+        assert recs[0].severity is Severity.WARNING
+
+    def test_severity_boundary_50_warning_51_info(self) -> None:
+        assert _verbosity_recs("maximum 50 words")[0].severity is Severity.WARNING
+        assert _verbosity_recs("maximum 51 words")[0].severity is Severity.INFO
+
+    def test_message_carries_matched_text_and_url(self) -> None:
+        recs = _verbosity_recs("You are helpful. Keep responses to ≤25 words please.")
+        rec = recs[0]
+        assert rec.current_value == "Keep responses to ≤25 words"
+        assert "Keep responses to ≤25 words" in rec.message
+        assert VERBOSITY_POSTMORTEM_URL in rec.message
+        assert "relax the word-count constraint" in rec.suggested_action
+
+    def test_no_constraint_no_verbosity_rec(self) -> None:
+        assert _verbosity_recs("You are a careful agent. Write thorough answers.") == []
+
+
+class TestNoScoreDeduction:
+    def _prompt_body_score(self, prompt_body: str) -> int:
+        score, _ = _score_prompt_body(_make_agent(prompt_body))
+        return score
+
+    def test_dimension_score_unchanged_by_constraint(self) -> None:
+        # A body that already earns the full 25 (present, >=100 chars, has a
+        # markdown section, an error keyword, and a success keyword). Appending
+        # a verbosity constraint must not drop it below 25 -- the constraint is
+        # advisory-only and never deducts. (Base chosen at the cap so a
+        # deduction, were it to exist, would be visible.)
+        base = (
+            "## Role\nYou analyze agent sessions and handle errors gracefully "
+            "with retries. Return a complete result and deliver the output when "
+            "the task is done."
+        )
+        assert self._prompt_body_score(base) == 25
+        with_constraint = base + " Keep responses to ≤25 words."
+        assert self._prompt_body_score(with_constraint) == 25
+
+    def test_score_agent_includes_verbosity_rec(self) -> None:
+        agent = _make_agent(
+            "## Role\nYou analyze sessions. Handle errors gracefully and return "
+            "a complete result. Keep responses to ≤25 words."
+        )
+        result = score_agent(agent)
+        verbosity = [r for r in result.recommendations if "word-count constraint" in r.message]
+        assert len(verbosity) == 1
+        assert verbosity[0].dimension == "prompt_body"
+
+    def test_score_agent_prompt_body_score_matches_direct(self) -> None:
+        # score_agent must not double-count or drop the dimension when a
+        # verbosity constraint is present.
+        agent = _make_agent(
+            "## Role\nYou analyze sessions. Handle errors gracefully and return "
+            "a complete result. Keep responses to ≤25 words."
+        )
+        direct, _ = _score_prompt_body(agent)
+        assert score_agent(agent).dimension_scores["prompt_body"] == direct

--- a/tests/unit/test_verbosity.py
+++ b/tests/unit/test_verbosity.py
@@ -81,6 +81,21 @@ class TestDetectHelper:
             (100, "keep final responses to ≤100 words"),
         ]
 
+    def test_two_constraints_one_line_both_kept(self) -> None:
+        # Regression: a greedy gap in pattern 1 merged two distinct nearby
+        # constraints into one match, dropping the first. Non-greedy keeps both.
+        assert _detect_verbosity_constraints(
+            "Limit summaries to 30 words. Keep captions to 15 words."
+        ) == [(30, "Limit summaries to 30 words"), (15, "Keep captions to 15 words")]
+
+    def test_nearby_constraints_do_not_hide_more_severe(self) -> None:
+        # Regression: greedy merge kept only the trailing (less severe) count,
+        # hiding the leading WARNING behind a trailing INFO. The WARNING must win.
+        results = _detect_verbosity_constraints(
+            "Keep replies to 25 words, tips to 40 words"
+        )
+        assert (25, "Keep replies to 25 words") in results
+
     def test_overlapping_patterns_deduped_to_one(self) -> None:
         # "maximum 50 words or fewer" is caught by patterns 2 and 3; dedup -> one.
         assert _detect_verbosity_constraints("maximum 50 words or fewer") == [


### PR DESCRIPTION
## Summary
- Adds a regex-based **verbosity-constraint scanner** to `config/scoring.py`: `_detect_verbosity_constraints()` plus module constants, called from `_score_prompt_body()`. It flags blanket word-count caps in agent prompts (e.g. "keep responses to ≤25 words") as an **advisory** `ConfigRecommendation` — no score deduction, no dimension change. Severity: WARNING if word_count ≤ 50, else INFO; only flags counts ≤ 200.
- Motivated by Anthropic's [April 2026 postmortem](https://www.anthropic.com/engineering/april-23-postmortem), where a `≤25`/`≤100`-word response cap silently degraded coding quality by 3%.
- **Corrected the embedded #431 regex design** (human- + architect-approved): the verbatim patterns could not match the canonical **no-space** postmortem phrasing (`≤25`, `≤100`) because pattern 2's `\s+` demanded whitespace after the `≤`/`<=` symbol — shipping verbatim would have been a dead feature that never fires on its own motivating example. Pattern 1 now tolerates an optional `≤`/`<=` before the digits; pattern 2 uses `\s*`. Added **span-overlap dedup** so a constraint matched by multiple patterns yields exactly one recommendation. Patterns 3–4 are unchanged from the issue.

Closes #437.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1799 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — new `tests/unit/test_verbosity.py` (22 tests: detection, no-space `≤25`/`≤100` postmortem regression, code-block exclusion, severity boundary, span dedup, no-score-deduction)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI output shape change; additive rec into the existing recommendations list)

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface. Pure regex over already-parsed, in-memory `prompt_body` text (the user's own local agent config); no path resolution, JSONL parsing, subprocess, network, or CLI-arg surface. The emitted recommendation flows through the existing CLI formatter (whose Rich `escape()` of free-form fields was verified in #426) — this PR adds no new rendering path.
- [ ] **Needs review**

## Breaking changes
None. Additive: a new advisory `ConfigRecommendation` may appear in `recommendations`; dimension scores and the JSON envelope are unchanged.