### PR TITLE
feat(pricing): date-aware base-rate lookup via session timestamp (#546)

### DIFF
--- a/docs/COST_MODEL.md
+++ b/docs/COST_MODEL.md
@@ -19,6 +19,7 @@ AgentFluent prices sessions on top of [pydantic/genai-prices](https://github.com
 | Data residency US (1.1×) | Low–Medium | Overlay | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
 | Web search ($10 / 1k) | Medium *if used* | Overlay (counts present in JSONL) | [pydantic/genai-prices#288](https://github.com/pydantic/genai-prices/pull/288) (PR in flight — retire overlay once merged + pin bumped) |
 | Code execution ($/hr) | Partial (duration not in single-session JSONL) | Document limitation; surface count | not modeled |
+| >200K context tier | Medium *if a session exceeds 200K context* | **Gap** — the adapter takes `TieredPrices.base` and discards `tiers`, so >200K-context sessions are priced at the base tier (tracked in #639) | modeled (`tiers`) |
 
 The rates, multipliers, and field mappings behind this table are in the canonical doc; this is only AgentFluent's coverage status against it. The **Upstream** column tracks getting each lever modeled in the shared dataset — as those land and we bump the pinned genai-prices slice, the matching local overlay can be retired.
 
@@ -29,6 +30,14 @@ The 1-hour cache-write overlay (#534) lands in **v0.10**. Before it, AgentFluent
 This matters for `agentfluent diff`: a baseline snapshot captured **before** v0.10 stores costs computed under the old all-5m rate. Diffing it against a snapshot taken **after** upgrading will show a positive cost delta on cache-heavy sessions that comes purely from the pricing fix, not from any change in agent behavior. To compare like-for-like, **re-capture your baseline after upgrading to v0.10** so both sides price 1h writes the same way. Token counts (which the diff also reports) are unaffected.
 
 A follow-up will stamp the pricing-model version into snapshots so the diff can flag a cross-version comparison automatically (tracked in #543).
+
+## Date-aware base rates (session priced at the rate in effect when it ran)
+
+From **v0.11**, AgentFluent resolves each session's base rate at the session's own date — the first-message timestamp is threaded through the cost path into genai-prices' dated `constraint`s (`get_pricing(model, timestamp=...)`, #546). The intent is that a historical session reports the cost it actually incurred, not today's rate.
+
+**This is presently date-invariant, by measurement.** As of the pinned `genai-prices` slice, **no model AgentFluent prices carries a dated _base-rate_ change** — the only dated Anthropic constraints move the >200K context tier (the gap above, #639), which the adapter discards, so the base `(input, output, cache_write_5m, cache_read)` rates are identical at every date. Analyzing an old session therefore yields the same dollar cost it would at "latest"; **no historical cost is restated today**, and no `agentfluent diff` cross-date delta arises from rate changes yet.
+
+The wiring is a forward-compat guarantee: the day Anthropic ships a genuine dated base-rate change and it lands in the pinned dataset, historical sessions auto-price correctly with no code change. A guard test (`tests/`) asserts the current date-invariance per model and **fails loudly** if that ever stops holding — that failure is the signal to write the user-facing "historical costs now differ" note here and to activate #543's cross-date-delta caveat for `diff`.
 
 ---
 

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -27,6 +27,7 @@ from agentfluent.analytics.tokens import (
     compute_subagent_token_metrics,
     compute_token_metrics,
     fold_subagent_metrics_in,
+    session_price_timestamp,
 )
 from agentfluent.analytics.tools import (
     ConcentrationEntry,
@@ -214,7 +215,12 @@ def analyze_session(
     """
     messages = parse_session(path)
 
-    token_metrics = compute_token_metrics(messages)
+    # Price the session at the rate in effect when it ran (#546): derive the first-message
+    # timestamp once and apply it to both parent and subagent cost rows for one consistent
+    # session price date. None (no timestamped message) → latest rate.
+    price_date = session_price_timestamp(messages)
+
+    token_metrics = compute_token_metrics(messages, timestamp=price_date)
     tool_metrics = compute_tool_metrics(messages)
 
     invocations = extract_agent_invocations(messages)
@@ -227,7 +233,7 @@ def analyze_session(
     mcp_tool_calls = extract_mcp_calls_from_messages(messages)
 
     subagent_traces = [inv.trace for inv in invocations if inv.trace is not None]
-    subagent_rows = compute_subagent_token_metrics(subagent_traces)
+    subagent_rows = compute_subagent_token_metrics(subagent_traces, timestamp=price_date)
     token_metrics = fold_subagent_metrics_in(token_metrics, subagent_rows)
 
     agent_metrics = compute_agent_metrics(

--- a/src/agentfluent/analytics/pricing.py
+++ b/src/agentfluent/analytics/pricing.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 
 from agentfluent.analytics._genai_source import _resolve_rates
 
@@ -116,20 +117,29 @@ MODEL_SONNET = "claude-sonnet-4-6"
 MODEL_OPUS = "claude-opus-4-7"
 
 
-def get_pricing(model: str) -> ModelPricing | None:
+def get_pricing(model: str, timestamp: datetime | None = None) -> ModelPricing | None:
     """Look up pricing for a model name.
 
     Resolves aliases first (short names, ``[1m]`` suffixes), then sources the rate
     upstream-first from genai-prices, falling back to the documented local residual.
     Returns None and logs at DEBUG level if the model is unknown. The caller is expected
     to skip synthetic sentinel values (see ``SYNTHETIC_MODELS``) before invoking this.
+
+    ``timestamp`` selects the base rate in effect on that date via genai-prices' dated
+    constraints (#546); ``None``/omitted → the latest rate, preserving every existing
+    caller. Note (#546 falsifier finding, genai-prices==0.0.71): no model in
+    ``_KNOWN_MODELS`` currently carries a dated *base-rate* change -- the only dated
+    Anthropic constraints move the >200K context tier, which the adapter discards (see
+    ``_genai_source._base_rate``) -- so a timestamp is presently date-invariant at base-rate
+    granularity. The parameter is wired so a future upstream dated base-rate change applies
+    automatically; the forward-compat guard test in ``tests`` is the tripwire.
     """
     canonical = _ALIASES.get(model, model)
     if canonical not in _KNOWN_MODELS:
         logger.debug("Unknown model '%s' -- no pricing available", model)
         return None
 
-    rates = _resolve_rates(canonical)
+    rates = _resolve_rates(canonical, timestamp)
     if rates is not None:
         # cache_creation_1h is derived (2x input) by ModelPricing.__post_init__ -- the 1h
         # overlay dimension (#534) is never collapsed onto the upstream 5m cache_write.

--- a/src/agentfluent/analytics/tokens.py
+++ b/src/agentfluent/analytics/tokens.py
@@ -7,8 +7,10 @@ cost breakdown and parent-vs-subagent origin attribution.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
 from agentfluent.analytics.pricing import SYNTHETIC_MODELS, compute_cost, get_pricing
@@ -16,6 +18,8 @@ from agentfluent.core.session import SessionMessage, Usage
 
 if TYPE_CHECKING:
     from agentfluent.traces.models import SubagentTrace
+
+logger = logging.getLogger(__name__)
 
 Origin = Literal["parent", "subagent"]
 
@@ -106,11 +110,20 @@ def _accumulate_usage(breakdown: ModelTokenBreakdown, usage: Usage) -> None:
     breakdown.cache_creation_1h_tokens += usage.cache_creation_1h_input_tokens
 
 
-def _populate_costs(by_model: dict[tuple[str, str], ModelTokenBreakdown]) -> float:
-    """Compute per-row costs in place, return the summed total."""
+def _populate_costs(
+    by_model: dict[tuple[str, str], ModelTokenBreakdown],
+    timestamp: datetime | None = None,
+) -> float:
+    """Compute per-row costs in place, return the summed total.
+
+    ``timestamp`` is the session's price date (first-message timestamp, #546); it is
+    forwarded to ``get_pricing`` so each row is priced at the rate in effect when the
+    session ran. ``None`` → latest rate (the fallback for a missing/malformed session
+    timestamp, and the default for callers that do not price by date).
+    """
     total = 0.0
     for breakdown in by_model.values():
-        pricing = get_pricing(breakdown.model)
+        pricing = get_pricing(breakdown.model, timestamp)
         if pricing:
             breakdown.cost = compute_cost(
                 pricing,
@@ -153,7 +166,28 @@ def _aggregate_totals(
     )
 
 
-def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
+def session_price_timestamp(messages: list[SessionMessage]) -> datetime | None:
+    """Return the session's price date: the first message carrying a timestamp.
+
+    This is the single source of truth for pricing a session by the rate in effect
+    when it ran (#546, AC#2). Returns ``None`` when no message has a timestamp
+    (missing/malformed → latest-rate fallback, AC#3), which ``get_pricing`` treats as
+    "latest". The parser sets ``SessionMessage.timestamp`` to ``None`` for absent or
+    unparseable timestamps, so a malformed value never reaches pricing as a bad date.
+    """
+    price_date = next((m.timestamp for m in messages if m.timestamp is not None), None)
+    if price_date is None:
+        # AC3 (#546): no usable session timestamp (missing or parser-coerced malformed) ->
+        # cost falls back to the latest rate. Log at DEBUG so the fallback is observable.
+        logger.debug(
+            "Session has no usable message timestamp; pricing at the latest rate."
+        )
+    return price_date
+
+
+def compute_token_metrics(
+    messages: list[SessionMessage], *, timestamp: datetime | None = None
+) -> TokenMetrics:
     """Compute parent-session token usage totals and dollar costs.
 
     Processes only assistant messages that have usage data. Messages should
@@ -161,6 +195,11 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
     contributions are not included here — call
     ``compute_subagent_token_metrics`` separately and merge into the
     parent ``TokenMetrics`` (see ``analytics.pipeline.analyze_session``).
+
+    ``timestamp`` (#546) is the session price date used for date-aware rate lookup;
+    ``None`` → latest rate. The pipeline derives it once via ``session_price_timestamp``
+    and passes the same value here and to ``compute_subagent_token_metrics`` so parent
+    and subagent rows price at one consistent session date.
 
     Returns:
         TokenMetrics with parent-only totals, per-model breakdown
@@ -188,7 +227,7 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
 
         _accumulate_usage(breakdown, usage)
 
-    _populate_costs(by_model)
+    _populate_costs(by_model, timestamp)
     rows = list(by_model.values())
     (
         total_input, total_output, total_cache_creation, total_cache_read,
@@ -208,7 +247,7 @@ def compute_token_metrics(messages: list[SessionMessage]) -> TokenMetrics:
 
 
 def compute_subagent_token_metrics(
-    traces: list[SubagentTrace],
+    traces: list[SubagentTrace], *, timestamp: datetime | None = None
 ) -> list[ModelTokenBreakdown]:
     """Aggregate subagent-trace token usage into per-model breakdowns.
 
@@ -217,6 +256,9 @@ def compute_subagent_token_metrics(
     at zero by the parser (see traces/parser.py docstring). Skips
     traces with no model and traces whose usage is wholly zero (no
     assistant messages).
+
+    ``timestamp`` (#546) is the parent session's price date, applied to subagent rows
+    too so the whole session prices at one consistent date; ``None`` → latest rate.
 
     Returns one ``ModelTokenBreakdown`` per distinct subagent model,
     each carrying ``origin="subagent"``. Costs are populated. The
@@ -237,7 +279,7 @@ def compute_subagent_token_metrics(
             by_model[key] = breakdown
         _accumulate_usage(breakdown, usage)
 
-    _populate_costs(by_model)
+    _populate_costs(by_model, timestamp)
     return list(by_model.values())
 
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -109,6 +109,39 @@ class TestAnalyzeSession:
         # Verify token metrics use deduplicated data
         assert result.token_metrics.api_call_count == 2
 
+    def test_session_first_timestamp_reaches_pricing(
+        self, write_jsonl: WriteJSONL, monkeypatch: Any,
+    ) -> None:
+        # #546 AC#2 end-to-end: analyze_session derives the first-message timestamp and
+        # threads it into the cost path. Spy on tokens.get_pricing and assert it receives
+        # the session's first-message datetime (not None / not today).
+        from datetime import UTC, datetime
+
+        from agentfluent.analytics import tokens
+
+        path = write_jsonl(
+            "session_dated.jsonl",
+            [
+                user_message("hi", timestamp="2026-04-21T10:00:00.000Z"),
+                assistant_message(
+                    [{"type": "text", "text": "hello"}],
+                    message_id="m1",
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                    timestamp="2026-04-21T10:00:01.000Z",
+                ),
+            ],
+        )
+        seen: list[Any] = []
+        real = tokens.get_pricing
+
+        def _spy(model: str, timestamp: Any = None):  # type: ignore[no-untyped-def]
+            seen.append(timestamp)
+            return real(model, timestamp)
+
+        monkeypatch.setattr(tokens, "get_pricing", _spy)
+        analyze_session(path)
+        assert seen == [datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC)]
+
     def test_messages_field_in_memory_but_excluded_from_json(
         self, agent_session_path: Path,
     ) -> None:

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -1,6 +1,7 @@
 """Tests for model pricing lookup."""
 
 import logging
+from datetime import UTC, datetime
 
 import pytest
 
@@ -346,3 +347,88 @@ class TestResidualFallback:
         # Known id, no upstream, no residual -> None (degrade gracefully, never crash).
         monkeypatch.setattr(pricing, "_resolve_rates", lambda ref, timestamp=None: None)
         assert pricing.get_pricing("claude-opus-4-8") is None
+
+
+class TestDateAwareLookup:
+    """#546 date-aware base-rate lookup: timestamp threads to the resolver; None → latest.
+
+    These test the *mechanism*, not a fabricated rate change (Fred's Notes forbid the
+    latter, and the falsifier confirmed no priced model carries a dated base-rate change).
+    """
+
+    def test_timestamp_none_omitted_is_latest(self) -> None:
+        # Omitting the timestamp and passing None both mean "latest" and must agree.
+        assert get_pricing("claude-opus-4-6") == get_pricing("claude-opus-4-6", None)
+
+    def test_timestamp_forwarded_to_resolver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # AC#5(b): the caller-supplied timestamp actually reaches _resolve_rates.
+        from agentfluent.analytics import pricing
+
+        seen: dict[str, object] = {}
+
+        def _spy(ref: str, timestamp: datetime | None = None) -> None:
+            seen["ref"] = ref
+            seen["timestamp"] = timestamp
+            return None  # force residual/None path; we only care about the args
+
+        monkeypatch.setattr(pricing, "_resolve_rates", _spy)
+        when = datetime(2026, 2, 1, tzinfo=UTC)
+        pricing.get_pricing("claude-opus-4-6", when)
+        assert seen["ref"] == "claude-opus-4-6"
+        assert seen["timestamp"] is when
+
+    def test_timestamp_forwarded_through_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An alias resolves to canonical first, then the timestamp still threads through.
+        from agentfluent.analytics import pricing
+
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            pricing,
+            "_resolve_rates",
+            lambda ref, timestamp=None: seen.update(ref=ref, timestamp=timestamp),
+        )
+        when = datetime(2026, 5, 1, tzinfo=UTC)
+        pricing.get_pricing("opus", when)  # alias -> claude-opus-4-8
+        assert seen["ref"] == "claude-opus-4-8"
+        assert seen["timestamp"] is when
+
+    @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-sonnet-4-6"])
+    def test_either_side_of_genuine_constraint_resolves(self, model: str) -> None:
+        # AC#5(d): opus-4-6 / sonnet-4-6 carry a genuine StartDateConstraint(2026-03-13);
+        # dates on both sides must resolve without error (they price the same base today).
+        before = get_pricing(model, datetime(2026, 1, 1, tzinfo=UTC))
+        after = get_pricing(model, datetime(2026, 6, 1, tzinfo=UTC))
+        assert before is not None and after is not None
+
+
+class TestForwardCompatGuard:
+    """#546 tripwire: no priced model has a dated BASE-rate change today.
+
+    If genai-prices ever ships a dated Anthropic base-rate change for a model we price,
+    this fails loudly — the signal to write the user-facing 'historical costs now differ'
+    note (docs/COST_MODEL.md) and activate #543's cross-date-delta caveat for `diff`.
+    """
+
+    _EARLY = datetime(2024, 6, 1, tzinfo=UTC)
+
+    @pytest.mark.parametrize("model", list(_GOLDEN_RATES))
+    def test_base_rate_is_date_invariant(self, model: str) -> None:
+        early = get_pricing(model, self._EARLY)
+        latest = get_pricing(model, None)
+        assert early is not None and latest is not None
+        early_tuple = (
+            early.input, early.output, early.cache_creation_5m, early.cache_read
+        )
+        latest_tuple = (
+            latest.input, latest.output, latest.cache_creation_5m, latest.cache_read
+        )
+        assert early_tuple == latest_tuple, (
+            f"{model} base rate changed by date ({early_tuple} != {latest_tuple}). "
+            "genai-prices now carries a dated base-rate change for a priced model — "
+            "date-aware pricing (#546) is no longer inert. Write the historical-cost "
+            "restatement note in docs/COST_MODEL.md and activate #543's diff caveat."
+        )

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,6 +1,7 @@
 """Tests for token and cost analytics."""
 
 import logging
+from datetime import UTC, datetime
 
 import pytest
 
@@ -10,6 +11,7 @@ from agentfluent.analytics.tokens import (
     compute_subagent_token_metrics,
     compute_token_metrics,
     fold_subagent_metrics_in,
+    session_price_timestamp,
 )
 from agentfluent.core.session import ContentBlock, SessionMessage, Usage
 from agentfluent.traces.models import SubagentTrace
@@ -404,3 +406,101 @@ class TestFoldSubagentMetricsIn:
         result = fold_subagent_metrics_in(parent, subagent_rows)
         # Comprehensive = parent_cost + subagent_cost (both > 0).
         assert result.total_cost > parent.total_cost
+
+
+class TestSessionPriceTimestamp:
+    """#546: the session price date is the first message carrying a timestamp."""
+
+    def test_returns_first_timestamped_message(self) -> None:
+        early = datetime(2026, 1, 2, tzinfo=UTC)
+        later = datetime(2026, 3, 4, tzinfo=UTC)
+        messages = [
+            SessionMessage(type="user"),  # no timestamp — skipped
+            SessionMessage(type="user", timestamp=early),
+            SessionMessage(type="assistant", timestamp=later),
+        ]
+        assert session_price_timestamp(messages) == early
+
+    def test_none_when_no_message_has_timestamp(self) -> None:
+        # AC#3: missing timestamp → None → latest-rate fallback downstream.
+        assert session_price_timestamp([SessionMessage(type="user")]) is None
+        assert session_price_timestamp([]) is None
+
+    def test_missing_timestamp_logs_debug_fallback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # AC#3: the missing/malformed-timestamp → latest fallback emits a DEBUG log.
+        with caplog.at_level(logging.DEBUG, logger="agentfluent.analytics.tokens"):
+            session_price_timestamp([SessionMessage(type="user")])
+        assert any(
+            "no usable message timestamp" in r.message and r.levelno == logging.DEBUG
+            for r in caplog.records
+        )
+
+    def test_present_timestamp_does_not_log_fallback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="agentfluent.analytics.tokens"):
+            session_price_timestamp([
+                SessionMessage(type="user", timestamp=datetime(2026, 1, 1, tzinfo=UTC)),
+            ])
+        assert not any("no usable message timestamp" in r.message for r in caplog.records)
+
+
+class TestCostTimestampThreading:
+    """#546 AC#2/#5(b): the session timestamp threads into the pricing lookup."""
+
+    def test_parent_metrics_forward_timestamp_to_pricing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentfluent.analytics import tokens
+
+        seen: list[datetime | None] = []
+        real = tokens.get_pricing
+
+        def _spy(model: str, timestamp: datetime | None = None):  # type: ignore[no-untyped-def]
+            seen.append(timestamp)
+            return real(model, timestamp)
+
+        monkeypatch.setattr(tokens, "get_pricing", _spy)
+        when = datetime(2026, 2, 1, tzinfo=UTC)
+        compute_token_metrics([_assistant(input_tokens=100, output_tokens=50)], timestamp=when)
+        assert seen == [when]
+
+    def test_subagent_metrics_forward_timestamp_to_pricing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentfluent.analytics import tokens
+
+        seen: list[datetime | None] = []
+        real = tokens.get_pricing
+
+        def _spy(model: str, timestamp: datetime | None = None):  # type: ignore[no-untyped-def]
+            seen.append(timestamp)
+            return real(model, timestamp)
+
+        monkeypatch.setattr(tokens, "get_pricing", _spy)
+        when = datetime(2026, 2, 1, tzinfo=UTC)
+        compute_subagent_token_metrics(
+            [_trace("claude-haiku-4-5-20251001", input_tokens=100, output_tokens=50)],
+            timestamp=when,
+        )
+        assert seen == [when]
+
+    def test_default_none_timestamp_prices_at_latest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No timestamp passed → get_pricing receives None (latest); never raises.
+        from agentfluent.analytics import tokens
+
+        seen: list[datetime | None] = []
+        real = tokens.get_pricing
+
+        def _spy(model: str, timestamp: datetime | None = None):  # type: ignore[no-untyped-def]
+            seen.append(timestamp)
+            return real(model, timestamp)
+
+        monkeypatch.setattr(tokens, "get_pricing", _spy)
+        metrics = compute_token_metrics([_assistant(input_tokens=100, output_tokens=50)])
+        assert seen == [None]
+        assert metrics.total_cost > 0  # still priced, at latest


### PR DESCRIPTION
## Summary
- Threads each session's **first-message timestamp** through the cost-aggregation path into genai-prices' dated constraints (`get_pricing(model, timestamp=None)`), so a historical session is priced at the rate in effect when it ran. `None`/omitted = latest, so **every existing caller is unchanged** (backward-compatible optional param).
- **Reframed to substrate-plumbing-only** (maintainer-approved via the release loop): a plan-time falsifier probe found `genai-prices==0.0.71` carries **no dated _base-rate_ change** for any model AgentFluent prices — its only dated Anthropic constraints move the >200K context tier, which the adapter discards — so date-aware lookup is presently **bit-identical to latest**. Value delivered now is a completed, tested seam + a **forward-compat guard test** that fails loudly if upstream ever ships a dated base-rate change. Closes #546.
- The currently-false "historical costs may change" CHANGELOG line was dropped in favor of a `docs/COST_MODEL.md` note; the present-day >200K-tier mis-pricing the probe surfaced is split out as **#639**.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (2059 passed)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — mechanism tests (None→latest, timestamp-reaches-resolver spy, either-side-of-genuine-constraint, missing→DEBUG-log fallback) + a per-model forward-compat guard tripwire, in `test_pricing.py` / `test_tokens.py` / `test_pipeline.py`
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change; cost is date-invariant on the current catalog by design)

## Security review
- [x] **Skip review** — no security-sensitive surface. Caller-side threading that *consumes* an already-parsed `SessionMessage.timestamp` (the parser is unchanged), passes a `datetime` to genai-prices' existing static date lookup, adds no network/subprocess/CLI/path surface, and renders no user-controlled string.
- [ ] **Needs review**

## Breaking changes
None. `get_pricing` gains an **optional** `timestamp` param defaulting to `None` (= latest / current behavior); all three existing callers are untouched. No JSON envelope, CLI, or model-field change. Reported costs are unchanged on the current catalog (date-invariant base rates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)