### PR TITLE
docs(specs): add v0.10 dogfood portfolio analysis

### DIFF
--- a/.claude/specs/analysis/2026-07-03-v10-dogfood/analysis.md
+++ b/.claude/specs/analysis/2026-07-03-v10-dogfood/analysis.md
@@ -1,0 +1,165 @@
+# Agent Portfolio Analysis — v0.10 dogfood run
+
+**Date:** 2026-07-03
+**Author:** Claude (Opus 4.8, 1M context) with Fred Pearce
+**Source:** `uv run agentfluent analyze --project agentfluent --diagnostics --git --github --json`
+**Sessions analyzed:** 70
+**agentfluent version:** v0.10.0 (published 2026-07-03 07:31 UTC; analyzed from editable install at the v0.10.0 release commit `27b9acb`)
+**Baseline:** [`2026-06-05-v09-dogfood/analysis.md`](../2026-06-05-v09-dogfood/analysis.md)
+**Raw outputs:** [`analyze.json`](analyze.json), [`analyze.table.txt`](analyze.table.txt)
+
+## Purpose
+
+Fifth dogfood run, first at the v0.10.0 cut. Five goals:
+
+1. **Validate v0.10 ships clean on real data** — no parse exceptions, `tier3_degraded: false`, `warnings: []`, model-turn counts populate at every level.
+2. **Check the three v0.9-follow-up fixes that shipped in v0.10** — `PARAMETER_RETRY` actionability gate (#510/#555), `model_turns`-vs-`api_call_count` docs (#511), hook-coverage recommendations (#424/#425/#426).
+3. **First real-data exposure of the hook_inspector surface** — does `DurationOutlierRule` now emit `target: hooks` recommendations, and are they sound?
+4. **Re-check the deferred v0.9 candidates** — pm `get_issue` retries (#512), architect #479 re-measurement (#513), README documentation-thrash (#514) — all deferred past v0.10.
+5. **First populated delegation-suggestions surface** — the corpus finally crossed the clustering threshold; are the suggestions actionable?
+
+## Headline — delta across four cuts
+
+| Metric | v0.7 (25) | v0.8 (32) | v0.9 (46) | **v0.10 (70)** | Δ vs v0.9 |
+|---|---|---|---|---|---|
+| Total cost | $1,729 | $1,271 | $1,286 | **$1,847** ⚠️ | +$561 (see caveat) |
+| Total tokens | 2.52B | 1.71B | 1.92B | **2.17B** | +13% |
+| API calls | 8,116 | 6,287 | 7,533 | **9,415** | +25% |
+| Cache efficiency | 97.8% | 97.3% | 97.2% | **97.0%** | −0.2pp |
+| Total agent invocations | 377 | 255 | 301 | **367** | +22% |
+| Agent token % | 0.6% | 0.80% | 0.90% | **0.8%** | −0.1pp |
+| Subagent traces parsed | — | 242 | 286 | **352** | +23% |
+| Parent-session model turns | — | — | 7,533 | **9,415** | +25% |
+| Subagent model turns | — | — | 3,413 | **3,885** | +14% |
+| `<synthetic>` messages | — | — | 25 | **40** | +60% |
+| Cost per session | $69 | $40 | $28 | **$26** | −$2 |
+
+**⚠️ The absolute cost is not comparable across the v0.10 boundary.** [#534](https://github.com/frederick-douglas-pearce/agentfluent/issues/534) fixed a pricing bug where 1-hour cache writes were billed at the 5-minute rate — so v0.10 reports cache-write cost *more accurately (higher)* than every prior dogfood. The +$561 total is part corpus growth (70 vs 46 sessions) and part the pricing correction; the two can't be separated from this table alone. **The comparable number is cost-per-session, which held at $26** (v0.9: $28) — real per-session spend kept its downward trend *even after* the pricing fix inflated each session's measured cost. Don't read "+44% total cost" as a spend regression; it's a measurement made honest plus 24 more sessions.
+
+**The corpus rolled again to 70 sessions** — the largest window yet, up from 46. With `cleanupPeriodDays: 3650` global (the v0.9 #481 fix), sessions no longer age out, so each dogfood is a wider, less-truncated snapshot. **Cache efficiency held at 97.0%** — five cuts, all within 0.8pp. The parent-thread cache economics that make naive offloading a losing trade (below) are a load-tested invariant now.
+
+**`total_model_turns == api_call_count` again, exactly (9,415 == 9,415)**, with `<synthetic>` messages (40) tallied and excluded separately — the [#511](https://github.com/frederick-douglas-pearce/agentfluent/issues/511) documentation now covers this equality, so it's expected, not a coincidence to re-investigate.
+
+## The marquee: PARAMETER_RETRY's #510 gate landed — and exposed a residual self-referential false positive
+
+This is the finding of the run, and it's a good one: **AgentFluent's own error-handling vocabulary trips its own error detector when agents read AgentFluent's source.**
+
+[#510/#555](https://github.com/frederick-douglas-pearce/agentfluent/issues/510) shipped the actionability gate: `_build_parameter_retry_signal` now returns `None` unless `run_calls[0].is_error` is true (`trace_signals.py:271`), and the docstring correctly claims this "keeps that message truthful" by keying the message on the first attempt. **The intended fix works** — the v0.9 keyword-regex-on-successful-result class (paging/query-refinement described as "failed with") is gated out.
+
+**But the gate depends on `is_error`, and `is_error` is *synthesized* from result text by `detect_is_error_from_text` when the parser has no explicit flag** (`signals.py:49`). That synthesis matches `ERROR_REGEX` against the leading 200 chars — and for a **successful `Read`/`Grep`, the leading 200 chars are the top of the file**. On this corpus, agents spent the release cycle reading AgentFluent's *own diagnostics source*, whose files are literally named and documented for error handling.
+
+Breakdown of the 25 fires:
+
+| Category | Count | What it is |
+|---|---|---|
+| **Genuine tool error** | **15** | `<tool_use_error>InputValidationError` (offset-as-array, missing required param), `EISDIR`, `File does not exist`, `File content exceeds maximum allowed tokens` — real first-attempt failures, correctly fired |
+| **Self-referential content FP** | **10** | Successful `Read`/`Grep` of source whose *head* contains error vocabulary |
+
+Every one of the 10 false positives is a successful read of AgentFluent's own code or docs:
+
+> - architect → `Grep` `parser.py:33:from agentfluent.diagnostics.signals import detect_is_error_from_text` — the identifier **contains** "error"
+> - Explore → `Read` `class ParameterRetryRule: """PARAMETER_RETRY -> recommend input_examples...`
+> - candidate-verifier → `Read` `"""Behavior signal extraction... Detects error patterns in output..."`
+> - architect → `Read` `def compute_error_rate(inv: AgentInvocation) -> float:`
+> - architect → `Read` release-loop skill (`name: release-loop / description: Run one routed iteration of the supervised dev loop...`)
+> - pm → `Read` `run_diagnostics` pipeline docstring (×2)
+
+The rendered message quotes the successfully-read source as `First attempt failed with: '1 --- 2 name: release-loop 3 description: ...'` — the exact "quotes success as failure" symptom #510 set out to kill, surviving through a *different* path (`detect_is_error_from_text` synthesis rather than the old keyword-regex fallback). **40% of PARAMETER_RETRY fires on this corpus (10/25) are this self-referential FP.** Layer on the actionability caveat carried from v0.9 — genuine fires are 15/15 on built-in `Read`/`Grep`, whose definitions the user can't add `input_examples` to — and the signal's *practically-actionable* yield on this corpus is effectively zero.
+
+**This is the same root cause #281 already identified** for `iter_error_matches` ("98% of full-text matches were mid-text code identifiers like `tool_error_sequence`, `is_error?`") — but the 200-char leading-window defense that fixed the *counting* path doesn't help the *synthesis* path, because here the error keyword sits at the **very top** of the read (a grep hit line, a class name, a module docstring), not buried deep where the window bound excludes it.
+
+**The tight fix:** on file-reading tools (`Read`/`Grep`/`Glob`), require the result to *start with* a structured error signature (`<tool_use_error>`, `EISDIR`/`ENOENT`/`EACCES`, `File does not exist`, `File content ... exceeds maximum`) rather than merely *contain* error vocabulary anywhere in the leading window. All 15 genuine fires begin with such a signature; all 10 FPs have the keyword mid-line. An anchored check separates them cleanly and is unit-testable from the fixtures already captured. **This should be the top v0.11 candidate.**
+
+## First fires this cycle
+
+### `permission_failure` — pm denied `WebFetch` (first fire since it shipped)
+
+**1 fire, `critical`, `target: tools`:** *"Subagent 'pm' was denied access to tool 'WebFetch' ('blocked')."* The `PERMISSION_FAILURE` signal has existed since #231/#239 (v0.5) but stayed silent across three dogfoods — this is its **first real-data fire**. It's a **true positive with a genuine config question:** the pm agent definition lists `WebFetch` among its tools, yet a settings/permission layer blocked the call at runtime. Either the allow-list should grant `WebFetch` to pm (if research fetches are intended) or pm's prompt should stop reaching for it. Cheap to resolve, and a clean demonstration that the tool-access-audit surface fires correctly when the config and the observed behavior disagree. Worth a quick look at which layer produced the `'blocked'` — agent def vs `settings.local.json`.
+
+### Hook-coverage recommendations (#424/#425/#426) — first dogfood with `target: hooks`
+
+**2 recommendations, both `warning`, both `target: hooks`:** pm and architect each drew *"Add a PostToolUse hook that logs or gates on `duration_ms` to surface slow tool calls,"* driven by `duration_outlier` (pm: 65.8s/tool_use, 5.6×IQR above Q3; architect: up to 3.5×IQR). This is the new `hook_inspector` surface working end-to-end on real data for the first time — `DurationOutlierRule` now has a hook-coverage branch and emits `target: hooks` when a slow agent lacks `duration_ms` instrumentation. The recommendation is sound and actionable (both are custom agents whose configs the user owns). Recommendation-target distribution this run: `prompt: 24, tools: 10, subagent: 4, hooks: 2, description: 1` — the hook target is live and firing conservatively, exactly as intended.
+
+### Delegation suggestions — surface populated for the first time, but low-cohesion
+
+The corpus finally crossed the clustering threshold: **9 delegation suggestions** emitted (v0.9 skipped this surface entirely). The problem is they're **mostly noise on this corpus.** Cohesion scores run 0.29–0.73 (mostly ~0.4), and the auto-generated names/descriptions are vague TF-IDF buckets: `glossary-docs` ("glossary, docs, run"), `py-existing` ("py, existing, reuse"), `efficiency-hot` ("efficiency, hot, path"), `comments-quality`. These cluster the *ad-hoc review/verify subagents* Fred spins up per-PR (`AC-verify #504`, `Reuse review of #372`, `Angle A: line-by-line scan`) — genuinely recurring *shapes* of work, but the clustering keys on surface tokens and produces buckets too generic to paste in as an agent. Two calibration notes: (a) the suggested `model` is pinned to `claude-opus-4-7` (one release stale — current default is `4-8`); (b) low-cohesion clusters (< ~0.4) probably shouldn't surface as *named agent drafts* at all — they read as "you delegate a lot of review work" rather than "define *this* agent." Candidate for a cohesion floor before rendering a `yaml_draft`.
+
+## Model turns — general-purpose is *more* serialized, not less
+
+`avg_tool_calls_per_turn` remains the efficiency ratio that matters (high = batches calls within a turn; ~1.0 = serializes one call per round-trip):
+
+| Agent | Inv | Tool uses | Turns | **Tool calls/turn** | Tokens/turn | $/turn |
+|---|---|---|---|---|---|---|
+| claude-code-guide (builtin) | 8 | 97 | 45 | **2.16** | 6,041 | $0.0067 |
+| pm (custom) | 41 | 981 | 536 | **1.83** | 6,826 | $0.0078 |
+| architect (custom) | 90 | 1,451 | 875 | **1.66** | 5,674 | $0.0053 |
+| anthropic-research (custom) | 4 | 36 | 22 | 1.64 | 7,714 | $0.0090 |
+| candidate-verifier (custom) | 1 | 48 | 33 | 1.45 | 2,341 | $0.0027 |
+| Explore (builtin) | 30 | 521 | 402 | 1.30 | 3,922 | $0.0031 |
+| candidate-promoter (custom) | 3 | 24 | 21 | 1.14 | 5,314 | $0.0062 |
+| **general-purpose (builtin)** | **189** | **1,722** | **1,930** | **0.89** | 3,675 | $0.0031 |
+
+**The dominant agent got *more* serial, not less.** `general-purpose` — 189 invocations (up from 150), the single biggest token consumer at 7.1M — dropped from **0.96 → 0.89 tool calls per turn.** It's doing *less* than one tool call per model turn on average: a Read, a turn, another Read, another turn. The custom agents (architect 1.66, pm 1.83) still batch roughly 2× tighter. Three cuts running, the model-turn metric independently fingers the same structural hotspot: the built-in `general-purpose` catch-all is the serialization sink, and the lever is unchanged — wrap narrow tasks in custom subagents. Its prompt isn't user-editable, so the only fix is displacement, which the delegation-suggestions surface (above) is trying — however clumsily — to automate.
+
+## Deferred v0.9 candidates — status on the v0.10 window
+
+**#512 shipped; #513/#514 are open on v0.11.0.** All three re-measure against a corpus that *straddles* their fix dates, so none is a clean post-fix read.
+
+| Candidate | v0.9 | **v0.10** | Verdict |
+|---|---|---|---|
+| **#512** pm `get_issue` retries (apply #479 prompt fix to pm) | 7 | **8** | **Shipped** — pm.md was tightened (`mcp__github__get_issue` 404-handling, closed COMPLETED 2026-06-30). But pm.md is a *user-global* agent (no `src/` artifact, maintainer-tooling only), and the fix landed 3 days before this cut — most of the 70-session corpus (and most of pm's 41 invocations) predate it. The 8 retries are a **pre-fix reading**, not evidence the fix failed. Same corpus-straddle caveat as #479/#513; re-measure at v0.11 on a fully-post-fix window. Do not re-file. |
+| **#513** re-measure #479 (architect `Read`/`get_issue`) | 29 / 3 | **32 / 4** | ⬆️ flat-to-up, but **not measurable:** architect's `Read` retries are contaminated by the *same self-referential pattern* as PARAMETER_RETRY — `retry_loop` counts consecutive same-tool `Read`s, many of which are legitimate paging through AgentFluent's own multi-file diffs, not error recovery. #479's effect stays un-readable until the `retry_loop` denominator gets the same paging-vs-error disambiguation the PARAMETER_RETRY fix implies (see v0.11 candidate 3). Defer judgment again. |
+| **#514** README documentation-thrash | #1 (64 edits) | **#2 (66 edits)** | README held ~flat but is no longer the top `file_rework` target — it's displaced by `.claude/loop/v0.10.0/queue.md` (79) and `prd-loop-engineering.md` (65), the loop-engineering pilot artifacts churned all cycle. README thrash is real but *stable*, not accelerating; the structural fix (link release prose out to CHANGELOG) is still the right call but low-urgency. Already filed + milestoned. |
+
+## Calibration signals holding steady
+
+- **`ERROR_PATTERN`: 1 fire** — the same lone true positive as the last two cuts: `anthropic-research` output contains "not found" (self-bootstrap registration string). #333's per-invocation trace gating holds precision at the floor across three cycles. No drift.
+- **`reviewer_caught`: 69** (was 62), all on architect — the v0.6 quality signal firing as designed, growing with PR volume. Healthy.
+- **`feat_fix_proximity`: 31** — identical to v0.9. The #402 2-file threshold continues to suppress trivial coincidences. No re-calibration needed.
+- **`user_correction`: 6** — real mid-thread steering (architect-review requests, the "does api calls include synthetic messages" question that motivated #511, a `/simplify` framing correction). Working.
+- **`TOOL_ORCHESTRATION_CHAIN`: 4 INFO**, all carrying the low-confidence caveat — the expected metadata-only proxy on token-heavy agents, no genuine orchestration on this corpus. Unchanged from v0.9; still tracked as #499.
+- **`unused_agent`: 1** — `marketer` (user-scope, cross-project, 0 invocations here), the same lone not-actionable-here fire.
+
+## Critical-severity recommendations — same shape, still built-in-bound
+
+Five `critical` aggregated recommendations:
+
+| Agent | Signal | Count | Actionable? |
+|---|---|---|---|
+| general-purpose | tool_error_sequence | 16 | Built-in — wrap-in-subagent only |
+| architect | tool_error_sequence | 4 | Custom — but see #513 paging caveat |
+| candidate-verifier | tool_error_sequence | 2 | Custom — 1 invocation, low volume |
+| candidate-promoter | tool_error_sequence | 2 | Skill-converted residual |
+| **pm** | **permission_failure** | 1 | **Custom — new, genuinely actionable (WebFetch allow-list)** |
+
+Four of five are the familiar `tool_error_sequence` shape on the heavy agents; the fifth — pm's `permission_failure` — is the one fresh, cleanly-actionable critical this cycle.
+
+## Offload candidates — negative-savings, fourth cycle running
+
+10 offload candidates, **all ≤ $0 savings** (largest: `bash-agent` −$354, `bash-main` −$180, `release-bash` −$142, `loop-task` −$134; smallest `prices-genai` −$12). **Fourth consecutive dogfood with the same verdict:** naive offloading loses to parent-thread cache efficiency (97.0%) on this workload. The alternative-model targets updated to `claude-opus-4-8 → claude-sonnet-4-6` (concrete target model present, validating #170). The default behavior correctly hides these; "no actionable offloads" remains the right answer, not a missing-data symptom. This is a load-tested invariant of the workload now, not a finding.
+
+## v0.11 candidates, ranked by dogfood evidence
+
+Listed in priority order. Two are genuinely-new engine issues filed against **v0.11.0**; the rest reconcile to existing backlog items.
+
+1. **PARAMETER_RETRY: anchor `is_error` synthesis to a leading error signature on file-reading tools (HIGH — [#580](https://github.com/frederick-douglas-pearce/agentfluent/issues/580)).** 40% of fires (10/25) are self-referential FPs — successful `Read`/`Grep` of error-handling source whose head contains error vocabulary. Require `Read`/`Grep`/`Glob` results to *start with* a structured error signature (`<tool_use_error>`, `EISDIR`/`ENOENT`/`EACCES`, `File does not exist`, `File content ... exceeds maximum`) before synthesizing `is_error`. All 15 genuine fires pass; all 10 FPs fail. Unit-testable from captured fixtures. Same root cause as #281; the 200-char window doesn't cover head-of-file keywords.
+2. **`retry_loop` paging-vs-error disambiguation (MED — [#581](https://github.com/frederick-douglas-pearce/agentfluent/issues/581), unblocks #513).** `retry_loop` counts consecutive same-tool `Read`s, conflating legitimate multi-file paging with error recovery — which is *why* #513 (#479 re-measurement) can't get a clean read. Apply the same first-attempt-error gate PARAMETER_RETRY uses. This is the shared root cause behind candidate 1 and the un-readable architect/pm retry numbers.
+3. **Delegation-suggestions cohesion floor + model-pin refresh (MED — [#183](https://github.com/frederick-douglas-pearce/agentfluent/issues/183) comment).** The surface populated for the first time but renders low-cohesion (~0.3) TF-IDF buckets as named agent drafts. Add a cohesion floor (~0.4) below which a cluster surfaces as an *observation* rather than a paste-ready `yaml_draft`, and refresh the stale `claude-opus-4-7` model pin. #183 ("delegation drafts: skill-aware provenance + actionability note") already owns this surface — logged there as a dogfood evidence comment rather than a competing issue.
+
+**Reconciled to existing issues (not re-filed):**
+- **#512** pm `get_issue` — closed COMPLETED; shipped as a user-global pm.md edit, corpus predates it. Re-measure at v0.11, no new work.
+- **#513** #479 re-measurement — open on v0.11.0; blocked on candidate 2. Commented with the v0.10 numbers + the disambiguation dependency.
+- **#514** README thrash — open on v0.11.0; commented with the v0.10 data point (stable ~65, dropped to #2 behind loop-engineering artifacts).
+
+**Not filed (inline observation only):**
+- `TOOL_ORCHESTRATION_CHAIN` 4 INFO — expected corpus artifact, tracked as #499.
+- Offload negative-savings — correct, fourth confirmation, not a bug.
+- pm `WebFetch` `permission_failure` — a config decision for Fred (grant vs remove), not an engine bug; resolve directly.
+
+## What v0.10 proved
+
+The release shipped clean: 70 sessions parsed with `tier3_degraded: false`, `warnings: []`, no exceptions; model turns populate at every level and `total_model_turns == api_call_count` exactly (9,415) with `<synthetic>` (40) correctly excluded and now documented (#511). The two new surfaces both fired correctly on first real-data contact — `hook_inspector` drew sound `target: hooks` duration recommendations for pm and architect (#424/#425/#426), and `permission_failure` caught a real config gap (pm→WebFetch) on its first-ever fire. #534's pricing correction means absolute cost isn't comparable to prior cuts, but cost-per-session held at $26 through the fix — the honest number kept trending down.
+
+The one genuinely actionable engine finding is the **PARAMETER_RETRY self-referential false positive**: #510's `is_error` gate closed the class it targeted, but 40% of fires on this corpus are AgentFluent's own error-handling vocabulary tripping `detect_is_error_from_text` when agents successfully read its source. It's a precise, testable, one-rule fix — and a fitting dogfood result: the tool that diagnoses agents got caught mis-diagnosing the agents that *build the tool*. That's exactly the eating-its-own-tail signal the dogfood ritual exists to surface, and it should land before the v0.11 cut.
+
+The next dogfood will be at v0.11.0. Candidates 1 (the PARAMETER_RETRY anchor) and 2 (the shared `retry_loop` disambiguation, which also unblocks #513) should land before then so they show up in the v0.11 changelog rather than as backfilled notes.

--- a/.claude/specs/analysis/2026-07-03-v10-dogfood/analyze.table.txt
+++ b/.claude/specs/analysis/2026-07-03-v10-dogfood/analyze.table.txt
@@ -1,0 +1,3022 @@
+               Token Usage               
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ Metric                ┃         Value ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ Input tokens          │     1,057,055 │
+│ Output tokens         │     9,735,867 │
+│ Cache creation tokens │    64,443,826 │
+│ Cache read tokens     │ 2,099,046,119 │
+│ Total tokens          │ 2,174,282,867 │
+│ Total cost (API rate) │      $1847.48 │
+│ Cache efficiency      │         97.0% │
+│ API calls             │          9419 │
+│ Model turns           │          9419 │
+│ Synthetic responses   │            40 │
+└───────────────────────┴───────────────┘
+                     Cost by Model (API rate)                      
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Model                     ┃ Origin   ┃        Tokens ┃     Cost ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ claude-haiku-4-5-20251001 │ subagent │    18,446,774 │    $4.06 │
+│ claude-opus-4-6           │ subagent │    74,474,075 │  $102.92 │
+│ claude-opus-4-7           │ parent   │ 1,557,226,222 │ $1205.65 │
+│ claude-opus-4-7           │ subagent │    83,152,517 │   $90.29 │
+│ claude-opus-4-8           │ parent   │   413,196,917 │  $393.26 │
+│ claude-opus-4-8           │ subagent │    24,180,759 │   $48.61 │
+│ claude-sonnet-4-6         │ subagent │     3,605,603 │    $2.67 │
+└───────────────────────────┴──────────┴───────────────┴──────────┘
+                       Tool Usage                       
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
+┃ Tool                            ┃ Calls ┃ % of Total ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
+│ Bash                            │  5457 │      51.2% │
+│ Edit                            │  1743 │      16.3% │
+│ Read                            │  1377 │      12.9% │
+│ TaskUpdate                      │   683 │       6.4% │
+│ Agent                           │   367 │       3.4% │
+│ TaskCreate                      │   361 │       3.4% │
+│ Write                           │   268 │       2.5% │
+│ AskUserQuestion                 │   117 │       1.1% │
+│ ToolSearch                      │   102 │       1.0% │
+│ mcp__github__create_issue       │    30 │       0.3% │
+│ Skill                           │    27 │       0.3% │
+│ mcp__github__add_issue_comment  │    27 │       0.3% │
+│ mcp__github__get_issue          │    27 │       0.3% │
+│ Grep                            │    22 │       0.2% │
+│ WebFetch                        │    15 │       0.1% │
+│ ScheduleWakeup                  │     8 │       0.1% │
+│ mcp__github__list_issues        │     6 │       0.1% │
+│ mcp__github__search_issues      │     6 │       0.1% │
+│ mcp__github__update_issue       │     6 │       0.1% │
+│ TaskList                        │     4 │       0.0% │
+│ WebSearch                       │     4 │       0.0% │
+│ ExitPlanMode                    │     2 │       0.0% │
+│ Monitor                         │     1 │       0.0% │
+│ TaskGet                         │     1 │       0.0% │
+│ TaskStop                        │     1 │       0.0% │
+│ mcp__github__get_file_contents  │     1 │       0.0% │
+│ mcp__github__get_pull_request   │     1 │       0.0% │
+│ mcp__github__list_pull_requests │     1 │       0.0% │
+│ mcp__ide__executeCode           │     1 │       0.0% │
+│                                 │       │            │
+│ Total                           │ 10666 │            │
+│ Unique tools                    │    29 │            │
+└─────────────────────────────────┴───────┴────────────┘
+                               Agent Invocations                                
+┏━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃               ┃       ┃           ┃           ┃           Avg ┃          Avg ┃
+┃ Agent Type    ┃ Count ┃ Avg Turns ┃    Tokens ┃   Tokens/Call ┃ Duration/Ca… ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ anthropic-re… │     4 │       7.3 │   169,699 │        42,424 │       146.9s │
+│               │       │           │           │               │      (256.3s │
+│               │       │           │           │               │       wall)† │
+│ architect     │    90 │      10.3 │ 4,965,157 │        55,168 │       105.8s │
+│               │       │           │           │               │      (173.9s │
+│               │       │           │           │               │       wall)† │
+│ candidate-pr… │     3 │       7.0 │   111,590 │        37,196 │      203.3s† │
+│ candidate-ve… │     1 │      33.0 │    77,237 │        77,237 │       365.6s │
+│               │       │           │           │               │     (1130.3s │
+│               │       │           │           │               │        wall) │
+│ claude-code-… │     8 │       7.5 │   271,827 │        33,978 │       65.9s† │
+│ (builtin)     │       │           │           │               │              │
+│ Explore       │    30 │      13.4 │ 1,576,544 │        52,551 │        80.4s │
+│ (builtin)     │       │           │           │               │      (118.7s │
+│               │       │           │           │               │        wall) │
+│ general-purp… │   189 │      10.2 │ 7,093,647 │        37,532 │       111.7s │
+│ (builtin)     │       │           │           │               │      (150.7s │
+│               │       │           │           │               │       wall)† │
+│ Plan          │     1 │      21.0 │    78,800 │        78,800 │       217.3s │
+│ (builtin)     │       │           │           │               │     (1080.1s │
+│               │       │           │           │               │        wall) │
+│ pm            │    41 │      15.8 │ 3,658,797 │        89,238 │       288.3s │
+│               │       │           │           │               │     (3239.9s │
+│               │       │           │           │               │       wall)† │
+│               │       │           │           │               │              │
+│ Total         │   367 │           │           │               │              │
+│ Agent token % │  0.8% │           │           │               │              │
+└───────────────┴───────┴───────────┴───────────┴───────────────┴──────────────┘
+† Active duration covers only the trace-linked invocations; the average and 
+active/wall split use that subset.
+API rate — pay-per-token equivalent. Subscription plans 
+(Pro/Max/Team/Enterprise) have fixed monthly cost independent of usage.
+                               Diagnostic Signals                               
+┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Agent              ┃ Type                 ┃ Severity ┃ Message               ┃
+┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
+│ anthropic-research │ error_pattern        │ warning  │ Agent                 │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ output contains 'not  │
+│                    │                      │          │ found'.               │
+│ pm                 │ token_outlier        │ warning  │ Agent 'pm' has 29,762 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 18.9×IQR above Q3 of  │
+│                    │                      │          │ 4,574.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38,454                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.9×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 41,648                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 5.5×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,264                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.9×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 31,296                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.7×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,305                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,194                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38,782                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 5.0×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 37,953                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.9×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,857                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.6×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24,338                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 33,048                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.0×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 33,425                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 4.1×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,830                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.0×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,802                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 3.0×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ general-purpose    │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 26,102                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 9,381.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 6,461                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 7,120                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 6,580                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 7,792                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.5×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 6,442                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 1.5×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ architect          │ token_outlier        │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 7,130                 │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 4,272.                │
+│ claude-code-guide  │ token_outlier        │ warning  │ Agent                 │
+│                    │                      │          │ 'claude-code-guide'   │
+│                    │                      │          │ has 9,705             │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 4,385.                │
+│ Explore            │ token_outlier        │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 11,578                │
+│                    │                      │          │ tokens/tool_use,      │
+│                    │                      │          │ 2.8×IQR above Q3 of   │
+│                    │                      │          │ 4,812.                │
+│ pm                 │ duration_outlier     │ warning  │ Agent 'pm' has        │
+│                    │                      │          │ 65.8s/tool_use,       │
+│                    │                      │          │ 5.6×IQR above Q3 of   │
+│                    │                      │          │ 14.6s.                │
+│ pm                 │ duration_outlier     │ warning  │ Agent 'pm' has        │
+│                    │                      │          │ 29.7s/tool_use,       │
+│                    │                      │          │ 1.7×IQR above Q3 of   │
+│                    │                      │          │ 14.6s.                │
+│ pm                 │ duration_outlier     │ warning  │ Agent 'pm' has        │
+│                    │                      │          │ 46.4s/tool_use,       │
+│                    │                      │          │ 3.5×IQR above Q3 of   │
+│                    │                      │          │ 14.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 21.9s/tool_use,       │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 37.9s/tool_use,       │
+│                    │                      │          │ 4.4×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 22.6s/tool_use,       │
+│                    │                      │          │ 1.7×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.6s/tool_use,       │
+│                    │                      │          │ 4.5×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.8s/tool_use,       │
+│                    │                      │          │ 4.6×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 25.4s/tool_use,       │
+│                    │                      │          │ 2.2×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 29.7s/tool_use,       │
+│                    │                      │          │ 3.0×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 24.1s/tool_use,       │
+│                    │                      │          │ 2.0×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 474.5s/tool_use,      │
+│                    │                      │          │ 80.6×IQR above Q3 of  │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 461.8s/tool_use,      │
+│                    │                      │          │ 78.3×IQR above Q3 of  │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 29.2s/tool_use,       │
+│                    │                      │          │ 2.9×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 38.7s/tool_use,       │
+│                    │                      │          │ 4.5×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 27.5s/tool_use,       │
+│                    │                      │          │ 2.6×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 21.8s/tool_use,       │
+│                    │                      │          │ 1.6×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ general-purpose    │ duration_outlier     │ warning  │ Agent                 │
+│                    │                      │          │ 'general-purpose' has │
+│                    │                      │          │ 34.0s/tool_use,       │
+│                    │                      │          │ 3.7×IQR above Q3 of   │
+│                    │                      │          │ 12.6s.                │
+│ architect          │ duration_outlier     │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 11.9s/tool_use,       │
+│                    │                      │          │ 1.9×IQR above Q3 of   │
+│                    │                      │          │ 6.5s.                 │
+│ architect          │ duration_outlier     │ warning  │ Agent 'architect' has │
+│                    │                      │          │ 16.1s/tool_use,       │
+│                    │                      │          │ 3.5×IQR above Q3 of   │
+│                    │                      │          │ 6.5s.                 │
+│ Explore            │ duration_outlier     │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 45.0s/tool_use,       │
+│                    │                      │          │ 24.8×IQR above Q3 of  │
+│                    │                      │          │ 4.3s.                 │
+│ Explore            │ duration_outlier     │ warning  │ Agent 'Explore' has   │
+│                    │                      │          │ 36.6s/tool_use,       │
+│                    │                      │          │ 19.7×IQR above Q3 of  │
+│                    │                      │          │ 4.3s.                 │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 --- 2 name:  │
+│                    │                      │          │ release-loop 3        │
+│                    │                      │          │ description: Run one  │
+│                    │                      │          │ routed iteration of   │
+│                    │                      │          │ the supervised dev    │
+│                    │                      │          │ loop over a backlog   │
+│                    │                      │          │ (milestone/'.         │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Glob' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ 'src/agentfluent/tra… │
+│                    │                      │          │ agentfluent.diagnost… │
+│                    │                      │          │ import                │
+│                    │                      │          │ detect_is_error_from… │
+│                    │                      │          │ src/agentfluen'.      │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ claude-code-guide  │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'claude-code-guide'   │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ permission_failure   │ critical │ Subagent 'pm' was     │
+│                    │                      │          │ denied access to tool │
+│                    │                      │          │ 'WebFetch'            │
+│                    │                      │          │ ('blocked').          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 3   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Detect    │
+│                    │                      │          │ retry sequences       │
+│                    │                      │          │ within a subagent's   │
+│                    │                      │          │ tool_calls. 2 3 A     │
+│                    │                      │          │ retry sequence is two │
+│                    │                      │          │ or more consecutive   │
+│                    │                      │          │ tool calls ('.        │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read'   │
+│                    │                      │          │ 10 times with         │
+│                    │                      │          │ different parameter   │
+│                    │                      │          │ shapes before         │
+│                    │                      │          │ succeeding. First     │
+│                    │                      │          │ attempt failed with:  │
+│                    │                      │          │ '645 class            │
+│                    │                      │          │ ParameterRetryRule:   │
+│                    │                      │          │ 646                   │
+│                    │                      │          │ """PARAMETER_RETRY -> │
+│                    │                      │          │ recommend             │
+│                    │                      │          │ `input_examples` on   │
+│                    │                      │          │ the tool definition.  │
+│                    │                      │          │ 647 648 The a'.       │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'EISDIR:        │
+│                    │                      │          │ illegal operation on  │
+│                    │                      │          │ a directory, read     │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 3 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ tool_error_sequence  │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ Explore            │ parameter_retry      │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 7 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '855            │
+│                    │                      │          │ **Reference:** Issue  │
+│                    │                      │          │ #333; calibration     │
+│                    │                      │          │ data at               │
+│                    │                      │          │ `.claude/specs/analy… │
+│                    │                      │          │ architect revi'.      │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 6 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 5 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 6 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '76 def         │
+│                    │                      │          │ compute_error_rate(i… │
+│                    │                      │          │ AgentInvocation) ->   │
+│                    │                      │          │ float: 77 """Observed │
+│                    │                      │          │ error rate for a      │
+│                    │                      │          │ single invocation. 78 │
+│                    │                      │          │ 79 Trace'.            │
+│ architect          │ tool_error_sequence  │ critical │ Subagent 'architect'  │
+│                    │                      │          │ had 5 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 5 times.  │
+│ anthropic-research │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'WebFetch' 3 times.   │
+│ anthropic-research │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'anthropic-research'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-verifier │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Behavior  │
+│                    │                      │          │ signal extraction     │
+│                    │                      │          │ from agent            │
+│                    │                      │          │ invocations. 2 3      │
+│                    │                      │          │ Detects error         │
+│                    │                      │          │ patterns in output    │
+│                    │                      │          │ text, token           │
+│                    │                      │          │ consumption out'.     │
+│ candidate-verifier │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ retried tool 'Edit' 8 │
+│                    │                      │          │ times.                │
+│ candidate-verifier │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ had 3 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-verifier │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'candidate-verifier'  │
+│                    │                      │          │ had 6 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-promoter │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ retried tool 'Edit' 3 │
+│                    │                      │          │ times.                │
+│ candidate-promoter │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ candidate-promoter │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'candidate-promoter'  │
+│                    │                      │          │ had 4 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Grep' 4 times.  │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes.     │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1              │
+│                    │                      │          │ """Diagnostics        │
+│                    │                      │          │ orchestration. 2 3    │
+│                    │                      │          │ Owns the              │
+│                    │                      │          │ `run_diagnostics`     │
+│                    │                      │          │ pipeline: extracts    │
+│                    │                      │          │ metadata-level and 4  │
+│                    │                      │          │ trace-level signa'.   │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1              │
+│                    │                      │          │ """Diagnostics        │
+│                    │                      │          │ orchestration. 2 3    │
+│                    │                      │          │ Owns the              │
+│                    │                      │          │ `run_diagnostics`     │
+│                    │                      │          │ pipeline: extracts    │
+│                    │                      │          │ metadata-level and 4  │
+│                    │                      │          │ trace-level signa'.   │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__add_is… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Glob' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 4 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ tool_error_sequence  │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ had 2 consecutive     │
+│                    │                      │          │ tool errors.          │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File does not  │
+│                    │                      │          │ exist. Note: your     │
+│                    │                      │          │ current working       │
+│                    │                      │          │ directory is          │
+│                    │                      │          │ /home/fdpearce/Docum… │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 6 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File content   │
+│                    │                      │          │ (26154 tokens)        │
+│                    │                      │          │ exceeds maximum       │
+│                    │                      │          │ allowed tokens        │
+│                    │                      │          │ (25000). Use offset   │
+│                    │                      │          │ and limit parameters  │
+│                    │                      │          │ to read specific      │
+│                    │                      │          │ por'.                 │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The required          │
+│                    │                      │          │ parameter `file_path` │
+│                    │                      │          │ is miss'.             │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit'   │
+│                    │                      │          │ 10 times.             │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Grep' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: '1 """Behavior  │
+│                    │                      │          │ signal extraction     │
+│                    │                      │          │ from agent            │
+│                    │                      │          │ invocations. 2 3      │
+│                    │                      │          │ Detects error         │
+│                    │                      │          │ patterns in output    │
+│                    │                      │          │ text, token           │
+│                    │                      │          │ consumption out'.     │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 4 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 5 times.              │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__update… │
+│                    │                      │          │ 7 times.              │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ pm                 │ parameter_retry      │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 8 times   │
+│                    │                      │          │ with different        │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'EISDIR:        │
+│                    │                      │          │ illegal operation on  │
+│                    │                      │          │ a directory, read     │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 7 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 3 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool          │
+│                    │                      │          │ 'mcp__github__search… │
+│                    │                      │          │ 4 times.              │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 6 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ Explore            │ retry_loop           │ warning  │ Subagent 'Explore'    │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ Plan               │ retry_loop           │ warning  │ Subagent 'Plan'       │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ Plan               │ retry_loop           │ warning  │ Subagent 'Plan'       │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ architect          │ parameter_retry      │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 8 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with: 'File does not  │
+│                    │                      │          │ exist. Note: your     │
+│                    │                      │          │ current working       │
+│                    │                      │          │ directory is          │
+│                    │                      │          │ /home/fdpearce/Docum… │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool                  │
+│                    │                      │          │ 'mcp__github__get_is… │
+│                    │                      │          │ 3 times.              │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 7 │
+│                    │                      │          │ times.                │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 5 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ parameter_retry      │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 2 │
+│                    │                      │          │ times with different  │
+│                    │                      │          │ parameter shapes      │
+│                    │                      │          │ before succeeding.    │
+│                    │                      │          │ First attempt failed  │
+│                    │                      │          │ with:                 │
+│                    │                      │          │ '<tool_use_error>Inp… │
+│                    │                      │          │ Read failed due to    │
+│                    │                      │          │ the following issue:  │
+│                    │                      │          │ The parameter         │
+│                    │                      │          │ `offset` type is      │
+│                    │                      │          │ expected as'.         │
+│ architect          │ retry_loop           │ warning  │ Subagent 'architect'  │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ pm                 │ tool_error_sequence  │ warning  │ Subagent 'pm' had 2   │
+│                    │                      │          │ consecutive tool      │
+│                    │                      │          │ errors.               │
+│ pm                 │ retry_loop           │ warning  │ Subagent 'pm' retried │
+│                    │                      │          │ tool 'Read' 3 times.  │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Bash' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 4 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 3 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 4 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Edit' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ retry_loop           │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ retried tool 'Read' 3 │
+│                    │                      │          │ times.                │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ critical │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 7 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_error_sequence  │ warning  │ Subagent              │
+│                    │                      │          │ 'general-purpose' had │
+│                    │                      │          │ 2 consecutive tool    │
+│                    │                      │          │ errors.               │
+│ general-purpose    │ tool_orchestration_… │ info     │ Agent                 │
+│                    │                      │          │ 'general-purpose'     │
+│                    │                      │          │ made 1198 tool calls  │
+│                    │                      │          │ consuming 3,967,028   │
+│                    │                      │          │ tokens across 66      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,311 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ pm                 │ tool_orchestration_… │ info     │ Agent 'pm' made 972   │
+│                    │                      │          │ tool calls consuming  │
+│                    │                      │          │ 3,560,564 tokens      │
+│                    │                      │          │ across 34             │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,663 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ architect          │ tool_orchestration_… │ info     │ Agent 'architect'     │
+│                    │                      │          │ made 1336 tool calls  │
+│                    │                      │          │ consuming 4,654,985   │
+│                    │                      │          │ tokens across 64      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,484 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ Explore            │ tool_orchestration_… │ info     │ Agent 'Explore' made  │
+│                    │                      │          │ 389 tool calls        │
+│                    │                      │          │ consuming 1,177,665   │
+│                    │                      │          │ tokens across 21      │
+│                    │                      │          │ invocations. Average  │
+│                    │                      │          │ token cost per tool   │
+│                    │                      │          │ call: 3,027 tokens.   │
+│                    │                      │          │ Low-confidence        │
+│                    │                      │          │ heuristic: this       │
+│                    │                      │          │ metadata-only proxy   │
+│                    │                      │          │ cannot yet            │
+│                    │                      │          │ distinguish genuine   │
+│                    │                      │          │ orchestration chains  │
+│                    │                      │          │ from token-heavy      │
+│                    │                      │          │ reasoning agents, so  │
+│                    │                      │          │ verify against the    │
+│                    │                      │          │ agent's trace before  │
+│                    │                      │          │ acting on this.       │
+│ marketer           │ unused_agent         │ info     │ Agent 'marketer' is   │
+│                    │                      │          │ defined in            │
+│                    │                      │          │ /home/fdpearce/.clau… │
+│                    │                      │          │ but has 0 invocations │
+│                    │                      │          │ across 70 analyzed    │
+│                    │                      │          │ sessions.             │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: You    │
+│                    │                      │          │ are a senior security │
+│                    │                      │          │ engineer conducting a │
+│                    │                      │          │ focused security      │
+│                    │                      │          │ review of the changes │
+│                    │                      │          │ on this branch.       │
+│                    │                      │          │                       │
+│                    │                      │          │ GIT STATUS:           │
+│                    │                      │          │                       │
+│                    │                      │          │ ```                   │
+│                    │                      │          │ On branch feature/5…  │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: have   │
+│                    │                      │          │ the architect give a  │
+│                    │                      │          │ quick review just to  │
+│                    │                      │          │ make sure there are   │
+│                    │                      │          │ no edge cases, etc    │
+│                    │                      │          │ we're missing in the  │
+│                    │                      │          │ plan                  │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: I have │
+│                    │                      │          │ a question about      │
+│                    │                      │          │ token use aware       │
+│                    │                      │          │ agents. It seems to   │
+│                    │                      │          │ me this is one of the │
+│                    │                      │          │ problems with current │
+│                    │                      │          │ agent implementations │
+│                    │                      │          │ across the boa…       │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: wait   │
+│                    │                      │          │ does api calls        │
+│                    │                      │          │ include synthetic     │
+│                    │                      │          │ messages as the       │
+│                    │                      │          │ comment you just      │
+│                    │                      │          │ showed said? I        │
+│                    │                      │          │ thought both model    │
+│                    │                      │          │ turns and api calls   │
+│                    │                      │          │ excluded synthe…      │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread:        │
+│                    │                      │          │ `/simplify → 4        │
+│                    │                      │          │ cleanup agents in     │
+│                    │                      │          │ parallel → apply the  │
+│                    │                      │          │ fixes`                │
+│                    │                      │          │                       │
+│                    │                      │          │ You are improving the │
+│                    │                      │          │ quality of the        │
+│                    │                      │          │ changed code, not     │
+│                    │                      │          │ hunting for bugs.     │
+│                    │                      │          │ Revie…                │
+│ (global)           │ user_correction      │ warning  │ User correction in    │
+│                    │                      │          │ parent thread: sorry, │
+│                    │                      │          │ I meant the architect │
+│                    │                      │          │ agent should review   │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 79 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 66 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 44 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 13 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 16 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 13 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 65 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 53 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 21 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 22 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 46 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 15 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 21 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/.cla… │
+│                    │                      │          │ edited 36 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 30 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 14 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 32 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 25 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 15 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 27 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 53 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 17 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 14 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 45 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 49 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 44 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 20 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 18 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 22 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 16 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 38 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 35 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 36 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 23 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 33 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 13 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/Docu… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ (global)           │ file_rework          │ warning  │ File                  │
+│                    │                      │          │ '/home/fdpearce/.cla… │
+│                    │                      │          │ edited 12 times in    │
+│                    │                      │          │ this session          │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 6            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 1            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 3            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 5            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 4            │
+│                    │                      │          │ finding-keyword(s)    │
+│ architect          │ reviewer_caught      │ info     │ `architect` review    │
+│                    │                      │          │ surfaced 2            │
+│                    │                      │          │ finding-keyword(s)    │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 13e567c followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat f74c773 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 155cb1a followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 3a81554 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat d2c040d followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 942578e followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a274b3f followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a37c172 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 3147314 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c742b2b followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 0d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat b1b63a5 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 985d1a4 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 2fe7f65 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat a9502fb followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 0ccc759 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat d4ba779 followed │
+│                    │                      │          │ by 3 fixes on shared  │
+│                    │                      │          │ file(s) within 6d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat c5fdc80 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 6d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat b0cf957 followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat ee0d98c followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat c73f94b followed │
+│                    │                      │          │ by 4 fixes on shared  │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat ef80c4f followed │
+│                    │                      │          │ by 3 fixes on shared  │
+│                    │                      │          │ file(s) within 0d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat adfd205 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat baf81c4 followed │
+│                    │                      │          │ by 2 fixes on shared  │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c680db0 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 158dfb8 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat c08c873 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat b516e53 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 5d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 75238df followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 2d     │
+│ (global)           │ feat_fix_proximity   │ warning  │ feat 204b759 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 4d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat 2b5737e followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 3d     │
+│ (global)           │ feat_fix_proximity   │ info     │ feat b042976 followed │
+│                    │                      │          │ by 1 fix on shared    │
+│                    │                      │          │ file(s) within 1d     │
+└────────────────────┴──────────────────────┴──────────┴───────────────────────┘
+
+Top 5 priority fixes (see Recommendations table below for detail):
+ #1  critical  general-purpose     16×  target: prompt  [speed] 
+ #2  critical  architect            4×  target: prompt  [speed] 
+ #3  critical  candidate-verifier   2×  target: prompt  [speed] 
+ #4  critical  candidate-promoter   2×  target: prompt  [speed] 
+ #5  critical  pm                   1×  target: tools   [speed] 
+                                Recommendations                                 
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃  # ┃ Agent              ┃ Target      ┃ Severity ┃ Count ┃ Recommendation    ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│  1 │ general-purpose    │ prompt      │ critical │    16 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│  2 │ architect          │ prompt      │ critical │     4 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│  3 │ candidate-verifier │ prompt      │ critical │     2 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│  4 │ candidate-promoter │ prompt      │ critical │     2 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the agent's       │
+│    │                    │             │          │       │ prompt so it      │
+│    │                    │             │          │       │ recovers from     │
+│    │                    │             │          │       │ repeated tool     │
+│    │                    │             │          │       │ failures.         │
+│  5 │ pm                 │ tools       │ critical │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'pm' was denied   │
+│    │                    │             │          │       │ access to tool    │
+│    │                    │             │          │       │ 'WebFetch'        │
+│    │                    │             │          │       │ ('blocked'). The  │
+│    │                    │             │          │       │ subagent was      │
+│    │                    │             │          │       │ denied access to  │
+│    │                    │             │          │       │ a tool it         │
+│    │                    │             │          │       │ attempted to      │
+│    │                    │             │          │       │ call. 'WebFetch'  │
+│    │                    │             │          │       │ is listed in      │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ but was still     │
+│    │                    │             │          │       │ denied -- check   │
+│    │                    │             │          │       │ disallowed_tools  │
+│    │                    │             │          │       │ and any hooks     │
+│    │                    │             │          │       │ that might block  │
+│    │                    │             │          │       │ this tool.        │
+│  6 │ (global)           │ subagent    │ warning  │    39 │ [quality]         │
+│    │                    │             │          │       │ file_rework:      │
+│    │                    │             │          │       │ Consider an       │
+│    │                    │             │          │       │ architect         │
+│    │                    │             │          │       │ subagent for      │
+│    │                    │             │          │       │ design review     │
+│    │                    │             │          │       │ before starting   │
+│    │                    │             │          │       │ implementation in │
+│    │                    │             │          │       │ this area, or a   │
+│    │                    │             │          │       │ tester subagent   │
+│    │                    │             │          │       │ to verify         │
+│    │                    │             │          │       │ completion        │
+│    │                    │             │          │       │ claims.           │
+│  7 │ (global)           │ subagent    │ warning  │    31 │ [quality]         │
+│    │                    │             │          │       │ feat_fix_proximi… │
+│    │                    │             │          │       │ Consider routing  │
+│    │                    │             │          │       │ similar feature   │
+│    │                    │             │          │       │ work through an   │
+│    │                    │             │          │       │ architect or      │
+│    │                    │             │          │       │ code-reviewer     │
+│    │                    │             │          │       │ subagent before   │
+│    │                    │             │          │       │ commit.           │
+│  8 │ general-purpose    │ prompt      │ warning  │    15 │ [cost]            │
+│    │                    │             │          │       │ token_outlier     │
+│    │                    │             │          │       │ (2.5×–5.5×IQR     │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│  9 │ general-purpose    │ prompt      │ warning  │    15 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.6×–80.6×IQR    │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 10 │ architect          │ tools       │ warning  │     8 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ No action on the  │
+│    │                    │             │          │       │ built-in 'Read'   │
+│    │                    │             │          │       │ itself. For any   │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool showing the  │
+│    │                    │             │          │       │ same pattern, add │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to its      │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Observed          │
+│    │                    │             │          │       │ successful call   │
+│    │                    │             │          │       │ shape             │
+│    │                    │             │          │       │ (informational):  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "offset": 300,  │
+│    │                    │             │          │       │   "limit": 180    │
+│    │                    │             │          │       │ }                 │
+│ 11 │ general-purpose    │ tools       │ warning  │     8 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ No action on the  │
+│    │                    │             │          │       │ built-in 'Read'   │
+│    │                    │             │          │       │ itself. For any   │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool showing the  │
+│    │                    │             │          │       │ same pattern, add │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to its      │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Observed          │
+│    │                    │             │          │       │ successful call   │
+│    │                    │             │          │       │ shape             │
+│    │                    │             │          │       │ (informational):  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "offset": 170,  │
+│    │                    │             │          │       │   "limit": 60     │
+│    │                    │             │          │       │ }                 │
+│ 12 │ (global)           │ subagent    │ warning  │     6 │ [quality]         │
+│    │                    │             │          │       │ user_correction:  │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ delegating to a   │
+│    │                    │             │          │       │ review-style      │
+│    │                    │             │          │       │ subagent          │
+│    │                    │             │          │       │ (architect,       │
+│    │                    │             │          │       │ code-reviewer)    │
+│    │                    │             │          │       │ for design checks │
+│    │                    │             │          │       │ before            │
+│    │                    │             │          │       │ implementation.   │
+│ 13 │ pm                 │ prompt      │ warning  │     5 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Add fallback      │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│ 14 │ Explore            │ tools       │ warning  │     5 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ No action on the  │
+│    │                    │             │          │       │ built-in 'Read'   │
+│    │                    │             │          │       │ itself. For any   │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool showing the  │
+│    │                    │             │          │       │ same pattern, add │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to its      │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Observed          │
+│    │                    │             │          │       │ successful call   │
+│    │                    │             │          │       │ shape             │
+│    │                    │             │          │       │ (informational):  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/tmp/simplify_4… │
+│    │                    │             │          │       │   "offset": 219,  │
+│    │                    │             │          │       │   "limit": 60     │
+│    │                    │             │          │       │ }                 │
+│ 15 │ architect          │ prompt      │ warning  │     6 │ [cost]            │
+│    │                    │             │          │       │ token_outlier     │
+│    │                    │             │          │       │ (1.5×–2.5×IQR     │
+│    │                    │             │          │       │ above Q3): Add    │
+│    │                    │             │          │       │ more specific     │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ to reduce         │
+│    │                    │             │          │       │ exploration.      │
+│ 16 │ Explore            │ prompt      │ warning  │     3 │ [speed]           │
+│    │                    │             │          │       │ tool_error_seque… │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 17 │ pm                 │ tools       │ warning  │     3 │ [speed]           │
+│    │                    │             │          │       │ parameter_retry:  │
+│    │                    │             │          │       │ No action on the  │
+│    │                    │             │          │       │ built-in 'Read'   │
+│    │                    │             │          │       │ itself. For any   │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool showing the  │
+│    │                    │             │          │       │ same pattern, add │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to its      │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Observed          │
+│    │                    │             │          │       │ successful call   │
+│    │                    │             │          │       │ shape             │
+│    │                    │             │          │       │ (informational):  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "offset": 0,    │
+│    │                    │             │          │       │   "limit": 605    │
+│    │                    │             │          │       │ }                 │
+│ 18 │ pm                 │ hooks       │ warning  │     3 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.7×–5.6×IQR     │
+│    │                    │             │          │       │ above Q3): Add a  │
+│    │                    │             │          │       │ PostToolUse hook  │
+│    │                    │             │          │       │ that logs or      │
+│    │                    │             │          │       │ gates on          │
+│    │                    │             │          │       │ `duration_ms` to  │
+│    │                    │             │          │       │ surface slow tool │
+│    │                    │             │          │       │ calls before they │
+│    │                    │             │          │       │ compound. Note:   │
+│    │                    │             │          │       │ project-level     │
+│    │                    │             │          │       │ hooks in          │
+│    │                    │             │          │       │ `.claude/setting… │
+│    │                    │             │          │       │ are not currently │
+│    │                    │             │          │       │ inspected.        │
+│ 19 │ claude-code-guide  │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'claude-code-gui… │
+│    │                    │             │          │       │ had 2 consecutive │
+│    │                    │             │          │       │ tool errors.      │
+│    │                    │             │          │       │ Multiple          │
+│    │                    │             │          │       │ consecutive tool  │
+│    │                    │             │          │       │ errors suggest    │
+│    │                    │             │          │       │ the agent lacks   │
+│    │                    │             │          │       │ fallback          │
+│    │                    │             │          │       │ instructions for  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails. Built-in   │
+│    │                    │             │          │       │ agent — prompt is │
+│    │                    │             │          │       │ not               │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 20 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'WebFetch' 3      │
+│    │                    │             │          │       │ times. Repeated   │
+│    │                    │             │          │       │ retries on the    │
+│    │                    │             │          │       │ same tool         │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. Add │
+│    │                    │             │          │       │ explicit retry /  │
+│    │                    │             │          │       │ fallback guidance │
+│    │                    │             │          │       │ to the prompt in  │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│ 21 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ had 2 consecutive │
+│    │                    │             │          │       │ tool errors.      │
+│    │                    │             │          │       │ Multiple          │
+│    │                    │             │          │       │ consecutive tool  │
+│    │                    │             │          │       │ errors suggest    │
+│    │                    │             │          │       │ the agent lacks   │
+│    │                    │             │          │       │ fallback          │
+│    │                    │             │          │       │ instructions for  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails. Add        │
+│    │                    │             │          │       │ fallback          │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ so the agent      │
+│    │                    │             │          │       │ knows what to do  │
+│    │                    │             │          │       │ when a tool call  │
+│    │                    │             │          │       │ fails repeatedly. │
+│ 22 │ candidate-verifier │ tools       │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-verif… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Read' 3 times    │
+│    │                    │             │          │       │ with different    │
+│    │                    │             │          │       │ parameter shapes. │
+│    │                    │             │          │       │ First attempt     │
+│    │                    │             │          │       │ failed with: '1   │
+│    │                    │             │          │       │ """Behavior       │
+│    │                    │             │          │       │ signal extraction │
+│    │                    │             │          │       │ from agent        │
+│    │                    │             │          │       │ invocations. 2 3  │
+│    │                    │             │          │       │ Detects error     │
+│    │                    │             │          │       │ patterns in       │
+│    │                    │             │          │       │ output text,      │
+│    │                    │             │          │       │ token consumption │
+│    │                    │             │          │       │ out'. 'Read' is a │
+│    │                    │             │          │       │ built-in Claude   │
+│    │                    │             │          │       │ Code tool, so its │
+│    │                    │             │          │       │ definition cannot │
+│    │                    │             │          │       │ be edited to add  │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array -- this     │
+│    │                    │             │          │       │ finding is        │
+│    │                    │             │          │       │ informational,    │
+│    │                    │             │          │       │ not directly      │
+│    │                    │             │          │       │ user-tunable. The │
+│    │                    │             │          │       │ retry pattern     │
+│    │                    │             │          │       │ still indicates   │
+│    │                    │             │          │       │ input-format      │
+│    │                    │             │          │       │ guessing; the fix │
+│    │                    │             │          │       │ applies only if   │
+│    │                    │             │          │       │ it recurs on a    │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool you own. No  │
+│    │                    │             │          │       │ action on the     │
+│    │                    │             │          │       │ built-in 'Read'   │
+│    │                    │             │          │       │ itself. For any   │
+│    │                    │             │          │       │ custom SDK/MCP    │
+│    │                    │             │          │       │ tool showing the  │
+│    │                    │             │          │       │ same pattern, add │
+│    │                    │             │          │       │ an                │
+│    │                    │             │          │       │ `input_examples`  │
+│    │                    │             │          │       │ array to its      │
+│    │                    │             │          │       │ definition        │
+│    │                    │             │          │       │ showing the       │
+│    │                    │             │          │       │ expected          │
+│    │                    │             │          │       │ parameter shape.  │
+│    │                    │             │          │       │ Observed          │
+│    │                    │             │          │       │ successful call   │
+│    │                    │             │          │       │ shape             │
+│    │                    │             │          │       │ (informational):  │
+│    │                    │             │          │       │ {                 │
+│    │                    │             │          │       │   "file_path":    │
+│    │                    │             │          │       │ "/home/fdpearce/… │
+│    │                    │             │          │       │   "limit": 100    │
+│    │                    │             │          │       │ }                 │
+│ 23 │ candidate-verifier │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-verif… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Edit' 8 times.   │
+│    │                    │             │          │       │ Repeated retries  │
+│    │                    │             │          │       │ on the same tool  │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. The │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 24 │ candidate-promoter │ prompt      │ warning  │     1 │ [speed] Subagent  │
+│    │                    │             │          │       │ 'candidate-promo… │
+│    │                    │             │          │       │ retried tool      │
+│    │                    │             │          │       │ 'Edit' 3 times.   │
+│    │                    │             │          │       │ Repeated retries  │
+│    │                    │             │          │       │ on the same tool  │
+│    │                    │             │          │       │ indicate the      │
+│    │                    │             │          │       │ agent lacks       │
+│    │                    │             │          │       │ recovery guidance │
+│    │                    │             │          │       │ for failures. Add │
+│    │                    │             │          │       │ explicit retry /  │
+│    │                    │             │          │       │ fallback guidance │
+│    │                    │             │          │       │ to the agent's    │
+│    │                    │             │          │       │ prompt body.      │
+│ 25 │ architect          │ hooks       │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (1.9×–3.5×IQR     │
+│    │                    │             │          │       │ above Q3): Add a  │
+│    │                    │             │          │       │ PostToolUse hook  │
+│    │                    │             │          │       │ that logs or      │
+│    │                    │             │          │       │ gates on          │
+│    │                    │             │          │       │ `duration_ms` to  │
+│    │                    │             │          │       │ surface slow tool │
+│    │                    │             │          │       │ calls before they │
+│    │                    │             │          │       │ compound. Note:   │
+│    │                    │             │          │       │ project-level     │
+│    │                    │             │          │       │ hooks in          │
+│    │                    │             │          │       │ `.claude/setting… │
+│    │                    │             │          │       │ are not currently │
+│    │                    │             │          │       │ inspected.        │
+│ 26 │ Explore            │ prompt      │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ duration_outlier  │
+│    │                    │             │          │       │ (19.7×–24.9×IQR   │
+│    │                    │             │          │       │ above Q3):        │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 27 │ anthropic-research │ prompt      │ warning  │     1 │ [speed] Agent     │
+│    │                    │             │          │       │ 'anthropic-resea… │
+│    │                    │             │          │       │ output contains   │
+│    │                    │             │          │       │ 'not found'.      │
+│    │                    │             │          │       │ Repeated errors   │
+│    │                    │             │          │       │ suggest the agent │
+│    │                    │             │          │       │ lacks error       │
+│    │                    │             │          │       │ handling          │
+│    │                    │             │          │       │ guidance. Add     │
+│    │                    │             │          │       │ error handling    │
+│    │                    │             │          │       │ guidance to the   │
+│    │                    │             │          │       │ prompt body in    │
+│    │                    │             │          │       │ ~/Documents/Proj… │
+│ 28 │ pm                 │ prompt      │ warning  │     1 │ [cost] Agent 'pm' │
+│    │                    │             │          │       │ has 29,762        │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 18.9×IQR above Q3 │
+│    │                    │             │          │       │ of 4,574. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Add more │
+│    │                    │             │          │       │ specific          │
+│    │                    │             │          │       │ instructions to   │
+│    │                    │             │          │       │ the prompt in     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ to reduce         │
+│    │                    │             │          │       │ exploration.      │
+│ 29 │ claude-code-guide  │ prompt      │ warning  │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'claude-code-gui… │
+│    │                    │             │          │       │ has 9,705         │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 2.0×IQR above Q3  │
+│    │                    │             │          │       │ of 4,385. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Built-in │
+│    │                    │             │          │       │ agent — prompt is │
+│    │                    │             │          │       │ not               │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 30 │ Explore            │ prompt      │ warning  │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'Explore' has     │
+│    │                    │             │          │       │ 11,578            │
+│    │                    │             │          │       │ tokens/tool_use,  │
+│    │                    │             │          │       │ 2.8×IQR above Q3  │
+│    │                    │             │          │       │ of 4,812. High    │
+│    │                    │             │          │       │ token usage       │
+│    │                    │             │          │       │ suggests the      │
+│    │                    │             │          │       │ agent is          │
+│    │                    │             │          │       │ exploring         │
+│    │                    │             │          │       │ broadly. Built-in │
+│    │                    │             │          │       │ agent — prompt is │
+│    │                    │             │          │       │ not               │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Consider: (a) a   │
+│    │                    │             │          │       │ custom wrapper    │
+│    │                    │             │          │       │ subagent that     │
+│    │                    │             │          │       │ narrows the task  │
+│    │                    │             │          │       │ scope, (b)        │
+│    │                    │             │          │       │ tightening the    │
+│    │                    │             │          │       │ delegation prompt │
+│    │                    │             │          │       │ passed to this    │
+│    │                    │             │          │       │ agent, or (c)     │
+│    │                    │             │          │       │ rerouting this    │
+│    │                    │             │          │       │ task to a         │
+│    │                    │             │          │       │ different agent.  │
+│ 31 │ architect          │ subagent    │ info     │    69 │ [quality]         │
+│    │                    │             │          │       │ reviewer_caught:  │
+│    │                    │             │          │       │ No action needed: │
+│    │                    │             │          │       │ this rate sits in │
+│    │                    │             │          │       │ the healthy band  │
+│    │                    │             │          │       │ (25%-75%).        │
+│    │                    │             │          │       │ Investigate only  │
+│    │                    │             │          │       │ if it falls below │
+│    │                    │             │          │       │ that band.        │
+│ 32 │ pm                 │ prompt      │ warning  │    28 │ [speed]           │
+│    │                    │             │          │       │ retry_loop: The   │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 33 │ general-purpose    │ prompt      │ warning  │    68 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+│ 34 │ Explore            │ prompt      │ warning  │    19 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+│ 35 │ general-purpose    │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'general-purpose' │
+│    │                    │             │          │       │ made 1198 tool    │
+│    │                    │             │          │       │ calls consuming   │
+│    │                    │             │          │       │ 3,967,028 tokens  │
+│    │                    │             │          │       │ across 66         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,311       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ tool list is not  │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Route this task   │
+│    │                    │             │          │       │ to a custom       │
+│    │                    │             │          │       │ subagent with     │
+│    │                    │             │          │       │ explicit tool     │
+│    │                    │             │          │       │ grants, or        │
+│    │                    │             │          │       │ confirm the       │
+│    │                    │             │          │       │ built-in agent's  │
+│    │                    │             │          │       │ fixed tool set is │
+│    │                    │             │          │       │ actually          │
+│    │                    │             │          │       │ required.         │
+│ 36 │ pm                 │ tools       │ info     │     1 │ [cost] Agent 'pm' │
+│    │                    │             │          │       │ made 972 tool     │
+│    │                    │             │          │       │ calls consuming   │
+│    │                    │             │          │       │ 3,560,564 tokens  │
+│    │                    │             │          │       │ across 34         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,663       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ migrating the     │
+│    │                    │             │          │       │ tools this agent  │
+│    │                    │             │          │       │ calls to          │
+│    │                    │             │          │       │ `allowed_callers: │
+│    │                    │             │          │       │ ["code_execution… │
+│    │                    │             │          │       │ so intermediate   │
+│    │                    │             │          │       │ results are       │
+│    │                    │             │          │       │ processed in the  │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ sandbox           │
+│    │                    │             │          │       │ (estimated        │
+│    │                    │             │          │       │ savings:          │
+│    │                    │             │          │       │ ~1,317,408 tokens │
+│    │                    │             │          │       │ at the 37%        │
+│    │                    │             │          │       │ benchmark) — edit │
+│    │                    │             │          │       │ the tool          │
+│    │                    │             │          │       │ definitions       │
+│    │                    │             │          │       │ referenced by     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 37 │ architect          │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'architect' made  │
+│    │                    │             │          │       │ 1336 tool calls   │
+│    │                    │             │          │       │ consuming         │
+│    │                    │             │          │       │ 4,654,985 tokens  │
+│    │                    │             │          │       │ across 64         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,484       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ migrating the     │
+│    │                    │             │          │       │ tools this agent  │
+│    │                    │             │          │       │ calls to          │
+│    │                    │             │          │       │ `allowed_callers: │
+│    │                    │             │          │       │ ["code_execution… │
+│    │                    │             │          │       │ so intermediate   │
+│    │                    │             │          │       │ results are       │
+│    │                    │             │          │       │ processed in the  │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ sandbox           │
+│    │                    │             │          │       │ (estimated        │
+│    │                    │             │          │       │ savings:          │
+│    │                    │             │          │       │ ~1,722,344 tokens │
+│    │                    │             │          │       │ at the 37%        │
+│    │                    │             │          │       │ benchmark) — edit │
+│    │                    │             │          │       │ the tool          │
+│    │                    │             │          │       │ definitions       │
+│    │                    │             │          │       │ referenced by     │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 38 │ Explore            │ tools       │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'Explore' made    │
+│    │                    │             │          │       │ 389 tool calls    │
+│    │                    │             │          │       │ consuming         │
+│    │                    │             │          │       │ 1,177,665 tokens  │
+│    │                    │             │          │       │ across 21         │
+│    │                    │             │          │       │ invocations.      │
+│    │                    │             │          │       │ Average token     │
+│    │                    │             │          │       │ cost per tool     │
+│    │                    │             │          │       │ call: 3,027       │
+│    │                    │             │          │       │ tokens.           │
+│    │                    │             │          │       │ Low-confidence    │
+│    │                    │             │          │       │ heuristic: this   │
+│    │                    │             │          │       │ metadata-only     │
+│    │                    │             │          │       │ proxy cannot yet  │
+│    │                    │             │          │       │ distinguish       │
+│    │                    │             │          │       │ genuine           │
+│    │                    │             │          │       │ orchestration     │
+│    │                    │             │          │       │ chains from       │
+│    │                    │             │          │       │ token-heavy       │
+│    │                    │             │          │       │ reasoning agents, │
+│    │                    │             │          │       │ so verify against │
+│    │                    │             │          │       │ the agent's trace │
+│    │                    │             │          │       │ before acting on  │
+│    │                    │             │          │       │ this. Sequential  │
+│    │                    │             │          │       │ tool-call chains  │
+│    │                    │             │          │       │ with large        │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ payloads inflate  │
+│    │                    │             │          │       │ context-window    │
+│    │                    │             │          │       │ usage.            │
+│    │                    │             │          │       │ Programmatic Tool │
+│    │                    │             │          │       │ Calling lets the  │
+│    │                    │             │          │       │ agent orchestrate │
+│    │                    │             │          │       │ tool calls in a   │
+│    │                    │             │          │       │ sandboxed         │
+│    │                    │             │          │       │ code-execution    │
+│    │                    │             │          │       │ environment where │
+│    │                    │             │          │       │ intermediate      │
+│    │                    │             │          │       │ results don't     │
+│    │                    │             │          │       │ enter the context │
+│    │                    │             │          │       │ window. Anthropic │
+│    │                    │             │          │       │ reports a 37%     │
+│    │                    │             │          │       │ token reduction   │
+│    │                    │             │          │       │ on complex        │
+│    │                    │             │          │       │ research tasks.   │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ tool list is not  │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Route this task   │
+│    │                    │             │          │       │ to a custom       │
+│    │                    │             │          │       │ subagent with     │
+│    │                    │             │          │       │ explicit tool     │
+│    │                    │             │          │       │ grants, or        │
+│    │                    │             │          │       │ confirm the       │
+│    │                    │             │          │       │ built-in agent's  │
+│    │                    │             │          │       │ fixed tool set is │
+│    │                    │             │          │       │ actually          │
+│    │                    │             │          │       │ required.         │
+│ 39 │ marketer           │ description │ info     │     1 │ [cost] Agent      │
+│    │                    │             │          │       │ 'marketer' is     │
+│    │                    │             │          │       │ defined in        │
+│    │                    │             │          │       │ /home/fdpearce/.… │
+│    │                    │             │          │       │ but has 0         │
+│    │                    │             │          │       │ invocations       │
+│    │                    │             │          │       │ across 70         │
+│    │                    │             │          │       │ analyzed          │
+│    │                    │             │          │       │ sessions. An      │
+│    │                    │             │          │       │ agent defined but │
+│    │                    │             │          │       │ never delegated   │
+│    │                    │             │          │       │ to is either      │
+│    │                    │             │          │       │ misaligned with   │
+│    │                    │             │          │       │ how the parent    │
+│    │                    │             │          │       │ frames tasks, or  │
+│    │                    │             │          │       │ the triggering    │
+│    │                    │             │          │       │ context isn't     │
+│    │                    │             │          │       │ present in this   │
+│    │                    │             │          │       │ analysis window.  │
+│    │                    │             │          │       │ Compare the       │
+│    │                    │             │          │       │ description       │
+│    │                    │             │          │       │ against           │
+│    │                    │             │          │       │ parent-thread     │
+│    │                    │             │          │       │ phrasing. Current │
+│    │                    │             │          │       │ description:      │
+│    │                    │             │          │       │ "Invoke when      │
+│    │                    │             │          │       │ drafting          │
+│    │                    │             │          │       │ marketing or      │
+│    │                    │             │          │       │ communications    │
+│    │                    │             │          │       │ content — blog    │
+│    │                    │             │          │       │ posts, case       │
+│    │                    │             │          │       │ studies,          │
+│    │                    │             │          │       │ LinkedIn/X/dev.to │
+│    │                    │             │          │       │ posts, project    │
+│    │                    │             │          │       │ announcements, or │
+│    │                    │             │          │       │ other             │
+│    │                    │             │          │       │ public-facing     │
+│    │                    │             │          │       │ writing in Fred's │
+│    │                    │             │          │       │ voice. Also       │
+│    │                    │             │          │       │ handles           │
+│    │                    │             │          │       │ series-planning   │
+│    │                    │             │          │       │ work: turning a   │
+│    │                    │             │          │       │ topic shortlist   │
+│    │                    │             │          │       │ the parent has    │
+│    │                    │             │          │       │ already chosen    │
+│    │                    │             │          │       │ into a sharpened  │
+│    │                    │             │          │       │ outline (titles,  │
+│    │                    │             │          │       │ scope, audience   │
+│    │                    │             │          │       │ hooks, bridges)   │
+│    │                    │             │          │       │ ready for         │
+│    │                    │             │          │       │ issue-filing.     │
+│    │                    │             │          │       │ Returns either a  │
+│    │                    │             │          │       │ proposed filename │
+│    │                    │             │          │       │ + post body       │
+│    │                    │             │          │       │ (single piece) or │
+│    │                    │             │          │       │ a structured      │
+│    │                    │             │          │       │ outline (series   │
+│    │                    │             │          │       │ planning),        │
+│    │                    │             │          │       │ depending on the  │
+│    │                    │             │          │       │ request shape. Do │
+│    │                    │             │          │       │ NOT invoke for:   │
+│    │                    │             │          │       │ code comments,    │
+│    │                    │             │          │       │ docstrings,       │
+│    │                    │             │          │       │ README updates,   │
+│    │                    │             │          │       │ commit messages,  │
+│    │                    │             │          │       │ PR descriptions,  │
+│    │                    │             │          │       │ internal/private  │
+│    │                    │             │          │       │ docs, or          │
+│    │                    │             │          │       │ technical         │
+│    │                    │             │          │       │ documentation     │
+│    │                    │             │          │       │ that lives in the │
+│    │                    │             │          │       │ codebase — those  │
+│    │                    │             │          │       │ stay with the     │
+│    │                    │             │          │       │ parent agent.".   │
+│    │                    │             │          │       │ Consider          │
+│    │                    │             │          │       │ broadening the    │
+│    │                    │             │          │       │ description,      │
+│    │                    │             │          │       │ rewriting it, or  │
+│    │                    │             │          │       │ accepting that    │
+│    │                    │             │          │       │ 'marketer' is     │
+│    │                    │             │          │       │ unused for this   │
+│    │                    │             │          │       │ workload. File:   │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│ 40 │ architect          │ prompt      │ warning  │    48 │ [speed]           │
+│    │                    │             │          │       │ retry_loop: The   │
+│    │                    │             │          │       │ prompt in         │
+│    │                    │             │          │       │ ~/.claude/agents… │
+│    │                    │             │          │       │ mentions error    │
+│    │                    │             │          │       │ handling, but the │
+│    │                    │             │          │       │ agent still       │
+│    │                    │             │          │       │ retried without   │
+│    │                    │             │          │       │ progress.         │
+│    │                    │             │          │       │ Consider more     │
+│    │                    │             │          │       │ specific stop     │
+│    │                    │             │          │       │ conditions or     │
+│    │                    │             │          │       │ alternative-tool  │
+│    │                    │             │          │       │ fallbacks.        │
+│ 41 │ Plan               │ prompt      │ warning  │     2 │ [speed]           │
+│    │                    │             │          │       │ retry_loop:       │
+│    │                    │             │          │       │ Built-in agent —  │
+│    │                    │             │          │       │ prompt is not     │
+│    │                    │             │          │       │ user-editable.    │
+│    │                    │             │          │       │ Add retry bounds  │
+│    │                    │             │          │       │ or exit           │
+│    │                    │             │          │       │ conditions to the │
+│    │                    │             │          │       │ *delegating*      │
+│    │                    │             │          │       │ agent's prompt,   │
+│    │                    │             │          │       │ since the         │
+│    │                    │             │          │       │ built-in agent    │
+│    │                    │             │          │       │ cannot enforce    │
+│    │                    │             │          │       │ them itself.      │
+│    │                    │             │          │       │ Alternatively,    │
+│    │                    │             │          │       │ wrap this call in │
+│    │                    │             │          │       │ a custom subagent │
+│    │                    │             │          │       │ that owns the     │
+│    │                    │             │          │       │ recovery logic.   │
+└────┴────────────────────┴─────────────┴──────────┴───────┴───────────────────┘
+
+Deep Diagnostics: 228 trace signal(s) across 9 subagent(s). Use --verbose for 
+per-call evidence.
+
+Suggested Subagents
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━┓
+┃ Name          ┃ Model        ┃ Confidence ┃ Cluster size ┃ Tools      ┃ Note ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━┩
+│ glossary-docs │ claude-opus… │ low        │           27 │ Bash, Read │      │
+│ py-existing   │ claude-opus… │ medium     │           36 │ Bash, Read │      │
+│ efficiency-h… │ claude-opus… │ medium     │           35 │ Bash, Read │      │
+│ claude-md     │ claude-opus… │ medium     │           26 │ Bash, Read │      │
+│ comments-qua… │ claude-opus… │ medium     │           36 │ Bash, Read │      │
+│ text--detect… │ claude-opus… │ medium     │            6 │ Bash, Read │      │
+│ py-angle      │ claude-opus… │ medium     │           17 │ Bash, Read │      │
+│ tools-members │ claude-opus… │ medium     │            6 │ Bash, Read │      │
+└───────────────┴──────────────┴────────────┴──────────────┴────────────┴──────┘
+
+Offload Candidates
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃            ┃            ┃    Cluster ┃            ┃       Est. ┃             ┃
+┃ Name       ┃ Confidence ┃       size ┃ Tools      ┃    savings ┃ Note        ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ wave-bash  │ high       │         21 │ Bash       │    +$48.69 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ security-… │ high       │         35 │ Bash, Read │    +$73.82 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ id-task    │ high       │         27 │ Bash       │    +$83.47 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ loop-skill │ high       │         42 │ Bash,      │    +$90.18 │ offload     │
+│            │            │            │ Edit, Read │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ architect… │ medium     │         52 │ Agent,     │    +$92.88 │ offload     │
+│            │            │            │ Bash       │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ bash-main  │ medium     │         53 │ Bash       │   +$113.83 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ release-b… │ high       │         37 │ Bash       │   +$122.80 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ bash-mile… │ medium     │         82 │ Bash       │   +$137.85 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+│ diff-code  │ high       │         30 │ Agent,     │   +$142.42 │ offload     │
+│            │            │            │ Bash,      │            │ would cost  │
+│            │            │            │ Edit, Read │            │ MORE        │
+│ bash-clau… │ low        │        147 │ Bash       │   +$350.20 │ offload     │
+│            │            │            │            │            │ would cost  │
+│            │            │            │            │            │ MORE        │
+└────────────┴────────────┴────────────┴────────────┴────────────┴─────────────┘
+See docs/GLOSSARY.md for term definitions.
+
+Sessions analyzed: 70


### PR DESCRIPTION
## Summary
- Adds the **v0.10 dogfood portfolio analysis** (`.claude/specs/analysis/2026-07-03-v10-dogfood/`) — fifth dogfood run, first at the v0.10.0 cut, 70 sessions. Includes `analysis.md` + raw `analyze.json`/`analyze.table.txt` artifacts, matching the v0.9 precedent (#515).
- **Headline finding:** #510/#555's PARAMETER_RETRY `is_error` gate landed, but **40% of fires (10/25) are self-referential false positives** — successful `Read`/`Grep` of AgentFluent's *own* error-handling source (`detect_is_error_from_text`, `class ParameterRetryRule`, `"""Detects error patterns"""`) whose head trips `detect_is_error_from_text`. Filed **#580** (anchor `is_error` synthesis to a leading error signature on file-reading tools) and **#581** (shared `retry_loop` paging-vs-error disambiguation, unblocks #513).
- **Validated first-time surfaces:** hook-coverage recommendations (#424–426, `target: hooks` for pm/architect) and `permission_failure` (pm→WebFetch) both fired correctly on first real-data contact. Reconciled deferred v0.9 candidates: #512 shipped as a user-global pm.md edit (corpus predates it), #513/#514 commented with v0.10 data.
- Clean run: `tier3_degraded: false`, `warnings: []`, no parse exceptions. Cost-per-session held at $26 through #534's pricing correction (absolute cost not comparable across that fix).

## Test plan
Docs/analysis artifacts only — no code, no runtime surface.
- [x] Unit tests pass: N/A (no `src/` change)
- [x] Lint clean: N/A (no `src/` change)
- [x] Type check clean: N/A (no `src/` change)
- [x] New/changed behavior has test coverage: N/A (docs-only)
- [x] Manual smoke test: the artifacts *are* the output of `uv run agentfluent analyze --project agentfluent --diagnostics --git --github --json` at release commit `27b9acb`

## Security review
- [x] **Skip review** — docs/analysis artifacts only; no security-sensitive surface. (`analyze.json` embeds the author's own absolute repo paths in `file_rework` messages, same as the committed v0.9 run; no secrets or third-party data.)
- [ ] **Needs review**

## Breaking changes
None — no public contract touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)