### PR TITLE
chore(skills): add value-framing step at release-loop planning gate (#573)

### DIFF
--- a/.claude/skills/release-loop/SKILL.md
+++ b/.claude/skills/release-loop/SKILL.md
@@ -66,6 +66,32 @@ Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
 `issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
 research/docs.
 
+**Value framing (opens the plan, route-scaled).** State *why this should exist* in
+user terms — the question the architect/AC-verifier/code-review gates never ask (they check we
+build the thing right, not that it's the right thing). You write it inline; it is not extra
+ceremony. Scale it to the route:
+- **`feat:`** — a compact user-story map: one backbone activity + 1–3 `as a <user>, I want
+  <capability>, so that <outcome>` stories. Each carries **who benefits**, its **prevalence**
+  (how often real configs/corpora actually hit it), and a **falsifier** — *what single
+  observation would show this feature is misdirected?* (e.g. "~0 matching instances in any real
+  corpus"). A story with no credible user, or no checkable falsifier, is a red flag.
+- **`fix:`** — one line: who hits the bug, how often, what breaks without the fix.
+- **`docs:`** — who reads it and what it unblocks.
+- **`research:`** — the question, the downstream decision it informs, and what a **null result**
+  would mean (a null that changes nothing is a sign the question isn't worth asking).
+
+**Source-fidelity check (candidates from `anthropic-feature-watch`).** If the issue traces to a
+research-scout candidate citing an external article/postmortem, confirm the source actually
+supports the generalization the issue makes — **locus** (does the incident occur on the surface
+this feature inspects?), **evidence base** (n, scope, whether the source itself generalizes),
+and **current relevance** (already fixed upstream? version-specific?). An issue that extrapolates
+past what its source establishes is misdirected regardless of implementation quality. (The #437
+lesson — decision D046.)
+
+**When you can't articulate it, escalate — don't build.** If you cannot state a credible user
+*and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not
+proceed on a plan whose value story doesn't hold.
+
 ## 4. Architect gate (conditional)
 If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
 the plan; address `blocking`/`important` concerns before coding. Skip for docs and trivial
@@ -73,9 +99,12 @@ research.
 
 ## 5. Human gate (conditional — every mode)
 The plan gate is **conditional in every mode** — `mode:` gates the merge gate only (§11), never
-this one. Present the plan and STOP for approval when: acceptance criteria are ambiguous; the
-change is risky/irreversible; SCOPE/ DESIGN agents disagree or punt; or you are otherwise unsure.
-Otherwise proceed (note "auto-approved" + why in the journal). Route scope questions to
+this one. It is **value-first**: present the §3 value framing (user-story map / value statement)
+alongside the approach, and treat a **non-credible value story — no plausible user, or no
+checkable falsifier — as itself a reason to STOP**, not just ambiguous ACs. Present the plan and
+STOP for approval when: the value story doesn't hold; acceptance criteria are ambiguous; the
+change is risky/irreversible; SCOPE/DESIGN agents disagree or punt; or you are otherwise unsure.
+Otherwise proceed (note "auto-approved" + why in the journal). Route scope/value questions to
 SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
 (human or auto), advance the row to `plan-approved`.
 
@@ -143,9 +172,10 @@ issues. The ledger is gitignored — do NOT commit it (spec §6.4). STOP. (Drive
 fresh context for the next issue.)
 
 ## Escalation rubric (when unsure)
-Scope/priority/requirements → SCOPE_AGENT. Design/implementation → DESIGN_AGENT. Escalate to
-the HUMAN only when those disagree/punt, ACs are unresolvable, an action is
-destructive/irreversible, a review finding is contested, or the same step failed twice.
+Scope/priority/requirements — including any plan whose value story lacks a credible user or a
+checkable falsifier (§3) — → SCOPE_AGENT (pm), before implementing. Design/implementation →
+DESIGN_AGENT. Escalate to the HUMAN only when those disagree/punt, ACs are unresolvable, an
+action is destructive/irreversible, a review finding is contested, or the same step failed twice.
 
 ## Guardrails
 One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL

--- a/.claude/skills/release-loop/SKILL.md
+++ b/.claude/skills/release-loop/SKILL.md
@@ -79,14 +79,22 @@ ceremony. Scale it to the route:
 - **`docs:`** — who reads it and what it unblocks.
 - **`research:`** — the question, the downstream decision it informs, and what a **null result**
   would mean (a null that changes nothing is a sign the question isn't worth asking).
+- **`chore:` / `refactor:`** — one line: what internal tooling or quality this serves and why
+  now; no user-facing story required (state "internal tooling, no PyPI-visible change" if so).
 
-**Source-fidelity check (candidates from `anthropic-feature-watch`).** If the issue traces to a
-research-scout candidate citing an external article/postmortem, confirm the source actually
-supports the generalization the issue makes — **locus** (does the incident occur on the surface
-this feature inspects?), **evidence base** (n, scope, whether the source itself generalizes),
-and **current relevance** (already fixed upstream? version-specific?). An issue that extrapolates
-past what its source establishes is misdirected regardless of implementation quality. (The #437
-lesson — decision D046.)
+**Discharge cheap falsifiers at plan time — don't just state them.** If a story's falsifier is
+checkable *before* code (a grep / corpus / prevalence pass), RUN it now, or escalate; a
+stated-but-unrun falsifier is not sufficient. This is the load-bearing step: the cheap corpus
+pass is exactly what caught #437 — but only post-hoc. Defer discharge only when the check
+genuinely requires the built feature.
+
+**Source-fidelity check (any externally-cited justification).** If the issue's rationale leans on
+an external source — a research-scout (`anthropic-feature-watch`) candidate, a linked article, a
+postmortem — confirm the source actually supports the generalization the issue makes: **locus**
+(does the incident occur on the surface this feature inspects?), **evidence base** (n, scope,
+whether the source itself generalizes), and **current relevance** (already fixed upstream?
+version-specific?). An issue that extrapolates past what its source establishes is misdirected
+regardless of implementation quality. (The #437 lesson — decision D046.)
 
 **When you can't articulate it, escalate — don't build.** If you cannot state a credible user
 *and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not

--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -990,3 +990,39 @@ upstream coverage so overlays retire as genai-prices catches up.
 #252 (folded into #545); spec `prd-pricing-genai-migration.md`.
 
 ---
+
+## D046: Defer verbosity-constraint scanner (#437) — corpus prevalence is 0; re-enter only on evidence
+
+**Date:** 2026-07-01
+**Context:** #437 (PR #571, built + held at merge gate) shipped a regex scanner flagging ≤200-word
+caps in the user's *own* agent prompts, citing Anthropic's April 2026 postmortem "3% coding
+regression." A value re-review (`.claude/specs/value-review-437-verbosity.md`) found: (a) the
+incident was in Anthropic's Claude Code **harness** system prompt — a surface the scanner cannot
+see (locus mismatch); (b) evidence is n=1, internal, self-corrected, coding-specific, no
+generalization claimed by the source; (c) v1 flags the common+correct case (scoped word caps on
+summarizers/classifiers) and cannot distinguish the rare valid case (blanket caps on tool-using
+agents); (d) v1 hands judgment back to the user, contradicting the "tells you what to change"
+tagline; (e) the bare 3% citation is misapplied evidence that erodes recommendation credibility.
+A read-only prevalence pass of the detector over the dogfood corpus (all `~/.claude/agents/` +
+project `.claude/agents/` defs, 2026-07-01) found **0 blanket caps on tool-having agents**; the
+corpus's only word-count constraints are all legitimate scoped output specs (marketer per-artifact
+lengths; three research agents' "under 200 words" summaries) — the exact population v1 risks
+mis-flagging.
+**Decision:** DEFER, and the 0-prevalence result resolves the DEFER-vs-RESCOPE fork toward DEFER
+(not immediate rescope). PR #571 closed **unmerged** (branch deleted; work preserved on the PR).
+#437 closed as **misdirected-as-written** (not "kept open" — an older issue with architect-blessed
+ACs written against the article, not a corpus). Correctly-scoped, evidence-gated successor filed as
+**#572** (unmilestoned, backlog). Re-entry gate: build only if a corpus surfaces real blanket
+response caps on agentic/tool-using prompts; if so, re-enter as RESCOPE-NARROW (tool-having gate +
+scoped-field FP guard + mechanism-based copy, no bare 3% stat).
+**Rationale:** The binding constraint is unproven prevalence, not implementation quality — and the
+prevalence check returned 0. Cost asymmetry favors waiting: DEFER is reversible; shipping a
+trust-damaging citation is not. A prevalence oracle already existed at zero marginal cost (the
+dogfood corpus).
+**Meta / process:** This effort was corrected only by a post-hoc user-story mapping requested after
+implementation. Surfaced a release-loop gap → adding a user-focused value framing at the *planning*
+gate so misdirected effort is caught before code (#573).
+**Reference:** #437 (closed), #572 (successor), #431 (C-006a epic), PR #571 (closed unmerged),
+spec `value-review-437-verbosity.md`, [postmortem](https://www.anthropic.com/engineering/april-23-postmortem).
+
+---

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -284,10 +284,12 @@ The `- Budget:` line is the per-iteration cost record (#565). Fields:
 
 ## Value framing (route-scaled — see §3)
 <feat: backbone activity + 1–3 `as a … I want … so that …`, each with who-benefits +
-prevalence + a falsifier ("what observation would show this is misdirected?").
+prevalence + a falsifier ("what observation would show this is misdirected?"); discharge cheap
+falsifiers here (run the grep/corpus pass) rather than only stating them.
 fix: who hits it / how often / what breaks. docs: who reads it / what it unblocks.
 research: question + downstream decision + what a null result means.
-Add a source-fidelity note if the issue derives from an anthropic-feature-watch candidate.>
+chore:/refactor: what internal tooling/quality it serves + why now.
+Add a source-fidelity note if the rationale leans on any externally-cited source.>
 
 ## Acceptance criteria (verbatim from issue)
 - [ ] ...
@@ -409,14 +411,22 @@ ceremony. Scale it to the route:
 - **`docs:`** — who reads it and what it unblocks.
 - **`research:`** — the question, the downstream decision it informs, and what a **null result**
   would mean (a null that changes nothing is a sign the question isn't worth asking).
+- **`chore:` / `refactor:`** — one line: what internal tooling or quality this serves and why
+  now; no user-facing story required (state "internal tooling, no PyPI-visible change" if so).
 
-**Source-fidelity check (candidates from `anthropic-feature-watch`).** If the issue traces to a
-research-scout candidate citing an external article/postmortem, confirm the source actually
-supports the generalization the issue makes — **locus** (does the incident occur on the surface
-this feature inspects?), **evidence base** (n, scope, whether the source itself generalizes),
-and **current relevance** (already fixed upstream? version-specific?). An issue that extrapolates
-past what its source establishes is misdirected regardless of implementation quality. (The #437
-lesson — decision D046.)
+**Discharge cheap falsifiers at plan time — don't just state them.** If a story's falsifier is
+checkable *before* code (a grep / corpus / prevalence pass), RUN it now, or escalate; a
+stated-but-unrun falsifier is not sufficient. This is the load-bearing step: the cheap corpus
+pass is exactly what caught #437 — but only post-hoc. Defer discharge only when the check
+genuinely requires the built feature.
+
+**Source-fidelity check (any externally-cited justification).** If the issue's rationale leans on
+an external source — a research-scout (`anthropic-feature-watch`) candidate, a linked article, a
+postmortem — confirm the source actually supports the generalization the issue makes: **locus**
+(does the incident occur on the surface this feature inspects?), **evidence base** (n, scope,
+whether the source itself generalizes), and **current relevance** (already fixed upstream?
+version-specific?). An issue that extrapolates past what its source establishes is misdirected
+regardless of implementation quality. (The #437 lesson — decision D046.)
 
 **When you can't articulate it, escalate — don't build.** If you cannot state a credible user
 *and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -282,6 +282,13 @@ The `- Budget:` line is the per-iteration cost record (#565). Fields:
 # Plan: #<N> — <title>
 **Route:** <code|research|docs>  **Branch:** <BRANCH_FMT>
 
+## Value framing (route-scaled — see §3)
+<feat: backbone activity + 1–3 `as a … I want … so that …`, each with who-benefits +
+prevalence + a falsifier ("what observation would show this is misdirected?").
+fix: who hits it / how often / what breaks. docs: who reads it / what it unblocks.
+research: question + downstream decision + what a null result means.
+Add a source-fidelity note if the issue derives from an anthropic-feature-watch candidate.>
+
 ## Acceptance criteria (verbatim from issue)
 - [ ] ...
 
@@ -389,6 +396,32 @@ Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
 `issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
 research/docs.
 
+**Value framing (opens the plan, route-scaled).** State *why this should exist* in
+user terms — the question the architect/AC-verifier/code-review gates never ask (they check we
+build the thing right, not that it's the right thing). You write it inline; it is not extra
+ceremony. Scale it to the route:
+- **`feat:`** — a compact user-story map: one backbone activity + 1–3 `as a <user>, I want
+  <capability>, so that <outcome>` stories. Each carries **who benefits**, its **prevalence**
+  (how often real configs/corpora actually hit it), and a **falsifier** — *what single
+  observation would show this feature is misdirected?* (e.g. "~0 matching instances in any real
+  corpus"). A story with no credible user, or no checkable falsifier, is a red flag.
+- **`fix:`** — one line: who hits the bug, how often, what breaks without the fix.
+- **`docs:`** — who reads it and what it unblocks.
+- **`research:`** — the question, the downstream decision it informs, and what a **null result**
+  would mean (a null that changes nothing is a sign the question isn't worth asking).
+
+**Source-fidelity check (candidates from `anthropic-feature-watch`).** If the issue traces to a
+research-scout candidate citing an external article/postmortem, confirm the source actually
+supports the generalization the issue makes — **locus** (does the incident occur on the surface
+this feature inspects?), **evidence base** (n, scope, whether the source itself generalizes),
+and **current relevance** (already fixed upstream? version-specific?). An issue that extrapolates
+past what its source establishes is misdirected regardless of implementation quality. (The #437
+lesson — decision D046.)
+
+**When you can't articulate it, escalate — don't build.** If you cannot state a credible user
+*and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not
+proceed on a plan whose value story doesn't hold.
+
 ## 4. Architect gate (conditional)
 If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
 the plan; address `blocking`/`important` concerns before coding. Skip for docs and trivial
@@ -396,9 +429,12 @@ research.
 
 ## 5. Human gate (conditional — every mode)
 The plan gate is **conditional in every mode** — `mode:` gates the merge gate only (§11), never
-this one. Present the plan and STOP for approval when: acceptance criteria are ambiguous; the
-change is risky/irreversible; SCOPE/ DESIGN agents disagree or punt; or you are otherwise unsure.
-Otherwise proceed (note "auto-approved" + why in the journal). Route scope questions to
+this one. It is **value-first**: present the §3 value framing (user-story map / value statement)
+alongside the approach, and treat a **non-credible value story — no plausible user, or no
+checkable falsifier — as itself a reason to STOP**, not just ambiguous ACs. Present the plan and
+STOP for approval when: the value story doesn't hold; acceptance criteria are ambiguous; the
+change is risky/irreversible; SCOPE/DESIGN agents disagree or punt; or you are otherwise unsure.
+Otherwise proceed (note "auto-approved" + why in the journal). Route scope/value questions to
 SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
 (human or auto), advance the row to `plan-approved`.
 
@@ -465,9 +501,10 @@ issues. The ledger is gitignored — do NOT commit it (spec §6.4). STOP. (Drive
 fresh context for the next issue.)
 
 ## Escalation rubric (when unsure)
-Scope/priority/requirements → SCOPE_AGENT. Design/implementation → DESIGN_AGENT. Escalate to
-the HUMAN only when those disagree/punt, ACs are unresolvable, an action is
-destructive/irreversible, a review finding is contested, or the same step failed twice.
+Scope/priority/requirements — including any plan whose value story lacks a credible user or a
+checkable falsifier (§3) — → SCOPE_AGENT (pm), before implementing. Design/implementation →
+DESIGN_AGENT. Escalate to the HUMAN only when those disagree/punt, ACs are unresolvable, an
+action is destructive/irreversible, a review finding is contested, or the same step failed twice.
 
 ## Guardrails
 One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL

--- a/.claude/specs/value-review-437-verbosity.md
+++ b/.claude/specs/value-review-437-verbosity.md
@@ -1,0 +1,182 @@
+# Value Review: #437 Verbosity-Constraint Scanner (Track C-006a, epic #431)
+
+**Status:** PR #571 HELD at merge gate pending this review. Analysis only — no merge, no new issues, no label/body changes.
+**Date:** 2026-07-01
+**Author:** PM agent, at Fred's request after re-reading the source article.
+
+---
+
+## 1. What the feature does
+
+`_detect_verbosity_constraints()` in `src/agentfluent/config/scoring.py` regex-scans an
+agent's **own** prompt body for word-count caps (e.g. "keep responses to ≤25 words").
+For each match with captured count ≤200 it emits an **advisory** `ConfigRecommendation`
+(no score deduction): WARNING if ≤50 words, else INFO. Fenced code blocks are excluded.
+The recommendation copy cites Anthropic's April 2026 postmortem and its "3% quality
+regression" figure. The issue explicitly states "No false-positive heuristics in v1 —
+flag and let the user decide."
+
+## 2. What the source article actually establishes
+
+Verified against https://www.anthropic.com/engineering/april-23-postmortem (2026-07-01):
+
+| Claim | Reality |
+|---|---|
+| Where the constraint lived | Anthropic's **own** Claude Code system prompt (the harness), added while tuning for Opus 4.7. NOT model training. NOT anything a customer controls. |
+| Exact text | "Length limits: keep text between tool calls to ≤25 words. Keep final responses to ≤100 words unless the task requires more detail." |
+| Impact | ~3% coding-quality drop on Opus 4.6 **and** 4.7, found via ablation. |
+| Fix | Entirely Anthropic-side, reverted in the April 20 release. **No user action required.** |
+| Guidance to developers | **None.** No generalizable lesson about blanket length caps is articulated beyond this one incident. |
+
+**Evidence base: n=1, internal, self-corrected, coding-specific, with no generalization claimed by the source.**
+
+### The locus mismatch (the core problem)
+
+The scanner reads the **user's own agent prompts**. The incident occurred in
+**Claude Code's harness system prompt** — a surface the user does not author and the
+scanner cannot see. So the feature does not detect the documented incident class. It
+detects a *hypothesized analog*: "what if a user hand-wrote a similar blanket cap on
+their own agentic prompt." That analog may be real, but it is unproven and is not what
+the article documents.
+
+## 3. User-story map
+
+**Backbone activity:** "Audit my agent config for silent quality regressions before shipping."
+
+| # | Story | Prevalence | Precision (v1) | Holds? |
+|---|---|---|---|---|
+| S1 | As an Agent SDK dev, I want to be warned when my **coding / tool-using** agent has a **blanket** response-length cap, so I don't silently degrade reasoning the way Anthropic's harness did. | LOW but non-zero. Only story mapping to the actual incident. | v1 doesn't know if the agent has tools or if the cap is blanket vs scoped — flags all ≤200-word caps identically. | Concept HOLDS; **implementation FAILS** (no agent-type / blanket discrimination). |
+| S2 | As a subagent author, I want a word cap on my **title / commit-message / summarizer / classifier** subagent to **not** be flagged, because that cap is correct and required. | HIGH. Word caps are common *and correct* on non-agentic tasks — likely the majority of all matches. | v1 flags these by design ("flag and let the user decide"). | **FAILS.** This is the dominant real-world case and the feature gets it backwards. |
+| S3 | As a dev, I want the recommendation to tell me **what to change**, so I can act without more research. | — | v1 says "review whether this constraint is scoped to a single field" — hands the judgment back to the user. | **FAILS.** Directly contradicts the product tagline ("tells you what to change"). |
+| S4 | As a dev, I want cited evidence to be **relevant to my situation**. | — | v1 cites the coding-agent 3% figure on every match, including summarizers where a cap is correct. | **FAILS.** Misapplied evidence (see §5). |
+
+**Score: 1 of 4 stories holds conceptually; 0 of 4 are delivered well by v1. The one story that holds (S1) is also the rarest by prevalence, and v1 lacks the discrimination to serve it.**
+
+## 4. Value verdict
+
+**Is the kernel real?** Yes. AgentFluent's thesis — catch *silent* config-level quality
+regressions a dev would never notice because agents run blind — is sound, and a blanket
+length cap on an agentic prompt is a legitimate member of that class. Even Anthropic's
+experts shipped one by accident.
+
+**Does the current implementation deliver it?** No. v1:
+- cannot see the surface where the documented incident occurred (harness ≠ user prompt);
+- targets a hypothesized analog with **zero demonstrated prevalence** in real configs;
+- inverts precision — the majority case (S2, correct scoped caps) is flagged, and the
+  rare valid case (S1) is not distinguished;
+- hands adjudication back to the user (S3), contradicting the tagline;
+- attaches a misapplied statistic (S4) that damages recommendation credibility.
+
+Net: v1 ships **noise plus a trust-eroding citation**, not the kernel.
+
+## 5. Is the "3% regression" citation defensible messaging?
+
+**No, not as written.** The figure is coding-agent-specific, internal-harness-specific,
+and model-version-specific (Opus 4.6/4.7), and the source **explicitly declines to
+generalize**. Citing a bare "3% quality regression" on every matched constraint —
+including non-coding agents where a word cap is correct — manufactures false authority.
+
+For a diagnostics product whose entire value is the *credibility* of its recommendations,
+one visibly-bogus citation discounts every other recommendation the tool makes (the
+"cried wolf" effect). If the feature ever ships, the copy must: (a) drop the bare "3%"
+number; (b) condition on the agent being tool-using / agentic; (c) describe the
+*mechanism* ("blanket response caps can suppress intermediate reasoning in tool-using
+agents") rather than borrow a headline statistic from an unrelated context.
+
+**Corroborating tell:** PR #571 had to correct the issue's own regex — the canonical
+`≤25` / `≤100` no-space postmortem phrasing did not match the shipped patterns until
+fixed in the PR. The feature's motivating example didn't match its own detector. That is
+a symptom of a spec written *abstractly* against an article rather than against real
+instances in a corpus.
+
+## 6. Recommendation: **DEFER** (revert to backlog; gate re-entry on corpus evidence)
+
+Among KEEP-AS-IS / RESCOPE-NARROW / DEFER:
+
+**DEFER.** Park PR #571 (it is HELD, not merged, so this is ~free), keep #437 open, and
+gate re-entry on **finding real blanket-cap-on-tool-having-agent instances in the dogfood
+corpus**. Wire the detector as a read-only / dry-run pass over the corpus Fred already
+runs each release; let measured prevalence decide.
+
+**Reasoning:**
+1. **The binding constraint is evidence of prevalence, not implementation quality.** We
+   have n=1, and it is not even in the class the scanner can observe. Everything downstream
+   (severity, copy, FP guards) is premature until we know the signal fires on real data.
+2. **Cost asymmetry favors waiting.** DEFER costs nothing (branch parks, issue stays open,
+   fully reversible). KEEP costs trust (worst, and hard to walk back). RESCOPE costs real
+   dev time hardening a signal whose prevalence is unconfirmed.
+3. **A prevalence oracle already exists at zero marginal cost.** Fred runs the dogfood
+   corpus after every release. Run the detector across it once. If it finds zero blanket
+   caps on tool-having agents, that is decisive evidence the feature isn't worth shipping.
+   If it finds some, those instances become the calibration set for a precise v2.
+4. **Avoids the classic trap:** building FP machinery before validating demand.
+
+**Second-best: RESCOPE-NARROW.** If Fred wants to keep momentum rather than park it:
+restrict flagging to blanket caps on **tool-having** agents (skip agents with no/only
+read tools and obvious summarizer/classifier roles), add scoped-field detection to
+suppress "title: max 10 words"–style matches, and rewrite the copy per §5 (no bare 3%
+claim, mechanism-based, conditional). This preserves S1 and kills S2/S3/S4 — but spends
+the effort *before* confirming a single real instance exists, which is why it ranks below
+DEFER. It only becomes first-best if the dogfood pass in DEFER surfaces real instances.
+
+**Reject KEEP-AS-IS:** it ships the S2/S3/S4 failures and the misapplied citation into a
+product whose value is recommendation credibility, with no evidence any user config
+contains the pattern.
+
+## 7. Proposed decision-log entry (for `.claude/specs/decisions.md`)
+
+> Note: `decisions.md` is append-only. Proposed text below — append during implementation,
+> do not merge this review's file content into it.
+
+```
+## D0XX: Defer verbosity-constraint scanner (#437) pending corpus prevalence evidence
+
+**Date:** 2026-07-01
+**Context:** #437 (PR #571, HELD at merge gate) ships a regex scanner flagging ≤200-word
+caps in the user's own agent prompts, citing Anthropic's April 2026 postmortem "3% coding
+regression." Value re-review found: (a) the incident was in Anthropic's harness system
+prompt, a surface the scanner cannot see (locus mismatch); (b) evidence is n=1, internal,
+self-corrected, coding-specific, with no generalization claimed by the source; (c) v1 flags
+the common+correct case (word caps on summarizers/classifiers) and cannot distinguish the
+rare valid case (blanket caps on tool-using agents); (d) v1 hands judgment back to the user,
+contradicting the "tells you what to change" tagline; (e) the bare 3% citation is misapplied
+evidence that erodes recommendation credibility.
+**Decision:** DEFER. Park PR #571, keep #437 open, gate re-entry on finding real
+blanket-cap-on-tool-having-agent instances in the dogfood corpus (run the detector as a
+read-only pass). If prevalence is confirmed, re-enter as RESCOPE-NARROW (tool-having gate +
+scoped-field FP guard + mechanism-based copy with no bare 3% stat).
+**Rationale:** Binding constraint is unproven prevalence, not implementation quality. PR is
+HELD so DEFER is ~free and reversible; shipping a trust-damaging citation is not.
+**Second-best:** RESCOPE-NARROW immediately — ranks below DEFER because it hardens a signal
+whose prevalence is still unconfirmed.
+```
+
+## 8. Handoff notes
+
+- No code, labels, or issue bodies changed. PR #571 remains HELD.
+- If DEFER is accepted: the cheap next action is a one-off read-only run of the detector
+  over the dogfood corpus to measure prevalence — that datum decides DEFER-vs-RESCOPE.
+- Full-length recommendation copy rewrite (§5) is only needed if/when the feature re-enters.
+
+---
+
+## 9. Prevalence check result (2026-07-01) — DEFER confirmed
+
+Ran the corrected detector (PR #571 patterns incl. the non-greedy fix) as a read-only pass
+over every discoverable agent definition under `$HOME` (`~/.claude/agents/*.md` + all
+project `.claude/agents/*.md`; 7 parseable agent defs after excluding non-agent `.md`).
+
+**Scanner flags: 0 / 7.** Zero blanket caps; zero on tool-having agents.
+
+Context scan (raw `N word(s)` mentions) — the corpus's *only* word-count constraints, all
+**legitimate scoped output specs**, none a blanket response cap:
+- `marketer`: "~800–1200 words" (blog), "350–450 words" (LinkedIn), "~1000–2500 words" (case study), "~400–800 words" (dev.to)
+- `anthropic-research`, `candidate-verifier`, `jsonl-format-research`: "short run summary (under 200 words)" — scoped to the return summary (the "scope it to a field" GOOD pattern)
+
+**Interpretation:** the harmful population the feature targets is empty in real configs, while
+the population it risks mis-flagging is well-populated. The three "under 200 words" summaries
+dodge the flag only by phrasing luck ("under" isn't in a pattern) and sit right at the ≤200
+threshold — the precision inversion in §3/§4 is concrete, not hypothetical. Per the pre-agreed
+rule (0 blanket caps on tool agents → DEFER), this resolves the DEFER-vs-RESCOPE fork toward
+**DEFER**. Executed: #437 closed (misdirected-as-written), PR #571 closed unmerged, successor
+#572 filed (unmilestoned, evidence-gated), decision **D046** recorded.


### PR DESCRIPTION
## Summary
- Adds a **route-scaled, user-focused value framing** step to the release-loop **planning gate** (`SKILL.md` §3), so misdirected effort is caught *before* implementation. This is the gap #437 exposed: it passed all three technical gates (architect / AC-verifier / code-review) yet was misdirected — caught only by a *post-hoc* user-story map + a 0-result dogfood prevalence check.
- Makes the plan gate **value-first** (§5): a non-credible value story — no plausible user, or no checkable **falsifier** — is itself a reason to stop; escalation rubric routes such plans to `pm` *before* building. Adds a **source-fidelity check** for `anthropic-feature-watch`-derived candidates (does the source support the generalization?).
- Adds a **Value framing** section to the `issue-<N>.plan.md` template (spec §6.3); updates the spec §7 SKILL mirror in lockstep so the "ready-to-drop-in" copy doesn't drift.
- Bundles the pending #437 disposition specs from `main`: decision **D046** (defer verbosity-constraint scanner — corpus prevalence 0) and `value-review-437-verbosity.md` (PM value review + prevalence result).

Closes #573.

## Test plan
- [ ] Unit tests pass: `uv run pytest -m "not integration"`
- [ ] Lint clean: `uv run ruff check src/ tests/`
- [ ] Type check clean: `uv run mypy src/agentfluent/`
- [ ] New/changed behavior has test coverage
- [ ] Manual smoke test via `uv run agentfluent ...` — required for CLI output changes

**N/A — `.claude/`-only change** (skill + spec Markdown). No `src/` code, CLI, or package surface is touched, so there is nothing for pytest/ruff/mypy to exercise and no PyPI-visible behavior change. Verification is editorial: the four #573 acceptance criteria are satisfied and the SKILL.md §3/§5/escalation edits are mirrored verbatim in spec §7.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [x] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

The `security-review.yml` labeled workflow excludes `.claude/` paths; per the loop's §10, a local `/security-review` covers this change instead.

## Breaking changes
None. Process/skill documentation only — no public contract, CLI flag, JSON envelope, or Pydantic model is affected.