### PR TITLE
[DO NOT MERGE] #583 red-path recovery exercise

### DIFF
--- a/scratch-redpath-583.md
+++ b/scratch-redpath-583.md
@@ -1,0 +1,12 @@
+# Red-path exercise (#583)
+
+Throwaway artifact for the release-loop red-path recovery exercise (#583). This branch is
+**DO NOT MERGE** — it exists only to observe the loop's two red-recovery paths execute.
+
+## AC-verifier path
+
+Exercises SKILL §7. The AC-verifier runs in a fresh context against `git diff main...HEAD`
+and the verbatim acceptance criteria. If any criterion is not met, the orchestrator fixes
+the gap and re-verifies, bounded to a maximum of two rounds before escalating. This section
+documents the FAIL → fix → re-verify loopback that auto-merge for the `docs`/`research`
+routes depends on.

--- a/scratch-redpath-583.md
+++ b/scratch-redpath-583.md
@@ -10,3 +10,9 @@ and the verbatim acceptance criteria. If any criterion is not met, the orchestra
 the gap and re-verifies, bounded to a maximum of two rounds before escalating. This section
 documents the FAIL → fix → re-verify loopback that auto-merge for the `docs`/`research`
 routes depends on.
+
+## CI-red path
+
+Exercises SKILL §8. After the PR opens, the orchestrator waits for CI and fixes until
+green — it never merges red. This section documents the CI red → fix-until-green recovery
+that guards auto-merge from ever shipping a failing build for the `docs`/`research` routes.

--- a/tests/scratch_redpath_583.py
+++ b/tests/scratch_redpath_583.py
@@ -1,0 +1,7 @@
+"""Throwaway scratch module for the #583 CI-red exercise. DO NOT MERGE.
+
+Named without a ``test_`` prefix so pytest does not collect it; ``ruff check tests/``
+still lints it. The unused import below is a deliberate F401 to trip the CI Lint step.
+"""
+
+import os  # deliberate F401 for the #583 CI-red exercise

--- a/tests/scratch_redpath_583.py
+++ b/tests/scratch_redpath_583.py
@@ -1,7 +1,0 @@
-"""Throwaway scratch module for the #583 CI-red exercise. DO NOT MERGE.
-
-Named without a ``test_`` prefix so pytest does not collect it; ``ruff check tests/``
-still lints it. The unused import below is a deliberate F401 to trip the CI Lint step.
-"""
-
-import os  # deliberate F401 for the #583 CI-red exercise


### PR DESCRIPTION
> ⚠️ **THROWAWAY — DO NOT MERGE.** This is the #583 red-path recovery exercise. It deliberately opens with a failing CI (an intentional `F401`) to observe the loop's §8 fix-until-green recovery, then gets fixed to green and is **closed unmerged**. Nothing here ships.

## Summary
- Scratch artifact validating the release-loop's red-recovery control flow ahead of the #562 docs/research auto-merge flip.
- Deliberately trips the CI Lint step (`F401` unused import in `tests/scratch_redpath_583.py`), then fixes to green — exercising SKILL §8 "CI red → fix-until-green, never merge red."
- Companion to the §7 AC-verifier FAIL→fix→re-verify path already exercised locally on this branch.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"`
- [x] Lint clean: `uv run ruff check src/ tests/` — *intentionally red on first push, fixed to green*
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [ ] New/changed behavior has test coverage — n/a (throwaway scratch artifact, not merged)
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI change)

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface (throwaway scratch docs + scratch module; nothing merges).
- [ ] **Needs review**

## Breaking changes
None — throwaway exercise, closed unmerged.
