### PR TITLE
chore(core): add SDK line types to SKIP_TYPES; fix status doc-example nit (#594)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ lives on a sibling `toolUseResult` key (camelCase fields):
     ]
   },
   "toolUseResult": {
-    "status": "success",
+    "status": "completed",
     "prompt": "...",
     "agentId": "uuid",
     "agentType": "general-purpose",

--- a/src/agentfluent/core/session.py
+++ b/src/agentfluent/core/session.py
@@ -290,5 +290,12 @@ SKIP_TYPES: frozenset[str] = frozenset(
         "bash_progress",
         "system",
         "create",
+        # SDK/CC session bookkeeping lines (confirmed against
+        # claude-agent-sdk==0.2.106 / CLI 2.1.185, #594): skipped intentionally
+        # rather than falling through to the debug-`else` branch in parse_session.
+        "queue-operation",
+        "attachment",
+        "last-prompt",
+        "ai-title",
     }
 )

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -141,6 +141,55 @@ class TestSkipTypes:
         assert "file-history-snapshot" not in types
         assert "create" not in types
 
+    # Issue #594 (S4): the four SDK/CC session line types below are now skipped
+    # *intentionally* (in SKIP_TYPES), not via the debug-`else` fall-through in
+    # parse_session. This test locks both the extraction invariant (no change to
+    # user/assistant data) and the intentional-skip property (no "Unknown message
+    # type" debug record) — the latter is what distinguishes the fix from the
+    # prior else-fallthrough that also happened to drop them.
+    _SDK_SKIP_TYPES = ("queue-operation", "attachment", "last-prompt", "ai-title")
+
+    def test_sdk_line_types_skipped_intentionally(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        lines = [json.dumps({"type": t}) for t in self._SDK_SKIP_TYPES]
+        lines.insert(
+            2,
+            json.dumps(
+                {"type": "user", "message": {"role": "user", "content": "hi"}}
+            ),
+        )
+        lines.append(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "hello"}],
+                    },
+                }
+            )
+        )
+        path = tmp_path / "sdk_skip.jsonl"
+        path.write_text("\n".join(lines) + "\n")
+
+        with caplog.at_level(logging.DEBUG, logger="agentfluent.core.parser"):
+            messages = parse_session(path)
+
+        # (a) the four SDK types are absent from the parsed output ...
+        assert [m.type for m in messages] == ["user", "assistant"]
+        # ... and (b) the surviving user/assistant data is unchanged.
+        assert messages[0].text == "hi"
+        assert messages[1].text == "hello"
+
+        # (c) intentional skip: the debug-`else` branch is NOT reached for any of
+        # the four types (they were filtered at iter_raw_messages).
+        debug_text = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG
+        )
+        for skip_type in self._SDK_SKIP_TYPES:
+            assert f"Unknown message type '{skip_type}'" not in debug_text
+
 
 class TestMalformedInput:
     def test_skips_bad_lines(self, malformed_session_path: Path) -> None:

--- a/tests/unit/test_session_models.py
+++ b/tests/unit/test_session_models.py
@@ -263,6 +263,11 @@ class TestSkipTypes:
             "bash_progress",
             "system",
             "create",
+            # SDK/CC session bookkeeping lines (#594)
+            "queue-operation",
+            "attachment",
+            "last-prompt",
+            "ai-title",
         }
         assert SKIP_TYPES == expected
 


### PR DESCRIPTION
## Summary
- Add four SDK/CC session bookkeeping line types (`queue-operation`, `attachment`, `last-prompt`, `ai-title`) to the `SKIP_TYPES` frozenset in `core/session.py` so they are skipped **intentionally** rather than falling through to the debug-`else` branch in `parse_session`. Restores that branch's diagnostic value for genuinely-unknown types; **no change to extracted user/assistant data** (both paths drop the line without appending a message).
- Fix the `CLAUDE.md` `toolUseResult` doc-example: `status: "success"` → the observed `"completed"` (findings S4/§5).
- Add a regression test that proves the *intentional*-skip property (asserts the debug-`else` branch is not reached for the four types), plus extend the `SKIP_TYPES` drift-guard.

Parser hygiene for the Agent SDK ingestion stream (epic #589, S4). Confirmed against `claude-agent-sdk==0.2.106` / CLI `2.1.185`.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1923 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (`test_sdk_line_types_skipped_intentionally` — verified as a genuine discriminator; drift-guard equality in `test_session_models.py`)
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

_(JSONL-parsing surface touched — the change only **narrows** what the parser processes, adding literal strings to a skip-set. Label deferred until dev-complete per the label-timing convention.)_

## Breaking changes
None. Additive to an internal skip-set + a one-word doc fix. No public contract, CLI flag, JSON envelope, or Pydantic field change. These four types were already dropped from parsed output (via the else branch); this only makes the skip intentional.

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)