### PR TITLE
refactor(pricing): formalize the base ⊕ overlay merge seam (#547)

### DIFF
--- a/docs/COST_MODEL.md
+++ b/docs/COST_MODEL.md
@@ -9,19 +9,35 @@ This file keeps only what is **AgentFluent-specific**: how our pricing implement
 
 ## genai-prices coverage and local overlay
 
-AgentFluent prices sessions on top of [pydantic/genai-prices](https://github.com/pydantic/genai-prices) (MIT). For Anthropic it models only `input_mtok`, `output_mtok`, `cache_read_mtok`, a single `cache_write_mtok` (5m-equivalent), context-length `tiers`, and dated `constraint`s. The levers it does **not** model — which AgentFluent must supply via a local pricing overlay, and/or request upstream — are our coverage ledger:
+AgentFluent prices sessions on top of [pydantic/genai-prices](https://github.com/pydantic/genai-prices) (MIT). For Anthropic it models only `input_mtok`, `output_mtok`, `cache_read_mtok`, a single `cache_write_mtok` (5m-equivalent), context-length `tiers`, and dated `constraint`s. The levers it does **not** model — which AgentFluent must supply via a local pricing overlay, and/or request upstream — are our coverage ledger. Each lever plugs into the [base ⊕ overlay merge seam](#the-base--overlay-merge-seam-547) at one of three named plug points (its **Class** below):
 
-| Gap | Cost impact for users | Local status | Upstream (genai-prices) |
-|---|---|---|---|
-| 1-hour cache write (2×) | **High** (commonly the dominant TTL) | Overlay — landed (#534): parser splits `usage.cache_creation` into 5m/1h, priced separately | [pydantic/genai-prices#295](https://github.com/pydantic/genai-prices/issues/295) (shape proposed, PR offered) |
-| Fast mode premium rates | High *if used* | Overlay | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
-| Batch (0.5×) / Priority tier | Medium | Overlay | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
-| Data residency US (1.1×) | Low–Medium | Overlay | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
-| Web search ($10 / 1k) | Medium *if used* | Overlay (counts present in JSONL) | [pydantic/genai-prices#288](https://github.com/pydantic/genai-prices/pull/288) (PR in flight — retire overlay once merged + pin bumped) |
-| Code execution ($/hr) | Partial (duration not in single-session JSONL) | Document limitation; surface count | not modeled |
-| >200K context tier | Medium *if a session exceeds 200K context* | **Gap** — the adapter takes `TieredPrices.base` and discards `tiers`, so >200K-context sessions are priced at the base tier (tracked in #639) | modeled (`tiers`) |
+| Gap | Class | Seam plug point | Cost impact for users | Local status | Upstream (genai-prices) |
+|---|---|---|---|---|---|
+| 1-hour cache write (2×) | A (rate-level) | `ModelPricing.__post_init__` (derived 2× input) | **High** (commonly the dominant TTL) | Overlay — landed (#534): parser splits `usage.cache_creation` into 5m/1h, priced separately | [pydantic/genai-prices#295](https://github.com/pydantic/genai-prices/issues/295) (shape proposed, PR offered) |
+| Fast mode premium rates | A (rate-level) | `ModelPricing` rate table (#536) | High *if used* | Overlay — future (#536, blocked by #547) | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
+| Batch (0.5×) / Priority tier | B (multiplier) | `compute_cost(request_multipliers=…)` (#537) | Medium | Overlay — future (#537, blocked by #547) | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
+| Data residency US (1.1×) | B (multiplier) | `compute_cost(request_multipliers=…)` (#538) | Low–Medium | Overlay — future (#538, blocked by #547) | [pydantic/genai-prices#429](https://github.com/pydantic/genai-prices/issues/429) (filed) |
+| Web search ($10 / 1k) | C (surcharge) | `compute_cost(surcharge_usd=…)` (#539) | Medium *if used* | Overlay — future (#539, blocked by #547; counts present in JSONL) | [pydantic/genai-prices#288](https://github.com/pydantic/genai-prices/pull/288) (PR in flight — retire overlay once merged + pin bumped) |
+| Code execution ($/hr) | C (surcharge) | `compute_cost(surcharge_usd=…)` (future) | Partial (duration not in single-session JSONL) | Document limitation; surface count | not modeled |
+| >200K context tier | (base, not overlay) | upstream `tiers` — adapter discards them | Medium *if a session exceeds 200K context* | **Gap** — the adapter takes `TieredPrices.base` and discards `tiers`, so >200K-context sessions are priced at the base tier (tracked in #639) | modeled (`tiers`) |
 
-The rates, multipliers, and field mappings behind this table are in the canonical doc; this is only AgentFluent's coverage status against it. The **Upstream** column tracks getting each lever modeled in the shared dataset — as those land and we bump the pinned genai-prices slice, the matching local overlay can be retired.
+The rates, multipliers, and field mappings behind this table are in the canonical doc; this is only AgentFluent's coverage status against it. The **Upstream** column tracks getting each lever modeled in the shared dataset — as those land and we bump the pinned genai-prices slice, the matching local overlay can be retired at its single plug point (drop the class-A transform, or the class-B/C argument).
+
+### The base ⊕ overlay merge seam (#547)
+
+Every session's final per-request cost is `base (upstream) ⊕ overlay (local)`. genai-prices supplies only the **base** rate table (via the isolated `analytics/_genai_source.py` adapter — the only genai-prices contact point); the overlay levers above are the pieces it does not model. They are **not uniform** — they compose in three classes, in one fixed documented order:
+
+```
+final = ( (base ⊕ rate_overlays[A]) · tokens ) · Π(multipliers[B]) + Σ(surcharges[C])
+```
+
+| Class | What it does | Scope | Single plug point | Members |
+|---|---|---|---|---|
+| **A — rate-level** | transforms the per-token rate table *before* token×rate | per model + date | `ModelPricing` construction in `get_pricing` (e.g. `__post_init__` derives the 1h rate) | 1h cache write (#534, landed); fast mode (#536) |
+| **B — per-request multiplier** | scales the token-derived dollar subtotal (multipliers commute) | per invocation | `compute_cost(request_multipliers=…)` | batch/priority (#537); data residency (#538) |
+| **C — additive surcharge** | adds fixed dollars *after* the multipliers (a flat fee is never discounted by a batch 0.5×) | per invocation | `compute_cost(surcharge_usd=…)` | server-tool / web search (#539) |
+
+`compute_cost` is the merge point (`analytics/pricing.py`); its class-B/C parameters default to no-op (empty multiplier product = `1.0`, zero surcharge), so a base-only session prices bit-identically to the pre-seam flat sum. "Is this lever upstream or overlay?" is a one-line answer per lever (the **Class**/**Plug point** columns above), and retiring an overlay when genai-prices models it upstream is a localized change at that single plug point. The ordering is load-bearing: class C is added strictly after class B.
 
 ## Reading cost diffs across the v0.10 upgrade
 

--- a/src/agentfluent/analytics/pricing.py
+++ b/src/agentfluent/analytics/pricing.py
@@ -7,11 +7,39 @@ Base rates are sourced from genai-prices (upstream, D045) via the isolated
 ``_genai_source`` adapter; a small documented local residual (``_RESIDUAL``) supplies any
 model genai-prices does not cover. This module is the public pricing surface -- nothing
 outside ``_genai_source`` imports ``genai_prices`` directly.
+
+The base ⊕ overlay merge seam (#547)
+------------------------------------
+Final per-request cost is ``base (upstream) ⊕ overlay (local)``. genai-prices models only
+the *base* rate table; AgentFluent adds the levers it does not model (see
+``docs/COST_MODEL.md``) through this seam. The overlay levers fall into **three composition
+classes** that compose in one fixed, documented order::
+
+    final = ( (base ⊕ rate_overlays[A]) · tokens ) · Π(multipliers[B]) + Σ(surcharges[C])
+
+- **Class A -- rate-table transforms** (per model+date): modify the per-token rate table
+  *before* token×rate. Plug point: ``ModelPricing`` construction in ``get_pricing``. Members:
+  1-hour cache write (#534, landed -- ``ModelPricing.__post_init__`` derives it as 2× input);
+  fast-mode premium rates (#536, future -- also class A, replaces the rate table).
+- **Class B -- per-request multipliers** (per invocation): scale the dollar subtotal. Plug
+  point: ``compute_cost(..., request_multipliers=...)``. Members: batch 0.5× / priority (#537),
+  data residency US 1.1× (#538). They commute (multiplication).
+- **Class C -- additive surcharges** (per invocation): add fixed dollars *after* the
+  multipliers (a flat server-tool fee must not be discounted by a 0.5× batch multiplier). Plug
+  point: ``compute_cost(..., surcharge_usd=...)``. Members: server-tool / web-search $10/1k
+  (#539).
+
+"Is this lever upstream or overlay?" is therefore a one-line answer per lever, and retiring an
+overlay when genai-prices adds it upstream is a localized change (drop the class-A transform or
+the class-B/C argument at its single plug point). ``compute_cost``'s class-B/C parameters default
+to no-op (empty multiplier product = 1.0, zero surcharge), so the base-only path is bit-identical.
 """
 
 from __future__ import annotations
 
 import logging
+import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -39,6 +67,14 @@ class ModelPricing:
     ``cache_write_mtok`` — the 1h dimension is supplied by this overlay
     and has no upstream field; an adapter mapping must not collapse it
     back onto the 5m rate.
+
+    This rate table is the **class-A plug point** of the base ⊕ overlay
+    seam (see the module docstring): rate-table overlays (the 1h-cache
+    derivation below; fast-mode premium rates, #536) apply here, *before*
+    token×rate. Keep the 1h derivation in ``__post_init__`` — it is the
+    single-source-of-truth invariant that makes every ``ModelPricing``
+    valid regardless of construction path; do not relocate it to the
+    per-request stages (``compute_cost``), which are classes B and C.
     """
 
     input: float
@@ -165,26 +201,48 @@ def compute_cost(
     cache_creation_5m_tokens: int = 0,
     cache_read_input_tokens: int = 0,
     cache_creation_1h_tokens: int = 0,
+    request_multipliers: Sequence[float] = (),
+    surcharge_usd: float = 0.0,
 ) -> float:
-    """Compute dollar cost in USD from token counts and pricing rates.
+    """Compute final per-request dollar cost in USD (the base ⊕ overlay merge point, #547).
 
-    The cache-write total is split by TTL: ``cache_creation_5m_tokens`` is
-    billed at the 5-minute write rate, ``cache_creation_1h_tokens`` at the
-    1-hour rate (2x base). The parameter is named for the 5m bucket (not the
-    undifferentiated total) on purpose — passing ``Usage``'s authoritative
-    ``cache_creation_input_tokens`` here alongside a separate 1h count would
-    double-bill the 1h portion. Callers that only know the undifferentiated
-    total pass it here, which prices the whole sum at the 5m rate — the
-    documented fallback for sessions whose JSONL lacks the
-    ``usage.cache_creation`` TTL split (see #534).
+    This is the single merge point where the upstream **base** rate table (``pricing``,
+    already carrying any class-A rate-table overlay assembled in ``get_pricing``) combines
+    with the local **per-request overlay** levers to produce the final cost, in the fixed
+    documented order (see the module docstring)::
+
+        final = (Σ rate·token / 1e6) · Π(request_multipliers) + surcharge_usd
+                └─── base ⊕ class-A ───┘   └── class B ──┘       └─ class C ─┘
+
+    - ``request_multipliers`` (**class B**, per-request multipliers): scale the token-derived
+      dollar subtotal. Empty (the default) → an empty product of ``1.0`` → no scaling. Plug
+      point for batch 0.5× / priority (#537) and data residency US 1.1× (#538); they commute.
+    - ``surcharge_usd`` (**class C**, additive surcharge): fixed dollars added *after* the
+      multipliers, so a flat fee is never discounted by a batch multiplier. Default ``0.0`` →
+      no surcharge. Plug point for server-tool / web-search $10/1k (#539).
+
+    With both at their no-op defaults the overlay stages are exactly identity
+    (``subtotal · 1.0 + 0.0 == subtotal`` in IEEE-754), so every existing caller prices
+    bit-identically — this is a pure refactor of the prior flat rate×token sum.
+
+    The cache-write total is split by TTL: ``cache_creation_5m_tokens`` is billed at the
+    5-minute write rate, ``cache_creation_1h_tokens`` at the 1-hour rate (2x base, class A).
+    The parameter is named for the 5m bucket (not the undifferentiated total) on purpose —
+    passing ``Usage``'s authoritative ``cache_creation_input_tokens`` here alongside a
+    separate 1h count would double-bill the 1h portion. Callers that only know the
+    undifferentiated total pass it here, which prices the whole sum at the 5m rate — the
+    documented fallback for sessions whose JSONL lacks the ``usage.cache_creation`` TTL split
+    (see #534).
     """
-    return (
+    subtotal_usd = (
         input_tokens * pricing.input
         + output_tokens * pricing.output
         + cache_creation_5m_tokens * pricing.cache_creation_5m
         + cache_creation_1h_tokens * pricing.cache_creation_1h
         + cache_read_input_tokens * pricing.cache_read
     ) / 1_000_000
+    # class B (multipliers) then class C (surcharge), in the documented stacking order.
+    return subtotal_usd * math.prod(request_multipliers) + surcharge_usd
 
 
 def get_known_models() -> list[str]:

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -195,6 +195,122 @@ class TestComputeCost:
             assert pricing.cache_creation_1h == pricing.input * 2.0
 
 
+class TestOverlaySeam:
+    """#547: the base ⊕ overlay merge seam in ``compute_cost``.
+
+    Three composition classes stack in one documented order::
+
+        final = (Σ rate·token / 1e6) · Π(request_multipliers[B]) + surcharge_usd[C]
+
+    Class A (rate-level, e.g. the 1h cache write) is folded into ``ModelPricing`` upstream of
+    here. The AC's base-only / base+single-overlay / base+stacked-overlay cases are exercised
+    below; the stacked case combines the real shipped class-A lever (1h cache) with a
+    **test-injected** class-B multiplier and class-C surcharge — proving the seam composes ≥2
+    overlays across classes without pulling #536–539 (the future levers) into scope.
+    """
+
+    def _opus(self) -> ModelPricing:
+        pricing = get_pricing("claude-opus-4-6")
+        assert pricing is not None
+        return pricing
+
+    def test_base_only_no_overlays(self) -> None:
+        # Base-only: no class-A 1h tokens, no class-B multipliers, no class-C surcharge.
+        pricing = self._opus()
+        cost = compute_cost(pricing, input_tokens=1_000_000, output_tokens=1_000_000)
+        # 1M*5/1M + 1M*25/1M = 30.0
+        assert cost == 30.0
+
+    def test_base_plus_single_overlay_class_a_1h(self) -> None:
+        # Single overlay: the real, shipped class-A lever (1h cache = 2× input, #534).
+        pricing = self._opus()
+        cost = compute_cost(
+            pricing, input_tokens=1_000_000, output_tokens=0,
+            cache_creation_1h_tokens=1_000_000,
+        )
+        # (1M*5 + 1M*10)/1M = 15.0  (1h priced at 2× input, not the 5m rate)
+        assert cost == 15.0
+
+    def test_base_plus_stacked_overlay_a_b_c(self) -> None:
+        # Stacked across classes: real class-A 1h + injected class-B multiplier + class-C surcharge.
+        pricing = self._opus()
+        cost = compute_cost(
+            pricing, input_tokens=1_000_000, output_tokens=0,
+            cache_creation_1h_tokens=1_000_000,     # class A (real): subtotal -> 15.0
+            request_multipliers=(0.5,),             # class B: 15.0 * 0.5 = 7.5
+            surcharge_usd=2.0,                      # class C: 7.5 + 2.0 = 9.5
+        )
+        assert cost == pytest.approx(9.5)
+
+    def test_no_op_defaults_are_bit_identical(self) -> None:
+        # The seam's overlay stages default to exact identity: passing the no-op class-B/C
+        # values must equal omitting them, for every golden model.
+        for name in get_known_models():
+            pricing = get_pricing(name)
+            assert pricing is not None
+            omitted = compute_cost(
+                pricing, input_tokens=123_456, output_tokens=7_890,
+                cache_creation_5m_tokens=1_000, cache_read_input_tokens=42_000,
+                cache_creation_1h_tokens=5_000,
+            )
+            explicit_noop = compute_cost(
+                pricing, input_tokens=123_456, output_tokens=7_890,
+                cache_creation_5m_tokens=1_000, cache_read_input_tokens=42_000,
+                cache_creation_1h_tokens=5_000,
+                request_multipliers=(), surcharge_usd=0.0,
+            )
+            assert omitted == explicit_noop  # exact, not approx
+
+    def test_class_b_multipliers_commute(self) -> None:
+        # Per-request multipliers compose by multiplication → order-independent.
+        pricing = self._opus()
+        a = compute_cost(pricing, input_tokens=1_000_000, output_tokens=0,
+                         request_multipliers=(0.5, 1.1))
+        b = compute_cost(pricing, input_tokens=1_000_000, output_tokens=0,
+                         request_multipliers=(1.1, 0.5))
+        assert a == b
+
+    def test_empty_multiplier_product_is_one(self) -> None:
+        # An empty ``request_multipliers`` is an empty product (1.0), i.e. no scaling.
+        pricing = self._opus()
+        scaled = compute_cost(pricing, input_tokens=1_000_000, output_tokens=0,
+                              request_multipliers=())
+        unscaled = compute_cost(pricing, input_tokens=1_000_000, output_tokens=0)
+        assert scaled == unscaled == 5.0
+
+    def test_surcharge_added_after_multipliers_not_before(self) -> None:
+        # Load-bearing ordering: a flat class-C surcharge must NOT be discounted by a
+        # class-B multiplier. final = subtotal·Π(mult) + surcharge, never (subtotal+surcharge)·Π.
+        pricing = self._opus()
+        cost = compute_cost(
+            pricing, input_tokens=1_000_000, output_tokens=0,   # subtotal 5.0
+            request_multipliers=(0.5,), surcharge_usd=10.0,
+        )
+        assert cost == pytest.approx(5.0 * 0.5 + 10.0)          # 12.5, not (5.0+10.0)*0.5=7.5
+        assert cost != pytest.approx((5.0 + 10.0) * 0.5)
+
+    @pytest.mark.parametrize("model", get_known_models())
+    def test_default_path_matches_pre_seam_flat_sum(self, model: str) -> None:
+        # Bit-identity regression: the default (no-overlay) ``compute_cost`` equals the
+        # pre-#547 flat rate×token sum exactly — the seam is a pure refactor.
+        pricing = get_pricing(model)
+        assert pricing is not None
+        it, ot, c5, cr, c1 = 111_111, 22_222, 3_333, 44_444, 5_555
+        pre_seam = (
+            it * pricing.input
+            + ot * pricing.output
+            + c5 * pricing.cache_creation_5m
+            + c1 * pricing.cache_creation_1h
+            + cr * pricing.cache_read
+        ) / 1_000_000
+        got = compute_cost(
+            pricing, input_tokens=it, output_tokens=ot,
+            cache_creation_5m_tokens=c5, cache_read_input_tokens=cr,
+            cache_creation_1h_tokens=c1,
+        )
+        assert got == pre_seam  # exact
+
+
 class TestGetKnownModels:
     def test_returns_sorted_list(self) -> None:
         models = get_known_models()


### PR DESCRIPTION
## Summary
- Makes the implicit **base ⊕ overlay** pricing merge point explicit and documented as the extension contract #536–539 implement against (Phase-1 substrate of epic #535; blocks the four overlay-lever issues).
- Classifies overlay levers into **3 composition classes** that stack in one fixed documented order — `final = ((base ⊕ rate_overlays[A])·tokens)·Π(multipliers[B]) + Σ(surcharges[C])`. Class A stays in the `ModelPricing` rate table (`__post_init__`, unchanged); classes B/C become real no-op-default params on `compute_cost` (`request_multipliers`, `surcharge_usd`).
- **Pure refactor**: with default args the overlay stages are exact identity (`x·1.0 + 0.0 == x`), so every existing caller prices bit-identically (regression-locked). No public-shape or caller changes.
- `docs/COST_MODEL.md` overlay table now carries **Class** + **seam plug point** columns and a dedicated "base ⊕ overlay merge seam" section; "is this lever upstream or overlay?" is a one-line answer per lever.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (2072 passed, +13 new)
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `TestOverlaySeam`: base-only, base+single-overlay (class A), base+stacked-overlay (A+B+C), C-after-B ordering, no-op identity, and a bit-identity regression vs the pre-#547 flat sum across all 8 golden models
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a (no CLI output change; internal cost arithmetic, bit-identical)

## Security review
Pick one.
- [x] **Skip review** — no security-sensitive surface (pure internal refactor of cost arithmetic; no hooks/secrets/pyproject/workflows/CLI parsing/path resolution/JSONL parsing/network/subprocess/user-string rendering).
- [ ] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

## Breaking changes
None. `compute_cost` gains two optional params with no-op defaults; `get_pricing`/`compute_cost`/`ModelPricing` public shapes are unchanged and costs are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)