### PR TITLE
chore(dogfood): rotate synthesizer main model to diversify SDK corpus (#636)

### DIFF
--- a/tests/unit/tools/test_dogfood_model_rotation.py
+++ b/tests/unit/tools/test_dogfood_model_rotation.py
@@ -1,0 +1,95 @@
+"""Tests for #636 main-model rotation and run-manifest recording (runner layer).
+
+`select_main_model` is a pure, date-keyed rotation (unit-testable without the SDK
+or a live model), and `_record_run_best_effort` is the seam that must NEVER flip
+the gate — a missing session_id or an I/O error is swallowed, mirroring the
+best-effort contract of synthesis itself.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from tools.dogfood_runner import runner
+
+
+def _stamp(iso_date: str) -> str:
+    """A runstamp (``YYYYMMDDTHHMMSSZ``) for a given ``YYYY-MM-DD``."""
+    return iso_date.replace("-", "") + "T120000Z"
+
+
+class TestSelectMainModel:
+    def test_override_wins_regardless_of_date(self) -> None:
+        assert (
+            runner.select_main_model(_stamp("2026-07-15"), "claude-pinned-x")
+            == "claude-pinned-x"
+        )
+
+    def test_empty_override_falls_through_to_rotation(self) -> None:
+        # An empty string (e.g. an unset env var read as "") must not pin.
+        assert runner.select_main_model(_stamp("2026-07-15"), "") in runner.MAIN_MODELS
+
+    def test_deterministic_for_the_same_date(self) -> None:
+        stamp = _stamp("2026-07-15")
+        assert runner.select_main_model(stamp) == runner.select_main_model(stamp)
+
+    def test_three_consecutive_days_cover_the_full_cycle(self) -> None:
+        picks = {
+            runner.select_main_model(_stamp(f"2026-07-{15 + i:02d}"))
+            for i in range(len(runner.MAIN_MODELS))
+        }
+        # Consecutive ordinals mod N are distinct → every tier is exercised.
+        assert picks == set(runner.MAIN_MODELS)
+
+    def test_period_equals_number_of_models(self) -> None:
+        base = _stamp("2026-07-15")
+        later = _stamp("2026-07-18")  # +3 days == len(MAIN_MODELS)
+        assert runner.select_main_model(base) == runner.select_main_model(later)
+
+    def test_matches_ordinal_formula(self) -> None:
+        stamp = _stamp("2026-07-15")
+        expected = runner.MAIN_MODELS[date(2026, 7, 15).toordinal() % len(runner.MAIN_MODELS)]
+        assert runner.select_main_model(stamp) == expected
+
+
+class TestRecordRunBestEffort:
+    def test_records_resolved_session_path_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            runner, "_resolve_session_jsonl", lambda sid: f"/corpus/{sid}.jsonl"
+        )
+        monkeypatch.setattr(
+            runner, "record_run", lambda **kw: captured.update(kw) or None
+        )
+
+        runner._record_run_best_effort("20260715T120000Z", "claude-opus-4-8", "sess-9")
+
+        assert captured == {
+            "runstamp": "20260715T120000Z",
+            "main_model": "claude-opus-4-8",
+            "subagent_model": runner.SUBAGENT_MODEL,
+            "session_id": "sess-9",
+            "session_jsonl": "/corpus/sess-9.jsonl",
+        }
+
+    def test_none_session_id_is_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _must_not_call(**_kw: object) -> None:
+            raise AssertionError("record_run must not run without a session_id")
+
+        monkeypatch.setattr(runner, "record_run", _must_not_call)
+        # No session_id → logged and swallowed, no write, no raise.
+        runner._record_run_best_effort("20260715T120000Z", "claude-opus-4-8", None)
+
+    def test_io_error_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(runner, "_resolve_session_jsonl", lambda sid: "/x.jsonl")
+
+        def _boom(**_kw: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(runner, "record_run", _boom)
+        # Must not propagate — a manifest write can never flip the gate.
+        runner._record_run_best_effort("20260715T120000Z", "claude-haiku-4-5", "s1")

--- a/tests/unit/tools/test_dogfood_paths.py
+++ b/tests/unit/tools/test_dogfood_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -68,3 +69,58 @@ def test_prune_snapshots_never_wipes_below_one(tmp_path: Path) -> None:
     deleted = paths.prune_snapshots(slug, keep=0, root=tmp_path)
     assert deleted == []
     assert paths.latest_snapshot(slug, root=tmp_path) is not None
+
+
+def test_runs_manifest_path_at_state_root(tmp_path: Path) -> None:
+    assert paths.runs_manifest_path(root=tmp_path) == tmp_path / "runs.jsonl"
+
+
+def test_record_run_appends_one_json_line(tmp_path: Path) -> None:
+    path = paths.record_run(
+        runstamp="20260715T120000Z",
+        main_model="claude-opus-4-8",
+        subagent_model="claude-haiku-4-5",
+        session_id="sess-1",
+        session_jsonl="/corpus/sess-1.jsonl",
+        root=tmp_path,
+    )
+    assert path == tmp_path / "runs.jsonl"
+    record = json.loads(path.read_text().strip())
+    assert record == {
+        "runstamp": "20260715T120000Z",
+        "main_model": "claude-opus-4-8",
+        "subagent_model": "claude-haiku-4-5",
+        "session_id": "sess-1",
+        "session_jsonl": "/corpus/sess-1.jsonl",
+    }
+
+
+def test_record_run_appends_across_calls(tmp_path: Path) -> None:
+    for i, model in enumerate(("claude-opus-4-8", "claude-sonnet-4-6")):
+        paths.record_run(
+            runstamp=f"2026071{i}T120000Z",
+            main_model=model,
+            subagent_model="claude-haiku-4-5",
+            session_id=f"sess-{i}",
+            session_jsonl=f"/corpus/sess-{i}.jsonl",
+            root=tmp_path,
+        )
+    lines = (tmp_path / "runs.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    assert [json.loads(line)["main_model"] for line in lines] == [
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+    ]
+
+
+def test_record_run_creates_state_root_if_absent(tmp_path: Path) -> None:
+    root = tmp_path / "nonexistent" / "dogfood"
+    paths.record_run(
+        runstamp="20260715T120000Z",
+        main_model="claude-haiku-4-5",
+        subagent_model="claude-haiku-4-5",
+        session_id="s",
+        session_jsonl="/c/s.jsonl",
+        root=root,
+    )
+    assert (root / "runs.jsonl").is_file()

--- a/tests/unit/tools/test_dogfood_runner_main.py
+++ b/tests/unit/tools/test_dogfood_runner_main.py
@@ -35,7 +35,7 @@ def test_main_exits_one_on_red_report(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_main_no_synthesis_never_imports_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(runner, "run_gate", lambda *a, **k: _healthy())
 
-    def _boom(_report: GateReport) -> str:
+    def _boom(_report: GateReport, _model: str) -> str:
         raise AssertionError("synthesize must not be called under --no-synthesis")
 
     monkeypatch.setattr(runner, "synthesize", _boom)
@@ -45,9 +45,12 @@ def test_main_no_synthesis_never_imports_sdk(monkeypatch: pytest.MonkeyPatch) ->
 def test_main_synthesis_failure_never_flips_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(runner, "run_gate", lambda *a, **k: _healthy())
 
-    async def _boom(_report: GateReport) -> str:
+    async def _boom(_report: GateReport, _model: str) -> tuple[str, str | None]:
         raise RuntimeError("SDK not installed / auth missing")
 
     monkeypatch.setattr(runner, "synthesize", _boom)
+    # A synthesis failure leaves session_id None; recording must also stay
+    # best-effort and never flip the gate.
+    monkeypatch.setattr(runner, "_record_run_best_effort", lambda *a, **k: None)
     # Synthesis blows up, but the gate was green → exit stays 0 (best-effort).
     assert runner.main([]) == 0

--- a/tools/dogfood_runner/README.md
+++ b/tools/dogfood_runner/README.md
@@ -51,10 +51,14 @@ errored (alert the maintainer the tool is broken), `0` otherwise. A detected
 regression is a *successful* dogfood that found something — it is reported, not
 treated as a runner failure.
 
-The Haiku subagents synthesize the narrative only. Running a distinct parent /
-child model is deliberate: it emits the model-divergence and nested-trace bytes
-that the S5 trace linker (#595) and #112's model-routing signal consume, so the
-runner dogfoods the exact v0.11 surfaces.
+The Haiku subagents synthesize the narrative only. Delegating to a subagent for
+clean context and a narrower task scope is deliberate: it always emits the
+nested-trace bytes — and, on the days rotation puts a non-Haiku model on the
+parent, the parent≠child model-divergence bytes — that the S5 trace linker (#595)
+and #112's model-routing signal consume, so the runner dogfoods the exact v0.11
+surfaces. (A Haiku-parent day runs parent and subagent as separate instances of
+the same tier: still a real delegation trace, just no model divergence — itself a
+useful dogfood data point.)
 
 ## Main-model rotation (#636)
 

--- a/tools/dogfood_runner/README.md
+++ b/tools/dogfood_runner/README.md
@@ -51,10 +51,31 @@ errored (alert the maintainer the tool is broken), `0` otherwise. A detected
 regression is a *successful* dogfood that found something — it is reported, not
 treated as a runner failure.
 
-The Haiku subagents synthesize the narrative only. Running parent-Opus /
-child-Haiku is deliberate: it emits the model-divergence and nested-trace bytes
+The Haiku subagents synthesize the narrative only. Running a distinct parent /
+child model is deliberate: it emits the model-divergence and nested-trace bytes
 that the S5 trace linker (#595) and #112's model-routing signal consume, so the
 runner dogfoods the exact v0.11 surfaces.
+
+## Main-model rotation (#636)
+
+Every run otherwise sits at one point in the model dimension, so the corpus never
+tells us how the diagnostics behave across models. The **synthesis parent model
+rotates** across `MAIN_MODELS` (`claude-opus-4-8` → `claude-sonnet-4-6` →
+`claude-haiku-4-5`) by run **date** — `date.toordinal() % 3` — so consecutive
+daily cron runs cycle the tiers. The rotation is keyed off the date (not a
+persistent counter) so a session's main model is reproducible from its own
+timestamp (the map #112's intended-vs-resolved check wants) and a missed cron day
+can't corrupt a counter. The subagent stays Haiku (this is a main-model-only axis;
+structural diversity — turns, delegations — is #637).
+
+- Pin one tier for an ad-hoc run: `--main-model claude-sonnet-4-6` (or
+  `DOGFOOD_MAIN_MODEL` for the cron). Unset → rotation.
+- **Discoverability:** each synthesis run appends a line to a run manifest at
+  `$XDG_STATE_HOME/agentfluent/dogfood/runs.jsonl` —
+  `{runstamp, main_model, subagent_model, session_id, session_jsonl}` — mapping
+  each corpus session to the main-model variant it ran under. Same out-of-tree,
+  never-committed state tree as the snapshots. The write is **best-effort**: a
+  missing `session_id` or an I/O error is logged, never allowed to flip the gate.
 
 ## Running it
 
@@ -131,6 +152,12 @@ of S0.
 - **Zero slugs is surfaced, not red.** An empty corpus is legitimate, so it stays
   exit 0 — but the report prints a `WARNING` so a misconfigured corpus path under
   cron is visible in `cron.log` rather than passing as a clean run.
+- **Model rotation makes rotation-boundary `diff` findings expected.** The
+  synthesis runs with `cwd=REPO_DIR`, so its own sessions feed the agentfluent
+  slug's next window; when the parent model rotates day-over-day, that slug's cost
+  profile shifts and `diff` surfaces a benign "regression" at each boundary. This
+  is **not** red (exit 3 is a finding, excluded from `is_red`) — it's an expected
+  artifact of diversifying the corpus, not a tool malfunction.
 
 ## Layout
 

--- a/tools/dogfood_runner/paths.py
+++ b/tools/dogfood_runner/paths.py
@@ -16,6 +16,7 @@ in ``agentfluent.core.paths``::
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -33,10 +34,18 @@ __all__ = [
     "latest_snapshot",
     "new_snapshot_path",
     "prune_snapshots",
+    "record_run",
+    "runs_manifest_path",
     "slug_dir",
 ]
 
 DOGFOOD_SUBDIR = "dogfood"
+
+# Append-only manifest mapping each synthesis run to the main-model variant it
+# used (#636 corpus-diversification discoverability). One JSON object per line at
+# the dogfood state root, a sibling of the per-slug snapshot dirs — same
+# out-of-tree, gitignored-by-location tree, never committed.
+RUNS_MANIFEST = "runs.jsonl"
 
 SNAPSHOT_PREFIX = "snapshot-"
 SNAPSHOT_SUFFIX = ".json"
@@ -55,6 +64,42 @@ _SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 def dogfood_state_dir() -> Path:
     """Root of the dogfood snapshot tree (``<agentfluent-state>/dogfood``)."""
     return agentfluent_state_dir() / DOGFOOD_SUBDIR
+
+
+def runs_manifest_path(*, root: Path | None = None) -> Path:
+    """Path to the append-only run manifest (``<dogfood-state>/runs.jsonl``)."""
+    return (root or dogfood_state_dir()) / RUNS_MANIFEST
+
+
+def record_run(
+    *,
+    runstamp: str,
+    main_model: str,
+    subagent_model: str,
+    session_id: str,
+    session_jsonl: str,
+    root: Path | None = None,
+) -> Path:
+    """Append one run record (a single JSON line) to the run manifest.
+
+    Kept as pure filesystem I/O with NO ``claude_agent_sdk`` dependency so it stays
+    importable by the SDK-free gate layer (``cli_runner`` imports this module at
+    load). The caller (``runner``, already SDK-bound) resolves ``session_jsonl`` via
+    ``project_key_for_directory`` and passes it in. Records the *intended*
+    ``main_model`` — the map a #112 intended-vs-resolved cross-check needs.
+    """
+    path = runs_manifest_path(root=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "runstamp": runstamp,
+        "main_model": main_model,
+        "subagent_model": subagent_model,
+        "session_id": session_id,
+        "session_jsonl": session_jsonl,
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+    return path
 
 
 def slug_dir(slug: str, *, root: Path | None = None) -> Path:

--- a/tools/dogfood_runner/runner.py
+++ b/tools/dogfood_runner/runner.py
@@ -11,13 +11,16 @@ Two layers, deliberately separated (architect review, #590):
 1. **The gate** (:func:`tools.dogfood_runner.cli_runner.run_gate`) — deterministic,
    drives the real ``agentfluent`` CLI, owns pass/fail by reading exit codes. Runs
    with or without the ``research`` group; ``--no-synthesis`` stops here.
-2. **Narrative synthesis** — an Agent SDK ``query()`` (parent Opus) fans out one
-   Haiku subagent per slug to summarize that slug's snapshot, and the parent
-   stitches a report. Best-effort: a synthesis failure is logged but NEVER flips
-   the gate (the gate is about analysis correctness, not the narrative). The
-   parent-Opus / child-Haiku split is intentional — it emits the model-divergence
-   and nested-trace bytes that S5 (#595) and #112 will consume, so the runner
-   dogfoods the exact v0.11 surfaces.
+2. **Narrative synthesis** — an Agent SDK ``query()`` (a rotated parent model)
+   fans out one Haiku subagent per slug to summarize that slug's snapshot, and the
+   parent stitches a report. Best-effort: a synthesis failure is logged but NEVER
+   flips the gate (the gate is about analysis correctness, not the narrative). The
+   parent/child model split is intentional — it emits the model-divergence and
+   nested-trace bytes that S5 (#595) and #112 will consume, so the runner dogfoods
+   the exact v0.11 surfaces. The parent model **rotates** across
+   :data:`MAIN_MODELS` by run date (#636), diversifying the corpus's model
+   dimension; each run is recorded in the out-of-tree run manifest (``paths``) so
+   sessions are discoverable by their main-model variant.
 
 ``claude_agent_sdk`` is imported lazily inside :func:`synthesize` so this module
 imports (and the gate runs) without the ``research`` dependency-group installed.
@@ -29,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -41,6 +45,7 @@ from tools.dogfood_runner.cli_runner import (
     render_gate_report,
     run_gate,
 )
+from tools.dogfood_runner.paths import record_run
 
 # Repo root — the subagents run `uv run agentfluent report` here, so their cwd must
 # resolve the project venv. tools/dogfood_runner/runner.py → parents[2] is the root.
@@ -48,15 +53,45 @@ REPO_DIR = Path(__file__).resolve().parents[2]
 
 # Non-dated aliases on purpose: a dated model pin (e.g. ``claude-haiku-4-5-20251001``)
 # starts long-hanging then 529s once that snapshot is retired. Centralized here so
-# there is one place to bump. Current tiers: Opus 4.8 parent, Haiku 4.5 subagent.
-PARENT_MODEL = "claude-opus-4-8"
+# there is one place to bump.
+#
+# The parent (synthesis) model is ROTATED across these tiers to diversify the SDK
+# dogfood corpus's model dimension (#636) — every run otherwise sits at one point
+# in the model dimension, and opus is overkill for orchestration+summarization
+# (#635). The subagent stays Haiku (main-model-only per #636 scope). ``sonnet-4-6``
+# is the non-dated alias the rest of the repo already trusts (fixtures, builders,
+# the #519 matrix runner).
+MAIN_MODELS = ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5")
 SUBAGENT_MODEL = "claude-haiku-4-5"
 SYNTHESIS_MAX_TURNS = 20
+
+# Manual override for the rotated parent model (``--main-model`` or this env var,
+# for the cron). Unset → deterministic date-based rotation.
+DOGFOOD_MAIN_MODEL_ENV = "DOGFOOD_MAIN_MODEL"
 
 
 def _runstamp(now: datetime | None = None) -> str:
     """UTC stamp that sorts lexically by recency — drives ``latest_snapshot``."""
     return (now or datetime.now(UTC)).strftime("%Y%m%dT%H%M%SZ")
+
+
+def select_main_model(runstamp: str, override: str | None = None) -> str:
+    """Pick the synthesis parent model for this run.
+
+    An explicit ``override`` (``--main-model`` / ``DOGFOOD_MAIN_MODEL``) wins so a
+    manual run can pin one tier. Otherwise rotate deterministically across
+    :data:`MAIN_MODELS` by the run's calendar date (the ``YYYYMMDD`` prefix of the
+    runstamp): consecutive daily cron runs cycle opus → sonnet → haiku.
+
+    Keyed off the date rather than a persistent counter so the choice is
+    reproducible from a session's own timestamp (the map a #112 intended-vs-resolved
+    cross-check wants) and so a missed cron day cannot corrupt a round-robin counter
+    — at N=3 vs a 7-day week the skipped ordinals drift and even out.
+    """
+    if override:
+        return override
+    ordinal = datetime.strptime(runstamp[:8], "%Y%m%d").date().toordinal()
+    return MAIN_MODELS[ordinal % len(MAIN_MODELS)]
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -86,12 +121,22 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Run the deterministic gate only; skip the SDK narrative synthesis.",
     )
+    parser.add_argument(
+        "--main-model",
+        default=None,
+        help=(
+            "Pin the synthesis parent model (overrides the date-based rotation "
+            f"across {', '.join(MAIN_MODELS)}). Also settable via ${DOGFOOD_MAIN_MODEL_ENV}."
+        ),
+    )
     return parser.parse_args(argv)
 
 
-async def synthesize(report: GateReport) -> str:
-    """Fan out Haiku subagents (one per snapshot) under an Opus parent; return the
-    synthesized narrative. Lazy-imports the SDK so the gate never depends on it."""
+async def synthesize(report: GateReport, main_model: str) -> tuple[str, str | None]:
+    """Fan out Haiku subagents (one per snapshot) under a parent on ``main_model``;
+    return ``(narrative, session_id)``. The ``session_id`` (off the SDK result
+    stream) lets the caller record this run's corpus session against its main-model
+    variant (#636). Lazy-imports the SDK so the gate never depends on it."""
     from claude_agent_sdk import (  # noqa: PLC0415 — lazy by design (research group)
         AgentDefinition,
         ClaudeAgentOptions,
@@ -101,7 +146,7 @@ async def synthesize(report: GateReport) -> str:
 
     snapshots = [(r.slug, r.snapshot) for r in report.results if r.snapshot is not None]
     if not snapshots:
-        return "(no snapshots produced this run — nothing to synthesize)"
+        return "(no snapshots produced this run — nothing to synthesize)", None
 
     # The subagent renders the snapshot with `agentfluent report` (the tool's OWN
     # deterministic interpreter of the JSON schema) and condenses that Markdown — it
@@ -131,7 +176,7 @@ async def synthesize(report: GateReport) -> str:
         f"Snapshots:\n{manifest}"
     )
     options = ClaudeAgentOptions(
-        model=PARENT_MODEL,
+        model=main_model,
         # Bash so the subagents can run `agentfluent report`; Task/Agent to delegate.
         allowed_tools=["Read", "Bash", "Task", "Agent"],
         disallowed_tools=["WebFetch", "WebSearch"],
@@ -143,30 +188,78 @@ async def synthesize(report: GateReport) -> str:
         max_turns=SYNTHESIS_MAX_TURNS,
     )
     final = ""
+    session_id: str | None = None
     async for message in query(prompt=prompt, options=options):
         if isinstance(message, ResultMessage):
             final = message.result or final
-    return final or "(synthesis produced no result text)"
+            session_id = message.session_id or session_id
+    return final or "(synthesis produced no result text)", session_id
+
+
+def _resolve_session_jsonl(session_id: str) -> str:
+    """Absolute path of the corpus JSONL the SDK wrote for ``session_id``.
+
+    Mirrors ``research/agent-sdk-probe/agent.py``: the synthesis ``query()`` runs
+    with ``cwd=REPO_DIR``, so its session lands under the repo's project-slug.
+    ``project_key_for_directory`` is an SDK import, kept lazy here so the SDK-free
+    gate layer (``paths``/``cli_runner``) never transitively pulls it in.
+    """
+    from claude_agent_sdk import project_key_for_directory  # noqa: PLC0415 — lazy by design
+
+    slug = project_key_for_directory(str(REPO_DIR))
+    return str(Path.home() / ".claude" / "projects" / slug / f"{session_id}.jsonl")
+
+
+def _record_run_best_effort(runstamp: str, main_model: str, session_id: str | None) -> None:
+    """Append this run to the discoverability manifest — BEST-EFFORT.
+
+    A manifest write must never flip the exit code (the same rule as synthesis:
+    the deterministic gate owns pass/fail). A missing ``session_id`` or any I/O
+    error is logged and swallowed, not surfaced as a failure.
+    """
+    if session_id is None:
+        print(
+            "[warn] no session_id from synthesis — run not recorded in manifest",
+            file=sys.stderr,
+        )
+        return
+    try:
+        record_run(
+            runstamp=runstamp,
+            main_model=main_model,
+            subagent_model=SUBAGENT_MODEL,
+            session_id=session_id,
+            session_jsonl=_resolve_session_jsonl(session_id),
+        )
+    except Exception as exc:  # noqa: BLE001 — recording must never flip the gate
+        print(f"[warn] could not record run in manifest: {exc}", file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
+    runstamp = _runstamp()
     cli = CliRunner()
     report = run_gate(
         cli,
         window=args.window,
-        runstamp=_runstamp(),
+        runstamp=runstamp,
         retention=args.retention,
         fail_on=args.fail_on,
     )
     print(render_gate_report(report))
 
     if not args.no_synthesis:
+        main_model = select_main_model(
+            runstamp, args.main_model or os.environ.get(DOGFOOD_MAIN_MODEL_ENV)
+        )
+        session_id: str | None = None
         try:
-            narrative = asyncio.run(synthesize(report))
-            print("\n--- synthesis ---\n" + narrative)
+            narrative, session_id = asyncio.run(synthesize(report, main_model))
+            print(f"\n--- synthesis (main model: {main_model}) ---\n" + narrative)
         except Exception as exc:  # noqa: BLE001 — synthesis must never flip the gate
             print(f"\n[warn] narrative synthesis skipped: {exc}", file=sys.stderr)
+        # Record whether or not synthesis raised: a None session_id just no-ops.
+        _record_run_best_effort(runstamp, main_model, session_id)
 
     # Exit code reflects ANALYSIS health only. A regression is a successful dogfood
     # that found something (surfaced in the report), not a runner failure.


### PR DESCRIPTION
## Summary
- **Phase 1 of the SDK-dogfood-corpus diversification split (#636).** Rotates the #590 synthesizer's parent model across `MAIN_MODELS` (`claude-opus-4-8` → `claude-sonnet-4-6` → `claude-haiku-4-5`) by run **date** (`date.toordinal() % N`), replacing the hardcoded `PARENT_MODEL = opus`. Every run previously sat at one point in the model dimension; the corpus now exercises the diagnostics across tiers. Date-keyed (not a persistent counter) so a session's main model is reproducible from its own timestamp — the map #112's intended-vs-resolved check wants — and a missed cron day can't desync a round-robin. `--main-model` / `DOGFOOD_MAIN_MODEL` pins a tier for ad-hoc runs.
- **Discoverability manifest.** `paths.record_run()` appends `{runstamp, main_model, subagent_model, session_id, session_jsonl}` to an out-of-tree `runs.jsonl` (same gitignored-by-location state tree as the snapshots), mapping each corpus session to its main-model variant. Kept **SDK-free** per architect review — the caller (`runner`, already SDK-bound) resolves the JSONL path via `project_key_for_directory`, so the deterministic anti-false-green gate layer never transitively imports the SDK. The manifest write is **best-effort**: a missing `session_id` or I/O error is logged, never allowed to flip the gate.
- **Scope guard.** Subagent stays Haiku (this is a main-model-only axis; structural diversity — turns, delegations — is #637, which owns the positive-#112-emission AC per the [architect ruling](https://github.com/frederick-douglas-pearce/agentfluent/issues/635#issuecomment-4978101544)). All changes under `tools/` → `chore:` scope, nothing ships in the PyPI wheel. **Milestone unset**: background infra, deliberately off the v0.11 release-gating critical path.

Architect design review (APPROVE-WITH-CHANGES): [#636 comment](https://github.com/frederick-douglas-pearce/agentfluent/issues/636#issuecomment-4978272330). All requested changes incorporated (SDK-free `record_run`, best-effort write, documented rotation-boundary `diff` artifact).

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (2036 passed)
- [x] Lint clean: `uv run ruff check src/ tests/` (also ran on `tools/`)
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `select_main_model` rotation/override/period, `record_run` append/format/path-creation, best-effort recorder (None session_id + I/O error swallowed), updated `main()` synthesize stubs to the 2-arg signature
- [ ] Manual smoke test via `uv run agentfluent ...` — N/A (no CLI-output change; this is the out-of-tree dogfood runner, not the shipped CLI)

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface. Out-of-tree `tools/` maintainer infra (not shipped to PyPI), runs headless over the maintainer's own local corpus. New code is: model-alias constant selection, a fixed-name manifest append (`runs.jsonl`; `session_id`/path are written as JSON text, never used to open a file, so no traversal), and one new opt-in flag. No untrusted external input, no secret handling, no new subprocess or shell interpolation (the pre-existing `subprocess` gate is unchanged), no rendering of user-controlled strings. Model additions consumed only by trusted internal code.
- [ ] **Needs review**

## Breaking changes
None. `synthesize()`'s signature changed (`report` → `report, main_model`; returns `(narrative, session_id)`), but it's an internal function of an unshipped tool with no public contract. No CLI flag removed/renamed, no JSON envelope bump, no exit-code or Pydantic-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)