### PR TITLE
chore(loop): CI-guard SKILL.md ↔ prd-loop-engineering §7 mirror against drift (#575)

### DIFF
--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -327,9 +327,11 @@ Add a source-fidelity note if the rationale leans on any externally-cited source
 
 ## 7. C3 — `/release-loop` orchestrator skill
 
-Create `.claude/skills/release-loop/SKILL.md`. Below is the **complete, ready-to-drop-in
-content** (the body IS the orchestrator's operating procedure). A builder may copy it
-verbatim, adjusting only `Project Parameters` references.
+The live skill lives at `.claude/skills/release-loop/SKILL.md`; the block below is a
+**byte-identical mirror** of it (the body IS the orchestrator's operating procedure), kept
+here so the spec stays self-contained and ready-to-drop-in. The two copies are CI-guarded
+to stay byte-for-byte identical (`tests/unit/test_loop_skill_drift.py`) — **edit both
+together**; on a conflict `SKILL.md` is the operative copy and this block mirrors it.
 
 ````markdown
 ---

--- a/tests/unit/test_loop_skill_drift.py
+++ b/tests/unit/test_loop_skill_drift.py
@@ -1,0 +1,77 @@
+"""CI drift guard: the release-loop skill body and its spec mirror must match.
+
+The orchestrator procedure lives in two hand-maintained copies:
+
+  * ``.claude/skills/release-loop/SKILL.md`` -- the live skill (what actually
+    runs when ``/release-loop`` is invoked); and
+  * ``.claude/specs/prd-loop-engineering.md`` section 7 -- a byte-identical
+    mirror embedded in a 4-backtick fenced block, kept so the spec stays
+    self-contained and "ready-to-drop-in".
+
+Every edit to the loop's operating steps must land in BOTH copies or the spec
+silently drifts from the live skill (see issue #575). This test fails if they
+diverge. On a conflict, ``SKILL.md`` is the operative copy and section 7 mirrors
+it -- but sync direction is the editor's call; reconcile both to match.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = REPO_ROOT / ".claude" / "skills" / "release-loop" / "SKILL.md"
+SPEC_PATH = REPO_ROOT / ".claude" / "specs" / "prd-loop-engineering.md"
+
+# The mirror is embedded in a 4-backtick fence (SKILL.md's own body uses inner
+# 3-backtick fences, so a 4-backtick anchor is unambiguous). Capture the content
+# between the opening ````<info-string> line and the closing ```` line, without
+# the fence lines themselves, preserving bytes exactly (raw slice -- no
+# line-split/rejoin, which would risk mangling the trailing newline).
+_FENCE_BLOCK = re.compile(
+    r"^````[a-zA-Z0-9]*\n(?P<body>.*?)^````[ \t]*$\n?",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _extract_mirror(spec_text: str) -> str:
+    """Return the single 4-backtick fenced block embedding the skill mirror."""
+    matches = list(_FENCE_BLOCK.finditer(spec_text))
+    # Anchor-integrity: exactly one 4-backtick block, or the guard is unreliable
+    # (a future spec restructure must not silently make this test vacuous).
+    assert len(matches) == 1, (
+        f"Expected exactly one 4-backtick fenced block in {SPEC_PATH.name} "
+        f"(the release-loop skill mirror in section 7); found {len(matches)}. "
+        "The drift guard's extraction anchor is ambiguous -- update "
+        "tests/unit/test_loop_skill_drift.py to re-anchor on the mirror block."
+    )
+    body = matches[0].group("body")
+    # Vacuity guard: the block must actually be the skill (its frontmatter),
+    # so a restructure can't leave a passing empty/placeholder stub.
+    assert body.startswith("---\nname: release-loop"), (
+        f"The 4-backtick block in {SPEC_PATH.name} does not start with the "
+        "release-loop skill frontmatter (`---\\nname: release-loop`). The drift "
+        "guard is anchored on the wrong block -- update "
+        "tests/unit/test_loop_skill_drift.py."
+    )
+    return body
+
+
+def test_release_loop_skill_matches_spec_mirror() -> None:
+    """The live SKILL.md must equal the section-7 mirror byte-for-byte."""
+    skill_text = SKILL_PATH.read_text(encoding="utf-8")
+    mirror_text = _extract_mirror(SPEC_PATH.read_text(encoding="utf-8"))
+    if skill_text != mirror_text:
+        pytest.fail(
+            "The release-loop orchestrator procedure has drifted between its two "
+            "hand-maintained copies:\n"
+            f"  * {SKILL_PATH.relative_to(REPO_ROOT)} (live skill)\n"
+            f"  * {SPEC_PATH.relative_to(REPO_ROOT)} section 7 (spec mirror, "
+            "the 4-backtick fenced block)\n"
+            "Edit BOTH copies so they stay byte-for-byte identical. If they "
+            "already say what you intend, copy one over the other -- SKILL.md is "
+            "the operative copy that runs at loop time, so it is the authority "
+            "when resolving a genuine conflict.",
+        )


### PR DESCRIPTION
## Summary
- Add `tests/unit/test_loop_skill_drift.py` — a CI diff-check (Option 1 from #575) that fails if the live release-loop skill (`.claude/skills/release-loop/SKILL.md`) and its byte-identical mirror in `prd-loop-engineering.md` §7 (the 4-backtick fenced block) diverge.
- Extraction uses a raw regex slice (byte-exact, no line-split/rejoin that could mangle the trailing newline), asserts **exactly one** 4-backtick block, and requires it to start with the `release-loop` frontmatter — so a future spec restructure can't silently make the guard vacuous.
- Reconcile the §7 intro (outside the fence) to name `SKILL.md` the operative copy and document the CI coupling, preserving the "ready-to-drop-in" self-contained contract.

Closes #575. Prerequisite for #584 (RUN PARKED sentinel), which dual-edits the mirrored procedure — this guard protects that edit. Architect review: https://github.com/frederick-douglas-pearce/agentfluent/issues/575#issuecomment-4885112705

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1787 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/` (new test also mypy-clean)
- [x] New/changed behavior has test coverage — the change *is* a test; verified positive (identical → pass) and negative (perturbed SKILL.md → fail with drift message, then restored)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A, no CLI surface

## Security review
- [x] **Skip review** — test-only + a `.claude/` spec doc note; no security-sensitive surface. The new test reads two in-repo files and does string comparison; no network, subprocess, secret handling, or user-controlled input.

## Breaking changes
None — no public contract, CLI, or model change. `.claude/`-only tooling plus a new test; nothing ships to the PyPI package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)