### PR TITLE
fix: README screenshots don't render on PyPI (absolute raw URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,29 @@ If you write your own prompts each session, use CodeFluent. If your prompts live
 
 ## Screenshots
 
+<!-- Image URLs MUST be absolute (raw.githubusercontent.com), not relative (images/*.svg).
+     PyPI renders this README as standalone HTML with no repo base URL, so relative paths
+     break on the PyPI project page (they render fine on GitHub). Keep these absolute. -->
+
 **Execution Analytics** — `agentfluent analyze --project <name> --no-diagnostics`
 
-![Execution Analytics: token usage, Cost by Model with parent vs subagent Origin column, tool frequency, and Agent Invocations tables](images/demo-analyze.svg)
+![Execution Analytics: token usage, Cost by Model with parent vs subagent Origin column, tool frequency, and Agent Invocations tables](https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-analyze.svg)
 
 **Behavior Diagnostics** — `agentfluent analyze --project <name>` (diagnostics on by default)
 
-![Behavior Diagnostics: Diagnostic Signals + Top-N priority fixes summary above the aggregated Recommendations table + Offload Candidates section ranking parent-thread tool-burst clusters by estimated savings](images/demo-diagnostics.svg)
+![Behavior Diagnostics: Diagnostic Signals + Top-N priority fixes summary above the aggregated Recommendations table + Offload Candidates section ranking parent-thread tool-burst clusters by estimated savings](https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-diagnostics.svg)
 
 **Suggested Subagents with copy-paste-ready YAML draft** — `agentfluent analyze --project <name> --verbose`
 
-![Suggested Subagents: medium-confidence cluster + YAML subagent definition ready to save as ~/.claude/agents/<name>.md](images/demo-subagents.svg)
+![Suggested Subagents: medium-confidence cluster + YAML subagent definition ready to save as ~/.claude/agents/<name>.md](https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-subagents.svg)
 
 **Comparison Workflow** — `agentfluent diff baseline.json current.json`
 
-![agentfluent diff output: New / Resolved / Persisting recommendation row classes with severity, count_delta, priority_score_delta, plus token / cost / cache deltas and per-agent invocation deltas](images/demo-diff.svg)
+![agentfluent diff output: New / Resolved / Persisting recommendation row classes with severity, count_delta, priority_score_delta, plus token / cost / cache deltas and per-agent invocation deltas](https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-diff.svg)
 
 **Config Assessment** — `agentfluent config-check`
 
-![Config Assessment: per-agent 0-100 scoring across description, tools, model, prompt dimensions with recommendations](images/demo-config-check.svg)
+![Config Assessment: per-agent 0-100 scoring across description, tools, model, prompt dimensions with recommendations](https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-config-check.svg)
 
 <sub>Screenshots are regenerated from real session data via <code>scripts/generate_readme_screenshots.py</code>.</sub>
 


### PR DESCRIPTION
## Summary
- PyPI renders `README.md` as standalone HTML with no repository base URL, so the five relative `images/demo-*.svg` screenshot paths resolved to nothing on the [PyPI project page](https://pypi.org/project/agentfluent/) (they render fine on GitHub).
- Switches the five screenshot refs to absolute `https://raw.githubusercontent.com/frederick-douglas-pearce/agentfluent/main/images/demo-*.svg` URLs (verified `HTTP 200` + `content-type: image/svg+xml`).
- Adds an HTML comment above the Screenshots block documenting why absolute URLs are required, to prevent regressions.

## Test plan
- [ ] Unit tests pass: `uv run pytest -m "not integration"` — N/A, README-only change, no code touched
- [ ] Lint clean: `uv run ruff check src/ tests/` — N/A, no `src/` or `tests/` change
- [ ] Type check clean: `uv run mypy src/agentfluent/` — N/A, no Python change
- [ ] New/changed behavior has test coverage — N/A, docs-only (no runtime behavior)
- [x] Manual smoke test — all five `raw.githubusercontent.com` URLs return `HTTP 200` + `content-type: image/svg+xml`; 0 relative refs remain, 5 absolute refs present

## Security review
- [x] **Skip review** — no security-sensitive surface (docs / README-only, static image URLs to an existing public repo path).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. No public contract, CLI, JSON envelope, or Pydantic model changed — only Markdown image URLs in `README.md`.

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)