### PR TITLE
chore(loop): split loop spec into generic engine + per-project config (#612)

### DIFF
--- a/.claude/loop.config.md
+++ b/.claude/loop.config.md
@@ -1,0 +1,119 @@
+# Loop config — AgentFluent
+
+Per-project bindings for the supervised dev loop. `loop-engine.md` (the generic engine)
+references every value below **by parameter name**; this file is the only surface a porting
+project edits. A non-Python / non-`src/` / non-GitHub project revises **all four sections
+below** (parameters, architect triggers, source layout, security routing) — never the engine.
+
+See `.claude/skills/release-loop/loop-engine.md` for the operating procedure and semantics.
+
+---
+
+## 1. Project parameters
+
+The binding table. The engine names each parameter in `CAPS`; the values here are AgentFluent's.
+
+| Parameter | AgentFluent value | Notes |
+|-----------|-------------------|-------|
+| `BACKLOG_SOURCE` | GitHub milestone (e.g. `v0.11.0`) via `gh` | could be a label (an epic is the label case — `gh issue list --label epic:<name>`), or a local `TODO.md` |
+| `SCOPE_AGENT` | `pm` (user-global subagent) | answers scope/priority/requirements questions; remove if project has none |
+| `DESIGN_AGENT` | `architect` (user-global subagent) | reviews plans pre-implementation; remove if none |
+| `CODE_REVIEW` | `/code-review` (Claude Code **built-in skill**) | independent post-impl review; verified 2026-06-29. The repo's `/review`/`/simplify` (CLAUDE.md) are alternatives, not this. |
+| `SECURITY_REVIEW` | local `/security-review` (built-in skill) for `.claude/`-only; else `needs-security-review` label → `security-review.yml` | see §4 below |
+| `VERIFY` | `/verify` (built-in skill) | runtime behavior check when an AC needs proof-by-running |
+| `PRIORITY_LABELS` | `priority:high > priority:medium > priority:low`; tiebreak: issue number ascending | drives selection (engine → Select / Initialization) |
+| `ARCHITECT_TRIGGERS` | see §2 below | **project-specific — edit when porting** |
+| `SOURCE_LAYOUT` | see §3 below | router uses this; **edit when porting** |
+| `TEST_CMD` | `uv run pytest -m "not integration"` | |
+| `LINT_CMD` | `uv run ruff check src/ tests/` | |
+| `TYPE_CMD` | `uv run mypy src/agentfluent/` | |
+| `CI_STATUS_CMD` | `gh pr checks <PR>` | |
+| `BRANCH_FMT` | `feature/<n>-slug` / `fix/<n>-slug` | from CLAUDE.md |
+| `COMMIT_CONV` | Conventional Commits; `.claude/**`→`chore:`/`docs:` | see commit-scope rule below |
+| `PR_TEMPLATE` | `.github/PULL_REQUEST_TEMPLATE.md` (must replicate) | |
+| `MERGE_METHOD` | squash, `--delete-branch`, explicit `--subject` scope | |
+| `APPEND_ONLY_FILES` | `.claude/specs/decisions.md` | guarded by the C1 hook |
+| `PERMISSION_POSTURE` | background agents validate-only → parent implements | see hard constraints below |
+| `LEDGER_ROOT` | `.claude/loop/` | **gitignored** — local working state, never committed |
+| `RELEASE_SCHEME` | SemVer via release-please; PyPI artifact | the engine's merge gate reads "≤ patch bump or no bump"; a project with **no** release cycle (e.g. an epic-sourced run) treats every change as "no release-artifact bump" |
+
+**Workflow conventions (from CLAUDE.md).** Branch from `main`; PR with passing CI before
+merge (naming `BRANCH_FMT`). PR body **must replicate** `PR_TEMPLATE` (CI's `PR Template Check`
+rejects otherwise). Tests required for code changes; no regressions; mypy strict on `src/`.
+
+**Commit-scope rule.** `.claude/**` changes are maintainer-only tooling → `chore:`/`docs:`,
+never `feat:`/`fix:` (avoids release-please mis-bumps). The orchestrator sets the squash
+**`--subject` scope explicitly**, not inheriting the PR title.
+
+**Hard constraints that shape the loop here (project-specific unless noted):**
+1. Background/non-interactive agents are **validate-only** — `settings.local.json` withholds
+   Edit/Write/git/gh from agents that can't prompt. The parent (interactive) thread does all
+   implementation + git/gh; no fan-out of implementation. *(A project without this restriction
+   could parallelize iterations via worktrees — see engine roadmap.)*
+2. *(General, Claude Code)* Subagents can't invoke subagents — the orchestrator drives
+   `SCOPE_AGENT`/`DESIGN_AGENT` directly.
+3. CI is gated on `branches:[main]`; stacked PRs break it → one PR at a time, each from `main`.
+4. `SCOPE_AGENT`/`DESIGN_AGENT` are user-global, not repo-tracked; editing them yields no PR
+   and needs a session restart.
+
+---
+
+## 2. `ARCHITECT_TRIGGERS`
+
+Fire `DESIGN_AGENT` when the plan: touches shared models (`SessionMessage`, `AgentInvocation`);
+changes a cross-module interface; adds a new diagnostics rule, correlation logic, or analytics
+pipeline; **or the orchestrator is unsure.** Bias toward calling it (read-only, cheap vs. a bad
+implementation). Skip for docs and trivial research.
+
+---
+
+## 3. `SOURCE_LAYOUT` — router signals
+
+The project-specific inputs to the engine's Route classification (engine → Router):
+
+- **Package layout:** code in `src/agentfluent/`; tests in `tests/`; research/throwaway
+  scaffolding lives **outside** `src/` with **no runtime-dep leakage** into the package.
+- **`docs` label / path:** GitHub label `documentation`, change confined to `docs/`/markdown.
+- **`research` label / path:** GitHub label `research` or an epic named `*-discovery`; "artifact
+  under study is data"; no test-coverage gate.
+- **`stub-defer` marker:** issue body says "NOT implementation-ready" / is a tracking stub
+  (e.g. #469, D041 — carried, not implemented).
+- **`code` (default):** `bug`/`enhancement` touching `src/` → full pipeline.
+
+---
+
+## 4. Security routing (host-repo / GitHub specifics)
+
+The engine's step-10 security gate reads its *specifics* from here (engine keeps the gate's
+position + confidence-bar discipline):
+
+- **`.claude/`-only change** → run local `SECURITY_REVIEW` (`/security-review`). The labeled
+  workflow (`security-review.yml`) **excludes** `.claude/`, so the label does nothing here; the
+  local skill needs `git remote set-head origin -a` if it errors on `origin/HEAD...`.
+- **Otherwise, sensitive surface touched** → apply the `needs-security-review` label **only when
+  dev-complete** (the workflow triggers on `[labeled]`, not on push — labeling early leaves later
+  commits unreviewed). Skip for docs/no-surface changes.
+
+**Mechanical rules (both learned in the #500 pilot):** `.claude/`-only → local review, not the
+label (workflow excludes `.claude/`; local skill needs `origin/HEAD` set); squash `--subject`
+scope set explicitly (`chore:` for `.claude/**`), not inherited from the PR title.
+
+---
+
+## 5. Project examples referenced by the engine's guidance
+
+The engine states its principles generically; these are the AgentFluent instances it draws on,
+kept here so the engine stays project-agnostic:
+
+- **Post-hoc token/cost analyzer** (engine journal step, `tokens=deferred`): AgentFluent itself,
+  run over the loop's own JSONL corpus.
+- **Externally-cited-source fidelity check** (engine Plan step): a research-scout candidate feed
+  (`anthropic-feature-watch`) is one such source. The #437 / decision **D046** episode is the
+  worked example — a feature extrapolated past what its source established.
+- **Cheap-falsifier-caught-late** (engine Plan step): the #437 corpus pass caught a misdirected
+  feature, but only post-hoc.
+- **Notes-as-decision, not-evidence** (engine Triage step + ledger discipline): the v0.10.0
+  row-12 resume-instability failure is the worked example of mutable live evidence in Notes
+  destabilizing resume.
+- **First route graduation** (engine merge gate, `graduated-routes`): decision **D047** graduated
+  `docs`+`research`.

--- a/.claude/skills/release-loop/SKILL.md
+++ b/.claude/skills/release-loop/SKILL.md
@@ -5,260 +5,40 @@ description: Run one routed iteration of the supervised dev loop over a backlog 
 
 # Release Loop — orchestrator (ONE issue per invocation)
 
-You are the orchestrator of a supervised dev loop. Each invocation handles exactly ONE
-issue end-to-end, journals, and stops. State lives in the ledger, not your context — so a
-fresh invocation resumes correctly. Read the project parameters in
-`.claude/specs/prd-loop-engineering.md` §4.0.
+You are the orchestrator of a supervised dev loop. Each invocation handles exactly ONE issue
+end-to-end, journals, and stops. **State lives in the ledger, not your context** — so a fresh
+invocation resumes correctly.
 
-## 0. Load or initialize state
-1. Identify the active run (most recent `LEDGER_ROOT/<run>/`). If none exists, ask the user which
-   milestone/label to run, then INITIALIZE per §7.5 of the spec. Otherwise scan the FULL
-   `progress.md` for the **most recent** run-state sentinel — the last of `{RUN COMPLETE, RUN
-   PARKED, RUN RESUMED}` by append order (the log is append-only, so a superseded sentinel still
-   sits above; last one wins) — and act only on it:
-   - `RUN COMPLETE` (§9) → report done and STOP; do not re-scan (the run is terminal).
-   - `RUN PARKED — awaiting <condition>` (§9) — the run finished all *workable* rows and rests on
-     an external event:
-     - **If this invocation explicitly releases the park** (the human names a met condition — "the
-       cut is out, resume"): perform the concrete un-park mutation, **scoped to the released
-       condition** — flip back to `routed` (retain Route, clear the `awaiting:` marker) ONLY the
-       `parked` rows whose `awaiting:` condition the human named; leave rows still gated on *other*
-       conditions `parked` with their markers intact (if which rows a release covers is ambiguous,
-       ask — do NOT flip all, that would prematurely release a still-unmet gate). Append a `RUN
-       RESUMED` sentinel (now last-wins) and continue to step 2; any rows left parked simply
-       re-append `RUN PARKED` at the next §1 pass (last-wins over `RUN RESUMED`), which the existing
-       machinery handles. A bare re-fire (e.g. the `/loop` driver) does NOT release the park.
-     - **Otherwise take the cheap parked path (no full re-scan):** read `queue.md` + the FULL
-       `progress.md`, run the §1 milestone-roster reconciliation (the one scan a parked run still
-       owes — this is how milestone drift is still caught), then **re-derive selectability from
-       `queue.md` alone** (no git/PR reconcile). If that produced selectable work (a joiner the
-       human pulled in, or an in-run dep that has since cleared) fall through to §1 **at selection**
-       (the reconciliation just ran — do not repeat it); otherwise STOP and report "parked —
-       awaiting <condition>" **without** running §0 step 3 resume or any per-row live reconcile —
-       skipping resume is provably safe here (a valid PARKED state has every non-`parked` row
-       terminal, so no interrupted pipeline row can coexist).
-   - `RUN RESUMED` or no sentinel → continue to step 2 (a released or never-parked run runs
-     normally).
-2. Read `queue.md` (note its `mode:` / `graduated-routes:` header and any `hold`/`parked` rows) and the tail of `progress.md`.
-3. **Resume before selecting (spec §7.6).** If any row sits in an *interrupted* status —
-   non-terminal and NOT `queued`/`routed`/`hold`/`parked` (i.e. `planning`/`plan-approved`/
-   `implementing`/`in-pr`/`in-review`) — a prior iteration was cut off. Reconcile it against
-   LIVE git/PR state as the source of truth — branch exists? PR open? already merged? CI
-   status? — plus the working tree (status is only a coarse anchor; git wins on conflict),
-   then re-enter the pipeline at the matching stage and FINISH that issue BEFORE selecting a
-   new one. This is what makes "one PR at a time" hold across `/clear`/compaction. A `hold` or
-   `parked` row is NOT an interruption: skip it here — a `hold` stays held until the human
-   releases the merge, a `parked` row stays gated until its external condition is released (step
-   1); neither blocks working other issues.
+The operating procedure and all semantics live in two sibling files. Sibling files are read on
+demand, not auto-injected, so **your literal first step is to read both** — do not act on the
+invariants below without them:
 
-## 1. Select
-**Budget cap (iteration start, retrospective).** Read `iteration-cap:` / `subagent-cap:` from the
-`queue.md` header (both default `none` = uncapped). Cumulative iterations = the count of **distinct
-issues at a terminal status** (`done`/`deferred`/`blocked`) in `queue.md` — never count
-`progress.md` blocks (a `/clear`-resume re-enters an iteration and double-counts). Breach = that
-count ≥ `iteration-cap`, OR the **prior** iteration's journaled `- Budget:` line (§12) shows
-`subagent-runs` ≥ `subagent-cap`. On breach: **manual re-invoke is advisory** — journal + surface
-it and proceed (the human who invoked is the budget authority); **the driver halts.** Inert while
-both caps are `none`.
+1. **`${CLAUDE_PROJECT_DIR}/.claude/loop.config.md`** — the per-project bindings (what
+   `BACKLOG_SOURCE`, `SCOPE_AGENT`, `DESIGN_AGENT`, `CODE_REVIEW`, `PRIORITY_LABELS`, `LINT_CMD`/
+   `TYPE_CMD`/`TEST_CMD`, `BRANCH_FMT`, `COMMIT_CONV`, `MERGE_METHOD`, … resolve to for this repo).
+2. **`.claude/skills/release-loop/loop-engine.md`** — the generic engine: the numbered pipeline
+   (step 0 load/resume → 1 select → 2 route → 3 plan → 4 architect → 5 human gate → 6 implement →
+   7 AC-verify → 8 commit/PR → 9 code-review → 10 security → 11 merge → 12 journal), plus the
+   ledger format, router, AC-verifier, initialization, resume, routing table, and
+   gate/convergence/park-hold/budget semantics.
 
-**Milestone-roster reconciliation (iteration start).** The queue built at init (§7.5) is the
-authoritative work set — the *curated subset*; milestone membership may drift afterward, and drift
-is **surfaced to the human once, never auto-applied** — neither auto-added on join nor auto-ejected
-on leave. Compute the delta between the live `BACKLOG_SOURCE` roster (one `gh issue list
---milestone <run> --state open`) and `queue.md`, deduping against prior curation records via a
-FULL-file scan of `progress.md` (not the tail) for exact `- surfaced-join:` / `- surfaced-leave:`
-lines:
-- **Joined** (in the milestone, no `queue.md` row, not already surfaced) → surface once: "#N joined
-  <run> after init — pull in, or leave out? (never auto-added)." Record `- surfaced-join: #N` in a
-  `## <ISO8601> — curation` block. Only on the human's "pull in" add a `queued` row; a bare surface
-  never adds one.
-- **Left** (a non-terminal `queue.md` row whose issue is no longer in the milestone, not already
-  recorded) → surface once: "#N left <run> — eject, or keep? (never auto-ejected)." Record
-  `- surfaced-leave: #N`. On "keep", write the decision to the row's Notes (`kept: out-of-<run>
-  roster (curation)`) so it self-dedups; on "eject", an in-flight leaver (`planning`..`in-review`,
-  open PR) is **finish-then-reconsider**, not a bare eject (only a pre-pipeline row ejects cleanly —
-  close/clean its PR+branch first), then set the row `deferred` with a curation Notes reason.
-This paragraph is the sub-unit the §0 step 1 parked path invokes standalone.
+Read config for **bindings**, engine for **logic**. Execute the engine's pipeline exactly, for
+exactly one issue, then STOP.
 
-A row is **selectable** if its status is `queued`/`routed`, OR it is `blocked` on an unmet
-dependency that has SINCE cleared (all its `Depends on` issues are now `done` — re-route it via
-§2; this does NOT apply to a `blocked: too-large` park, which waits on a split). A `parked` row is
-never selectable here — it is released only by explicit human un-park (§0 step 1). Among selectable
-rows pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable,
-determine the resting state from the remaining non-terminal rows (test in this order):
-- Any `hold` row present → report "<n> held — awaiting human merge-release" and STOP **without** a
-  sentinel (a held row needs the human now; the run is neither complete nor cleanly parked).
-- Else if ≥1 `parked` row is present AND every non-`parked` row is `done`/`deferred` → append the §9
-  `RUN PARKED — awaiting <condition(s)>` sentinel to `progress.md` (name the awaited condition(s) +
-  the parked rows) and STOP. This is a **resting, non-terminal** state: the next invocation
-  short-circuits on it (§0 step 1) instead of re-reconciling. (Tested BEFORE COMPLETE so a
-  release-gated row is not swallowed as terminal; it requires truly-terminal peers — a plain
-  in-run-`blocked` row present routes to pending below, not to a false park.)
-- Else if EVERY row is terminal (`done`/`deferred`/`blocked`) → append the §9 `RUN COMPLETE —
-  <run-slug>` sentinel to `progress.md` (counts + any blocked/deferred items) and STOP
-  (convergence).
-- Else (rows still `blocked` on an open in-run dependency, or `blocked: too-large` awaiting a split)
-  → report what's pending and STOP without a sentinel.
-**Size guard:** before entering the pipeline, estimate scope from the issue body — if it
-plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
-fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
-go back to select. Aggressively offload reading/analysis to subagents (architect, AC-verifier)
-within an iteration to conserve the parent's context.
+## Fail-safe invariants (hold even before the engine loads)
 
-## 2. Triage / route (if not already routed)
-Run §7.3 to set the row's **Route** (`code`/`research`/`docs`/`stub-defer`) and its **initial
-Status** (Route and Status are distinct — §6.1): `stub-defer` → Status `deferred` (terminal); an
-unmet in-run dependency → Status `blocked` (record the dep, or `too-large`, in Notes — the Route is
-retained so the row resumes as that route when the dependency clears, §1); a row whose work is
-gated on an **external event** (a release cut, a dogfood window — not an in-run issue) → Status
-`parked` with Notes `awaiting: <condition>` (non-terminal, resting; released only by explicit human
-un-park, §0 step 1); otherwise → Status `routed`. If the Status is `deferred`/`blocked`/`parked`,
-journal why and go back to §1 — do not implement.
+These are restated here so a partial load **over-escalates** (safe) rather than under-gates. The
+engine is authoritative; on any conflict, follow the engine — but never do less than this:
 
-**Write parked/blocked Notes as the curation DECISION, never the mutable evidence.** The durable
-*why* (`awaiting: v0.11.0 cut`, `deliberately out of <run> at init (curation)`, `kept: out-of-<run>
-roster (curation)`) survives a later live re-check; the mutable live evidence ("not in milestone",
-"no PR yet") is contradicted by the next re-check and destabilizes resume (the v0.10.0 row-12
-failure).
-
-## 3. Plan
-Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
-`issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
-research/docs.
-
-**Value framing (opens the plan, route-scaled).** State *why this should exist* in
-user terms — the question the architect/AC-verifier/code-review gates never ask (they check we
-build the thing right, not that it's the right thing). You write it inline; it is not extra
-ceremony. Scale it to the route:
-- **`feat:`** — a compact user-story map: one backbone activity + 1–3 `as a <user>, I want
-  <capability>, so that <outcome>` stories. Each carries **who benefits**, its **prevalence**
-  (how often real configs/corpora actually hit it), and a **falsifier** — *what single
-  observation would show this feature is misdirected?* (e.g. "~0 matching instances in any real
-  corpus"). A story with no credible user, or no checkable falsifier, is a red flag.
-- **`fix:`** — one line: who hits the bug, how often, what breaks without the fix.
-- **`docs:`** — who reads it and what it unblocks.
-- **`research:`** — the question, the downstream decision it informs, and what a **null result**
-  would mean (a null that changes nothing is a sign the question isn't worth asking).
-- **`chore:` / `refactor:`** — one line: what internal tooling or quality this serves and why
-  now; no user-facing story required (state "internal tooling, no PyPI-visible change" if so).
-
-**Discharge cheap falsifiers at plan time — don't just state them.** If a story's falsifier is
-checkable *before* code (a grep / corpus / prevalence pass), RUN it now, or escalate; a
-stated-but-unrun falsifier is not sufficient. This is the load-bearing step: the cheap corpus
-pass is exactly what caught #437 — but only post-hoc. Defer discharge only when the check
-genuinely requires the built feature.
-
-**Source-fidelity check (any externally-cited justification).** If the issue's rationale leans on
-an external source — a research-scout (`anthropic-feature-watch`) candidate, a linked article, a
-postmortem — confirm the source actually supports the generalization the issue makes: **locus**
-(does the incident occur on the surface this feature inspects?), **evidence base** (n, scope,
-whether the source itself generalizes), and **current relevance** (already fixed upstream?
-version-specific?). An issue that extrapolates past what its source establishes is misdirected
-regardless of implementation quality. (The #437 lesson — decision D046.)
-
-**When you can't articulate it, escalate — don't build.** If you cannot state a credible user
-*and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not
-proceed on a plan whose value story doesn't hold.
-
-## 4. Architect gate (conditional)
-If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
-the plan; address `blocking`/`important` concerns before coding. Skip for docs and trivial
-research.
-
-## 5. Human gate (conditional — every mode)
-The plan gate is **conditional in every mode** — `mode:` gates the merge gate only (§11), never
-this one. It is **value-first**: present the §3 value framing (user-story map / value statement)
-alongside the approach, and treat a **non-credible value story — no plausible user, or no
-checkable falsifier — as itself a reason to STOP**, not just ambiguous ACs. Present the plan and
-STOP for approval when: the value story doesn't hold; acceptance criteria are ambiguous; the
-change is risky/irreversible; SCOPE/DESIGN agents disagree or punt; or you are otherwise unsure.
-Otherwise proceed (note "auto-approved" + why in the journal). Route scope/value questions to
-SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
-(human or auto), advance the row to `plan-approved`.
-
-## 6. Implement (you, the parent thread)
-Advance the row to `implementing`. Create the branch (`BRANCH_FMT`). Implement code + tests +
-docs per the plan. TDD where it fits (write failing tests, commit, do not modify tests later).
-Run `LINT_CMD`, `TYPE_CMD`, `TEST_CMD` until green. Do NOT stage unrelated pre-existing
-working-tree changes.
-
-## 7. Verify done (independent, fresh context)
-Run the AC-verifier (spec §7.4): a fresh check that the diff satisfies EVERY acceptance
-criterion — verify state, not your claim. If gaps, fix and re-verify (max 2 rounds, else
-escalate).
-
-## 8. Commit + PR
-Commit with correct `COMMIT_CONV` scope. Open the PR; **replicate `PR_TEMPLATE` fully** in
-the body; make the Security-review choice up front. Advance the row to `in-pr` and record the
-PR number. Wait for CI; fix until green.
-
-## 9. Code review
-Advance the row to `in-review`. Run CODE_REVIEW on the diff. Implement viable findings;
-decline others with a one-line rationale; **verify recs were applied**. Bounded to 2 rounds —
-contested findings escalate to the human, do not loop. Commit fixes.
-
-## 10. Security review (by route)
-- `.claude/`-only change → run local `/security-review` (the labeled workflow excludes
-  `.claude/`; the local skill needs `git remote set-head origin -a` if it errors on
-  `origin/HEAD...`).
-- Otherwise, if a sensitive surface is touched → apply `needs-security-review` ONLY now
-  (dev-complete). Skip for docs/no-surface changes.
-Address findings ≥ the project's confidence bar.
-
-## 11. Merge
-Read the run `mode` and `graduated-routes` from the `queue.md` header. The merge gate is the
-**only** gate `mode` changes (§5 is conditional in every mode). A row is **auto-merge-eligible**
-only when ALL of these hold:
-- `mode: escalation-only`, AND
-- the row's Route is listed in the header's `graduated-routes` field, AND
-- the version bump is ≤ patch — a `docs`/`chore` change produces no bump, which qualifies, AND
-- the row is **not** `hold`, AND
-- none of the always-escalate conditions apply: a `feat:`/breaking change, a risky/irreversible
-  change, a touched security surface, or a contested review finding.
-
-**Default-deny:** if route graduation or any always-escalate condition is uncertain, the row is
-**not** auto-merge-eligible — fall back to the human merge gate.
-
-If the row is **not** auto-merge-eligible — which includes *every* row under `mode: calibration`
-(the default) and any `hold` row — STOP and ask the human before merging; never auto-merge.
-**If the human holds the merge (now or in any later invocation),
-WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
-it persists across `/clear`; resume (step 0.3), §1, and this gate all key on Status `hold` and
-honor it until the human clears it (restoring the row's prior status). When the row **is**
-auto-merge-eligible (or the human has approved), and CI + security are green AND the row is not
-`hold`:
-squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
-`--delete-branch`. Confirm the issue closed.
-
-## 12. Journal + stop
-Append the iteration block to `progress.md`, including a `- Budget:` line (spec §6.2):
-`subagent-runs=<n>` · `gate-rounds=architect=<a>,code-review=<c>,ac-verify=<v>` ·
-`wall-clock=<elapsed, includes gate-wait — not a cap input>` · `tokens=deferred` (computed
-post-hoc by AgentFluent over the loop JSONL; the named slot keeps the line forward-stable).
-Set the `queue.md` row to `done` (or `blocked`/`deferred` with reason); note newly-unblocked
-issues. The ledger is gitignored — do NOT commit it (spec §6.4). STOP. (Driver re-invokes with
-fresh context for the next issue.)
-
-## Escalation rubric (when unsure)
-Scope/priority/requirements — including any plan whose value story lacks a credible user or a
-checkable falsifier (§3) — → SCOPE_AGENT (pm), before implementing. Design/implementation →
-DESIGN_AGENT. Escalate to the HUMAN only when those disagree/punt, ACs are unresolvable, an
-action is destructive/irreversible, a review finding is contested, or the same step failed twice.
-
-## Guardrails
-One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL
-`progress.md` (not just the tail) for the signature: an identical CI failure, or the same
-tool+args failing again — NOT merely re-entering a status (a legitimate `/clear`-resume
-re-enters `implementing` and must not be flagged). On a genuine repeat: stop, escalate, mark
-`blocked`, move on. Respect any iteration/budget cap (`iteration-cap:`/`subagent-cap:` in the
-`queue.md` header): checked at iteration start (§1) against the ledger — **advisory in manual
-re-invoke (journaled + surfaced, not gating), halted by the driver**.
-
-## Tool surface — and what you must NOT do
-This skill intentionally runs with the full session toolset (no `allowed-tools` restriction):
-an orchestrator needs Write/Edit, Bash(git+gh+tests), Agent (pm/architect/AC-verifier), and
-the built-in review skills. With that power come hard limits — never force-push; never bypass
-failing CI (no `gh pr merge --admin`, never merge red); only `--delete-branch` the PR's own
-branch; never `git add` unrelated pre-existing working-tree changes; never edit the
-user-global SCOPE_AGENT/DESIGN_AGENT definitions. The C1 append-only guard and the
-human/merge gates are the enforced backstops; the rest of this list is your contract.
+- **One issue per invocation, then STOP and journal.** Never batch. The driver re-invokes with
+  fresh context for the next issue.
+- **Resume before selecting.** If a ledger row is mid-pipeline (interrupted), finish it against
+  live git/PR state before starting anything new. One PR at a time; no stacked PRs.
+- **Never auto-merge under uncertainty.** Default-deny: if you are unsure whether a row is
+  auto-merge-eligible, STOP and ask the human. Never merge red CI, never force-push, never
+  admin-merge, only `--delete-branch` the PR's own branch.
+- **Escalate rather than guess.** Scope/value → `SCOPE_AGENT`; design → `DESIGN_AGENT`; unresolved,
+  contested, or irreversible → the human.
+- **Never edit the user-global `SCOPE_AGENT`/`DESIGN_AGENT` definitions**, and never `git add`
+  unrelated pre-existing working-tree changes.
+- **The ledger is gitignored** — do NOT commit it.

--- a/.claude/skills/release-loop/loop-engine.md
+++ b/.claude/skills/release-loop/loop-engine.md
@@ -1,0 +1,592 @@
+# Loop engine — generic operating procedure & semantics
+
+This is the **project-agnostic engine** for the supervised dev loop: control flow, gate /
+convergence / resume semantics, the ledger format, the router procedure shape, and the budget
+machinery. It contains **no project-specific values**.
+
+Every name in `CAPS` (`BACKLOG_SOURCE`, `LEDGER_ROOT`, `SCOPE_AGENT`, `DESIGN_AGENT`,
+`CODE_REVIEW`, `PRIORITY_LABELS`, `ARCHITECT_TRIGGERS`, `SOURCE_LAYOUT`, `LINT_CMD`/`TYPE_CMD`/
+`TEST_CMD`, `BRANCH_FMT`, `COMMIT_CONV`, `MERGE_METHOD`, `RELEASE_SCHEME`, …) is bound in the
+per-project **`loop.config.md`**. **Read that config first** — this engine depends on the
+config's parameter *vocabulary*, never its layout.
+
+Cross-references within this doc are by **named section** (e.g. "the Resume procedure below"),
+and pipeline steps are numbered 0–12. The live skill (`SKILL.md`) is the thin entry point that
+loads this engine plus the config; the full procedure lives here, once.
+
+---
+
+## The pipeline (ONE issue per invocation)
+
+You are the orchestrator of a supervised dev loop. Each invocation handles exactly ONE issue
+end-to-end, journals, and stops. State lives in the ledger, not your context — so a fresh
+invocation resumes correctly.
+
+### 0. Load or initialize state
+1. Identify the active run (most recent `LEDGER_ROOT/<run>/`). If none exists, ask the user which
+   `BACKLOG_SOURCE` (milestone/label/`TODO.md`) to run, then INITIALIZE per the Initialization
+   procedure below. Otherwise scan the FULL `progress.md` for the **most recent** run-state
+   sentinel — the last of `{RUN COMPLETE, RUN PARKED, RUN RESUMED}` by append order (the log is
+   append-only, so a superseded sentinel still sits above; last one wins) — and act only on it:
+   - `RUN COMPLETE` (see Convergence) → report done and STOP; do not re-scan (the run is terminal).
+   - `RUN PARKED — awaiting <condition>` (see Convergence) — the run finished all *workable* rows
+     and rests on an external event:
+     - **If this invocation explicitly releases the park** (the human names a met condition — "the
+       cut is out, resume"): perform the concrete un-park mutation, **scoped to the released
+       condition** — flip back to `routed` (retain Route, clear the `awaiting:` marker) ONLY the
+       `parked` rows whose `awaiting:` condition the human named; leave rows still gated on *other*
+       conditions `parked` with their markers intact (if which rows a release covers is ambiguous,
+       ask — do NOT flip all, that would prematurely release a still-unmet gate). Append a `RUN
+       RESUMED` sentinel (now last-wins) and continue to step 2; any rows left parked simply
+       re-append `RUN PARKED` at the next step-1 pass (last-wins over `RUN RESUMED`), which the
+       existing machinery handles. A bare re-fire (e.g. the `/loop` driver) does NOT release the
+       park.
+     - **Otherwise take the cheap parked path (no full re-scan):** read `queue.md` + the FULL
+       `progress.md`, run the step-1 roster reconciliation (the one scan a parked run still owes —
+       this is how `BACKLOG_SOURCE` drift is still caught), then **re-derive selectability from
+       `queue.md` alone** (no git/PR reconcile). If that produced selectable work (a joiner the
+       human pulled in, or an in-run dep that has since cleared) fall through to step 1 **at
+       selection** (the reconciliation just ran — do not repeat it); otherwise STOP and report
+       "parked — awaiting <condition>" **without** running the step-3 resume or any per-row live
+       reconcile — skipping resume is provably safe here (a valid PARKED state has every non-`parked`
+       row terminal, so no interrupted pipeline row can coexist).
+   - `RUN RESUMED` or no sentinel → continue to step 2 (a released or never-parked run runs
+     normally).
+2. Read `queue.md` (note its `mode:` / `graduated-routes:` header and any `hold`/`parked` rows) and the tail of `progress.md`.
+3. **Resume before selecting (see the Resume procedure below).** If any row sits in an *interrupted*
+   status — non-terminal and NOT `queued`/`routed`/`hold`/`parked` (i.e. `planning`/`plan-approved`/
+   `implementing`/`in-pr`/`in-review`) — a prior iteration was cut off. Reconcile it against
+   LIVE git/PR state as the source of truth — branch exists? PR open? already merged? CI
+   status? — plus the working tree (status is only a coarse anchor; git wins on conflict),
+   then re-enter the pipeline at the matching stage and FINISH that issue BEFORE selecting a
+   new one. This is what makes "one PR at a time" hold across `/clear`/compaction. A `hold` or
+   `parked` row is NOT an interruption: skip it here — a `hold` stays held until the human
+   releases the merge, a `parked` row stays gated until its external condition is released (step
+   1); neither blocks working other issues.
+
+### 1. Select
+**Budget cap (iteration start, retrospective).** Read `iteration-cap:` / `subagent-cap:` from the
+`queue.md` header (both default `none` = uncapped). Cumulative iterations = the count of **distinct
+issues at a terminal status** (`done`/`deferred`/`blocked`) in `queue.md` — never count
+`progress.md` blocks (a `/clear`-resume re-enters an iteration and double-counts). Breach = that
+count ≥ `iteration-cap`, OR the **prior** iteration's journaled `- Budget:` line (step 12) shows
+`subagent-runs` ≥ `subagent-cap`. On breach: **manual re-invoke is advisory** — journal + surface
+it and proceed (the human who invoked is the budget authority); **the driver halts.** Inert while
+both caps are `none`.
+
+**Roster reconciliation (iteration start).** The queue built at init (see Initialization) is the
+authoritative work set — the *curated subset*; `BACKLOG_SOURCE` membership may drift afterward, and
+drift is **surfaced to the human once, never auto-applied** — neither auto-added on join nor
+auto-ejected on leave. Compute the delta between the live `BACKLOG_SOURCE` roster (one enumeration,
+e.g. `gh issue list --milestone <run> --state open` for a milestone source) and `queue.md`,
+deduping against prior curation records via a FULL-file scan of `progress.md` (not the tail) for
+exact `- surfaced-join:` / `- surfaced-leave:` lines:
+- **Joined** (in the `BACKLOG_SOURCE` roster, no `queue.md` row, not already surfaced) → surface
+  once: "#N joined <run> after init — pull in, or leave out? (never auto-added)." Record `-
+  surfaced-join: #N` in a `## <ISO8601> — curation` block. Only on the human's "pull in" add a
+  `queued` row; a bare surface never adds one.
+- **Left** (a non-terminal `queue.md` row whose issue is no longer in the roster, not already
+  recorded) → surface once: "#N left <run> — eject, or keep? (never auto-ejected)." Record
+  `- surfaced-leave: #N`. On "keep", write the decision to the row's Notes (`kept: out-of-<run>
+  roster (curation)`) so it self-dedups; on "eject", an in-flight leaver (`planning`..`in-review`,
+  open PR) is **finish-then-reconsider**, not a bare eject (only a pre-pipeline row ejects cleanly —
+  close/clean its PR+branch first), then set the row `deferred` with a curation Notes reason.
+This paragraph is the sub-unit the step-0.1 parked path invokes standalone.
+
+A row is **selectable** if its status is `queued`/`routed`, OR it is `blocked` on an unmet
+dependency that has SINCE cleared (all its `Depends on` issues are now `done` — re-route it via
+step 2; this does NOT apply to a `blocked: too-large` park, which waits on a split). A `parked` row
+is never selectable here — it is released only by explicit human un-park (step 0.1). Among
+selectable rows pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are
+selectable, determine the resting state from the remaining non-terminal rows (test in this order):
+- Any `hold` row present → report "<n> held — awaiting human merge-release" and STOP **without** a
+  sentinel (a held row needs the human now; the run is neither complete nor cleanly parked).
+- Else if ≥1 `parked` row is present AND every non-`parked` row is `done`/`deferred` → append the
+  `RUN PARKED — awaiting <condition(s)>` sentinel (see Convergence) to `progress.md` (name the
+  awaited condition(s) + the parked rows) and STOP. This is a **resting, non-terminal** state: the
+  next invocation short-circuits on it (step 0.1) instead of re-reconciling. (Tested BEFORE COMPLETE
+  so a release-gated row is not swallowed as terminal; it requires truly-terminal peers — a plain
+  in-run-`blocked` row present routes to pending below, not to a false park.)
+- Else if EVERY row is terminal (`done`/`deferred`/`blocked`) → append the `RUN COMPLETE —
+  <run-slug>` sentinel (see Convergence) to `progress.md` (counts + any blocked/deferred items) and
+  STOP (convergence).
+- Else (rows still `blocked` on an open in-run dependency, or `blocked: too-large` awaiting a split)
+  → report what's pending and STOP without a sentinel.
+**Size guard:** before entering the pipeline, estimate scope from the issue body — if it
+plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
+fit one context window), mark it `blocked: too-large`, escalate to `SCOPE_AGENT` to split, and
+go back to select. Aggressively offload reading/analysis to subagents (`DESIGN_AGENT`,
+AC-verifier) within an iteration to conserve the parent's context.
+
+### 2. Triage / route (if not already routed)
+Run the Router (below) to set the row's **Route** (`code`/`research`/`docs`/`stub-defer`) and its
+**initial Status** (Route and Status are distinct — see Ledger format → queue.md): `stub-defer` →
+Status `deferred` (terminal); an unmet in-run dependency → Status `blocked` (record the dep, or
+`too-large`, in Notes — the Route is retained so the row resumes as that route when the dependency
+clears, step 1); a row whose work is gated on an **external event** (a release cut, a dogfood
+window — not an in-run issue) → Status `parked` with Notes `awaiting: <condition>` (non-terminal,
+resting; released only by explicit human un-park, step 0.1); otherwise → Status `routed`. If the
+Status is `deferred`/`blocked`/`parked`, journal why and go back to step 1 — do not implement.
+
+**Write parked/blocked Notes as the curation DECISION, never the mutable evidence.** The durable
+*why* (`awaiting: <external condition>`, `deliberately out of <run> at init (curation)`, `kept:
+out-of-<run> roster (curation)`) survives a later live re-check; the mutable live evidence ("not in
+roster", "no PR yet") is contradicted by the next re-check and destabilizes resume.
+
+### 3. Plan
+Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
+`issue-<N>.plan.md` (template in Ledger format → issue-<N>.plan.md), copying acceptance criteria
+verbatim. Lighter for research/docs.
+
+**Value framing (opens the plan, route-scaled).** State *why this should exist* in
+user terms — the question the architect/AC-verifier/code-review gates never ask (they check we
+build the thing right, not that it's the right thing). You write it inline; it is not extra
+ceremony. Scale it to the route:
+- **`feat:`** — a compact user-story map: one backbone activity + 1–3 `as a <user>, I want
+  <capability>, so that <outcome>` stories. Each carries **who benefits**, its **prevalence**
+  (how often real configs/corpora actually hit it), and a **falsifier** — *what single
+  observation would show this feature is misdirected?* (e.g. "~0 matching instances in any real
+  corpus"). A story with no credible user, or no checkable falsifier, is a red flag.
+- **`fix:`** — one line: who hits the bug, how often, what breaks without the fix.
+- **`docs:`** — who reads it and what it unblocks.
+- **`research:`** — the question, the downstream decision it informs, and what a **null result**
+  would mean (a null that changes nothing is a sign the question isn't worth asking).
+- **`chore:` / `refactor:`** — one line: what internal tooling or quality this serves and why
+  now; no user-facing story required (state "internal tooling, no release-visible change" if so).
+
+**Discharge cheap falsifiers at plan time — don't just state them.** If a story's falsifier is
+checkable *before* code (a grep / corpus / prevalence pass), RUN it now, or escalate; a
+stated-but-unrun falsifier is not sufficient. This is the load-bearing step: a cheap corpus pass
+has caught a misdirected feature in this project's history — but only post-hoc, which is exactly the
+argument for discharging it now. Defer discharge only when the check genuinely requires the built
+feature.
+
+**Source-fidelity check (any externally-cited justification).** If the issue's rationale leans on
+an external source — an automated research-scout candidate feed, a linked article, a postmortem —
+confirm the source actually supports the generalization the issue makes: **locus** (does the
+incident occur on the surface this feature inspects?), **evidence base** (n, scope, whether the
+source itself generalizes), and **current relevance** (already fixed upstream? version-specific?).
+An issue that extrapolates past what its source establishes is misdirected regardless of
+implementation quality — escalate rather than build.
+
+**When you can't articulate it, escalate — don't build.** If you cannot state a credible user
+*and* a checkable falsifier, route the issue to `SCOPE_AGENT` BEFORE implementing; do not
+proceed on a plan whose value story doesn't hold.
+
+### 4. Architect gate (conditional)
+If any `ARCHITECT_TRIGGERS` condition fires OR you are unsure about the design, invoke the
+`DESIGN_AGENT` with the plan; address `blocking`/`important` concerns before coding. Skip for docs
+and trivial research.
+
+### 5. Human gate (conditional — every mode)
+The plan gate is **conditional in every mode** — `mode:` gates the merge gate only (step 11), never
+this one. It is **value-first**: present the step-3 value framing (user-story map / value statement)
+alongside the approach, and treat a **non-credible value story — no plausible user, or no
+checkable falsifier — as itself a reason to STOP**, not just ambiguous ACs. Present the plan and
+STOP for approval when: the value story doesn't hold; acceptance criteria are ambiguous; the
+change is risky/irreversible; SCOPE/DESIGN agents disagree or punt; or you are otherwise unsure.
+Otherwise proceed (note "auto-approved" + why in the journal). Route scope/value questions to
+`SCOPE_AGENT` and design questions to `DESIGN_AGENT` BEFORE escalating to the human. On approval
+(human or auto), advance the row to `plan-approved`.
+
+### 6. Implement (you, the parent thread)
+Advance the row to `implementing`. Create the branch (`BRANCH_FMT`). Implement code + tests +
+docs per the plan. TDD where it fits (write failing tests, commit, do not modify tests later).
+Run `LINT_CMD`, `TYPE_CMD`, `TEST_CMD` until green. Do NOT stage unrelated pre-existing
+working-tree changes.
+
+### 7. Verify done (independent, fresh context)
+Run the AC-verifier (below): a fresh check that the diff satisfies EVERY acceptance
+criterion — verify state, not your claim. If gaps, fix and re-verify (max 2 rounds, else
+escalate).
+
+### 8. Commit + PR
+Commit with correct `COMMIT_CONV` scope. Open the PR; **replicate `PR_TEMPLATE` fully** in
+the body; make the Security-review choice up front. Advance the row to `in-pr` and record the
+PR number. Wait for CI; fix until green.
+
+### 9. Code review
+Advance the row to `in-review`. Run `CODE_REVIEW` on the diff. Implement viable findings;
+decline others with a one-line rationale; **verify recs were applied**. Bounded to 2 rounds —
+contested findings escalate to the human, do not loop. Commit fixes.
+
+### 10. Security review (by route)
+Run `SECURITY_REVIEW` per the routing in `loop.config.md` (the local-skill-vs-label choice and any
+host-repo Git incantation are project specifics; this engine only fixes the gate's position and
+that findings ≥ the project's confidence bar are addressed):
+- A `.claude/`-only (tooling-only) change → the **local** review path.
+- Otherwise, if a sensitive surface is touched → the **labeled** review path, applied ONLY now
+  (dev-complete). Skip for docs/no-surface changes.
+
+### 11. Merge
+Read the run `mode` and `graduated-routes` from the `queue.md` header. The merge gate is the
+**only** gate `mode` changes (step 5 is conditional in every mode). A row is **auto-merge-eligible**
+only when ALL of these hold:
+- `mode: escalation-only`, AND
+- the row's Route is listed in the header's `graduated-routes` field, AND
+- the change produces **no release-artifact bump**, or ≤ patch where `RELEASE_SCHEME` defines a
+  version scheme — a `docs`/`chore` change, or any change in a project with no release cycle,
+  produces no bump, which qualifies, AND
+- the row is **not** `hold`, AND
+- none of the always-escalate conditions apply: a `feat:`/breaking change, a risky/irreversible
+  change, a touched security surface, or a contested review finding.
+
+**Default-deny:** if route graduation or any always-escalate condition is uncertain, the row is
+**not** auto-merge-eligible — fall back to the human merge gate.
+
+If the row is **not** auto-merge-eligible — which includes *every* row under `mode: calibration`
+(the default) and any `hold` row — STOP and ask the human before merging; never auto-merge.
+**If the human holds the merge (now or in any later invocation),
+WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
+it persists across `/clear`; resume (step 0.3), step 1, and this gate all key on Status `hold` and
+honor it until the human clears it (restoring the row's prior status). When the row **is**
+auto-merge-eligible (or the human has approved), and CI + security are green AND the row is not
+`hold`:
+merge via `MERGE_METHOD` with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
+`--delete-branch`. Confirm the issue closed.
+
+### 12. Journal + stop
+Append the iteration block to `progress.md`, including a `- Budget:` line (Ledger format →
+progress.md):
+`subagent-runs=<n>` · `gate-rounds=architect=<a>,code-review=<c>,ac-verify=<v>` ·
+`wall-clock=<elapsed, includes gate-wait — not a cap input>` · `tokens=deferred` (computed
+post-hoc from the loop's own JSONL by an out-of-band analyzer, not inside the skill; the named
+slot keeps the line forward-stable).
+Set the `queue.md` row to `done` (or `blocked`/`deferred` with reason); note newly-unblocked
+issues. The ledger is gitignored — do NOT commit it (Ledger format → lifecycle). STOP. (Driver
+re-invokes with fresh context for the next issue.)
+
+### Escalation rubric (when unsure)
+Scope/priority/requirements — including any plan whose value story lacks a credible user or a
+checkable falsifier (step 3) — → `SCOPE_AGENT`, before implementing. Design/implementation →
+`DESIGN_AGENT`. Escalate to the HUMAN only when those disagree/punt, ACs are unresolvable, an
+action is destructive/irreversible, a review finding is contested, or the same step failed twice.
+
+### Guardrails
+One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL
+`progress.md` (not just the tail) for the signature: an identical CI failure, or the same
+tool+args failing again — NOT merely re-entering a status (a legitimate `/clear`-resume
+re-enters `implementing` and must not be flagged). On a genuine repeat: stop, escalate, mark
+`blocked`, move on. Respect any iteration/budget cap (`iteration-cap:`/`subagent-cap:` in the
+`queue.md` header): checked at iteration start (step 1) against the ledger — **advisory in manual
+re-invoke (journaled + surfaced, not gating), halted by the driver**.
+
+### Tool surface — and what you must NOT do
+This skill intentionally runs with the full session toolset (no `allowed-tools` restriction):
+an orchestrator needs Write/Edit, Bash(git+gh+tests), Agent (`SCOPE_AGENT`/`DESIGN_AGENT`/
+AC-verifier), and the built-in review skills. With that power come hard limits — never force-push;
+never bypass failing CI (no admin-merge, never merge red); only `--delete-branch` the PR's own
+branch; never `git add` unrelated pre-existing working-tree changes; never edit the
+user-global `SCOPE_AGENT`/`DESIGN_AGENT` definitions. The C1 append-only guard and the
+human/merge gates are the enforced backstops; the rest of this list is your contract.
+
+---
+
+## Ledger format
+
+Create `LEDGER_ROOT/<run-slug>/` (e.g. `.claude/loop/<run-slug>/`) containing three artifacts.
+The orchestrator is the only writer except where noted.
+
+### `queue.md` — work list (authoritative status)
+Dependency-ordered. One row per issue. **`Route` and `Status` are separate columns** (a row
+can be Route `research`, Status `blocked`). **Pipeline statuses** — advanced by the
+orchestrator as the issue moves through the pipeline, so an interrupted run leaves a non-terminal
+status resume keys on (see Resume): `queued → routed → planning → plan-approved → implementing →
+in-pr → in-review`. **Terminal statuses** — the run converges when every row is terminal:
+`done`; `deferred` (Route `stub-defer`); `blocked` (an unmet in-run dependency, or
+`blocked: too-large` awaiting a split). **Two non-terminal, resting statuses** sit outside both
+the pipeline and the terminal set: **`hold`** — a durable, human-set merge-hold that survives
+`/clear`; and **`parked`** — a row whose work is gated on an **external event** (a release cut, a
+dogfood window — *not* an in-run dependency), with the awaited condition in Notes as
+`awaiting: <condition>`. Both retain their Route and are released only by the human (a `hold` by
+clearing the hold at the merge gate; a `parked` row by explicit un-park, step 0.1 — which
+flips it back to `routed`). While any `hold` **or `parked`** row remains the run is NOT complete
+(Convergence distinguishes the resting `RUN PARKED` state from terminal `RUN COMPLETE`), but neither
+blocks selecting other queued work (steps 0–1).
+
+**Curated-subset invariant.** The queue built at init (see Initialization) is the authoritative
+work set; `BACKLOG_SOURCE` membership may drift afterward, and that drift is **surfaced to the
+human once, never auto-applied** — neither auto-added on join nor auto-ejected on leave (step-1
+roster reconciliation). A corollary is a Notes discipline: **write a `parked`/`blocked` row's Notes
+as the durable curation DECISION** (`awaiting: <external condition>`, `deliberately out of <run> at
+init (curation)`, `kept: out-of-<run> roster (curation)`), **never the mutable live evidence** ("not
+in roster", "no PR yet") — the latter is contradicted by a later live re-check and destabilizes
+resume.
+
+The header carries a `mode:` field that gates **the merge gate only** — it does
+**not** change the plan gate, which is conditional in *every* mode (step 5: the
+plan gate stops only on ambiguous ACs, risk/irreversibility, agent disagreement, or genuine
+uncertainty — never merely because of `mode:`). The two modes:
+- **`calibration`** (default) — the human approves **every** merge; the loop never auto-merges
+  (step 11). Plan gate conditional.
+- **`escalation-only`** — the human loosens the **merge gate per route**: a route the human has
+  *graduated* auto-merges when CI + AC-verifier + review are green and the change produces no
+  release-artifact bump (or ≤ patch where `RELEASE_SCHEME` defines one — a `docs`/`chore` change,
+  or any change with no release cycle, qualifies). *Which* routes are currently graduated is a
+  mutable human decision, recorded per-run in the `graduated-routes:` header and in the project
+  decision log — never frozen into this mechanism definition (the lesson: graduation *state* is
+  evidence, not a rule). The human merge gate is **retained** for every non-graduated route and,
+  regardless of route, for any of: a `feat:`/breaking change, a risky/irreversible change, a touched
+  security surface, a contested review finding, or a `hold` row — **and, by default-deny, whenever
+  route graduation or any always-escalate condition is uncertain, fall back to the human merge
+  gate.** Plan gate conditional (unchanged). Loosening to `escalation-only` presupposes the
+  calibration prerequisites are met (these pinned mode semantics, plus per-iteration budget
+  journaling — the `- Budget:` record and `iteration-cap:`/`subagent-cap:` fields below); it cannot
+  run headless.
+
+The set of graduated routes is recorded in a `graduated-routes:` header field beside `mode:`
+(default `none`; e.g. `graduated-routes: docs, research`). Under `mode: calibration` it is inert.
+*Which* routes graduate and the criteria for promoting one are out of scope here; this field only
+gives the merge gate (step 11) a place to read the human's decision from.
+
+The header also carries two **budget caps** (both default `none` = uncapped):
+`iteration-cap:` (max **issues per run** — in this engine one "iteration" = one issue) and
+`subagent-cap:` (max **subagent runs per iteration**). The orchestrator checks them at iteration
+start (step 1) as a **retrospective circuit-breaker** against the ledger — it does not watch
+its own spend mid-turn (that is why token/cost is deferred, below). Cumulative iterations are
+counted as the **distinct issues at a terminal status** (`done`/`deferred`/`blocked`) in
+`queue.md` — the authoritative status file — never by counting `progress.md` blocks, since a
+`/clear`-resume re-enters an iteration and would double-count. `subagent-cap` is enforced by
+reading the **prior** iteration's journaled `- Budget:` line: if it breached, halt before
+starting the next. On breach the behavior is **advisory in manual re-invoke** (journal + surface
+it and proceed — the human who invoked is the budget authority) and **halting under the driver**
+(see Convergence). The caps bound `escalation-only`'s runaway-consumption risk; bad-merge risk is
+already covered by the default-deny/always-escalate machinery above.
+
+```markdown
+# Loop run: <run-slug>
+_mode: calibration_
+_graduated-routes: none_
+_iteration-cap: none_       # max issues per run; none = uncapped
+_subagent-cap: none_        # max subagent runs per iteration; none = uncapped
+_Last updated: <ISO8601 by orchestrator>_
+
+| # | Issue | Route | Status | Depends on | PR | Notes |
+|---|-------|-------|--------|-----------|----|----|
+| 1 | #<a> precondition fix | code | done | — | #<pr> | precondition |
+| 2 | #<b> probe | research | queued | — | — | first in epic #<epic> |
+| 3 | #<c> follow-on | research | blocked | #<b> | — | needs #<b> findings |
+| 4 | #<d> stub | stub-defer | deferred | — | — | not implementation-ready |
+| 5 | #<e> post-release re-measure | code | parked | — | — | awaiting: <external condition> |
+```
+
+### `progress.md` — append-only journal (survives /clear + compaction)
+The orchestrator APPENDS one block per iteration (and per gate decision). Never rewritten.
+This is the audit trail and the resume anchor.
+
+```markdown
+## <ISO8601> — #<N> (research) — iteration start
+- Selected: #<N> (highest-priority unblocked).
+- Route: research (probe; no test-coverage gate).
+- Plan: issue-<N>.plan.md written.
+- Architect: skipped (research scaffolding, no shared-interface impact).
+- Human gate: plan auto-approved (route=research, low ambiguity).
+- Implemented: <path>; recorded findings in <path>.
+- AC-verify: 3/3 acceptance criteria met.
+- PR: #<pr> (chore scope). CI: green.
+- Code-review: 0 findings. Security: n/a (no deps added).
+- Budget: subagent-runs=3 · gate-rounds=architect=0,code-review=1,ac-verify=1 · wall-clock=18m · tokens=deferred
+- Merged: squash #<pr>. Issue #<N> closed.
+- Next: #<M> now unblocked.
+```
+
+The `- Budget:` line is the per-iteration cost record. Fields:
+- **`subagent-runs`** — the proxy cost signal the orchestrator can count for free. Its blind spot:
+  parent-thread token burn (a long implement step spawns no subagent yet can be the largest
+  consumer) is invisible to run-count — which is precisely what the deferred `tokens` field
+  eventually fixes.
+- **`gate-rounds`** — architect / code-review / ac-verify round counts (feeds review-thrash
+  detection downstream).
+- **`wall-clock`** — elapsed time including human gate-wait; recorded for the dogfood corpus, **not
+  a cap input** (an iteration that waited overnight for approval is not "expensive").
+- **`tokens=deferred`** — a reserved, named slot. Per-iteration token/cost is computed **post-hoc
+  from the loop's own JSONL by an out-of-band analyzer** (the loop JSONL is a first-class corpus),
+  not inside the skill (the orchestrator can't cleanly slice its live session mid-turn). A future
+  SDK driver backfills it via usage callbacks — keeping the slot named now makes that a backfill,
+  not a format change.
+
+### `issue-<N>.plan.md` — per-issue plan (architect-reviewed, human-approved)
+```markdown
+# Plan: #<N> — <title>
+**Route:** <code|research|docs>  **Branch:** <BRANCH_FMT>
+
+## Value framing (route-scaled — see step 3)
+<feat: backbone activity + 1–3 `as a … I want … so that …`, each with who-benefits +
+prevalence + a falsifier ("what observation would show this is misdirected?"); discharge cheap
+falsifiers here (run the grep/corpus pass) rather than only stating them.
+fix: who hits it / how often / what breaks. docs: who reads it / what it unblocks.
+research: question + downstream decision + what a null result means.
+chore:/refactor: what internal tooling/quality it serves + why now.
+Add a source-fidelity note if the rationale leans on any externally-cited source.>
+
+## Acceptance criteria (verbatim from issue)
+- [ ] ...
+
+## Approach
+<steps, files to touch, tests to add>
+
+## Architect triggers hit
+<which ARCHITECT_TRIGGERS fired, or "none">
+
+## Risks / open questions for human
+<empty if none>
+```
+
+### Lifecycle & commit policy
+- **Init:** orchestrator creates the dir + `queue.md` from `BACKLOG_SOURCE` (see Initialization).
+- **Per iteration:** update one `queue.md` row through its statuses; append `progress.md`;
+  write/update `issue-<N>.plan.md`.
+- **Commit policy — gitignore the ledger** (`LEDGER_ROOT/` is added to `.gitignore`). It is
+  local working state: it survives `/clear`/compaction on disk, but is **never committed**.
+  This is deliberate — committing it has no legal landing spot under a `main`-is-PR-only,
+  no-stacked-PRs repo (folding ledger commits into an issue's squash-merged PR would pollute that
+  PR's scope). Resolves the branch-protection collision.
+- **Dogfood corpus harvest:** read the JSONL + `progress.md` from the working tree directly; if a
+  versioned audit trail is later wanted, snapshot the ledger into a dedicated `docs:` PR on demand
+  — do not stream per-iteration ledger commits.
+- **No git/ledger divergence:** because the ledger is uncommitted, resume (see Resume) reconciles
+  the on-disk ledger against *live* git/PR state (branch exists? PR open? CI status?), which
+  is the source of truth — not a possibly-stale commit.
+
+---
+
+## Router — classification procedure
+Set the row's **Route** (the semantic kind) and its **initial Status** *separately* — they are
+distinct columns (Ledger format → queue.md), so a dependency-blocked research issue is Route
+`research` / Status `blocked`, not Route `blocked`.
+
+**Route**, from labels + body signals per `SOURCE_LAYOUT`, in order:
+1. Issue body says explicitly "NOT implementation-ready" / is a stub (per `SOURCE_LAYOUT`'s
+   stub-defer marker) → `stub-defer`.
+2. The project's docs label + change confined to docs/markdown (per `SOURCE_LAYOUT`) → `docs`.
+3. The project's research label or a `*-discovery` epic, throwaway scaffolding, "artifact under
+   study is data" (per `SOURCE_LAYOUT`) → `research` (no test-coverage gate; placement outside the
+   package; no runtime-dep leakage into the package).
+4. Otherwise (a bug/enhancement touching the package source) → `code` (full pipeline).
+
+**Initial Status:** Route `stub-defer` → `deferred` (terminal). Else if the row's work is gated on
+an **external event** (a release cut, a dogfood window — not an in-run issue) → `parked` with Notes
+`awaiting: <condition>` (non-terminal, resting; released only by explicit human un-park, step 0/1).
+Else if any `Depends on` issue is not `done` → `blocked` (record the dep in Notes; the semantic
+Route is retained so the row resumes as that route once the dependency clears, step 1). Else →
+`routed`.
+
+---
+
+## AC-verifier
+Default: **compose existing tools**, don't mint an agent.
+1. After implementation, spawn a fresh subagent with ONLY: the issue's acceptance criteria
+   (verbatim) + `git diff main...HEAD`. Prompt: *"For each acceptance criterion, state
+   met/not-met with the file:line or test that satisfies it. Verify the diff actually does
+   this; do not assume. Return a checklist + overall done/not-done."*
+2. For behavior that needs runtime proof, also run `VERIFY` (runs the app).
+3. `CODE_REVIEW` (step 9) provides the adversarial bug pass.
+Promote to a dedicated `ac-verifier` agent only if the composed approach proves too loose.
+
+---
+
+## Initialization procedure (new run)
+1. Derive `<run-slug>` from `BACKLOG_SOURCE`: milestone → the milestone name; label → the label
+   (slugified); `TODO.md` → its basename. `mkdir -p LEDGER_ROOT/<run-slug>`.
+2. Enumerate `BACKLOG_SOURCE` (e.g. `gh issue list --milestone <run> --state open --json
+   number,title,labels` for a milestone; `--label <name>` for a label/epic source).
+3. For each issue: determine route (Router) and dependencies (parse "Depends on"/"blocked by"
+   refs in the body; respect epic ordering notes). An epic *tracker* issue is not a work row —
+   carry it terminal (`deferred`) if the source enumerates it (the loop does not close epics).
+4. Topologically order by dependency, then by `PRIORITY_LABELS` (tiebreak issue-number asc).
+   Write `queue.md` with header `mode: calibration` **unless the human has already graduated routes
+   for this project** — check the decision log and, if so, init `mode: escalation-only` + the
+   graduated `graduated-routes:` instead, so a prior graduation persists across runs rather than
+   silently resetting to calibration. Step 11 reads `mode`/`graduated-routes` to gate **the merge
+   gate**, per route; it never affects the plan gate. Also set `iteration-cap: none` and
+   `subagent-cap: none` (the human sets them when loosening).
+5. Append an "init" block to `progress.md`. (Ledger is gitignored — not committed.)
+
+---
+
+## Resume after `/clear` or compaction
+The next invocation's step-0 resume (step 3) reads `queue.md` + tail of `progress.md` and, finding
+any *interrupted* row (non-terminal and NOT `queued`/`routed`/`hold`/`parked`), finishes it before
+selecting new work. A `hold` **or `parked`** row is **excluded** — a `hold` is a deliberate, durable
+human merge-hold and a `parked` row is gated on an external event (Ledger format → queue.md),
+neither an interruption; leave them (a `hold` until the human clears it at step 11; a `parked` row
+until explicit un-park at step 0.1) and neither blocks other work. A run resting under a `RUN
+PARKED` sentinel is likewise **not** an interrupted row — step 0 short-circuits it on the cheap
+parked path and never enters this resume scan (safe: a valid PARKED state has no non-terminal
+pipeline row). The on-disk ledger row status is only a **coarse anchor** (which stage); the **live
+git/PR state is the source of truth** for the details (the ledger is uncommitted): for an in-flight
+row, check whether its branch exists, whether a PR is open (or already merged), and the PR's CI
+status, and resume at the matching pipeline stage — git wins on any conflict with a stale status.
+Stages 4/7/10 need no distinct status because the surrounding statuses bracket them: a
+`plan-approved` row re-enters at implement (step 6), so the architect/human gates are NOT re-run.
+The one external-side-effect stage is the architect (step 4) — it posts a comment to the issue —
+so on the rare resume of a `planning` row, check for an existing architect comment and skip
+re-invoking if present (do not double-post). AC-verify (step 7) is side-effect-free; security (step
+10) re-labeling is a no-op. **Working-tree reconciliation:** if a crashed prior attempt left
+uncommitted changes, inspect them before proceeding — keep and continue if they match the plan, or
+`git restore`/stash if they're partial/unrelated. A resumed `implementing` row is NOT "stuck" (stuck
+keys on a repeated error signature, not status re-entry — see Guardrails).
+
+---
+
+## Routing table
+
+| Route | Pipeline differences |
+|-------|----------------------|
+| `code` | full pipeline, all gates |
+| `research` | lighter plan; **no test-coverage gate**; architect optional; security only if deps added; place outside the package source |
+| `docs` | skip architect + security; light review; `docs:` scope |
+| `stub-defer` | do NOT implement; journal why; leave in backlog (Status `deferred`) |
+
+`blocked` and `parked` are **Status overlays, not Routes**: a row keeps its semantic Route (`code`/
+`research`/`docs`) while resting on an unmet in-run dependency (`blocked`) or an external event
+(`parked`). Skip it; a `blocked` row returns to selection when its dependency closes (steps 1 /
+Router), a `parked` row when the human un-parks it (step 0.1).
+
+**Generic mechanical discipline:** set the squash `--subject` scope **explicitly** (per
+`COMMIT_CONV`), never inherited from the PR title. (Host-repo mechanical specifics — e.g. the
+`.claude/`-only security path and the `origin/HEAD` incantation — live in `loop.config.md`.)
+
+---
+
+## Gates, convergence & resting states
+
+Gate table:
+
+| Gate | Who | When | Output |
+|------|-----|------|--------|
+| Plan | orchestrator | every issue | `issue-<N>.plan.md` |
+| Architect | `DESIGN_AGENT` | `ARCHITECT_TRIGGERS` or unsure | issue comment |
+| Human (plan) | user | only if uncertain/irreversible | approve/redirect |
+| AC-verify | fresh subagent (+`VERIFY`) | every code/research issue | done/not-done + gaps |
+| Code review | `CODE_REVIEW` | every code issue | findings → fixes |
+| Security | `SECURITY_REVIEW` (local or label) | by route | clean/findings |
+| Merge | user (calibration / non-graduated route) → orchestrator (auto: graduated routes) | CI+security green | `MERGE_METHOD` |
+
+**Convergence & the resting states.** When nothing is selectable, step 1 classifies the run
+into one of four outcomes (tested in order: hold → parked → complete → pending) and appends a
+`progress.md` **run-state sentinel**; step 0 reads the **most recent** sentinel by append
+order (last-wins, since the log is append-only) and acts only on it:
+- **`RUN COMPLETE — <run-slug>`** (terminal) — every row is terminal (`done`/`deferred`/`blocked`).
+  Summarizes counts + any blocked/deferred items; the orchestrator stops and reports, and a later
+  re-invocation short-circuits without re-scanning.
+- **`RUN PARKED — awaiting <condition>`** (resting, **non-terminal**) — all *workable* rows are
+  terminal but ≥1 `parked` row awaits an external event (a release cut, a dogfood window). A
+  re-invocation short-circuits (step 0): it runs only the cheap roster reconciliation
+  + a `queue.md` selectability re-derivation, then re-reports parked **without** the expensive
+  per-row live reconcile / resume — until the human explicitly releases a **named** condition
+  (which flips only the `parked` rows awaiting *that* condition back to `routed`, appends a
+  superseding `RUN RESUMED` sentinel, and leaves rows gated on other conditions parked) or a
+  pulled-in joiner / cleared dep makes work selectable again. This is what stops a release-gated run
+  from re-reaching a *new* conclusion on every re-fire (the "converged-pending-release"
+  instability). Distinct from an *interrupted* row needing resume (see Resume): a valid PARKED state
+  has no non-terminal pipeline row, so resume is safely skipped.
+- **held / pending** (no sentinel) — a `hold` row needs the human now, or a row is still `blocked`
+  on an open in-run dependency; the orchestrator reports and stops without a sentinel (the run is
+  not complete and not cleanly parked).
+
+**Guardrails:** iteration/budget caps live in the `queue.md` header (`iteration-cap:`/
+`subagent-cap:`) and are checked at iteration start against the ledger — **advisory in manual
+re-invoke (journaled + surfaced, not gating — the human who invoked is the budget authority),
+halted by the driver**; one PR at a time; stuck-detection (repeated error signature) → escalate.
+The C1 append-only guard hook protects append-only logs once the loop commits its own work.

--- a/.claude/specs/prd-loop-engineering.md
+++ b/.claude/specs/prd-loop-engineering.md
@@ -6,17 +6,24 @@
 > workflow (plan → architect → implement → review → merge) as a loop over a backlog, with
 > human gates only where the orchestrator is genuinely unsure.
 >
-> **This document is self-contained and build-ready.** A fresh agent with no prior
-> conversation context can build every component from §5–§9 alone. AgentFluent-specific
-> values are isolated in the **Project Parameters** table (§4.0); porting to another project
-> means editing §4.0 **plus** the project-specific content flagged in the §4.4 Porting
-> checklist. Read §4.0 and §4.4 first.
+> **Split as of #612 — this document is now the design rationale (the "why"), not the
+> operative artifact.** The build-ready procedure, parameters, and semantics were extracted
+> into three files, which are the single source of truth at runtime:
+> - **`.claude/skills/release-loop/loop-engine.md`** — the generic engine: the numbered
+>   pipeline, ledger format, router, AC-verifier, initialization, resume, routing table, and
+>   gate/convergence/park-hold/budget semantics (former §6, §7.1, §7.3–§7.6, §8, §9).
+> - **`.claude/loop.config.md`** — the per-project bindings: the Project Parameters table,
+>   `ARCHITECT_TRIGGERS`, `SOURCE_LAYOUT`, and the host-repo security specifics (former §4.0,
+>   §7.2, §7.3 signals, §7.1 step 10).
+> - **`.claude/skills/release-loop/SKILL.md`** — the thin `/release-loop` entry point that
+>   reads the config for bindings and the engine for logic.
 >
-> **Runtime dependency:** the `/release-loop` skill reads this spec live (it points the
-> orchestrator at §4.0), so the spec must ship alongside the skill when porting, with paths
-> updated. **Built-in tooling:** `/code-review`, `/security-review`, `/verify`, `/simplify`,
-> `/review` are **Claude Code built-in skills** (not files to build); `/code-review` and
-> `/security-review` were verified working in the 2026-06-29 session.
+> Sections **4, 6, 7, 8, 9** below are retained as **pointers** to those files (their content
+> moved; keeping it here too would re-introduce the drift this split removed). Sections 1–3, 5,
+> and 10–15 remain the rationale, calibration history, and roadmap. **Built-in tooling:**
+> `/code-review`, `/security-review`, `/verify`, `/simplify`, `/review` are **Claude Code
+> built-in skills** (not files to build); `/code-review` and `/security-review` were verified
+> working in the 2026-06-29 session.
 
 ---
 
@@ -83,65 +90,18 @@ pattern adapted to an issue-driven, gated workflow.
 
 ## 4. Constraints & project parameters
 
-### 4.0 Project Parameters (change ONLY this table to port to another project)
+**Moved to `.claude/loop.config.md`** (as of #612). The Project Parameters table (former §4.0),
+the workflow conventions (former §4.1), the design-shaping hard constraints (former §4.2), the
+commit-scope rule (former §4.3), and the porting checklist (former §4.4) all live there now — it
+is the single per-project surface a porting project edits. The generic engine
+(`loop-engine.md`) references every parameter by name; `loop.config.md` binds each name to this
+repo's value.
 
-| Parameter | AgentFluent value | Notes |
-|-----------|-------------------|-------|
-| `BACKLOG_SOURCE` | GitHub milestone (e.g. `v0.10.0`) via `gh` | could be a label, or a local `TODO.md` |
-| `SCOPE_AGENT` | `pm` (user-global subagent) | answers scope/priority/requirements questions; remove if project has none |
-| `DESIGN_AGENT` | `architect` (user-global subagent) | reviews plans pre-implementation; remove if none |
-| `CODE_REVIEW` | `/code-review` (Claude Code **built-in skill**) | independent post-impl review; verified 2026-06-29. The repo's `/review`/`/simplify` (CLAUDE.md) are alternatives, not this. |
-| `SECURITY_REVIEW` | local `/security-review` (built-in skill) for `.claude/`-only; else `needs-security-review` label → `security-review.yml` | see §8 |
-| `VERIFY` | `/verify` (built-in skill) | runtime behavior check when an AC needs proof-by-running |
-| `PRIORITY_LABELS` | `priority:high > priority:medium > priority:low`; tiebreak: issue number ascending | drives selection (§7.1 step 1, §7.5 step 4) |
-| `ARCHITECT_TRIGGERS` | see §7.2 (shared models, cross-module interfaces, new diagnostics rule/pipeline) | **project-specific — edit when porting** |
-| `SOURCE_LAYOUT` | package `src/agentfluent/`; tests `tests/`; research outside `src/` | router uses this (§7.3); **edit when porting** |
-| `TEST_CMD` | `uv run pytest -m "not integration"` | |
-| `LINT_CMD` | `uv run ruff check src/ tests/` | |
-| `TYPE_CMD` | `uv run mypy src/agentfluent/` | |
-| `CI_STATUS_CMD` | `gh pr checks <PR>` | |
-| `BRANCH_FMT` | `feature/<n>-slug` / `fix/<n>-slug` | from CLAUDE.md |
-| `COMMIT_CONV` | Conventional Commits; `.claude/**`→`chore:`/`docs:` | §4.3 |
-| `PR_TEMPLATE` | `.github/PULL_REQUEST_TEMPLATE.md` (must replicate) | |
-| `MERGE_METHOD` | squash, `--delete-branch`, explicit `--subject` scope | |
-| `APPEND_ONLY_FILES` | `.claude/specs/decisions.md` | guarded by the hook |
-| `PERMISSION_POSTURE` | background agents validate-only → parent implements | §4.2 |
-| `LEDGER_ROOT` | `.claude/loop/` | **gitignored** — local working state, never committed (§6.4) |
-
-### 4.1 Workflow conventions (AgentFluent — from CLAUDE.md)
-- Branch from `main`; PR with passing CI before merge. Branch naming `BRANCH_FMT`.
-- PR body **must replicate** `PR_TEMPLATE` (CI's `PR Template Check` rejects otherwise).
-- Tests required for code changes; no regressions; mypy strict on `src/`.
-
-### 4.2 Hard constraints that shape the design (mark which are general vs. project)
-1. **(Project) Background/non-interactive agents are validate-only here** — `settings.local.json`
-   withholds Edit/Write/git/gh from agents that can't prompt. **The parent (interactive)
-   thread does all implementation + git/gh.** No fan-out of implementation. *(In a project
-   without this restriction, iterations could parallelize via worktrees — see §13.)*
-2. **(General, Claude Code) Subagents can't invoke subagents** — the orchestrator drives
-   `SCOPE_AGENT`/`DESIGN_AGENT` directly.
-3. **(Project) CI gated on `branches:[main]`; stacked PRs break it** → one PR at a time,
-   each branched from `main`.
-4. **(Project) `SCOPE_AGENT`/`DESIGN_AGENT` are user-global**, not repo-tracked; editing them
-   yields no PR and needs a session restart.
-
-### 4.3 Commit scope rule (AgentFluent)
-`.claude/**` changes are maintainer-only tooling → `chore:`/`docs:`, never `feat:`/`fix:`
-(avoids release-please mis-bumps). The orchestrator sets the **squash subject scope
-explicitly**, not inheriting the PR title.
-
-### 4.4 Porting checklist (what to edit beyond §4.0)
-Editing §4.0 is necessary but not sufficient — these sections carry project-specific content
-copied into the operating procedure:
-1. **§4.0 table** — all parameters (agents, commands, conventions, layout, priority labels).
-2. **§7.2 architect triggers** (`ARCHITECT_TRIGGERS`) — your project's "needs design review"
-   conditions; the AgentFluent list names `SessionMessage`/`AgentInvocation`/diagnostics.
-3. **§7.3 router signals** (`SOURCE_LAYOUT`) — `src/` layout, package-dep-leakage rule, and
-   any project-specific stub/defer markers (AgentFluent cites `#469`/`D041` as examples).
-4. **§7.1 skill step 10** — the `.claude/`-only-vs-label security routing and the
-   `git remote set-head` GitHub-ism are GitHub/this-repo specific.
-5. **Ship this spec with the skill** — the skill reads it at runtime; update the path.
-A non-Python / non-`src/` / non-GitHub project must revise all five, not just §4.0.
+**Porting framing (unchanged in spirit):** a non-Python / non-`src/` / non-GitHub project edits
+**only** `loop.config.md` — the four config sections (parameters, `ARCHITECT_TRIGGERS`,
+`SOURCE_LAYOUT`, security routing) — never the engine. The former §4.4 "ship the spec with the
+skill" step is obsolete: the runtime artifacts are now the skill + engine + config, and this spec
+is no longer read at loop time.
 
 ---
 
@@ -150,10 +110,10 @@ A non-Python / non-`src/` / non-GitHub project must revise all five, not just §
 | # | Component | Path | Status |
 |---|-----------|------|--------|
 | C1 | Append-only guard hook | `.claude/hooks/guard_append_only.py` | **Done** (#500/PR #550) |
-| C2 | State ledger convention | `.claude/loop/<run>/` | Build (§6) |
-| C3 | `/release-loop` orchestrator skill | `.claude/skills/release-loop/SKILL.md` | Build (§7) |
-| C4 | Router (issue→route) | folded into C3 | Build (§7.3) |
-| C5 | AC-verifier | composed `/code-review`+`/verify`+checklist prompt | Build (§7.4) |
+| C2 | State ledger convention | `.claude/loop/<run>/` | **Done** — format in `loop-engine.md` → Ledger format |
+| C3 | `/release-loop` orchestrator skill | `.claude/skills/release-loop/{SKILL.md,loop-engine.md}` + `.claude/loop.config.md` | **Done** — thin skill + generic engine + config (#612) |
+| C4 | Router (issue→route) | folded into C3 | **Done** — `loop-engine.md` → Router |
+| C5 | AC-verifier | composed `CODE_REVIEW`+`VERIFY`+checklist prompt | **Done** — `loop-engine.md` → AC-verifier |
 
 **Deliberately not building:** a stuck-detection hook (ledger + auto-mode backstop suffice),
 a separate triage agent (rules suffice), a shared hook lib (standalone stdlib scripts are
@@ -172,594 +132,59 @@ ENOENT (new file). Wired in `.claude/settings.json` under `PreToolUse` with a `W
 
 ## 6. C2 — State ledger
 
-Create `LEDGER_ROOT/<run-slug>/` (e.g. `.claude/loop/v0.10.0/`) containing three artifacts.
-The orchestrator is the only writer except where noted.
+**Moved to `loop-engine.md` → Ledger format** (as of #612). The three-artifact ledger
+(`queue.md` work list + status vocabulary; `progress.md` append-only journal + `- Budget:` line;
+`issue-<N>.plan.md` template), the `mode`/`graduated-routes` merge-gate machinery, the budget
+caps, and the gitignore-the-ledger lifecycle/commit policy all live there now. `LEDGER_ROOT` binds
+to `.claude/loop/` in `loop.config.md`.
 
-### 6.1 `queue.md` — work list (authoritative status)
-Dependency-ordered. One row per issue. **`Route` and `Status` are separate columns** (a row
-can be Route `research`, Status `blocked`). **Pipeline statuses** — advanced by the
-orchestrator as the issue moves through §7.1, so an interrupted run leaves a non-terminal
-status resume keys on (§7.6): `queued → routed → planning → plan-approved → implementing →
-in-pr → in-review`. **Terminal statuses** — the run converges when every row is terminal:
-`done`; `deferred` (Route `stub-defer`); `blocked` (an unmet in-run dependency, or
-`blocked: too-large` awaiting a split). **Two non-terminal, resting statuses** sit outside both
-the pipeline and the terminal set: **`hold`** — a durable, human-set merge-hold that survives
-`/clear`; and **`parked`** — a row whose work is gated on an **external event** (a release cut, a
-dogfood window — *not* an in-run dependency), with the awaited condition in Notes as
-`awaiting: <condition>`. Both retain their Route and are released only by the human (a `hold` by
-clearing the hold at the merge gate; a `parked` row by explicit un-park, §7.1 step 0.1 — which
-flips it back to `routed`). While any `hold` **or `parked`** row remains the run is NOT complete
-(§9 distinguishes the resting `RUN PARKED` state from terminal `RUN COMPLETE`), but neither blocks
-selecting other queued work (§7.1 steps 0–1).
-
-**Curated-subset invariant.** The queue built at init (§7.5) is the authoritative work set;
-milestone membership may drift afterward, and that drift is **surfaced to the human once, never
-auto-applied** — neither auto-added on join nor auto-ejected on leave (§7.1 step 1 milestone-roster
-reconciliation). A corollary is a Notes discipline: **write a `parked`/`blocked` row's Notes as the
-durable curation DECISION** (`awaiting: v0.11.0 cut`, `deliberately out of <run> at init
-(curation)`, `kept: out-of-<run> roster (curation)`), **never the mutable live evidence** ("not in
-milestone", "no PR yet") — the latter is contradicted by a later live re-check and destabilizes
-resume (the v0.10.0 row-12 failure).
-
-The header carries a `mode:` field that gates **the merge gate only** — it does
-**not** change the plan gate, which is conditional in *every* mode (§7.1 step 5 / skill §5: the
-plan gate stops only on ambiguous ACs, risk/irreversibility, agent disagreement, or genuine
-uncertainty — never merely because of `mode:`). The two modes:
-- **`calibration`** (default) — the human approves **every** merge; the loop never auto-merges
-  (§7.1 step 11). Plan gate conditional.
-- **`escalation-only`** — the human loosens the **merge gate per route**: a route the human has
-  *graduated* auto-merges when CI + AC-verifier + review are green and the version bump is
-  ≤ patch (a `docs`/`chore` change produces no bump, which qualifies). *Which* routes are
-  currently graduated is a mutable human decision, recorded per-run in the `graduated-routes:`
-  header and in the decision log (see **D047** for the first graduation — `docs`+`research`) —
-  never frozen into this mechanism definition (the #584 lesson: graduation *state* is evidence,
-  not a rule). The human merge gate is
-  **retained** for every non-graduated route and, regardless of route, for any of: a `feat:`/
-  breaking change, a risky/irreversible change, a touched security surface, a contested review
-  finding, or a `hold` row — **and, by default-deny, whenever route graduation or any
-  always-escalate condition is uncertain, fall back to the human merge gate.** Plan gate
-  conditional (unchanged). Loosening to `escalation-only` presupposes the calibration
-  prerequisites are met (these pinned mode semantics, #563, plus per-iteration budget
-  journaling — the `- Budget:` record and `iteration-cap:`/`subagent-cap:` fields below,
-  #565); it cannot run headless (§13/§14).
-
-The set of graduated routes is recorded in a `graduated-routes:` header field beside `mode:`
-(default `none`; e.g. `graduated-routes: docs, research`, per D047). Under `mode: calibration` it is inert. *Which*
-routes graduate and the criteria for promoting one (#562) are out of scope here; this field only
-gives the merge gate (§7.1 step 11) a place to read the human's decision from.
-
-The header also carries two **budget caps** (both default `none` = uncapped), #565:
-`iteration-cap:` (max **issues per run** — in this spec one "iteration" = one issue) and
-`subagent-cap:` (max **subagent runs per iteration**). The orchestrator checks them at iteration
-start (§7.1 step 1) as a **retrospective circuit-breaker** against the ledger — it does not watch
-its own spend mid-turn (that is why token/cost is deferred, §6.2). Cumulative iterations are
-counted as the **distinct issues at a terminal status** (`done`/`deferred`/`blocked`) in
-`queue.md` — the authoritative status file — never by counting `progress.md` blocks, since a
-`/clear`-resume re-enters an iteration and would double-count. `subagent-cap` is enforced by
-reading the **prior** iteration's journaled `- Budget:` line (§6.2): if it breached, halt before
-starting the next. On breach the behavior is **advisory in manual re-invoke** (journal + surface
-it and proceed — the human who invoked is the budget authority) and **halting under the driver**
-(§9). The caps bound `escalation-only`'s runaway-consumption risk; bad-merge risk is already
-covered by §6.1's default-deny/always-escalate machinery.
-
-```markdown
-# Loop run: v0.10.0
-_mode: calibration_
-_graduated-routes: none_
-_iteration-cap: none_       # max issues per run; none = uncapped (#565)
-_subagent-cap: none_        # max subagent runs per iteration; none = uncapped (#565)
-_Last updated: <ISO8601 by orchestrator>_
-
-| # | Issue | Route | Status | Depends on | PR | Notes |
-|---|-------|-------|--------|-----------|----|----|
-| 1 | #500 pm clobbers decisions.md | code | done | — | #550 | precondition |
-| 2 | #518 SDK hello-world probe | research | queued | — | — | first in epic #517 |
-| 3 | #522 representative SDK agent | research | blocked | #518 | — | needs S1a findings |
-| 4 | #510 PARAMETER_RETRY fixes | code | queued | — | — | high |
-| 5 | #469 per-turn ratios | stub-defer | deferred | dogfood | — | D041 — do not implement |
-| 6 | #513 post-release re-measure | code | parked | — | — | awaiting: v0.10.0 dogfood window |
-```
-
-### 6.2 `progress.md` — append-only journal (survives /clear + compaction)
-The orchestrator APPENDS one block per iteration (and per gate decision). Never rewritten.
-This is the audit trail and the resume anchor.
-
-```markdown
-## <ISO8601> — #518 (research) — iteration start
-- Selected: #518 (highest-priority unblocked).
-- Route: research (probe; no test-coverage gate).
-- Plan: issue-518.plan.md written.
-- Architect: skipped (research scaffolding, no shared-interface impact).
-- Human gate: plan auto-approved (route=research, low ambiguity).
-- Implemented: research/agent-sdk-probe/probe.py; recorded findings in <path>.
-- AC-verify: 3/3 acceptance criteria met (location, discriminator, options metadata).
-- PR: #NNN (chore scope). CI: green.
-- Code-review: 0 findings. Security: n/a (no deps added).
-- Budget: subagent-runs=3 · gate-rounds=architect=0,code-review=1,ac-verify=1 · wall-clock=18m · tokens=deferred
-- Merged: squash #NNN. Issue #518 closed.
-- Next: #522 now unblocked.
-```
-
-The `- Budget:` line is the per-iteration cost record (#565). Fields:
-- **`subagent-runs`** — the proxy cost signal the orchestrator can count for free (the v0.10.0
-  run's only quantitative signal was "~6 subagent runs/issue", §11.3). Its blind spot:
-  parent-thread token burn (a long implement step spawns no subagent yet can be the largest
-  consumer) is invisible to run-count — which is precisely what the deferred `tokens` field
-  eventually fixes.
-- **`gate-rounds`** — architect / code-review / ac-verify round counts (feeds §12 review-thrash
-  detection).
-- **`wall-clock`** — elapsed time including human gate-wait; recorded for the §12 corpus, **not a
-  cap input** (an iteration that waited overnight for approval is not "expensive").
-- **`tokens=deferred`** — a reserved, named slot. Per-iteration token/cost is computed **post-hoc
-  by AgentFluent over the loop's own JSONL** (the loop JSONL is a first-class corpus, §12), not
-  inside the skill (the orchestrator can't cleanly slice its live session mid-turn). The future
-  SDK driver (§13) backfills it via usage callbacks — keeping the slot named now makes that a
-  backfill, not a format change.
-
-### 6.3 `issue-<N>.plan.md` — per-issue plan (architect-reviewed, human-approved)
-```markdown
-# Plan: #<N> — <title>
-**Route:** <code|research|docs>  **Branch:** <BRANCH_FMT>
-
-## Value framing (route-scaled — see §3)
-<feat: backbone activity + 1–3 `as a … I want … so that …`, each with who-benefits +
-prevalence + a falsifier ("what observation would show this is misdirected?"); discharge cheap
-falsifiers here (run the grep/corpus pass) rather than only stating them.
-fix: who hits it / how often / what breaks. docs: who reads it / what it unblocks.
-research: question + downstream decision + what a null result means.
-chore:/refactor: what internal tooling/quality it serves + why now.
-Add a source-fidelity note if the rationale leans on any externally-cited source.>
-
-## Acceptance criteria (verbatim from issue)
-- [ ] ...
-
-## Approach
-<steps, files to touch, tests to add>
-
-## Architect triggers hit
-<which §7.2 triggers fired, or "none">
-
-## Risks / open questions for human
-<empty if none>
-```
-
-### 6.4 Lifecycle & commit policy
-- **Init:** orchestrator creates the dir + `queue.md` from `BACKLOG_SOURCE` (§7.5).
-- **Per iteration:** update one `queue.md` row through its statuses; append `progress.md`;
-  write/update `issue-<N>.plan.md`.
-- **Commit policy — gitignore the ledger** (`LEDGER_ROOT/` is added to `.gitignore`). It is
-  local working state: it survives `/clear`/compaction on disk, but is **never committed**.
-  This is deliberate — committing it has no legal landing spot under this repo's rules
-  (`main` is PR-only, no stacked PRs, and folding ledger commits into an issue's squash-merged
-  PR would pollute that PR's scope). Resolves the branch-protection collision the design
-  review flagged.
-- **Dogfood corpus (§12) harvest:** read the JSONL + `progress.md` from the working tree
-  directly; if a versioned audit trail is later wanted, snapshot the ledger into a dedicated
-  `docs(loop):` PR on demand — do not stream per-iteration ledger commits.
-- **No git/ledger divergence:** because the ledger is uncommitted, resume (§7.6) reconciles
-  the on-disk ledger against *live* git/PR state (branch exists? PR open? CI status?), which
-  is the source of truth — not a possibly-stale commit.
+The C2 component still exists (the ledger is real, uncommitted working state under
+`LEDGER_ROOT/<run-slug>/`); only its *definition* moved into the engine so the format has one
+source of truth.
 
 ---
 
 ## 7. C3 — `/release-loop` orchestrator skill
 
-The live skill lives at `.claude/skills/release-loop/SKILL.md`; the block below is a
-**byte-identical mirror** of it (the body IS the orchestrator's operating procedure), kept
-here so the spec stays self-contained and ready-to-drop-in. The two copies are CI-guarded
-to stay byte-for-byte identical (`tests/unit/test_loop_skill_drift.py`) — **edit both
-together**; on a conflict `SKILL.md` is the operative copy and this block mirrors it.
+**Moved to `.claude/skills/release-loop/SKILL.md` (thin entry) + `loop-engine.md` (the
+procedure)** (as of #612). Previously this section embedded a byte-identical *mirror* of the live
+skill — the drift that the split removes. There is now one copy of the procedure, in
+`loop-engine.md`; `SKILL.md` is the thin `/release-loop` entry that reads the config for bindings
+and the engine for logic; the CI guard (`tests/unit/test_loop_skill_drift.py`) no longer polices a
+mirror but instead pins the load-bearing semantics in the engine and the engine's genericity.
 
-````markdown
----
-name: release-loop
-description: Run one routed iteration of the supervised dev loop over a backlog (milestone/label). Selects the next unblocked issue, routes it, drives plan→architect→implement→review→merge with human gates on uncertainty, and journals to the ledger. Invoke once per issue; re-invoke (or drive via /loop) for the next. Use when the user wants to work a backlog as a loop, "run the release loop", or "do the next issue".
----
-
-# Release Loop — orchestrator (ONE issue per invocation)
-
-You are the orchestrator of a supervised dev loop. Each invocation handles exactly ONE
-issue end-to-end, journals, and stops. State lives in the ledger, not your context — so a
-fresh invocation resumes correctly. Read the project parameters in
-`.claude/specs/prd-loop-engineering.md` §4.0.
-
-## 0. Load or initialize state
-1. Identify the active run (most recent `LEDGER_ROOT/<run>/`). If none exists, ask the user which
-   milestone/label to run, then INITIALIZE per §7.5 of the spec. Otherwise scan the FULL
-   `progress.md` for the **most recent** run-state sentinel — the last of `{RUN COMPLETE, RUN
-   PARKED, RUN RESUMED}` by append order (the log is append-only, so a superseded sentinel still
-   sits above; last one wins) — and act only on it:
-   - `RUN COMPLETE` (§9) → report done and STOP; do not re-scan (the run is terminal).
-   - `RUN PARKED — awaiting <condition>` (§9) — the run finished all *workable* rows and rests on
-     an external event:
-     - **If this invocation explicitly releases the park** (the human names a met condition — "the
-       cut is out, resume"): perform the concrete un-park mutation, **scoped to the released
-       condition** — flip back to `routed` (retain Route, clear the `awaiting:` marker) ONLY the
-       `parked` rows whose `awaiting:` condition the human named; leave rows still gated on *other*
-       conditions `parked` with their markers intact (if which rows a release covers is ambiguous,
-       ask — do NOT flip all, that would prematurely release a still-unmet gate). Append a `RUN
-       RESUMED` sentinel (now last-wins) and continue to step 2; any rows left parked simply
-       re-append `RUN PARKED` at the next §1 pass (last-wins over `RUN RESUMED`), which the existing
-       machinery handles. A bare re-fire (e.g. the `/loop` driver) does NOT release the park.
-     - **Otherwise take the cheap parked path (no full re-scan):** read `queue.md` + the FULL
-       `progress.md`, run the §1 milestone-roster reconciliation (the one scan a parked run still
-       owes — this is how milestone drift is still caught), then **re-derive selectability from
-       `queue.md` alone** (no git/PR reconcile). If that produced selectable work (a joiner the
-       human pulled in, or an in-run dep that has since cleared) fall through to §1 **at selection**
-       (the reconciliation just ran — do not repeat it); otherwise STOP and report "parked —
-       awaiting <condition>" **without** running §0 step 3 resume or any per-row live reconcile —
-       skipping resume is provably safe here (a valid PARKED state has every non-`parked` row
-       terminal, so no interrupted pipeline row can coexist).
-   - `RUN RESUMED` or no sentinel → continue to step 2 (a released or never-parked run runs
-     normally).
-2. Read `queue.md` (note its `mode:` / `graduated-routes:` header and any `hold`/`parked` rows) and the tail of `progress.md`.
-3. **Resume before selecting (spec §7.6).** If any row sits in an *interrupted* status —
-   non-terminal and NOT `queued`/`routed`/`hold`/`parked` (i.e. `planning`/`plan-approved`/
-   `implementing`/`in-pr`/`in-review`) — a prior iteration was cut off. Reconcile it against
-   LIVE git/PR state as the source of truth — branch exists? PR open? already merged? CI
-   status? — plus the working tree (status is only a coarse anchor; git wins on conflict),
-   then re-enter the pipeline at the matching stage and FINISH that issue BEFORE selecting a
-   new one. This is what makes "one PR at a time" hold across `/clear`/compaction. A `hold` or
-   `parked` row is NOT an interruption: skip it here — a `hold` stays held until the human
-   releases the merge, a `parked` row stays gated until its external condition is released (step
-   1); neither blocks working other issues.
-
-## 1. Select
-**Budget cap (iteration start, retrospective).** Read `iteration-cap:` / `subagent-cap:` from the
-`queue.md` header (both default `none` = uncapped). Cumulative iterations = the count of **distinct
-issues at a terminal status** (`done`/`deferred`/`blocked`) in `queue.md` — never count
-`progress.md` blocks (a `/clear`-resume re-enters an iteration and double-counts). Breach = that
-count ≥ `iteration-cap`, OR the **prior** iteration's journaled `- Budget:` line (§12) shows
-`subagent-runs` ≥ `subagent-cap`. On breach: **manual re-invoke is advisory** — journal + surface
-it and proceed (the human who invoked is the budget authority); **the driver halts.** Inert while
-both caps are `none`.
-
-**Milestone-roster reconciliation (iteration start).** The queue built at init (§7.5) is the
-authoritative work set — the *curated subset*; milestone membership may drift afterward, and drift
-is **surfaced to the human once, never auto-applied** — neither auto-added on join nor auto-ejected
-on leave. Compute the delta between the live `BACKLOG_SOURCE` roster (one `gh issue list
---milestone <run> --state open`) and `queue.md`, deduping against prior curation records via a
-FULL-file scan of `progress.md` (not the tail) for exact `- surfaced-join:` / `- surfaced-leave:`
-lines:
-- **Joined** (in the milestone, no `queue.md` row, not already surfaced) → surface once: "#N joined
-  <run> after init — pull in, or leave out? (never auto-added)." Record `- surfaced-join: #N` in a
-  `## <ISO8601> — curation` block. Only on the human's "pull in" add a `queued` row; a bare surface
-  never adds one.
-- **Left** (a non-terminal `queue.md` row whose issue is no longer in the milestone, not already
-  recorded) → surface once: "#N left <run> — eject, or keep? (never auto-ejected)." Record
-  `- surfaced-leave: #N`. On "keep", write the decision to the row's Notes (`kept: out-of-<run>
-  roster (curation)`) so it self-dedups; on "eject", an in-flight leaver (`planning`..`in-review`,
-  open PR) is **finish-then-reconsider**, not a bare eject (only a pre-pipeline row ejects cleanly —
-  close/clean its PR+branch first), then set the row `deferred` with a curation Notes reason.
-This paragraph is the sub-unit the §0 step 1 parked path invokes standalone.
-
-A row is **selectable** if its status is `queued`/`routed`, OR it is `blocked` on an unmet
-dependency that has SINCE cleared (all its `Depends on` issues are now `done` — re-route it via
-§2; this does NOT apply to a `blocked: too-large` park, which waits on a split). A `parked` row is
-never selectable here — it is released only by explicit human un-park (§0 step 1). Among selectable
-rows pick by `PRIORITY_LABELS` order, tiebreak issue-number ascending. If none are selectable,
-determine the resting state from the remaining non-terminal rows (test in this order):
-- Any `hold` row present → report "<n> held — awaiting human merge-release" and STOP **without** a
-  sentinel (a held row needs the human now; the run is neither complete nor cleanly parked).
-- Else if ≥1 `parked` row is present AND every non-`parked` row is `done`/`deferred` → append the §9
-  `RUN PARKED — awaiting <condition(s)>` sentinel to `progress.md` (name the awaited condition(s) +
-  the parked rows) and STOP. This is a **resting, non-terminal** state: the next invocation
-  short-circuits on it (§0 step 1) instead of re-reconciling. (Tested BEFORE COMPLETE so a
-  release-gated row is not swallowed as terminal; it requires truly-terminal peers — a plain
-  in-run-`blocked` row present routes to pending below, not to a false park.)
-- Else if EVERY row is terminal (`done`/`deferred`/`blocked`) → append the §9 `RUN COMPLETE —
-  <run-slug>` sentinel to `progress.md` (counts + any blocked/deferred items) and STOP
-  (convergence).
-- Else (rows still `blocked` on an open in-run dependency, or `blocked: too-large` awaiting a split)
-  → report what's pending and STOP without a sentinel.
-**Size guard:** before entering the pipeline, estimate scope from the issue body — if it
-plausibly touches many files or spans multiple unrelated acceptance-criteria clusters (won't
-fit one context window), mark it `blocked: too-large`, escalate to SCOPE_AGENT to split, and
-go back to select. Aggressively offload reading/analysis to subagents (architect, AC-verifier)
-within an iteration to conserve the parent's context.
-
-## 2. Triage / route (if not already routed)
-Run §7.3 to set the row's **Route** (`code`/`research`/`docs`/`stub-defer`) and its **initial
-Status** (Route and Status are distinct — §6.1): `stub-defer` → Status `deferred` (terminal); an
-unmet in-run dependency → Status `blocked` (record the dep, or `too-large`, in Notes — the Route is
-retained so the row resumes as that route when the dependency clears, §1); a row whose work is
-gated on an **external event** (a release cut, a dogfood window — not an in-run issue) → Status
-`parked` with Notes `awaiting: <condition>` (non-terminal, resting; released only by explicit human
-un-park, §0 step 1); otherwise → Status `routed`. If the Status is `deferred`/`blocked`/`parked`,
-journal why and go back to §1 — do not implement.
-
-**Write parked/blocked Notes as the curation DECISION, never the mutable evidence.** The durable
-*why* (`awaiting: v0.11.0 cut`, `deliberately out of <run> at init (curation)`, `kept: out-of-<run>
-roster (curation)`) survives a later live re-check; the mutable live evidence ("not in milestone",
-"no PR yet") is contradicted by the next re-check and destabilizes resume (the v0.10.0 row-12
-failure).
-
-## 3. Plan
-Set the row status to `planning`. Fetch the issue (`gh issue view <N>`). Write
-`issue-<N>.plan.md` (template in spec §6.3), copying acceptance criteria verbatim. Lighter for
-research/docs.
-
-**Value framing (opens the plan, route-scaled).** State *why this should exist* in
-user terms — the question the architect/AC-verifier/code-review gates never ask (they check we
-build the thing right, not that it's the right thing). You write it inline; it is not extra
-ceremony. Scale it to the route:
-- **`feat:`** — a compact user-story map: one backbone activity + 1–3 `as a <user>, I want
-  <capability>, so that <outcome>` stories. Each carries **who benefits**, its **prevalence**
-  (how often real configs/corpora actually hit it), and a **falsifier** — *what single
-  observation would show this feature is misdirected?* (e.g. "~0 matching instances in any real
-  corpus"). A story with no credible user, or no checkable falsifier, is a red flag.
-- **`fix:`** — one line: who hits the bug, how often, what breaks without the fix.
-- **`docs:`** — who reads it and what it unblocks.
-- **`research:`** — the question, the downstream decision it informs, and what a **null result**
-  would mean (a null that changes nothing is a sign the question isn't worth asking).
-- **`chore:` / `refactor:`** — one line: what internal tooling or quality this serves and why
-  now; no user-facing story required (state "internal tooling, no PyPI-visible change" if so).
-
-**Discharge cheap falsifiers at plan time — don't just state them.** If a story's falsifier is
-checkable *before* code (a grep / corpus / prevalence pass), RUN it now, or escalate; a
-stated-but-unrun falsifier is not sufficient. This is the load-bearing step: the cheap corpus
-pass is exactly what caught #437 — but only post-hoc. Defer discharge only when the check
-genuinely requires the built feature.
-
-**Source-fidelity check (any externally-cited justification).** If the issue's rationale leans on
-an external source — a research-scout (`anthropic-feature-watch`) candidate, a linked article, a
-postmortem — confirm the source actually supports the generalization the issue makes: **locus**
-(does the incident occur on the surface this feature inspects?), **evidence base** (n, scope,
-whether the source itself generalizes), and **current relevance** (already fixed upstream?
-version-specific?). An issue that extrapolates past what its source establishes is misdirected
-regardless of implementation quality. (The #437 lesson — decision D046.)
-
-**When you can't articulate it, escalate — don't build.** If you cannot state a credible user
-*and* a checkable falsifier, route the issue to SCOPE_AGENT (pm) BEFORE implementing; do not
-proceed on a plan whose value story doesn't hold.
-
-## 4. Architect gate (conditional)
-If any §7.2 trigger fires OR you are unsure about the design, invoke the DESIGN_AGENT with
-the plan; address `blocking`/`important` concerns before coding. Skip for docs and trivial
-research.
-
-## 5. Human gate (conditional — every mode)
-The plan gate is **conditional in every mode** — `mode:` gates the merge gate only (§11), never
-this one. It is **value-first**: present the §3 value framing (user-story map / value statement)
-alongside the approach, and treat a **non-credible value story — no plausible user, or no
-checkable falsifier — as itself a reason to STOP**, not just ambiguous ACs. Present the plan and
-STOP for approval when: the value story doesn't hold; acceptance criteria are ambiguous; the
-change is risky/irreversible; SCOPE/DESIGN agents disagree or punt; or you are otherwise unsure.
-Otherwise proceed (note "auto-approved" + why in the journal). Route scope/value questions to
-SCOPE_AGENT and design questions to DESIGN_AGENT BEFORE escalating to the human. On approval
-(human or auto), advance the row to `plan-approved`.
-
-## 6. Implement (you, the parent thread)
-Advance the row to `implementing`. Create the branch (`BRANCH_FMT`). Implement code + tests +
-docs per the plan. TDD where it fits (write failing tests, commit, do not modify tests later).
-Run `LINT_CMD`, `TYPE_CMD`, `TEST_CMD` until green. Do NOT stage unrelated pre-existing
-working-tree changes.
-
-## 7. Verify done (independent, fresh context)
-Run the AC-verifier (spec §7.4): a fresh check that the diff satisfies EVERY acceptance
-criterion — verify state, not your claim. If gaps, fix and re-verify (max 2 rounds, else
-escalate).
-
-## 8. Commit + PR
-Commit with correct `COMMIT_CONV` scope. Open the PR; **replicate `PR_TEMPLATE` fully** in
-the body; make the Security-review choice up front. Advance the row to `in-pr` and record the
-PR number. Wait for CI; fix until green.
-
-## 9. Code review
-Advance the row to `in-review`. Run CODE_REVIEW on the diff. Implement viable findings;
-decline others with a one-line rationale; **verify recs were applied**. Bounded to 2 rounds —
-contested findings escalate to the human, do not loop. Commit fixes.
-
-## 10. Security review (by route)
-- `.claude/`-only change → run local `/security-review` (the labeled workflow excludes
-  `.claude/`; the local skill needs `git remote set-head origin -a` if it errors on
-  `origin/HEAD...`).
-- Otherwise, if a sensitive surface is touched → apply `needs-security-review` ONLY now
-  (dev-complete). Skip for docs/no-surface changes.
-Address findings ≥ the project's confidence bar.
-
-## 11. Merge
-Read the run `mode` and `graduated-routes` from the `queue.md` header. The merge gate is the
-**only** gate `mode` changes (§5 is conditional in every mode). A row is **auto-merge-eligible**
-only when ALL of these hold:
-- `mode: escalation-only`, AND
-- the row's Route is listed in the header's `graduated-routes` field, AND
-- the version bump is ≤ patch — a `docs`/`chore` change produces no bump, which qualifies, AND
-- the row is **not** `hold`, AND
-- none of the always-escalate conditions apply: a `feat:`/breaking change, a risky/irreversible
-  change, a touched security surface, or a contested review finding.
-
-**Default-deny:** if route graduation or any always-escalate condition is uncertain, the row is
-**not** auto-merge-eligible — fall back to the human merge gate.
-
-If the row is **not** auto-merge-eligible — which includes *every* row under `mode: calibration`
-(the default) and any `hold` row — STOP and ask the human before merging; never auto-merge.
-**If the human holds the merge (now or in any later invocation),
-WRITE the hold to the row before stopping** — set Status `hold` (record the reason in Notes) so
-it persists across `/clear`; resume (step 0.3), §1, and this gate all key on Status `hold` and
-honor it until the human clears it (restoring the row's prior status). When the row **is**
-auto-merge-eligible (or the human has approved), and CI + security are green AND the row is not
-`hold`:
-squash-merge with an explicit `--subject` carrying the correct `COMMIT_CONV` scope,
-`--delete-branch`. Confirm the issue closed.
-
-## 12. Journal + stop
-Append the iteration block to `progress.md`, including a `- Budget:` line (spec §6.2):
-`subagent-runs=<n>` · `gate-rounds=architect=<a>,code-review=<c>,ac-verify=<v>` ·
-`wall-clock=<elapsed, includes gate-wait — not a cap input>` · `tokens=deferred` (computed
-post-hoc by AgentFluent over the loop JSONL; the named slot keeps the line forward-stable).
-Set the `queue.md` row to `done` (or `blocked`/`deferred` with reason); note newly-unblocked
-issues. The ledger is gitignored — do NOT commit it (spec §6.4). STOP. (Driver re-invokes with
-fresh context for the next issue.)
-
-## Escalation rubric (when unsure)
-Scope/priority/requirements — including any plan whose value story lacks a credible user or a
-checkable falsifier (§3) — → SCOPE_AGENT (pm), before implementing. Design/implementation →
-DESIGN_AGENT. Escalate to the HUMAN only when those disagree/punt, ACs are unresolvable, an
-action is destructive/irreversible, a review finding is contested, or the same step failed twice.
-
-## Guardrails
-One PR at a time (no stacked PRs). **Stuck = the same error SIGNATURE recurs** — grep the FULL
-`progress.md` (not just the tail) for the signature: an identical CI failure, or the same
-tool+args failing again — NOT merely re-entering a status (a legitimate `/clear`-resume
-re-enters `implementing` and must not be flagged). On a genuine repeat: stop, escalate, mark
-`blocked`, move on. Respect any iteration/budget cap (`iteration-cap:`/`subagent-cap:` in the
-`queue.md` header): checked at iteration start (§1) against the ledger — **advisory in manual
-re-invoke (journaled + surfaced, not gating), halted by the driver**.
-
-## Tool surface — and what you must NOT do
-This skill intentionally runs with the full session toolset (no `allowed-tools` restriction):
-an orchestrator needs Write/Edit, Bash(git+gh+tests), Agent (pm/architect/AC-verifier), and
-the built-in review skills. With that power come hard limits — never force-push; never bypass
-failing CI (no `gh pr merge --admin`, never merge red); only `--delete-branch` the PR's own
-branch; never `git add` unrelated pre-existing working-tree changes; never edit the
-user-global SCOPE_AGENT/DESIGN_AGENT definitions. The C1 append-only guard and the
-human/merge gates are the enforced backstops; the rest of this list is your contract.
-````
-
-### 7.2 Architect-gate triggers (from CLAUDE.md)
-Fire the DESIGN_AGENT when the plan: touches shared models (`SessionMessage`,
-`AgentInvocation`); changes a cross-module interface; adds a new diagnostics rule,
-correlation logic, or analytics pipeline; **or the orchestrator is unsure.** Bias toward
-calling it (read-only, cheap vs. a bad implementation). Skip for docs and trivial research.
-
-### 7.3 Router — classification procedure
-Set the row's **Route** (the semantic kind) and its **initial Status** *separately* — they are
-distinct columns (§6.1), so a dependency-blocked research issue is Route `research` / Status
-`blocked`, not Route `blocked`.
-
-**Route**, from labels + body signals, in order:
-1. Issue body says explicitly "NOT implementation-ready" / is a stub (e.g. #469, D041) →
-   `stub-defer`.
-2. Label `documentation` and change is confined to `docs/`/markdown → `docs`.
-3. Label `research` or epic `*-discovery`, throwaway scaffolding, "artifact under study is
-   data" → `research` (no test-coverage gate; placement outside `src/`; no runtime-dep
-   leakage into the package).
-4. Otherwise (`bug`/`enhancement` touching `src/`) → `code` (full pipeline).
-
-**Initial Status:** Route `stub-defer` → `deferred` (terminal). Else if the row's work is gated on
-an **external event** (a release cut, a dogfood window — not an in-run issue) → `parked` with Notes
-`awaiting: <condition>` (non-terminal, resting; released only by explicit human un-park, §7.1 step
-0/1). Else if any `Depends on` issue is not `done` → `blocked` (record the dep in Notes; the
-semantic Route is retained so the row resumes as that route once the dependency clears, §1). Else →
-`routed`.
-
-### 7.4 C5 — AC-verifier
-Default: **compose existing tools**, don't mint an agent.
-1. After implementation, spawn a fresh subagent with ONLY: the issue's acceptance criteria
-   (verbatim) + `git diff main...HEAD`. Prompt: *"For each acceptance criterion, state
-   met/not-met with the file:line or test that satisfies it. Verify the diff actually does
-   this; do not assume. Return a checklist + overall done/not-done."*
-2. For behavior that needs runtime proof, also run `/verify` (runs the app).
-3. `/code-review` (§9) provides the adversarial bug pass.
-Promote to a dedicated `ac-verifier` agent only if the composed approach proves too loose.
-
-### 7.5 Initialization procedure (new run)
-1. Derive `<run-slug>` from `BACKLOG_SOURCE`: milestone → the milestone name (`v0.10.0`);
-   label → the label (slugified); `TODO.md` → its basename. `mkdir -p LEDGER_ROOT/<run-slug>`.
-2. Enumerate `BACKLOG_SOURCE` (e.g. `gh issue list --milestone <run> --state open --json
-   number,title,labels`).
-3. For each issue: determine route (§7.3) and dependencies (parse "Depends on"/"blocked by"
-   refs in the body; respect epic ordering notes).
-4. Topologically order by dependency, then by `PRIORITY_LABELS` (tiebreak issue-number asc).
-   Write `queue.md` (§6.1) with header `mode: calibration` **unless the human has already
-   graduated routes for this project** — check the decision log (e.g. **D047**: `docs`+`research`
-   graduated) and, if so, init `mode: escalation-only` + the graduated `graduated-routes:`
-   instead, so a prior graduation persists across runs rather than silently resetting to
-   calibration. Step 11 reads `mode`/`graduated-routes` to gate **the merge gate**, per route; it
-   never affects the plan gate. Also set `iteration-cap: none` and `subagent-cap: none` (the
-   budget caps, #565; the human sets them when loosening).
-5. Append an "init" block to `progress.md`. (Ledger is gitignored — not committed.)
-
-### 7.6 Resume after `/clear` or compaction
-The next `/release-loop` invocation's §0 resume step (step 3) reads `queue.md` + tail of
-`progress.md` and, finding any *interrupted* row (non-terminal and NOT
-`queued`/`routed`/`hold`/`parked`), finishes it before selecting new work. A `hold` **or `parked`**
-row is **excluded** — a `hold` is a deliberate, durable human merge-hold and a `parked` row is
-gated on an external event (§6.1), neither an interruption; leave them (a `hold` until the human
-clears it at §7.1 step 11; a `parked` row until explicit un-park at §7.1 step 0.1) and neither
-blocks other work. A run resting under a `RUN PARKED` sentinel is likewise **not** an interrupted
-row — §7.1 step 0 short-circuits it on the cheap parked path and never enters this resume scan
-(safe: a valid PARKED state has no non-terminal pipeline row). The on-disk
-ledger row status is only a **coarse anchor** (which stage); the **live git/PR state is the
-source of truth** for the details (the ledger is uncommitted, §6.4): for an in-flight row,
-check whether its branch exists, whether a PR is open (or already merged), and the PR's CI
-status, and resume at the matching pipeline stage — git wins on any conflict with a stale
-status. Stages 4/7/10 need no distinct status because the surrounding statuses bracket them:
-a `plan-approved` row re-enters at implement (§6), so the architect/human gates are NOT re-run.
-The one external-side-effect stage is the architect (§4) — it posts a comment to the issue —
-so on the rare resume of a `planning` row, check for an existing architect comment and skip
-re-invoking if present (do not double-post). AC-verify (§7) is side-effect-free; security (§10)
-re-labeling is a GitHub no-op. **Working-tree reconciliation:** if a crashed prior attempt left uncommitted changes, inspect them before
-proceeding — keep and continue if they match the plan, or `git restore`/stash if they're
-partial/unrelated. A resumed `implementing` row is NOT "stuck" (stuck keys on a repeated error
-signature, not status re-entry — see Guardrails).
+The former subsections map as follows:
+- **§7.1 skill body** → `loop-engine.md` → The pipeline (steps 0–12) + Escalation / Guardrails /
+  Tool surface.
+- **§7.2 architect triggers** (`ARCHITECT_TRIGGERS`) → `loop.config.md` (project-specific).
+- **§7.3 router** → `loop-engine.md` → Router (procedure shape); the project signals
+  (`SOURCE_LAYOUT`) → `loop.config.md`.
+- **§7.4 AC-verifier** → `loop-engine.md` → AC-verifier (compose `CODE_REVIEW` + `VERIFY` + a
+  fresh checklist subagent; no dedicated agent).
+- **§7.5 initialization** → `loop-engine.md` → Initialization procedure.
+- **§7.6 resume** → `loop-engine.md` → Resume after `/clear` or compaction.
+- **§7.1 step 10 security routing** (the `.claude/`-only-vs-label choice + `git remote set-head`
+  GitHub-ism) → `loop.config.md` → Security routing.
 
 ---
 
 ## 8. Routing rules & mechanical rules
 
-| Route | Pipeline differences |
-|-------|----------------------|
-| `code` | full pipeline, all gates |
-| `research` | lighter plan; **no test-coverage gate**; architect optional; security only if deps added; place outside `src/` |
-| `docs` | skip architect + security; light review; `docs:` scope |
-| `stub-defer` | do NOT implement; journal why; leave in backlog (Status `deferred`) |
-
-`blocked` and `parked` are **Status overlays, not Routes**: a row keeps its semantic Route (`code`/
-`research`/`docs`) while resting on an unmet in-run dependency (`blocked`) or an external event
-(`parked`). Skip it; a `blocked` row returns to selection when its dependency closes (§1, §7.3), a
-`parked` row when the human un-parks it (§7.1 step 0.1).
-
-**Mechanical rules (both learned in the #500 run — §11):**
-- `.claude/`-only change → local `/security-review`, not the label (workflow excludes
-  `.claude/`). Local skill needs `origin/HEAD` set.
-- Squash subject scope set explicitly (`chore:` for `.claude/**`), not inherited from PR title.
+**Moved to `loop-engine.md` → Routing table** (as of #612): the per-route pipeline differences,
+the `blocked`/`parked` Status-overlay-not-Route distinction, and the generic squash-`--subject`
+discipline. The host-repo mechanical specifics (the `.claude/`-only-vs-label security path, the
+`origin/HEAD` incantation) live in `loop.config.md` → Security routing. Both mechanical rules were
+learned in the #500 pilot (see §11).
 
 ---
 
 ## 9. Gates, escalation, convergence, guardrails
 
-(See §7.1 skill body for the operative procedure.) Gate table:
-
-| Gate | Who | When | Output |
-|------|-----|------|--------|
-| Plan | orchestrator | every issue | `issue-<N>.plan.md` |
-| Architect | DESIGN_AGENT | §7.2 triggers or unsure | issue comment |
-| Human (plan) | user | only if uncertain/irreversible | approve/redirect |
-| AC-verify | fresh subagent (+`/verify`) | every code/research issue | done/not-done + gaps |
-| Code review | CODE_REVIEW | every code issue | findings → fixes |
-| Security | local `/security-review` or label | by route | clean/findings |
-| Merge | user (calibration / non-graduated route) → orchestrator (auto: graduated routes, D047) | CI+security green | squash |
-
-**Convergence & the resting states.** When nothing is selectable, §7.1 step 1 classifies the run
-into one of four outcomes (tested in order: hold → parked → complete → pending) and appends a
-`progress.md` **run-state sentinel**; §7.1 step 0 reads the **most recent** sentinel by append
-order (last-wins, since the log is append-only) and acts only on it:
-- **`RUN COMPLETE — <run-slug>`** (terminal) — every row is terminal (`done`/`deferred`/`blocked`).
-  Summarizes counts + any blocked/deferred items; the orchestrator stops and reports, and a later
-  re-invocation short-circuits without re-scanning.
-- **`RUN PARKED — awaiting <condition>`** (resting, **non-terminal**) — all *workable* rows are
-  terminal but ≥1 `parked` row awaits an external event (a release cut, a dogfood window). A
-  re-invocation short-circuits (§7.1 step 0): it runs only the cheap milestone-roster reconciliation
-  + a `queue.md` selectability re-derivation, then re-reports parked **without** the expensive
-  per-row live reconcile / resume — until the human explicitly releases a **named** condition
-  (which flips only the `parked` rows awaiting *that* condition back to `routed`, appends a
-  superseding `RUN RESUMED` sentinel, and leaves rows gated on other conditions parked) or a
-  pulled-in joiner / cleared dep makes work selectable again. This is what stops a release-gated run from
-  re-reaching a *new* conclusion on every re-fire (the #584 "converged-pending-release"
-  instability). Distinct from an *interrupted* row needing resume (§7.6): a valid PARKED state has
-  no non-terminal pipeline row, so resume is safely skipped.
-- **held / pending** (no sentinel) — a `hold` row needs the human now, or a row is still `blocked`
-  on an open in-run dependency; the orchestrator reports and stops without a sentinel (the run is
-  not complete and not cleanly parked).
-
-**Guardrails:**
-iteration/budget caps live in the `queue.md` header (`iteration-cap:`/`subagent-cap:`, §6.1) and
-are checked at iteration start against the ledger — **advisory in manual re-invoke (journaled +
-surfaced, not gating — the human who invoked is the budget authority), halted by the driver**;
-one PR at a time; stuck-detection (repeated error signature) → escalate.
-The #500 guard hook protects append-only logs once the loop commits its own work.
+**Moved to `loop-engine.md` → Gates, convergence & resting states** (as of #612): the gate table,
+the four-outcome convergence classifier (hold → parked → complete → pending), the `RUN COMPLETE` /
+`RUN PARKED` / `RUN RESUMED` sentinel semantics, and the guardrails (budget caps, one-PR-at-a-time,
+stuck-detection, the C1 guard hook). The escalation rubric lives in `loop-engine.md` → Escalation
+rubric. §2's research principles above are the "why" behind these gates.
 
 ---
 
@@ -768,11 +193,12 @@ The #500 guard hook protects append-only logs once the loop commits its own work
 1. **C1 guard hook** — done (#500). Verify present + wired; extend `APPEND_ONLY_FILES` if the
    project needs more protected logs.
 2. **C2 ledger** — add `LEDGER_ROOT/` (`.claude/loop/`) to `.gitignore`; create the dir and
-   write the three templates (§6) as the run's seed (uncommitted, §6.4).
-3. **C3 skill** — create `.claude/skills/release-loop/SKILL.md` from §7.1 verbatim; adjust
-   `Project Parameters` references for the host project.
-4. **C4 router** — embodied in the skill (§7.3); no separate file.
-5. **C5 AC-verifier** — embodied in the skill (§7.4); compose existing tools.
+   write the three templates (`loop-engine.md` → Ledger format) as the run's seed (uncommitted).
+3. **C3 skill** — the thin `SKILL.md` (entry) + generic `loop-engine.md` (procedure) + per-project
+   `loop.config.md` (bindings) already exist (#612). Porting to a new project edits **only**
+   `loop.config.md`.
+4. **C4 router** — embodied in `loop-engine.md` → Router (signals in `loop.config.md`); no separate file.
+5. **C5 AC-verifier** — embodied in `loop-engine.md` → AC-verifier; compose existing tools.
 6. **Smoke test** — run `/release-loop` against a single easy issue in supervised mode; walk
    every gate; confirm the ledger updates and the PR ships.
 7. **Calibrate** — run 2–3 issues with the human present at the **merge** gate (and at the plan

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,9 @@ data/
 .claude/worktrees/
 # Loop-engineering harness ledger: local working state (queue/progress/plans),
 # never committed -- committing collides with branch protection (see
-# .claude/specs/prd-loop-engineering.md section 6.4).
+# .claude/skills/release-loop/loop-engine.md -> Ledger format -> Lifecycle & commit policy).
+# NOTE: trailing slash scopes this to the LEDGER_ROOT dir only -- it must NOT swallow the
+# tracked .claude/loop.config.md file. Do not simplify to a bare `.claude/loop`.
 .claude/loop/
 
 # IDE

--- a/tests/unit/test_loop_skill_drift.py
+++ b/tests/unit/test_loop_skill_drift.py
@@ -1,92 +1,50 @@
-"""CI drift guard: the release-loop skill body and its spec mirror must match.
+"""CI guards for the split release-loop harness (engine / config / thin skill).
 
-The orchestrator procedure lives in two hand-maintained copies:
+As of #612 the loop harness is three files instead of a spec-with-embedded-mirror:
 
-  * ``.claude/skills/release-loop/SKILL.md`` -- the live skill (what actually
-    runs when ``/release-loop`` is invoked); and
-  * ``.claude/specs/prd-loop-engineering.md`` section 7 -- a byte-identical
-    mirror embedded in a 4-backtick fenced block, kept so the spec stays
-    self-contained and "ready-to-drop-in".
+  * ``.claude/skills/release-loop/SKILL.md`` -- the thin ``/release-loop`` entry point;
+  * ``.claude/skills/release-loop/loop-engine.md`` -- the generic engine (the operating
+    procedure + all semantics), the single source of truth for the loop's logic; and
+  * ``.claude/loop.config.md`` -- the per-project bindings (parameters, architect triggers,
+    source layout, security routing).
 
-Every edit to the loop's operating steps must land in BOTH copies or the spec
-silently drifts from the live skill (see issue #575). This test fails if they
-diverge. On a conflict, ``SKILL.md`` is the operative copy and section 7 mirrors
-it -- but sync direction is the editor's call; reconcile both to match.
+The old byte-identity guard (SKILL.md == a spec mirror) is retired: the procedure now lives
+once, in the engine, so there is nothing to mirror. In its place these guards pin the invariants
+the split is supposed to hold:
+
+  * the engine still SAYS the load-bearing PARKED / curated-subset semantics (#584 / D048);
+  * the engine stays GENERIC -- no project-binding literal leaks across the seam;
+  * every parameter the engine names is DEFINED in the config (completeness); and
+  * the thin skill still POINTS at both sibling files (pointer-rot).
+
+See issue #612 and decision D051 for the split rationale.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_PATH = REPO_ROOT / ".claude" / "skills" / "release-loop" / "SKILL.md"
-SPEC_PATH = REPO_ROOT / ".claude" / "specs" / "prd-loop-engineering.md"
-
-# The mirror is embedded in a 4-backtick fence (SKILL.md's own body uses inner
-# 3-backtick fences, so a 4-backtick anchor is unambiguous). Capture the content
-# between the opening ````<info-string> line and the closing ```` line, without
-# the fence lines themselves, preserving bytes exactly (raw slice -- no
-# line-split/rejoin, which would risk mangling the trailing newline).
-_FENCE_BLOCK = re.compile(
-    r"^````[a-zA-Z0-9]*\n(?P<body>.*?)^````[ \t]*$\n?",
-    re.MULTILINE | re.DOTALL,
-)
+ENGINE_PATH = REPO_ROOT / ".claude" / "skills" / "release-loop" / "loop-engine.md"
+CONFIG_PATH = REPO_ROOT / ".claude" / "loop.config.md"
 
 
-def _extract_mirror(spec_text: str) -> str:
-    """Return the single 4-backtick fenced block embedding the skill mirror."""
-    matches = list(_FENCE_BLOCK.finditer(spec_text))
-    # Anchor-integrity: exactly one 4-backtick block, or the guard is unreliable
-    # (a future spec restructure must not silently make this test vacuous).
-    assert len(matches) == 1, (
-        f"Expected exactly one 4-backtick fenced block in {SPEC_PATH.name} "
-        f"(the release-loop skill mirror in section 7); found {len(matches)}. "
-        "The drift guard's extraction anchor is ambiguous -- update "
-        "tests/unit/test_loop_skill_drift.py to re-anchor on the mirror block."
-    )
-    body = matches[0].group("body")
-    # Vacuity guard: the block must actually be the skill (its frontmatter),
-    # so a restructure can't leave a passing empty/placeholder stub.
-    assert body.startswith("---\nname: release-loop"), (
-        f"The 4-backtick block in {SPEC_PATH.name} does not start with the "
-        "release-loop skill frontmatter (`---\\nname: release-loop`). The drift "
-        "guard is anchored on the wrong block -- update "
-        "tests/unit/test_loop_skill_drift.py."
-    )
-    return body
-
-
-def test_release_loop_skill_matches_spec_mirror() -> None:
-    """The live SKILL.md must equal the section-7 mirror byte-for-byte."""
-    skill_text = SKILL_PATH.read_text(encoding="utf-8")
-    mirror_text = _extract_mirror(SPEC_PATH.read_text(encoding="utf-8"))
-    if skill_text != mirror_text:
-        pytest.fail(
-            "The release-loop orchestrator procedure has drifted between its two "
-            "hand-maintained copies:\n"
-            f"  * {SKILL_PATH.relative_to(REPO_ROOT)} (live skill)\n"
-            f"  * {SPEC_PATH.relative_to(REPO_ROOT)} section 7 (spec mirror, "
-            "the 4-backtick fenced block)\n"
-            "Edit BOTH copies so they stay byte-for-byte identical. If they "
-            "already say what you intend, copy one over the other -- SKILL.md is "
-            "the operative copy that runs at loop time, so it is the authority "
-            "when resolving a genuine conflict.",
-        )
-
-
-# The RUN PARKED resting state + bidirectional curated-subset invariant (#584 /
-# D048). Byte-identity alone cannot catch BOTH copies dropping these semantics
-# together, so this content-presence guard pins the load-bearing tokens/phrases
-# that a future edit must not silently delete from the operating procedure.
+# ---------------------------------------------------------------------------
+# 1. Load-bearing loop semantics must survive in the engine.
+# ---------------------------------------------------------------------------
+# The RUN PARKED resting state + bidirectional curated-subset invariant (#584 / D048). These
+# tokens/phrases were formerly pinned in SKILL.md; the procedure moved to the engine, so they
+# are pinned there now. A future edit must not silently delete them from the operating
+# procedure.
 _REQUIRED_LOOP_SEMANTICS = (
     "RUN PARKED",  # the resting-state sentinel
     "RUN RESUMED",  # the explicit-release (un-park) sentinel
     "`parked`",  # the first-class non-terminal Status token
     "awaiting:",  # the Notes marker carrying the external condition
-    "Milestone-roster reconciliation",  # the surface-once curation step
+    "Roster reconciliation",  # the surface-once curation step (BACKLOG_SOURCE roster)
     "- surfaced-join:",  # greppable join-dedup record
     "- surfaced-leave:",  # greppable leave-dedup record
 )
@@ -94,16 +52,104 @@ _REQUIRED_LOOP_SEMANTICS = (
 
 @pytest.mark.parametrize("needle", _REQUIRED_LOOP_SEMANTICS)
 def test_release_loop_semantics_present(needle: str) -> None:
-    """The PARKED / curated-subset semantics must survive in the live skill.
-
-    Complements the byte-identity guard above: that test only proves the two
-    copies AGREE; this proves they still SAY the #584 semantics (a joint
-    deletion would pass byte-identity but silently regress the procedure).
-    """
-    skill_text = SKILL_PATH.read_text(encoding="utf-8")
-    assert needle in skill_text, (
+    """The PARKED / curated-subset semantics must survive in the generic engine."""
+    engine_text = ENGINE_PATH.read_text(encoding="utf-8")
+    assert needle in engine_text, (
         f"The release-loop procedure lost a load-bearing #584 token/phrase: "
-        f"{needle!r} is no longer in {SKILL_PATH.relative_to(REPO_ROOT)}. If this "
+        f"{needle!r} is no longer in {ENGINE_PATH.relative_to(REPO_ROOT)}. If this "
         "removal is intentional, update tests/unit/test_loop_skill_drift.py "
         "(_REQUIRED_LOOP_SEMANTICS) and record the decision in decisions.md."
     )
+
+
+# ---------------------------------------------------------------------------
+# 2. The engine must stay generic (no project-binding literals leak the seam).
+# ---------------------------------------------------------------------------
+# Scoped to *bindings* that belong in loop.config.md -- NOT to git/GitHub verbs or issue refs,
+# which the engine legitimately describes. Each of these is a value the porting seam is supposed
+# to isolate; its presence in the engine means a project binding leaked through.
+_FORBIDDEN_IN_ENGINE = (
+    "agentfluent",  # the project name (also catches src/agentfluent, mypy target)
+    "uv run",  # the LINT_CMD/TYPE_CMD/TEST_CMD runner
+    "mypy",  # the TYPE_CMD tool
+    "ruff",  # the LINT_CMD tool
+    "pytest",  # the TEST_CMD tool
+    "anthropic-feature-watch",  # the project's research-scout feed
+)
+
+
+@pytest.mark.parametrize("needle", _FORBIDDEN_IN_ENGINE)
+def test_engine_stays_generic(needle: str) -> None:
+    """No AgentFluent-specific binding literal may appear in the generic engine."""
+    engine_text = ENGINE_PATH.read_text(encoding="utf-8").lower()
+    assert needle not in engine_text, (
+        f"A project-binding literal leaked into the generic engine: {needle!r} appears in "
+        f"{ENGINE_PATH.relative_to(REPO_ROOT)}. Bindings belong in "
+        f"{CONFIG_PATH.relative_to(REPO_ROOT)} and must be referenced from the engine by "
+        "parameter NAME only. Move the value to the config (or express it as a parameter)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Config completeness: every parameter the engine names must be defined in the config.
+# ---------------------------------------------------------------------------
+# The engine references project values only by CAPS parameter name; the config must bind every
+# one. This is the DIP contract of the seam -- the engine depends on the config's vocabulary, so
+# a name the engine uses with no config definition is a broken binding.
+_ENGINE_PARAMETERS = (
+    "ARCHITECT_TRIGGERS",
+    "BACKLOG_SOURCE",
+    "BRANCH_FMT",
+    "CODE_REVIEW",
+    "COMMIT_CONV",
+    "DESIGN_AGENT",
+    "LEDGER_ROOT",
+    "LINT_CMD",
+    "MERGE_METHOD",
+    "PRIORITY_LABELS",
+    "PR_TEMPLATE",
+    "RELEASE_SCHEME",
+    "SCOPE_AGENT",
+    "SECURITY_REVIEW",
+    "SOURCE_LAYOUT",
+    "TEST_CMD",
+    "TYPE_CMD",
+    "VERIFY",
+)
+
+
+@pytest.mark.parametrize("parameter", _ENGINE_PARAMETERS)
+def test_config_defines_engine_parameters(parameter: str) -> None:
+    """Each parameter the engine names by CAPS must be bound in loop.config.md."""
+    engine_text = ENGINE_PATH.read_text(encoding="utf-8")
+    config_text = CONFIG_PATH.read_text(encoding="utf-8")
+    # The engine must actually reference it (keeps this list honest as the engine evolves)...
+    assert parameter in engine_text, (
+        f"{parameter!r} is listed in _ENGINE_PARAMETERS but no longer referenced in "
+        f"{ENGINE_PATH.relative_to(REPO_ROOT)}. Remove it from the list if the engine dropped it."
+    )
+    # ...and the config must define it.
+    assert parameter in config_text, (
+        f"The engine names {parameter!r} but {CONFIG_PATH.relative_to(REPO_ROOT)} does not "
+        "define it. Every engine parameter needs a per-project binding, or the loop has a "
+        "dangling reference at runtime."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Pointer-rot: the thin skill must still route to both sibling files.
+# ---------------------------------------------------------------------------
+def test_skill_points_to_engine_and_config() -> None:
+    """SKILL.md must name both the engine and the config it delegates to."""
+    skill_text = SKILL_PATH.read_text(encoding="utf-8")
+    # Frontmatter is load-bearing for skill triggering (and a downstream fixture pins it).
+    assert skill_text.startswith("---\nname: release-loop"), (
+        f"{SKILL_PATH.relative_to(REPO_ROOT)} lost its `name: release-loop` frontmatter -- the "
+        "skill would not register (or trigger) correctly."
+    )
+    for sibling in ("loop-engine.md", "loop.config.md"):
+        assert sibling in skill_text, (
+            f"The thin skill no longer points at {sibling!r}. A partial load must read both "
+            "siblings; without the reference the procedure/bindings never load. Restore the "
+            f"pointer in {SKILL_PATH.relative_to(REPO_ROOT)}."
+        )


### PR DESCRIPTION
## Summary
- Splits the release-loop harness's operative content out of the 869-line `prd-loop-engineering.md` into two movable artifacts — the standalone prerequisite gate for the loop-plugin epic (#611): a generic `loop-engine.md` (control flow, ledger format, router, AC-verifier, init, resume, gates/convergence — project values as parameter names only) and a per-project `.claude/loop.config.md` (~120 lines: params table, `ARCHITECT_TRIGGERS`, `SOURCE_LAYOUT`, security routing).
- Thins `SKILL.md` (294→~70 lines) to a fail-safe entry that reads the config for bindings and the engine for logic; frontmatter unchanged. Repoints `prd-loop-engineering.md` to keep the design rationale (§1–3, 5, 10–15) with §4/6/7/8/9 reduced to pointers (the embedded byte-identical mirror is removed).
- **Packaging refactor only — no loop semantics change.** Gates, convergence, resume, park/hold, and budget caps behave exactly as before. The engine/config seam was architect-gated (issue comment on #612) and independently AC-verified (GO, no semantic drift).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1947 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/` — no `src/` changes in this PR
- [x] New/changed behavior has test coverage — `tests/unit/test_loop_skill_drift.py` rewritten for the split: byte-identity mirror guard retired; added semantics-presence (on the engine), engine-genericity (no project-binding literals leak), config-completeness (every engine-named parameter is bound), and pointer-rot (SKILL names both siblings) guards (32 cases pass)
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI output change; `.claude/`-only tooling)

**Post-merge validation gate (AC / go-no-go for #613–#617):** after merge, the live v0.11.0 loop completes ≥1–2 real iterations end-to-end against the new engine+config with no behavior regression; that parity result is recorded on #612 and releases the plugin-construction stories.

## Security review
- [x] **Skip review** — no security-sensitive surface (documentation + tooling refactor; the one non-doc change is a `.gitignore` comment/scoping note, and the sole test file is test-only). `.claude/`-only changes are excluded from the labeled `security-review.yml` workflow anyway; a local `/security-review` was run on the branch diff and returned no findings.

## Breaking changes
None. No public contract changes (no CLI, JSON envelope, exit-code, or Pydantic-model changes). This is maintainer-only loop tooling under `.claude/**` — no PyPI-visible change, no version bump (no release milestone, per the #559 precedent).

Closes #612.