### PR TITLE
feat(pricing): add genai-prices dependency + adapter, replace hand-maintained _PRICING

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
     "rich>=14.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
+    # Pinned EXACTLY: we bind to genai-prices' internal (non-``__all__``) rate record in
+    # analytics/_genai_source.py, and it is pre-1.0 (no API-stability promise). A bump is a
+    # controlled channel (#82) gated by the golden-rate test. Do not loosen to ``>=``.
+    "genai-prices==0.0.71",
 ]
 
 [project.optional-dependencies]

--- a/src/agentfluent/analytics/_genai_source.py
+++ b/src/agentfluent/analytics/_genai_source.py
@@ -1,0 +1,97 @@
+"""Isolated genai-prices contact point -- the base side of the base ⊕ overlay seam.
+
+This module is the **only** place in AgentFluent that imports from ``genai_prices``
+(architect Concern 1, #545). Everything else consumes ``ModelPricing`` via
+``analytics.pricing``; a genai-prices bump therefore touches one file, not many. It is
+also the base side of the pricing seam formalized in #547 -- overlay levers (1h cache,
+fast mode, batch/priority, ...) apply *after* the base rates this module returns.
+
+**Static-only contract (local-first, D045 / CLAUDE.md):** this module reads only the
+bundled static snapshot (``genai_prices.data.providers``) and never constructs
+``UpdatePrices`` -- whose opt-in hourly GitHub fetch would introduce background network
+egress, a posture violation. No network I/O occurs during rate resolution.
+
+**Internal-surface binding (why the pin is exact):** the per-token rate table lives on
+genai-prices' *internal* record (``Provider.find_model`` -> ``ModelInfo.get_prices`` ->
+``ModelPrice.input_mtok`` / ...), which is outside its ``__all__`` and carries no
+pre-1.0 stability promise. The public ``calc_price`` returns a computed dollar *total*,
+not a rate table, and cannot supply the 5m/1h cache split ``compute_cost`` needs -- so
+we bind to the internal record and pin ``genai-prices`` exactly in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from genai_prices.data import (  # internal, non-``__all__`` surface -- see module docstring
+    ModelPrice,
+    TieredPrices,
+    providers,
+)
+
+_ANTHROPIC = next((p for p in providers if p.id == "anthropic"), None)
+
+
+@dataclass(frozen=True)
+class UpstreamRates:
+    """Anthropic base rates from genai-prices, in USD per 1M tokens.
+
+    genai-prices models a *single* ``cache_write_mtok`` (the 5-minute-equivalent write
+    rate); the 1-hour cache-write dimension (#534) has no upstream field and is supplied
+    by the local overlay -- the adapter must never collapse 1h onto this 5m rate.
+    """
+
+    input: float
+    output: float
+    cache_write_5m: float
+    cache_read: float
+
+
+def _base_rate(value: Decimal | TieredPrices | None) -> float | None:
+    """Return the standard (below-first-tier) rate as a float.
+
+    A genai-prices rate field is either a scalar ``Decimal`` (flat pricing) or a
+    ``TieredPrices(base, tiers)`` where ``base`` is the standard-context rate and
+    ``tiers`` add context-length surcharges (e.g. the >200K tier on Sonnet). AgentFluent's
+    ``_PRICING`` historically encoded the standard rate, so #545 resolves to ``base``;
+    context-tier-aware pricing is future overlay work (``ModelPricing`` has no tier slot).
+    """
+    if value is None:
+        return None
+    if isinstance(value, TieredPrices):
+        return float(value.base)
+    return float(value)  # scalar Decimal
+
+
+def _resolve_rates(
+    model_ref: str, timestamp: datetime | None = None
+) -> UpstreamRates | None:
+    """Resolve Anthropic base rates for ``model_ref`` from the static snapshot.
+
+    ``timestamp`` selects the rate in effect on that date via genai-prices' dated
+    constraints; ``None`` -> the current rate. #545 always passes ``None`` (date-aware
+    lookup is #546), but the parameter is wired now so #546 is a plumb-through rather than
+    a re-architecture. Returns ``None`` when the model is not covered upstream (the caller
+    then falls back to the documented local residual).
+    """
+    if _ANTHROPIC is None:  # pragma: no cover -- broken genai-prices install
+        return None
+    model = _ANTHROPIC.find_model(model_ref)
+    if model is None:
+        return None
+    when = timestamp if timestamp is not None else datetime.now(UTC)
+    price: ModelPrice = model.get_prices(when)
+    input_rate = _base_rate(price.input_mtok)
+    output_rate = _base_rate(price.output_mtok)
+    cache_write = _base_rate(price.cache_write_mtok)
+    cache_read = _base_rate(price.cache_read_mtok)
+    if input_rate is None or output_rate is None or cache_write is None or cache_read is None:
+        return None
+    return UpstreamRates(
+        input=input_rate,
+        output=output_rate,
+        cache_write_5m=cache_write,
+        cache_read=cache_read,
+    )

--- a/src/agentfluent/analytics/pricing.py
+++ b/src/agentfluent/analytics/pricing.py
@@ -2,12 +2,19 @@
 
 Maps Anthropic model names to per-token costs (USD per 1M tokens) for
 input, output, cache_creation, and cache_read token categories.
+
+Base rates are sourced from genai-prices (upstream, D045) via the isolated
+``_genai_source`` adapter; a small documented local residual (``_RESIDUAL``) supplies any
+model genai-prices does not cover. This module is the public pricing surface -- nothing
+outside ``_genai_source`` imports ``genai_prices`` directly.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+
+from agentfluent.analytics._genai_source import _resolve_rates
 
 logger = logging.getLogger(__name__)
 
@@ -44,41 +51,35 @@ class ModelPricing:
             object.__setattr__(self, "cache_creation_1h", self.input * 2.0)
 
 
-# Pricing data: USD per 1M tokens.
-# Source: https://platform.claude.com/docs/en/about-claude/pricing
-# Last verified: 2026-06-25
-# cache_creation_5m = 5-minute cache-write rate (1.25x input).
-# cache_creation_1h (2x input) is derived from `input` via __post_init__.
-# Update this dict when Anthropic changes pricing.
-_PRICING: dict[str, ModelPricing] = {
-    # Opus 4.5, 4.6, 4.7, 4.8 share the same pricing tier ($5 / $25 / $6.25 / $0.50).
-    "claude-opus-4-8": ModelPricing(
-        input=5.0, output=25.0, cache_creation_5m=6.25, cache_read=0.50,
-    ),
-    "claude-opus-4-7": ModelPricing(
-        input=5.0, output=25.0, cache_creation_5m=6.25, cache_read=0.50,
-    ),
-    "claude-opus-4-6": ModelPricing(
-        input=5.0, output=25.0, cache_creation_5m=6.25, cache_read=0.50,
-    ),
-    "claude-opus-4-5-20251101": ModelPricing(
-        input=5.0, output=25.0, cache_creation_5m=6.25, cache_read=0.50,
-    ),
-    # Sonnet 4, 4.5, 4.6 share the same pricing tier ($3 / $15 / $3.75 / $0.30).
-    "claude-sonnet-4-6": ModelPricing(
-        input=3.0, output=15.0, cache_creation_5m=3.75, cache_read=0.30,
-    ),
-    "claude-sonnet-4-5-20250929": ModelPricing(
-        input=3.0, output=15.0, cache_creation_5m=3.75, cache_read=0.30,
-    ),
-    "claude-sonnet-4-20250514": ModelPricing(
-        input=3.0, output=15.0, cache_creation_5m=3.75, cache_read=0.30,
-    ),
-    # Haiku 4.5 is $1 / $5 / $1.25 / $0.10 (distinct from Haiku 3.5's $0.80 / $4).
-    "claude-haiku-4-5-20251001": ModelPricing(
-        input=1.0, output=5.0, cache_creation_5m=1.25, cache_read=0.10,
-    ),
-}
+# Curated model-id registry: the Anthropic models AgentFluent knows about. Rates are
+# sourced upstream-first from genai-prices (D045) via ``_resolve_rates``; ``_RESIDUAL``
+# supplies a documented local fallback for any id genai-prices does not cover.
+#
+# The #545 coverage probe found genai-prices==0.0.71 covers ALL of these ids, with
+# base-tier rates identical to the former hand-maintained ``_PRICING`` dict:
+#   Opus 4.5/4.6/4.7/4.8  -> $5 / $25 / $6.25 / $0.50
+#   Sonnet 4.0/4.5/4.6    -> $3 / $15 / $3.75 / $0.30   (4.5 is context-tiered upstream;
+#                                                        base tier taken -- see _genai_source)
+#   Haiku 4.5             -> $1 / $5  / $1.25 / $0.10
+# so ``_RESIDUAL`` is currently empty. The golden-rate regression test locks these values.
+_KNOWN_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5-20251101",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5-20250929",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    }
+)
+
+# Documented local residual: model id -> ModelPricing for any model genai-prices lacks.
+# Empty as of genai-prices==0.0.71 (see _KNOWN_MODELS above). Add an entry ONLY for a model
+# the coverage probe shows upstream does not price -- this is the local-overlay escape
+# hatch, not a re-introduction of the hand-maintained rate table.
+_RESIDUAL: dict[str, ModelPricing] = {}
 
 # Aliases map short names and variant identifiers to canonical model names.
 # Aliases mirror the ID forms used elsewhere in the codebase (e.g.
@@ -103,22 +104,47 @@ SYNTHETIC_MODELS: frozenset[str] = frozenset({"<synthetic>"})
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
+# Canonical model-id constants for the model-routing recommendation targets (promoted from
+# diagnostics/_complexity.py, #252 fold, so pricing and routing share one source of truth).
+# Undated to match ``_ALIASES`` resolution.
+MODEL_HAIKU = "claude-haiku-4-5"
+MODEL_SONNET = "claude-sonnet-4-6"
+# MODEL_OPUS intentionally lags the ``opus`` alias (which resolves to claude-opus-4-8): the
+# model-routing recommendation *target* is 4-7, a distinct concern from the default-pricing
+# alias. Do NOT "fix" this to 4-8 -- it would silently change the recommendation target
+# (#252/#545).
+MODEL_OPUS = "claude-opus-4-7"
+
+
 def get_pricing(model: str) -> ModelPricing | None:
     """Look up pricing for a model name.
 
-    Checks exact match first, then aliases. Returns None and logs at DEBUG
-    level if the model is unknown. The caller is expected to skip synthetic
-    sentinel values (see ``SYNTHETIC_MODELS``) before invoking this function.
+    Resolves aliases first (short names, ``[1m]`` suffixes), then sources the rate
+    upstream-first from genai-prices, falling back to the documented local residual.
+    Returns None and logs at DEBUG level if the model is unknown. The caller is expected
+    to skip synthetic sentinel values (see ``SYNTHETIC_MODELS``) before invoking this.
     """
-    pricing = _PRICING.get(model)
-    if pricing:
-        return pricing
+    canonical = _ALIASES.get(model, model)
+    if canonical not in _KNOWN_MODELS:
+        logger.debug("Unknown model '%s' -- no pricing available", model)
+        return None
 
-    canonical = _ALIASES.get(model)
-    if canonical:
-        return _PRICING.get(canonical)
+    rates = _resolve_rates(canonical)
+    if rates is not None:
+        # cache_creation_1h is derived (2x input) by ModelPricing.__post_init__ -- the 1h
+        # overlay dimension (#534) is never collapsed onto the upstream 5m cache_write.
+        return ModelPricing(
+            input=rates.input,
+            output=rates.output,
+            cache_creation_5m=rates.cache_write_5m,
+            cache_read=rates.cache_read,
+        )
 
-    logger.debug("Unknown model '%s' -- no pricing available", model)
+    residual = _RESIDUAL.get(canonical)
+    if residual is not None:
+        return residual
+
+    logger.debug("Known model '%s' has neither upstream nor residual pricing", canonical)
     return None
 
 
@@ -152,5 +178,9 @@ def compute_cost(
 
 
 def get_known_models() -> list[str]:
-    """Return sorted list of all known model names (excluding aliases)."""
-    return sorted(_PRICING.keys())
+    """Return the sorted curated model set (excluding aliases).
+
+    This is the curated registry AgentFluent supports (``_KNOWN_MODELS``), NOT the full
+    genai-prices catalog (which carries many older Anthropic ids).
+    """
+    return sorted(_KNOWN_MODELS)

--- a/src/agentfluent/diagnostics/_complexity.py
+++ b/src/agentfluent/diagnostics/_complexity.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 
 from agentfluent.agents.models import WRITE_TOOLS
+from agentfluent.analytics.pricing import MODEL_HAIKU, MODEL_OPUS, MODEL_SONNET
 from agentfluent.diagnostics.signals import iter_error_matches
 
 if TYPE_CHECKING:
@@ -28,11 +29,10 @@ if TYPE_CHECKING:
 ComplexityTier = Literal["simple", "moderate", "complex"]
 
 
-# Model recommendation per tier — the one mapping both consumers use.
-# Kept undated to match the pricing module's _ALIASES resolution.
-MODEL_HAIKU = "claude-haiku-4-5"
-MODEL_SONNET = "claude-sonnet-4-6"
-MODEL_OPUS = "claude-opus-4-7"
+# Model recommendation per tier — the one mapping both consumers use. The MODEL_HAIKU/
+# SONNET/OPUS constants are defined in analytics.pricing (promoted there, #252 fold) and
+# imported above; delegation.py / model_routing.py keep importing them from here, so the
+# existing re-export chain stays green.
 
 
 # Complexity thresholds. Initial values per backlog E5-S1 guidance.

--- a/src/agentfluent/diagnostics/delegation.py
+++ b/src/agentfluent/diagnostics/delegation.py
@@ -42,6 +42,7 @@ except ImportError:  # pragma: no cover — exercised via the install-path test
     pass
 
 from agentfluent.agents.models import is_general_purpose
+from agentfluent.analytics.pricing import MODEL_HAIKU, MODEL_OPUS, MODEL_SONNET
 from agentfluent.diagnostics._clustering import (
     SKLEARN_AVAILABLE,
     SklearnMissingError,
@@ -52,9 +53,6 @@ from agentfluent.diagnostics._clustering import (
     top_tfidf_terms,
 )
 from agentfluent.diagnostics._complexity import (
-    MODEL_HAIKU,
-    MODEL_OPUS,
-    MODEL_SONNET,
     aggregate_cluster_stats,
     classify_complexity,
     recommend_model_for_complexity,
@@ -128,8 +126,10 @@ _PROMPT_BODY_SNIPPET_CHARS = 500
 # tracked in `scripts/calibration/threshold_validation.ipynb` (#140).
 DEFAULT_TOOL_FREQUENCY_THRESHOLD = 0.5
 
-# MODEL_HAIKU/SONNET/OPUS are re-exported from _complexity.py — see #185
-# for the consolidation. Pre-#185 they lived here directly.
+# MODEL_HAIKU/SONNET/OPUS are imported from analytics.pricing (their source
+# since the #545/#252 fold) and re-exported here via __all__ so downstream
+# importers (e.g. parent_workload.py) keep working. Pre-#185 they lived here
+# directly; #185 moved them to _complexity.py; #545 promoted them to pricing.py.
 
 
 @dataclass

--- a/tests/unit/test_genai_source.py
+++ b/tests/unit/test_genai_source.py
@@ -1,0 +1,105 @@
+"""Tests for the isolated genai-prices adapter (analytics/_genai_source.py).
+
+Covers the internal-record binding, base-tier extraction, the "5m-equivalent cache-write"
+assumption the 1h derivation rests on, and the local-first (no-network) contract.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from agentfluent.analytics import pricing
+from agentfluent.analytics._genai_source import (
+    UpstreamRates,
+    _base_rate,
+    _resolve_rates,
+)
+
+# The curated ids AgentFluent knows (== _KNOWN_MODELS); all upstream-covered at 0.0.71.
+_COVERED = [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5-20251101",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-4-5-20251001",
+]
+
+
+class TestResolveRates:
+    @pytest.mark.parametrize("model", _COVERED)
+    def test_covered_model_resolves(self, model: str) -> None:
+        rates = _resolve_rates(model)
+        assert isinstance(rates, UpstreamRates)
+        assert rates.input > 0
+        assert rates.output > 0
+        assert rates.cache_read > 0
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert _resolve_rates("definitely-not-a-real-model-xyz") is None
+
+    @pytest.mark.parametrize("model", _COVERED)
+    def test_cache_write_is_5m_equivalent(self, model: str) -> None:
+        # Validates the upstream assumption that the single genai-prices ``cache_write_mtok``
+        # is the 5-minute rate (1.25x input) -- the basis the 1h derivation (2x input) trusts.
+        # If upstream ever ships a different cache-write basis, this fails loudly.
+        rates = _resolve_rates(model)
+        assert rates is not None
+        assert rates.cache_write_5m == pytest.approx(1.25 * rates.input)
+
+
+class TestBaseRate:
+    def test_scalar_decimal_passthrough(self) -> None:
+        assert _base_rate(Decimal("3.5")) == 3.5
+
+    def test_none_stays_none(self) -> None:
+        assert _base_rate(None) is None
+
+    def test_tiered_takes_base_not_surcharge(self) -> None:
+        # A context-tiered field (e.g. Sonnet's >200K surcharge) must resolve to the base
+        # (standard-context) rate, which is what _PRICING historically encoded.
+        from genai_prices.data import Tier, TieredPrices
+
+        tiered = TieredPrices(
+            base=Decimal("3"), tiers=[Tier(start=200000, price=Decimal("6"))]
+        )
+        assert _base_rate(tiered) == 3.0
+
+
+class TestLocalFirstContract:
+    def test_no_network_during_resolution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import socket
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("network I/O attempted during pricing resolution")
+
+        monkeypatch.setattr(socket, "socket", _boom)
+        monkeypatch.setattr(socket, "create_connection", _boom)
+
+        assert _resolve_rates("claude-opus-4-8") is not None
+        assert pricing.get_pricing("claude-opus-4-8") is not None
+
+    def test_update_prices_never_constructed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import genai_prices
+
+        class _Boom:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
+                raise AssertionError("UpdatePrices was constructed (posture violation)")
+
+        monkeypatch.setattr(genai_prices, "UpdatePrices", _Boom)
+        assert pricing.get_pricing("claude-sonnet-4-6") is not None
+
+    def test_source_never_calls_update_prices(self) -> None:
+        import inspect
+
+        from agentfluent.analytics import _genai_source
+
+        src = inspect.getsource(_genai_source)
+        # "UpdatePrices" may appear in the docstring contract, but never as a call.
+        assert "UpdatePrices(" not in src

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -209,3 +209,140 @@ class TestGetKnownModels:
         models = get_known_models()
         assert "opus" not in models
         assert "sonnet" not in models
+
+
+# Golden base rates (USD per 1M tokens): input, output, cache_creation_5m, cache_read.
+# These are the pre-migration `_PRICING` values -- the regression lock for the genai-prices
+# swap (#545). COVERAGE PROBE (genai-prices==0.0.71, 2026-07-11): all 8 ids below are
+# covered upstream with base-tier rates equal to these values; the local `_RESIDUAL` is
+# therefore empty. `claude-sonnet-4-5-20250929` is context-tiered upstream (>200K surcharge);
+# the adapter takes the standard (base) tier. If a pin bump changes any value, this test
+# goes red -- that is the intended gate for #82.
+_GOLDEN_RATES: dict[str, tuple[float, float, float, float]] = {
+    "claude-opus-4-8": (5.0, 25.0, 6.25, 0.50),
+    "claude-opus-4-7": (5.0, 25.0, 6.25, 0.50),
+    "claude-opus-4-6": (5.0, 25.0, 6.25, 0.50),
+    "claude-opus-4-5-20251101": (5.0, 25.0, 6.25, 0.50),
+    "claude-sonnet-4-6": (3.0, 15.0, 3.75, 0.30),
+    "claude-sonnet-4-5-20250929": (3.0, 15.0, 3.75, 0.30),
+    "claude-sonnet-4-20250514": (3.0, 15.0, 3.75, 0.30),
+    "claude-haiku-4-5-20251001": (1.0, 5.0, 1.25, 0.10),
+}
+
+
+class TestGoldenRateRegression:
+    """The no-op bar: post-migration rates equal the pre-migration `_PRICING` values."""
+
+    @pytest.mark.parametrize("model,expected", list(_GOLDEN_RATES.items()))
+    def test_rate_equals_pre_migration(
+        self, model: str, expected: tuple[float, float, float, float]
+    ) -> None:
+        pricing = get_pricing(model)
+        assert pricing is not None, f"{model} lost pricing in the migration"
+        got = (
+            pricing.input,
+            pricing.output,
+            pricing.cache_creation_5m,
+            pricing.cache_read,
+        )
+        assert got == expected
+
+    def test_golden_set_is_exactly_the_curated_registry(self) -> None:
+        # Every known model has a golden lock, and no golden id is unknown.
+        assert set(_GOLDEN_RATES) == set(get_known_models())
+
+
+class TestCuratedRegistry:
+    def test_known_models_is_the_curated_eight(self) -> None:
+        assert get_known_models() == sorted(_GOLDEN_RATES)
+
+    def test_upstream_catalog_not_leaked(self) -> None:
+        # genai-prices carries many older ids (claude-2, claude-3-*) -- they must NOT appear.
+        known = get_known_models()
+        assert "claude-2" not in known
+        assert "claude-3-opus-latest" not in known
+        assert all(m.startswith("claude-opus-4") or m.startswith("claude-sonnet-4")
+                   or m.startswith("claude-haiku-4") for m in known)
+
+    @pytest.mark.parametrize("canonical", ["claude-opus-4-7", "claude-sonnet-4-6",
+                                           "claude-haiku-4-5-20251001"])
+    def test_canonical_targets_never_none(self, canonical: str) -> None:
+        # model_routing savings math breaks on a None -- recommendation targets must price.
+        assert get_pricing(canonical) is not None
+
+
+class TestCacheCreation1hNonCollapse:
+    """The 1h dimension (#534) is derived (2x input), never collapsed onto the 5m rate."""
+
+    @pytest.mark.parametrize("model", list(_GOLDEN_RATES))
+    def test_1h_is_2x_input_and_distinct_from_5m(self, model: str) -> None:
+        pricing = get_pricing(model)
+        assert pricing is not None
+        assert pricing.cache_creation_1h == pytest.approx(2.0 * pricing.input)
+        assert pricing.cache_creation_1h != pricing.cache_creation_5m
+
+
+class TestModelConstants:
+    """#252 fold: MODEL_* live in pricing.py; the re-export chain stays green."""
+
+    def test_single_source_across_chain(self) -> None:
+        from agentfluent.analytics import pricing as p
+        from agentfluent.diagnostics import _complexity, delegation
+
+        assert (
+            p.MODEL_OPUS
+            == _complexity.MODEL_OPUS
+            == delegation.MODEL_OPUS
+            == "claude-opus-4-7"
+        )
+        assert (
+            p.MODEL_SONNET
+            == _complexity.MODEL_SONNET
+            == delegation.MODEL_SONNET
+            == "claude-sonnet-4-6"
+        )
+        assert (
+            p.MODEL_HAIKU
+            == _complexity.MODEL_HAIKU
+            == delegation.MODEL_HAIKU
+            == "claude-haiku-4-5"
+        )
+
+    def test_model_opus_intentionally_lags_opus_alias(self) -> None:
+        from agentfluent.analytics.pricing import MODEL_OPUS
+
+        # MODEL_OPUS (routing target) differs from the `opus` default-pricing alias (-> 4-8).
+        assert MODEL_OPUS == "claude-opus-4-7"
+        assert get_pricing("opus") is not None  # alias still resolves (to 4-8)
+        assert get_pricing(MODEL_OPUS) is not None
+
+
+class TestResidualFallback:
+    """The documented local-overlay escape hatch when genai-prices lacks a model.
+
+    ``_RESIDUAL`` is empty at genai-prices==0.0.71 (full upstream coverage), so these
+    tests simulate an upstream miss to lock the fallback contract for a future uncovered
+    model.
+    """
+
+    def test_residual_used_when_upstream_misses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentfluent.analytics import pricing
+
+        sentinel = ModelPricing(
+            input=9.0, output=9.0, cache_creation_5m=9.0, cache_read=9.0
+        )
+        # Known model, but force the upstream lookup to miss and supply a residual entry.
+        monkeypatch.setattr(pricing, "_resolve_rates", lambda ref, timestamp=None: None)
+        monkeypatch.setitem(pricing._RESIDUAL, "claude-opus-4-8", sentinel)
+        assert pricing.get_pricing("claude-opus-4-8") is sentinel
+
+    def test_known_but_uncovered_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentfluent.analytics import pricing
+
+        # Known id, no upstream, no residual -> None (degrade gracefully, never crash).
+        monkeypatch.setattr(pricing, "_resolve_rates", lambda ref, timestamp=None: None)
+        assert pricing.get_pricing("claude-opus-4-8") is None

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ name = "agentfluent"
 version = "0.10.0"
 source = { editable = "." }
 dependencies = [
+    { name = "genai-prices" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -44,6 +45,7 @@ research = [
 
 [package.metadata]
 requires-dist = [
+    { name = "genai-prices", specifier = "==0.0.71" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14.0" },
@@ -732,6 +734,19 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -751,6 +766,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
 ]
 
 [[package]]
@@ -778,12 +806,28 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.13"
+name = "httpx2"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2746,6 +2790,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Swaps the hand-maintained `_PRICING` dict for [pydantic/genai-prices](https://github.com/pydantic/genai-prices) (MIT) as the Anthropic base-rate source — Phase 1 substrate of epic #535 (decision **D045**). **No user-visible cost change** at the default path: the coverage probe found `genai-prices==0.0.71` covers all 8 curated model ids with base-tier rates identical to the former dict, locked by a per-model golden-rate regression test.
- New `analytics/_genai_source.py` isolates **all** genai-prices contact (the base side of the #547 seam): binds to the internal `Provider.find_model`/`ModelInfo.get_prices` record (not public `calc_price`), wires a `timestamp=None` param so #546 is a plumb-through, and honors a static-only/local-first contract (never constructs `UpdatePrices` → no network egress).
- Curated `_KNOWN_MODELS` registry resolves upstream-first with a documented (currently empty) `_RESIDUAL` fallback; `cache_creation_1h` (#534) stays derived as 2× input, never collapsed onto the upstream 5m `cache_write`. Folds **#252**: `MODEL_HAIKU/SONNET/OPUS` promoted into `pricing.py` (`MODEL_OPUS` intentionally lags the `opus`→4-8 alias), re-export chain green.

**Coverage probe (`genai-prices==0.0.71`, 2026-07-11):** all 8 curated ids covered upstream with base-tier rates equal to the pre-migration `_PRICING` values (`claude-sonnet-4-5` is context-tiered upstream; base tier taken) → `_RESIDUAL` is empty. Pin is exact (`==`) because the binding is to a pre-1.0 internal surface; #82 is the gated bump channel with the golden-rate test as its gate.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 1996 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — golden-rate lock (all 8 ids), 5m-equivalent cache-write assertion, base-tier extraction, no-network + `UpdatePrices`-never-constructed guards, residual fallback, curated-set/leak guard, `MODEL_*` chain; new-code coverage `_genai_source.py` 97% / `pricing.py` 100%
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change; pricing is internal, default path byte-identical)

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings. *(Adds a runtime dependency in `pyproject.toml`; the dep is network-capable via `UpdatePrices`, which this PR is careful to never instantiate — static snapshot only, with a no-network guard test. Reviewer should confirm the isolation + static-only contract.)*

## Breaking changes
None. The public pricing surface (`get_pricing()`, `compute_cost()`, `get_known_models()`, `DEFAULT_MODEL`, `SYNTHETIC_MODELS`, alias/`[1m]` resolution) is behavior-preserving; the golden-rate test proves the default (no-timestamp) path is unchanged. `MODEL_HAIKU/SONNET/OPUS` moved to `analytics.pricing` but remain importable from `_complexity`/`delegation` (re-export chain intact).

Closes #545.