### PR TITLE
fix: anchor is_error synthesis to a leading error signature on file-reading tools (#580)

### DIFF
--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -72,14 +72,18 @@ FILE_READING_TOOLS = frozenset({"Read", "Grep", "Glob"})
 # Case-sensitive on purpose: these are literal Claude Code / Node system strings
 # (lowercase ``<tool_use_error>`` wrapper, uppercase errno codes) — matching them
 # case-insensitively would re-admit the very source-content FPs this guards. The
-# v0.10 dogfood confirmed all 15 genuine fires begin with one of these while all
+# v0.10 dogfood's 15 genuine fires all begin with one of these forms while all
 # 10 FPs carry the keyword mid-line (#580; analysis.md). ``ENOENT``/``EACCES``
 # are included defensively alongside the observed ``EISDIR`` at zero FP cost.
+# Leading ``\s*`` anchors the match after optional whitespace without copying the
+# (potentially multi-KB) result body via ``lstrip()``.
 LEADING_ERROR_REGEX = re.compile(
+    r"\s*(?:"
     r"<tool_use_error>"
     r"|EISDIR|ENOENT|EACCES"
     r"|File does not exist"
-    r"|File content .*? exceeds maximum",
+    r"|File content .*? exceeds maximum"
+    r")",
 )
 
 
@@ -97,7 +101,7 @@ def detect_is_error_for_tool(text: str | None, tool_name: str) -> bool:
     if not text:
         return False
     if tool_name in FILE_READING_TOOLS:
-        return bool(LEADING_ERROR_REGEX.match(text.lstrip()))
+        return bool(LEADING_ERROR_REGEX.match(text))
     return detect_is_error_from_text(text)
 
 

--- a/src/agentfluent/diagnostics/signals.py
+++ b/src/agentfluent/diagnostics/signals.py
@@ -60,6 +60,47 @@ def detect_is_error_from_text(text: str | None) -> bool:
     return bool(ERROR_REGEX.search(text[:ERROR_DETECTION_WINDOW_CHARS]))
 
 
+# File-reading tools whose *successful* output is file/source content — so a
+# leading-window keyword match is a false positive (#580): the head of a Read is
+# the top of the file, and a Grep hit line is `path:line:content`. On a
+# self-referential corpus (agents reading AgentFluent's own error-handling
+# source) that head IS error vocabulary, which the generic windowed
+# ``detect_is_error_from_text`` misreads as a real error.
+FILE_READING_TOOLS = frozenset({"Read", "Grep", "Glob"})
+
+# Structured error signatures a genuine Read/Grep/Glob failure *leads* with.
+# Case-sensitive on purpose: these are literal Claude Code / Node system strings
+# (lowercase ``<tool_use_error>`` wrapper, uppercase errno codes) — matching them
+# case-insensitively would re-admit the very source-content FPs this guards. The
+# v0.10 dogfood confirmed all 15 genuine fires begin with one of these while all
+# 10 FPs carry the keyword mid-line (#580; analysis.md). ``ENOENT``/``EACCES``
+# are included defensively alongside the observed ``EISDIR`` at zero FP cost.
+LEADING_ERROR_REGEX = re.compile(
+    r"<tool_use_error>"
+    r"|EISDIR|ENOENT|EACCES"
+    r"|File does not exist"
+    r"|File content .*? exceeds maximum",
+)
+
+
+def detect_is_error_for_tool(text: str | None, tool_name: str) -> bool:
+    """Synthesize ``is_error`` with tool-aware anchoring (#580).
+
+    For file-reading tools (``FILE_READING_TOOLS``) a successful result is
+    file/source content, so only a result that *begins* with a structured
+    error signature (after leading whitespace) counts as an error — merely
+    *containing* error vocabulary in the leading window does not. All other
+    tools keep the unchanged windowed behavior of
+    ``detect_is_error_from_text`` (preserving the #241 mcp_assessment path).
+    ``None``/empty always return False.
+    """
+    if not text:
+        return False
+    if tool_name in FILE_READING_TOOLS:
+        return bool(LEADING_ERROR_REGEX.match(text.lstrip()))
+    return detect_is_error_from_text(text)
+
+
 def iter_error_matches(
     text: str | None,
     *,

--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -256,10 +256,13 @@ def _build_parameter_retry_signal(
 
     The first attempt must carry ``is_error=True`` — the parser-supplied flag,
     which the parser also synthesizes from result text via
-    ``signals.detect_is_error_from_text``. That synthesis covers generic error
-    vocabulary (``failed``/``error``/``unable to``/…), NOT every validation-only
-    phrasing; a first call that sets neither ``is_error`` nor a generic error
-    token is treated as paging/refinement, not a parameter retry. This is a
+    ``signals.detect_is_error_for_tool``. That synthesis covers generic error
+    vocabulary (``failed``/``error``/``unable to``/…) for most tools, but on
+    file-reading tools (Read/Grep/Glob) it requires the result to *begin* with a
+    structured error signature — so a successful read whose head is error
+    vocabulary is not misread as a first-attempt failure (#580). A first call
+    that sets neither ``is_error`` nor a qualifying error signature is treated as
+    paging/refinement, not a parameter retry. This is a
     deliberate precision trade-off (#510): it drops the prior keyword-regex
     fallback (``invalid``/``validation``/``schema``/…) that fired on
     *successful* results whose text merely looked validation-flavored — the

--- a/src/agentfluent/traces/parser.py
+++ b/src/agentfluent/traces/parser.py
@@ -30,7 +30,7 @@ from typing import Any
 from agentfluent.analytics.pricing import SYNTHETIC_MODELS
 from agentfluent.core.parser import parse_session
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
-from agentfluent.diagnostics.signals import detect_is_error_from_text
+from agentfluent.diagnostics.signals import detect_is_error_for_tool
 from agentfluent.traces.discovery import AGENT_FILENAME_PATTERN
 from agentfluent.traces.models import (
     INPUT_DATA_MAX_CHARS,
@@ -101,17 +101,19 @@ def _truncate_result(text: str | None) -> str:
     return text[:RESULT_SUMMARY_MAX_CHARS]
 
 
-def _detect_is_error(block: ContentBlock) -> bool:
+def _detect_is_error(block: ContentBlock, tool_name: str) -> bool:
     """Detect whether a tool_result block represents an error.
 
     Explicit ``is_error`` field is authoritative when present (True or
-    False). When missing, fall back to ``detect_is_error_from_text``
-    (shared helper bounded by ``ERROR_DETECTION_WINDOW_CHARS``; see
-    #238 / #241 for the FP-defense rationale).
+    False). When missing, fall back to ``detect_is_error_for_tool``, which
+    is tool-aware: file-reading tools (Read/Grep/Glob) require the result to
+    *begin* with a structured error signature, so a successfully-read file
+    whose head is error vocabulary is not misread as a failure (#580).
+    Other tools keep the windowed behavior (see #238 / #241).
     """
     if block.is_error is not None:
         return block.is_error
-    return detect_is_error_from_text(block.text)
+    return detect_is_error_for_tool(block.text, tool_name)
 
 
 def _sum_usage(messages: list[SessionMessage]) -> Usage:
@@ -169,7 +171,7 @@ def _pair_tool_calls(messages: list[SessionMessage]) -> list[SubagentToolCall]:
             entry = results.get(block.id)
             if entry is not None:
                 result_block, result_ts = entry
-                is_error = _detect_is_error(result_block)
+                is_error = _detect_is_error(result_block, block.name or "")
                 result_text = result_block.text
             else:
                 is_error = False

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,9 +1,16 @@
 """Tests for behavior signal extraction."""
 
+import pytest
+
 from agentfluent.agents.models import AgentInvocation
 from agentfluent.config.models import Severity
 from agentfluent.diagnostics.models import SignalType
-from agentfluent.diagnostics.signals import extract_signals
+from agentfluent.diagnostics.signals import (
+    FILE_READING_TOOLS,
+    detect_is_error_for_tool,
+    detect_is_error_from_text,
+    extract_signals,
+)
 
 
 def _inv(
@@ -315,4 +322,95 @@ class TestInvocationIdPropagation:
         signals = extract_signals([*peers, slow])
         outlier = next(s for s in signals if s.signal_type == SignalType.DURATION_OUTLIER)
         assert outlier.invocation_id == "ag-slow"
+
+
+# The 15 genuine first-attempt failures from the v0.10 dogfood (#580): each
+# renders leading with a structured error signature. All must still synthesize
+# is_error=True on a file-reading tool.
+_GENUINE_FIRES = [
+    "<tool_use_error>InputValidationError: offset must be a number, got array",
+    "<tool_use_error>InputValidationError: missing required parameter 'pattern'",
+    "EISDIR: illegal operation on a directory, read",
+    "File does not exist.",
+    "File does not exist. Did you mean src/agentfluent/traces/parser.py?",
+    "File content (28451 tokens) exceeds maximum allowed tokens (25000). "
+    "Please use offset and limit to read specific portions.",
+]
+
+# The 10 self-referential false positives (#580): successful Read/Grep of
+# AgentFluent's own error-handling source, whose head carries error vocabulary
+# but does NOT lead with a structured signature (a grep hit line leads with the
+# filename; a Read leads with a line-number or a docstring/keyword). None may
+# synthesize is_error=True on a file-reading tool.
+_CONTENT_FPS = [
+    # architect -> Grep hit: leads with the filename, not a signature.
+    "parser.py:33:from agentfluent.diagnostics.signals import "
+    "detect_is_error_from_text",
+    "signals.py:44:# Real error messages lead with the indicator",
+    # Explore -> Read of a class whose docstring names the signal.
+    'class ParameterRetryRule:\n    """PARAMETER_RETRY -> recommend input_examples',
+    # candidate-verifier -> Read of a module docstring about error detection.
+    '"""Behavior signal extraction from agent invocations.\n\n'
+    "Detects error patterns in output text",
+    # architect -> Read of a function definition.
+    "def compute_error_rate(invocations: list[AgentInvocation]) -> float:",
+    # architect -> Read of the release-loop skill frontmatter (line-numbered).
+    "1\t---\n2\tname: release-loop\n3\tdescription: Run one routed iteration",
+    # pm -> Read of the run_diagnostics pipeline docstring (x2 in corpus).
+    '"""Run the diagnostics pipeline: signals -> correlation -> recommendations."""',
+    "run_diagnostics wires the error-pattern signal into the pipeline",
+    # A Read whose first line mentions an errno mid-line (not leading).
+    "The parser maps EISDIR and ENOENT to is_error in traces/parser.py",
+    # A Grep hit whose content line contains the literal wrapper string.
+    "signals.py:52:    r\"<tool_use_error>|EISDIR|ENOENT|EACCES\"",
+]
+
+
+class TestDetectIsErrorForTool:
+    """#580: tool-aware is_error synthesis anchored to a leading signature."""
+
+    @pytest.mark.parametrize("tool", sorted(FILE_READING_TOOLS))
+    @pytest.mark.parametrize("text", _GENUINE_FIRES)
+    def test_genuine_fires_still_fire_on_file_reading_tools(
+        self, tool: str, text: str,
+    ) -> None:
+        assert detect_is_error_for_tool(text, tool) is True
+
+    @pytest.mark.parametrize("tool", sorted(FILE_READING_TOOLS))
+    @pytest.mark.parametrize("text", _CONTENT_FPS)
+    def test_content_fps_suppressed_on_file_reading_tools(
+        self, tool: str, text: str,
+    ) -> None:
+        assert detect_is_error_for_tool(text, tool) is False
+
+    def test_leading_whitespace_before_signature_still_fires(self) -> None:
+        assert detect_is_error_for_tool("   \n  EISDIR: is a directory", "Read") is True
+
+    def test_signature_is_case_sensitive(self) -> None:
+        # Lowercase errno is source prose, not a system error string.
+        assert detect_is_error_for_tool("eisdir mentioned in a comment", "Read") is False
+
+    def test_non_file_reading_tool_keeps_windowed_behavior(self) -> None:
+        # Bash delegates to detect_is_error_from_text: a leading generic keyword
+        # still fires (the file-reading anchor does not apply).
+        assert detect_is_error_for_tool("Error: command not found", "Bash") is True
+        assert (
+            detect_is_error_for_tool("Error: command not found", "Bash")
+            == detect_is_error_from_text("Error: command not found")
+        )
+
+    def test_non_file_reading_mid_keyword_matches_windowed(self) -> None:
+        text = "wrote output; the word failed appears here"
+        assert detect_is_error_for_tool(text, "Bash") == detect_is_error_from_text(text)
+
+    def test_generic_keyword_leading_on_read_does_not_fire(self) -> None:
+        # The core #580 regression: "error"/"failed" at the top of a Read is
+        # source content, not a tool failure.
+        assert detect_is_error_for_tool("error handling utilities", "Read") is False
+        assert detect_is_error_for_tool("failed attempts are logged", "Grep") is False
+
+    def test_none_and_empty_return_false(self) -> None:
+        assert detect_is_error_for_tool(None, "Read") is False
+        assert detect_is_error_for_tool("", "Read") is False
+        assert detect_is_error_for_tool("   ", "Read") is False
 

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -324,9 +324,10 @@ class TestInvocationIdPropagation:
         assert outlier.invocation_id == "ag-slow"
 
 
-# The 15 genuine first-attempt failures from the v0.10 dogfood (#580): each
-# renders leading with a structured error signature. All must still synthesize
-# is_error=True on a file-reading tool.
+# The v0.10 dogfood's 15 genuine first-attempt failures (#580) reduce to these
+# 4 distinct structured-signature forms (each fire leads with one). Testing the
+# forms — not 15 literal transcripts — is the load-bearing coverage: all must
+# still synthesize is_error=True on a file-reading tool.
 _GENUINE_FIRES = [
     "<tool_use_error>InputValidationError: offset must be a number, got array",
     "<tool_use_error>InputValidationError: missing required parameter 'pattern'",

--- a/tests/unit/test_traces_parser.py
+++ b/tests/unit/test_traces_parser.py
@@ -9,7 +9,9 @@ from typing import Any
 
 import pytest
 
+from agentfluent.diagnostics.models import SignalType
 from agentfluent.diagnostics.signals import ERROR_DETECTION_WINDOW_CHARS
+from agentfluent.diagnostics.trace_signals import extract_trace_signals
 from agentfluent.traces.models import (
     INPUT_DATA_MAX_CHARS,
     INPUT_SUMMARY_MAX_CHARS,
@@ -369,6 +371,145 @@ class TestIsErrorDetection:
             ],
         )
         assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
+
+class TestFileReadingIsErrorAnchor:
+    """#580: file-reading tools synthesize is_error only when the result begins
+    with a structured error signature — not when error vocabulary merely appears
+    in the head of a successfully-read file."""
+
+    def test_read_error_vocab_head_does_not_synthesize(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # Successful Read of AgentFluent's own error-handling source: the head
+        # is error vocabulary but not a structured signature.
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Read", {"file_path": "signals.py"})]),
+                _user([_tool_result("t1", "error handling: def compute_error_rate(x)")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is False
+
+    def test_grep_hit_line_does_not_synthesize(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # Grep content-mode output leads with `path:line:` — never a signature.
+        hit = "parser.py:33:from agentfluent.diagnostics.signals import detect_is_error"
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Grep", {"pattern": "error"})]),
+                _user([_tool_result("t1", hit)]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is False
+
+    def test_read_leading_structured_signature_still_fires(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Read", {"file_path": "/nope"})]),
+                _user([_tool_result("t1", "File does not exist.")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
+    def test_non_file_reading_tool_leading_keyword_still_fires(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        # Bash is unaffected by the file-reading anchor (windowed path).
+        path = write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant([_tool_use("t1", "Bash", {"command": "cat x"})]),
+                _user([_tool_result("t1", "error: no such file or directory")]),
+            ],
+        )
+        assert parse_subagent_trace(path).tool_calls[0].is_error is True
+
+
+class TestFileReadingAnchorDownstream:
+    """#580: suppressing the phantom is_error keeps PARAMETER_RETRY,
+    total_errors, and RetrySequence error fields honest for the shared
+    is_error consumers (architect review Q4)."""
+
+    def _growing_shape_reads(self, write_jsonl: WriteJSONL) -> Path:
+        # Three consecutive Reads whose param SHAPE grows (adds offset, then
+        # limit) — so PARAMETER_RETRY's shape gate is satisfied and the ONLY
+        # thing that can suppress the signal is the is_error gate — and whose
+        # heads are error vocabulary (the self-referential FP shape).
+        return write_jsonl(
+            "agent-x.jsonl",
+            [
+                _user("go"),
+                _assistant(
+                    [_tool_use("t1", "Read", {"file_path": "signals.py"})],
+                    message_id="m1",
+                ),
+                _user([_tool_result("t1", "error-handling module docstring here")]),
+                _assistant(
+                    [_tool_use("t2", "Read", {"file_path": "signals.py", "offset": 40})],
+                    message_id="m2",
+                ),
+                _user([_tool_result("t2", "failed lookups fall through to regex")]),
+                _assistant(
+                    [
+                        _tool_use(
+                            "t3",
+                            "Read",
+                            {"file_path": "signals.py", "offset": 40, "limit": 50},
+                        ),
+                    ],
+                    message_id="m3",
+                ),
+                _user([_tool_result("t3", "the error detection window bounds FPs")]),
+            ],
+        )
+
+    def _identical_reads(self, write_jsonl: WriteJSONL) -> Path:
+        # Three identical-input Reads with error-vocab heads: forms a
+        # RetrySequence so the retry._build_retry_sequence path is exercised.
+        msgs: list[dict[str, Any]] = [_user("go")]
+        for i in range(1, 4):
+            msgs.append(
+                _assistant(
+                    [_tool_use(f"t{i}", "Read", {"file_path": "signals.py"})],
+                    message_id=f"m{i}",
+                ),
+            )
+            msgs.append(_user([_tool_result(f"t{i}", "error patterns are detected here")]))
+        return write_jsonl("agent-x.jsonl", msgs)
+
+    def test_no_parameter_retry_from_self_referential_reads(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        trace = parse_subagent_trace(self._growing_shape_reads(write_jsonl))
+        signals = extract_trace_signals(trace)
+        assert not any(s.signal_type == SignalType.PARAMETER_RETRY for s in signals)
+
+    def test_total_errors_drops_to_zero(self, write_jsonl: WriteJSONL) -> None:
+        trace = parse_subagent_trace(self._growing_shape_reads(write_jsonl))
+        assert trace.total_errors == 0
+
+    def test_retry_sequence_carries_no_error_message(
+        self, write_jsonl: WriteJSONL,
+    ) -> None:
+        trace = parse_subagent_trace(self._identical_reads(write_jsonl))
+        # The identical-input run forms a sequence; with the FP suppressed it
+        # reports no errors and eventual success (retry._build_retry_sequence).
+        assert trace.retry_sequences, "expected a retry sequence from 3 identical Reads"
+        for seq in trace.retry_sequences:
+            assert seq.first_error_message is None
+            assert seq.last_error_message is None
+            assert seq.eventual_success is True
 
 
 class TestUsageAggregation:


### PR DESCRIPTION
## Summary
- Fixes the self-referential PARAMETER_RETRY false positive (#580): #510's `is_error` gate depends on synthesis via `detect_is_error_from_text`, which matches error vocabulary in the leading 200 chars — so a **successful** `Read`/`Grep`/`Glob` of error-handling source (whose head is literally error vocabulary) synthesized a phantom `is_error`. v0.10 dogfood measured 10/25 (40%) of fires as this FP.
- Adds tool-aware wrapper `detect_is_error_for_tool`: on file-reading tools (`Read`/`Grep`/`Glob`) the result must **begin** with a structured error signature (`<tool_use_error>`, `EISDIR`/`ENOENT`/`EACCES`, `File does not exist`, `File content … exceeds maximum`); every other tool keeps the unchanged windowed behavior (preserves the #241 `mcp_assessment` path). Tool name threaded through `parser._detect_is_error`; explicit `is_error` stays authoritative.
- Corpus-validated: all 15 genuine fires begin with a signature; all 10 FPs carry the keyword mid-line. Chose the strict start-anchor over a line-number-prefix inversion because Grep results lead with `path:line:` (not digits), which the inversion would misclassify and re-admit the Grep FP (architect review on #580).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — **1906 passed, 39 deselected**
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `TestDetectIsErrorForTool` (6 genuine × 3 tools + 10 FP × 3 tools + edge cases), `TestFileReadingIsErrorAnchor` (parser synthesis), `TestFileReadingAnchorDownstream` (no PARAMETER_RETRY, `total_errors` intentional drop, `retry._build_retry_sequence` error fields)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI output change; internal diagnostics heuristic)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

> Rationale: the change lives in the JSONL-parsing module (`traces/parser.py`) so it is flagged conservatively. The actual change is a bounded regex heuristic on already-parsed result text — no new deserialization, path/shell/network sink, or user-string rendering; the added `LEADING_ERROR_REGEX` is anchored (`.match`) and its one lazy `.*?` is gated behind a literal `File content ` prefix (no ReDoS on arbitrary input). Label to be applied at dev-complete per the timing convention.

## Breaking changes
None. No public contract change — internal `is_error` synthesis becomes stricter on file-reading tools only; JSON envelope, CLI flags, and Pydantic models are unchanged. The shift is a **reduction** in false-positive `is_error=True` (and therefore fewer phantom PARAMETER_RETRY fires); `TOOL_ERROR_SEQUENCE` and `compute_error_rate` are path-independent (they read the explicit flag / `iter_error_matches` on `output_text`, not this synthesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)