### PR TITLE
chore: sync uv.lock to 0.11.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentfluent"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "genai-prices" },


### PR DESCRIPTION
## Summary
- Regenerate `uv.lock` so the `agentfluent` editable self-version reads `0.11.0`, matching `pyproject.toml` after the v0.11.0 release.
- Post-release housekeeping only — the sole diff is the self-version line (`0.10.0` → `0.11.0`); no dependency versions move.
- Removes the transiently-stale lockfile on `main`; #653 tracks folding this into the release PR so the follow-up commit is no longer needed.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` (unaffected — no source change)
- [x] Lint clean: `uv run ruff check src/ tests/` (unaffected)
- [x] Type check clean: `uv run mypy src/agentfluent/` (unaffected)
- [x] New/changed behavior has test coverage — N/A, lockfile-only
- [x] Manual smoke test — N/A, no CLI output change. Verified `uv sync --frozen` is now consistent (exit 0, installs `agentfluent==0.11.0`).

## Security review
- [x] **Skip review** — no security-sensitive surface. Lockfile self-version bump only; no dependency resolution changes, no new/updated packages.

## Breaking changes
None. `uv.lock`-only; no public contract, CLI, JSON envelope, or model change.