### PR TITLE
fix(diagnostics): gate RETRY_LOOP on leading is_error to exclude paging (#581)

### DIFF
--- a/src/agentfluent/diagnostics/trace_signals.py
+++ b/src/agentfluent/diagnostics/trace_signals.py
@@ -15,7 +15,11 @@ trace-specific signal types:
 - `STUCK_PATTERN` — 4+ consecutive identical calls to the same tool.
   Indicates a missing exit condition in the prompt.
 - `RETRY_LOOP` — a `RetrySequence` with `attempts >= 3` that is not
-  `STUCK_PATTERN`. Indicates missing error-recovery guidance.
+  `STUCK_PATTERN` AND whose LEADING call errored. Indicates missing
+  error-recovery guidance. The leading-`is_error` gate (#581) separates
+  genuine error recovery from legitimate paging (an agent reading
+  successive line-ranges — every call `is_error=False` — is not a retry),
+  mirroring PARAMETER_RETRY's first-attempt gate.
 - `TOOL_ERROR_SEQUENCE` — 2+ consecutive `is_error=True` results that
   are not covered by a STUCK or RETRY sequence. Indicates missing
   fallback instructions.
@@ -396,6 +400,19 @@ def _extract_retry_and_stuck(
                 ),
             )
         else:
+            # RETRY_LOOP only counts genuine error recovery, not legitimate
+            # paging (#581): a same-tool run is a retry only if its LEADING
+            # call errored — the same first-attempt gate PARAMETER_RETRY uses
+            # (`_extract_parameter_retries`). A paging run (successive
+            # line-ranges, every call `is_error=False`) is suppressed and,
+            # crucially, left OUT of `covered` (mirrors PARAMETER_RETRY's
+            # return-None-no-cover) so a genuine error sub-run inside a
+            # similarity-grouped sequence can still surface as
+            # TOOL_ERROR_SEQUENCE. STUCK stays ungated: it requires identical
+            # inputs, which drifting paging never matches, and an identical
+            # no-error repeat is a real missing-exit-condition loop.
+            if not calls[0].is_error:
+                continue
             signals.append(
                 _build_retry_signal(
                     agent_type, seq, calls, invocation_id=invocation_id,

--- a/tests/unit/test_trace_signals.py
+++ b/tests/unit/test_trace_signals.py
@@ -270,11 +270,77 @@ class TestRetryLoop:
         assert not any(s.signal_type == SignalType.STUCK_PATTERN for s in signals)
 
 
+class TestRetryLoopLeadingErrorGate:
+    """#581: RETRY_LOOP fires only when the run's LEADING call errored, so a
+    legitimate paging run (successive line-ranges, no error) is not counted."""
+
+    def test_paging_run_no_leading_error_does_not_emit_retry(self) -> None:
+        # Agent pages through successive line-ranges of one file — every call
+        # succeeds (is_error=False). This is not error recovery; no RETRY_LOOP.
+        trace = _trace(
+            calls=[
+                _tc(tool="Read", inp="read lines 1-40", res="ok"),
+                _tc(tool="Read", inp="read lines 41-80", res="ok"),
+                _tc(tool="Read", inp="read lines 81-120", res="ok"),
+            ],
+            sequences=[_rs(tool="Read", attempts=3, indices=[0, 1, 2])],
+        )
+        signals = extract_trace_signals(trace)
+        assert not any(s.signal_type == SignalType.RETRY_LOOP for s in signals)
+        # Nothing else should fire either: no errors → no TOOL_ERROR_SEQUENCE.
+        assert not any(
+            s.signal_type == SignalType.TOOL_ERROR_SEQUENCE for s in signals
+        )
+
+    def test_error_recovery_leading_error_emits_retry(self) -> None:
+        # Same similarity-grouped run, but the leading call errored — genuine
+        # error recovery. RETRY_LOOP fires.
+        trace = _trace(
+            calls=[
+                _tc(tool="Read", inp="read foo.py", res="No such file", err=True),
+                _tc(tool="Read", inp="read foo.py", res="No such file", err=True),
+                _tc(tool="Read", inp="read foo.py", res="ok"),
+            ],
+            sequences=[
+                _rs(tool="Read", attempts=3, indices=[0, 1, 2], first_err="No such file"),
+            ],
+        )
+        signals = extract_trace_signals(trace)
+        loops = [s for s in signals if s.signal_type == SignalType.RETRY_LOOP]
+        assert len(loops) == 1
+        assert loops[0].detail["retry_count"] == 3
+
+    def test_suppressed_paging_leaves_error_tail_uncovered(self) -> None:
+        # Mixed run: leading call succeeds (so RETRY is suppressed), but a
+        # genuine error sub-run follows. Because the suppressed sequence is NOT
+        # added to `covered`, the error tail still surfaces as
+        # TOOL_ERROR_SEQUENCE (#581 decision 2).
+        trace = _trace(
+            calls=[
+                _tc(tool="Read", inp="read a 1-40", res="ok"),
+                _tc(tool="Read", inp="read a 41-80", res="boom", err=True),
+                _tc(tool="Read", inp="read a 81-120", res="boom", err=True),
+            ],
+            sequences=[_rs(tool="Read", attempts=3, indices=[0, 1, 2])],
+        )
+        signals = extract_trace_signals(trace)
+        assert not any(s.signal_type == SignalType.RETRY_LOOP for s in signals)
+        errseqs = [
+            s for s in signals if s.signal_type == SignalType.TOOL_ERROR_SEQUENCE
+        ]
+        assert len(errseqs) == 1
+        # Only the uncovered error tail [1, 2], not the leading success.
+        assert errseqs[0].detail["error_count"] == 2
+        assert errseqs[0].detail["start_index"] == 1
+
+
 class TestStuckPattern:
     def test_three_identical_is_retry_not_stuck(self) -> None:
         # attempts=3 is below STUCK threshold (>=4) regardless of identical inputs.
+        # Leading call errors (#581 gate) so the RETRY branch is reached; the
+        # point under test is the STUCK-vs-RETRY threshold, not the gate.
         trace = _trace(
-            calls=[_tc(inp="ls") for _ in range(3)],
+            calls=[_tc(inp="ls", err=(i == 0)) for i in range(3)],
             sequences=[_rs(attempts=3)],
         )
         signals = extract_trace_signals(trace)
@@ -283,6 +349,10 @@ class TestStuckPattern:
         assert SignalType.STUCK_PATTERN not in types
 
     def test_four_identical_is_stuck(self) -> None:
+        # No leading error, yet STUCK still fires: STUCK is intentionally NOT
+        # gated on is_error (#581 decision 1). An identical no-progress repeat
+        # is a missing-exit-condition loop regardless of error; only the RETRY
+        # branch takes the leading-is_error gate.
         trace = _trace(
             calls=[_tc(inp="ls /missing") for _ in range(4)],
             sequences=[_rs(attempts=4)],
@@ -296,9 +366,10 @@ class TestStuckPattern:
 
     def test_four_near_identical_is_retry_not_stuck(self) -> None:
         # One-char drift — passes RETRY's 0.80 similarity but fails STUCK's
-        # exact-match requirement.
+        # exact-match requirement. Leading call errors (#581 gate) so the RETRY
+        # branch is reached; the point under test is the STUCK-vs-RETRY split.
         trace = _trace(
-            calls=[_tc(inp=f"ls /tmp/{i}") for i in range(4)],
+            calls=[_tc(inp=f"ls /tmp/{i}", err=(i == 0)) for i in range(4)],
             sequences=[_rs(attempts=4)],
         )
         signals = extract_trace_signals(trace)


### PR DESCRIPTION
## Summary
- `RETRY_LOOP` conflated legitimate **paging** (agent reading successive line-ranges; every call `is_error=False`) with genuine **error recovery**, inflating the signal count and blocking #513's architect-prompt re-measurement.
- Fix: apply the same first-attempt `is_error` gate `PARAMETER_RETRY` already uses (`_extract_retry_and_stuck`, RETRY branch) — a same-tool run counts as a `RETRY_LOOP` only if its **leading call errored**. `STUCK_PATTERN` stays ungated (it requires identical inputs, which drifting paging never matches). A suppressed run is left out of `covered` so a genuine error sub-run can still surface as `TOOL_ERROR_SEQUENCE`.
- The parser already synthesizes `is_error` via `detect_is_error_for_tool` (#580's tool-aware fix), so the gate reads an already-trustworthy flag (AC #2).
- **Before/after on the agentfluent corpus:** `retry_loop` 181 → 5; architect `Read` 38 → 0; pm `Read` 17 → 1; **all 5 survivors carry a real leading error** (`InputValidationError` / `EISDIR` / `Permission denied`). Gives #513 a clean measurable denominator.
- Architect-reviewed (comment on #581): both design decisions (gate-RETRY-only; don't-cover-on-suppress) confirmed. Follow-up noted for #459 — the #395 `_retry_noise_multiplier` (0.3 Read/Grep down-weight) was a *proxy* for the paging noise now removed at source; its premise shifts and should be re-validated there (out of scope here).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (1999 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage (new `TestRetryLoopLeadingErrorGate`: paging→no retry, leading-error→retry, suppressed-paging→error-tail still emits `TOOL_ERROR_SEQUENCE`; mutation-checked — gate removed → 2 fail, inverted → 7 fail)
- [x] Manual smoke test via `uv run agentfluent analyze --project agentfluent --diagnostics --json` — before/after documented above (no CLI output-shape change)

## Security review
- [x] **Skip review** — no security-sensitive surface. Internal diagnostics logic only: reads an already-parsed `SubagentToolCall.is_error` boolean; no JSONL parsing, CLI argument parsing, path resolution, network, or subprocess changes.
- [ ] **Needs review**

## Breaking changes
None. No public contract changes. `RETRY_LOOP` fires strictly *less* often (paging runs no longer emit); the JSON envelope, CLI flags, exit codes, and Pydantic models are unchanged. A signal-count *reduction* is the intended behavior, not a contract break.