### PR TITLE
chore(loop): graduate docs+research to escalation-only auto-merge (D047)

### DIFF
--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -1026,3 +1026,47 @@ gate so misdirected effort is caught before code (#573).
 spec `value-review-437-verbosity.md`, [postmortem](https://www.anthropic.com/engineering/april-23-postmortem).
 
 ---
+
+## D047: Graduate `docs` + `research` to `escalation-only` auto-merge (release-loop)
+
+**Date:** 2026-07-04
+**Context:** The v0.10.0 release-loop run (14 issues to terminal, zero regressions, zero bad
+merges) ran entirely under `mode: calibration` — the human approved every merge. The
+retrospective (#562) established that all high-value human intervention landed **upstream** at
+triage/plan; the calibration merge gate rubber-stamped ~11 of 14 rows, its one load-bearing
+event being #437's hold → DEFER (a *value* catch on a `feat:`, the route that stays gated). The
+`escalation-only` + `graduated-routes` semantics are pinned (§6.1 / §7.1 step 11, #563) and
+per-iteration budget journaling is in place (§6.1 / §6.2, #565). The two evidence gaps that had
+blocked graduation are now closed: `research` was driven **start-to-finish for the first time**
+(#520/#521 — previously only *reconciled*), and the two red-path recovery paths auto-merge
+relies on (§7.1 step 7 AC-verifier FAIL→re-verify, step 8 CI red→fix-until-green) were validated
+by a controlled, architect-reviewed exercise (#583).
+**Decision:** Graduate **`docs` and `research`** to auto-merge under `mode: escalation-only`. The
+next run (v0.11.0) inits with `mode: escalation-only` + `graduated-routes: docs, research` (§7.5
+now reads this decision at init so it persists across runs). A graduated-route row auto-merges
+**only** when CI + AC-verifier + review are green AND the bump is ≤ patch AND it is not `hold`
+AND none of the always-escalate conditions apply (`feat:`/breaking, risky/irreversible, security
+surface, contested review finding); **default-deny** on any uncertainty (§6.1 / §7.1 step 11).
+The **plan gate stays conditional/human in every mode** (unchanged — that is where the human
+value landed). **`code`/`feat:` keeps the human merge gate**, pending its own per-route promotion
+criteria (#562).
+**Scope of the #583 evidence:** validates the step 7/8 *control flow* (loopback + fix-until-green),
+NOT AC-verifier *sensitivity* (the induced gap was deliberately obvious). Now that the
+docs/research human merge gate is off, sensitivity assurance — if wanted — comes from
+spot-auditing the first N auto-merged rows (tracked in #562), not from #583. Residual risk is
+low: docs/research don't break runtime, and the CI-green precondition still guards against
+merging red.
+**Rationale:** Graduate the part the evidence earned, not all-or-nothing. Docs/research are
+no-bump, low-blast-radius, and cleared an independent AC-verifier + CI gate that carry without a
+human. The human merge gate added value once in 14 tries — on a `feat:`. The flip removes ~half
+the run's rubber-stamp merge gates while keeping human eyes where they paid off (triage/plan, and
+every `code`/`feat:` merge). Cost asymmetry favors it: reversible (flip back to `calibration`),
+and bad-merge risk stays covered by default-deny/always-escalate + budget caps (#565).
+**Companion (not a blocker):** #584 (RUN PARKED sentinel + one-directional milestone-delta
+surfacing) should land alongside autonomy — the "converged-pending-release" re-scan instability
+compounds under a reduced re-fire cadence — but does not gate this flip.
+**Reference:** #562 (retrospective umbrella), #563 (mode semantics), #565 (budget journaling),
+#520/#521 (research E2E), #583 (red-path validation, closed), #584 (companion), #437 / D046 (the
+load-bearing merge-gate hold), spec §6.1 / §7.1 step 11 / §7.5.
+
+---

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -481,10 +481,10 @@ Address findings ≥ the project's confidence bar.
 
 ## 11. Merge
 Read the run `mode` and `graduated-routes` from the `queue.md` header. The merge gate is the
-**only** gate `mode` changes (§6.1). A row is **auto-merge-eligible** only when ALL of these
-hold:
+**only** gate `mode` changes (§5 is conditional in every mode). A row is **auto-merge-eligible**
+only when ALL of these hold:
 - `mode: escalation-only`, AND
-- the row's Route is listed in the header's `graduated-routes` field (§6.1), AND
+- the row's Route is listed in the header's `graduated-routes` field, AND
 - the version bump is ≤ patch — a `docs`/`chore` change produces no bump, which qualifies, AND
 - the row is **not** `hold`, AND
 - none of the always-escalate conditions apply: a `feat:`/breaking change, a risky/irreversible
@@ -494,12 +494,13 @@ hold:
 **not** auto-merge-eligible — fall back to the human merge gate.
 
 If the row is **not** auto-merge-eligible — which includes *every* row under `mode: calibration`
-(the default) and any `hold` row — **STOP and ask the human before merging; never auto-merge.**
-**If the human holds the merge (now or in any later invocation), WRITE the hold to the row before
-stopping** — set Status `hold` (record the reason in Notes) so it persists across `/clear`;
-resume (step 0.3), §1, and this gate all key on Status `hold` and honor it until the human clears
-it (restoring the row's prior status). When the row **is** auto-merge-eligible (or the human has
-approved), and CI + security are green AND the row is not `hold`:
+(the default) and any `hold` row — STOP and ask the human before merging; never auto-merge.
+**If the human holds the merge (now or in any later invocation),
+WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
+it persists across `/clear`; resume (step 0.3), §1, and this gate all key on Status `hold` and
+honor it until the human clears it (restoring the row's prior status). When the row **is**
+auto-merge-eligible (or the human has approved), and CI + security are green AND the row is not
+`hold`:
 squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
 `--delete-branch`. Confirm the issue closed.
 

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -208,7 +208,7 @@ uncertainty — never merely because of `mode:`). The two modes:
   #565); it cannot run headless (§13/§14).
 
 The set of graduated routes is recorded in a `graduated-routes:` header field beside `mode:`
-(default `none`; e.g. `graduated-routes: docs`). Under `mode: calibration` it is inert. *Which*
+(default `none`; e.g. `graduated-routes: docs, research`, per D047). Under `mode: calibration` it is inert. *Which*
 routes graduate and the criteria for promoting one (#562) are out of scope here; this field only
 gives the merge gate (§7.1 step 11) a place to read the human's decision from.
 
@@ -642,7 +642,7 @@ runs as its Route when the dependency closes (§1, §7.3).
 | AC-verify | fresh subagent (+`/verify`) | every code/research issue | done/not-done + gaps |
 | Code review | CODE_REVIEW | every code issue | findings → fixes |
 | Security | local `/security-review` or label | by route | clean/findings |
-| Merge | user (calibration) → orchestrator (later) | CI+security green | squash |
+| Merge | user (calibration / non-graduated route) → orchestrator (auto: graduated routes, D047) | CI+security green | squash |
 
 **Convergence:** the run is complete when every `queue.md` row is terminal (`done` |
 `deferred` | `blocked`). The **completion sentinel** is a final `progress.md` block titled

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -193,9 +193,11 @@ uncertainty — never merely because of `mode:`). The two modes:
   (§7.1 step 11). Plan gate conditional.
 - **`escalation-only`** — the human loosens the **merge gate per route**: a route the human has
   *graduated* auto-merges when CI + AC-verifier + review are green and the version bump is
-  ≤ patch (a `docs`/`chore` change produces no bump, which qualifies). Initially only `docs`;
-  `research` graduates after its first clean end-to-end loop run (to date it has only been
-  *reconciled*, never driven — see the v0.10.0 retrospective, #562). The human merge gate is
+  ≤ patch (a `docs`/`chore` change produces no bump, which qualifies). *Which* routes are
+  currently graduated is a mutable human decision, recorded per-run in the `graduated-routes:`
+  header and in the decision log (see **D047** for the first graduation — `docs`+`research`) —
+  never frozen into this mechanism definition (the #584 lesson: graduation *state* is evidence,
+  not a rule). The human merge gate is
   **retained** for every non-graduated route and, regardless of route, for any of: a `feat:`/
   breaking change, a risky/irreversible change, a touched security surface, a contested review
   finding, or a `hold` row — **and, by default-deny, whenever route graduation or any
@@ -577,10 +579,13 @@ Promote to a dedicated `ac-verifier` agent only if the composed approach proves 
 3. For each issue: determine route (§7.3) and dependencies (parse "Depends on"/"blocked by"
    refs in the body; respect epic ordering notes).
 4. Topologically order by dependency, then by `PRIORITY_LABELS` (tiebreak issue-number asc).
-   Write `queue.md` (§6.1) with header `mode: calibration` (default; the human loosens to
-   `escalation-only` after calibration — step 11 reads this to gate **the merge gate**, per
-   route; it never affects the plan gate), plus `graduated-routes: none`, `iteration-cap: none`,
-   and `subagent-cap: none` (the budget caps, #565; the human sets them when loosening).
+   Write `queue.md` (§6.1) with header `mode: calibration` **unless the human has already
+   graduated routes for this project** — check the decision log (e.g. **D047**: `docs`+`research`
+   graduated) and, if so, init `mode: escalation-only` + the graduated `graduated-routes:`
+   instead, so a prior graduation persists across runs rather than silently resetting to
+   calibration. Step 11 reads `mode`/`graduated-routes` to gate **the merge gate**, per route; it
+   never affects the plan gate. Also set `iteration-cap: none` and `subagent-cap: none` (the
+   budget caps, #565; the human sets them when loosening).
 5. Append an "init" block to `progress.md`. (Ledger is gitignored — not committed.)
 
 ### 7.6 Resume after `/clear` or compaction


### PR DESCRIPTION
## Summary
- Records **D047**: graduate the release-loop **`docs` + `research`** routes to `escalation-only` auto-merge, per the v0.10.0 retrospective (#562). `code`/`feat:` keeps the human merge gate; the plan gate stays conditional/human in **every** mode.
- **No new machinery** — §6.1 / §7.1 step 11 already implement `escalation-only` + `graduated-routes` (#563) and budget journaling is in place (#565). This is the *decision* + two small spec de-frost edits.
- §6.1: de-freezes the stale *"`research` … never driven"* clause (now false — #520/#521 drove it start-to-finish) → graduation *state* now lives in the run header + decision log, not baked into the mechanism prose (the #584 lesson).
- §7.5: init reads the decision log so a prior graduation **persists across runs** instead of silently resetting to `calibration`.

### Evidence trail (why now)
| Prereq | Status |
|---|---|
| Mode semantics pinned | ✅ #563 |
| Budget journaling | ✅ #565 (§6.1/§6.2) |
| `research` clean end-to-end run | ✅ #520/#521 (driven, not reconciled) |
| Red-path recovery validated | ✅ #583 (architect-reviewed, closed) |

### What the next run (v0.11.0) inits with
```markdown
# Loop run: v0.11.0
_mode: escalation-only_
_graduated-routes: docs, research_
_iteration-cap: none_
_subagent-cap: none_
```
A graduated row auto-merges **only** when CI + AC-verifier + review are green AND bump ≤ patch AND not `hold` AND no always-escalate condition applies (`feat:`/breaking, risky/irreversible, security surface, contested finding); **default-deny** on any uncertainty.

### Scope note (per the #583 architect review)
This trusts the §7/§8 *control flow*, not AC-verifier *sensitivity*. If sensitivity assurance is wanted now the docs/research human merge gate is off, spot-audit the first N auto-merged rows (tracked in #562) — not covered by #583. Reversible: flip back to `calibration` any time.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — n/a to the diff (docs/spec-only, no Python touched); CI confirms.
- [x] Lint clean: `uv run ruff check src/ tests/` — no code changed.
- [x] Type check clean: `uv run mypy src/agentfluent/` — no code changed.
- [ ] New/changed behavior has test coverage — n/a (spec/decision prose; no runtime surface).
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI change).

## Security review
Pick one.
- [x] **Skip review** — `.claude/specs/` docs + decision-log prose only; no code, parsing, CLI, path, or network surface.
- [ ] **Needs review**

## Breaking changes
None. `.claude/`-only maintainer tooling (no PyPI-visible change). Reversible (revert D047 / flip the header back to `calibration`).
