### PR TITLE
feat(core): surface resolvedModel on ToolResultMetadata (#593)

### DIFF
--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -140,6 +140,11 @@ class ToolResultMetadata(BaseModel):
     tool_uses: int | None = Field(None, alias="totalToolUseCount")
     duration_ms: int | None = Field(None, alias="totalDurationMs")
     agent_id: str | None = Field(None, alias="agentId")
+    resolved_model: str | None = Field(None, alias="resolvedModel")
+    """The child agent's concrete resolved model on an ``Agent`` tool result
+    (e.g. a haiku child under a sonnet main). ``None`` when ``resolvedModel`` is
+    absent. Surfaced for #112 model-routing diagnostics so a configured subagent
+    model can be verified without a cross-file join into the child trace (#593)."""
     tool_stats: dict[str, int] | None = Field(None, alias="toolStats")
     """Per-tool invocation counts keyed by tool name (e.g.
     ``{"Read": 3, "Bash": 1}``). ``None`` when ``toolStats`` is absent

--- a/tests/unit/test_sdk_session_fixture.py
+++ b/tests/unit/test_sdk_session_fixture.py
@@ -12,9 +12,10 @@ fixture carries together:
   ``ClaudeAgentOptions.model`` (``claude-sonnet-4-6``), exposed by the production
   parser as ``SessionMessage.model``.
 * **Model divergence ("the #112 artifact")** — a sonnet main delegates to a haiku
-  child; ``toolUseResult.resolvedModel`` reports the *child's* model. That field
-  is dropped by the current parser (``extra="ignore"``); it lives in the bytes as
-  a forward test-bed. Assert it against the raw bytes, not the parsed model.
+  child; ``toolUseResult.resolvedModel`` reports the *child's* model. The parser
+  now surfaces it as ``ToolResultMetadata.resolved_model`` (#593 S3), so #112 can
+  verify a configured subagent model with no cross-file join; asserted against both
+  the raw bytes (source of truth) and the parsed metadata.
 
 These tests assert the fixture parses cleanly, that discovery finds the child,
 and that the load-bearing fields are present. The parser/router that consumes
@@ -28,7 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from agentfluent.core.parser import parse_session
-from agentfluent.core.session import classify_session
+from agentfluent.core.session import ToolResultMetadata, classify_session
 from agentfluent.traces.discovery import discover_session_subagents
 
 _FIXTURE = Path(__file__).parent.parent / "fixtures" / "sdk_session"
@@ -84,14 +85,23 @@ class TestDiscriminator:
 
 class TestModelDivergence:
     def test_resolved_model_reports_the_child_model(self) -> None:
-        # resolvedModel is dropped by the parser (extra="ignore"); it is the
-        # field #112 will need, so it lives in the bytes as a forward test-bed.
+        # `resolvedModel` reports the *child's* concrete model — the #112 artifact.
+        # Assert against the raw bytes (source of truth)...
         result_lines = [obj for obj in _raw(_MAIN_JSONL) if "toolUseResult" in obj]
         assert len(result_lines) == 1
         tur = result_lines[0]["toolUseResult"]
         assert tur["resolvedModel"] == _CHILD_MODEL
         assert tur["resolvedModel"] != _MAIN_MODEL
         assert tur["status"] == "completed"
+
+    def test_parser_surfaces_resolved_model_on_metadata(self) -> None:
+        # ...and that the parser now surfaces it (#593 S3) so #112 needs no
+        # cross-file join into the child trace.
+        msgs = parse_session(_MAIN_JSONL)
+        metas = [m.metadata for m in msgs if m.metadata is not None]
+        assert len(metas) == 1
+        assert metas[0].resolved_model == _CHILD_MODEL
+        assert metas[0].resolved_model != _MAIN_MODEL
 
     def test_child_trace_ran_the_resolved_model(self) -> None:
         child_models = [
@@ -100,6 +110,19 @@ class TestModelDivergence:
             if obj.get("type") == "assistant"
         ]
         assert child_models == [_CHILD_MODEL]
+
+
+class TestResolvedModelField:
+    """Unit-level locks for the #593 field, independent of the fixture."""
+
+    def test_alias_populates_resolved_model(self) -> None:
+        meta = ToolResultMetadata.model_validate({"resolvedModel": _CHILD_MODEL})
+        assert meta.resolved_model == _CHILD_MODEL
+
+    def test_absent_resolved_model_is_none(self) -> None:
+        # A tool result with no `resolvedModel` parses without crashing.
+        meta = ToolResultMetadata.model_validate({"agentId": "x", "totalTokens": 1})
+        assert meta.resolved_model is None
 
 
 class TestDiscoveryAndLinkage:


### PR DESCRIPTION
## Summary
- Add `resolved_model: str | None` (alias `resolvedModel`) to `ToolResultMetadata` in `core/session.py` — the child agent's concrete resolved model on an `Agent` tool result (e.g. a haiku child under a sonnet main).
- Surfaces the "#112 artifact" so model-routing diagnostics can verify a configured subagent model with **no cross-file join** into the child trace. Groundwork primitive for #112; no v0.11 consumer lands before it.
- Purely additive under the model's existing `populate_by_name` + `extra="ignore"` config, mirroring the 5 sibling aliased fields; no parse-path change (parser already deserializes the whole `toolUseResult` blob).

Closes #593.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1922 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — parsed-metadata assertion on the committed `sdk_session` divergence fixture (`test_parser_surfaces_resolved_model_on_metadata`) + fixture-independent alias/None-case unit locks (`TestResolvedModelField`)
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change; parser-model field only)

## Security review
Pick one.
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

<sub>(JSONL-parsing surface: one optional string field, `extra="ignore"`, no new logic. Marginal — label to be applied at dev-complete per the label-timing convention, not at PR-create.)</sub>

## Breaking changes
None. Purely additive optional field on a Pydantic model; absent `resolvedModel` → `None` (no crash), existing consumers unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)