### PR TITLE
feat(traces): link subagent traces across depths (parent_invocation_id + depth)

### DIFF
--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -540,13 +540,17 @@ def _link_subagent_traces(
     # session, then hang depth->=2 traces off their parent as `children`.
     # Depth->=2 agents deliberately do NOT become AgentInvocation rows.
     main_session_tool_use_ids = {inv.tool_use_id for inv in invocations}
-    lineages = resolve_lineage(subagent_files, main_session_tool_use_ids)
-
     linked_by_agent_id = {
         inv.agent_id: inv.trace
         for inv in invocations
         if inv.agent_id is not None and inv.trace is not None
     }
+    # Pass the linked agent ids as a second depth-1 source: an invocation row
+    # exists only for a main-session delegation, so it proves depth 1 even when
+    # that agent's sidecar is missing.
+    lineages = resolve_lineage(
+        subagent_files, main_session_tool_use_ids, set(linked_by_agent_id),
+    )
     for agent_id, trace in linked_by_agent_id.items():
         lineage = lineages.get(agent_id)
         if lineage is not None:
@@ -571,6 +575,14 @@ def _link_subagent_traces(
     ):
         if lineage.depth < 2 or lineage.parent_invocation_id is None:
             continue
+        if agent_id in linked_by_agent_id:
+            # Already reachable as `invocation.trace`. Re-parsing would append a
+            # SECOND object for the same agent: it would serialize twice, any
+            # depth-3 descendant would attach to the copy rather than the object
+            # the invocation holds, and the depth gate would drop it from token
+            # metrics so its spend vanished from total_cost. Cheaper to make the
+            # state unrepresentable than to rely on the invariant holding.
+            continue
         parent_trace = attached_by_agent_id.get(lineage.parent_invocation_id)
         if parent_trace is None:
             # Parent is itself unattached (orphaned subtree). #648 AC3
@@ -581,6 +593,11 @@ def _link_subagent_traces(
             continue
         child_trace.parent_invocation_id = lineage.parent_invocation_id
         child_trace.depth = lineage.depth
+        if lineage.agent_type:
+            # The parser defaults an unlinked trace to UNKNOWN_AGENT_TYPE, and
+            # there is no invocation row here to overwrite it from -- the
+            # sidecar is the only source of the spawning side's name.
+            child_trace.agent_type = lineage.agent_type
         parent_trace.children.append(child_trace)
         attached_by_agent_id[agent_id] = child_trace
 

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -512,10 +512,18 @@ def _link_subagent_traces(
     to matching invocations.
 
     Scoped per session: subagent files for a session ``<uuid>.jsonl`` live
-    under ``<uuid>/subagents/``. Lazy-loads the traces whose ``agent_id``
-    appears in ``invocations``, plus -- since #595 PR B -- any **depth-2**
-    trace being attached as a child, which by construction appears in no
-    invocation. Other files cost one dict lookup each.
+    under ``<uuid>/subagents/``. Parses the traces whose ``agent_id`` appears
+    in ``invocations``, plus -- since #595 PR B -- any **depth-2** trace being
+    attached as a child, which normally appears in no invocation (a trace whose
+    parse failed is the exception: its invocation carries ``trace=None``, so it
+    is absent from ``linked_by_agent_id`` and can be offered here again; the
+    loader returns ``None`` a second time and the attach loop skips it).
+
+    **Not free for the remaining files.** Lineage resolution reads the small
+    ``.meta.json`` sidecar for **every** trace in the session, and on the
+    depth->=2 escalation path it scans sibling trace files line by line. What
+    stays lazy is full trace *parsing*, which is the expensive part; do not
+    read this as "untouched files cost nothing".
 
     Traces with no matching invocation are debug-logged as orphans. **That log
     over-counts: a depth-2 trace successfully attached as a child is still
@@ -545,7 +553,8 @@ def _link_subagent_traces(
     invocations = link_traces(invocations, loader)
 
     # Lineage (#595 PR B): resolve depth + parent for every trace in the
-    # session, then hang depth->=2 traces off their parent as `children`.
+    # session, then hang **depth-2** traces off their parent as `children`
+    # (attachment is capped -- see the loop below; depth->=3 is #659).
     # Depth->=2 agents deliberately do NOT become AgentInvocation rows.
     main_session_tool_use_ids = {inv.tool_use_id for inv in invocations}
     linked_by_agent_id = {
@@ -578,12 +587,24 @@ def _link_subagent_traces(
     #
     # ATTACHMENT IS CAPPED AT DEPTH 2 (#595 AC2 as amended; depth->=3 is #659).
     # `resolve_lineage` still computes arbitrary depth -- it is attachment that
-    # stops here. The cap is what makes `parent_invocation_id`'s documented
-    # identity domain TRUE: every parent named below owns an invocation row, so
-    # every non-None parent_invocation_id joins against
-    # `SessionAnalysis.invocations`. Lifting the cap without also relaxing that
-    # docstring would reintroduce the defect the cap removed. Measured
-    # prevalence when capped: depth-1 1317, depth-2 16, depth->=3 0 of 1333.
+    # stops here.
+    #
+    # TWO things enforce the cap, and the load-bearing one is NOT the depth
+    # predicate. Verified by experiment: relaxing `!= 2` to `< 2` alone still
+    # does not attach a depth-3 trace. What blocks it is that the parent is
+    # looked up in `linked_by_agent_id` -- invocation-owning traces only -- so a
+    # depth-3 trace, whose parent is a depth-2 trace, finds no parent and is
+    # skipped. The depth predicate is a redundant, legible restatement.
+    # Re-admitting depth->=3 takes BOTH a relaxed predicate and an accumulator
+    # that adds each attached child to the lookup. #659 must change both, and
+    # must relax `parent_invocation_id`'s docstring with them -- the invariant
+    # that every non-None value joins to an invocation row holds *because* the
+    # parent lookup is restricted, so widening the lookup is what breaks it.
+    #
+    # Measured prevalence when capped: depth-1 1317, depth-2 16, depth->=3 0
+    # of 1333. Locked by tests/unit/test_lineage_fold_gate.py::TestDepthTwoCap,
+    # which builds a depth-3 session because the committed fixtures cannot
+    # distinguish capped from uncapped code.
     for agent_id, lineage in lineages.items():
         if lineage.depth != 2 or lineage.parent_invocation_id is None:
             continue

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -259,8 +259,15 @@ def analyze_session(
     #
     # `inv.trace` is always depth 1 (an invocation row exists only for a
     # main-session delegation), so `depth == 1` is currently redundant. It is
-    # written anyway, and tested, because the thing being pinned is a DECISION,
-    # not an accident of how this line happens to be spelled. Depth->=2 traces
+    # written anyway because the thing being pinned is a DECISION, not an
+    # accident of how this line happens to be spelled.
+    #
+    # **It is redundant, therefore it is NOT tested, and cannot be.** The
+    # acceptance gate's mutation pass deleted this predicate and the whole
+    # suite stayed green -- correctly, since removing a no-op changes no
+    # behavior. Do not read the cross-reference below as pinning the
+    # predicate; a test that failed on its removal would be asserting a
+    # tautology. Depth->=2 traces
     # now reach here via `trace.children`, and the moment anyone flattens that
     # tree into this list, depth->=2 usage silently enters `total_cost`,
     # `cache_efficiency`, `by_model` and every `diff` baseline for any session
@@ -272,7 +279,10 @@ def analyze_session(
     # #648 AC2's deliberate act, with its own CHANGELOG line and its own
     # before/after dogfood read. It is not PR B's.
     #
-    # Locked by: tests/unit/test_lineage_fold_gate.py::TestNonFoldingGate
+    # What IS locked, by
+    # tests/unit/test_lineage_fold_gate.py::TestNonFoldingGate: that the
+    # child tree is not flattened into this list. That mutation -- the
+    # regression this gate exists to stop -- is killed by the suite.
     subagent_traces = [
         inv.trace
         for inv in invocations

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -512,9 +512,17 @@ def _link_subagent_traces(
     to matching invocations.
 
     Scoped per session: subagent files for a session ``<uuid>.jsonl`` live
-    under ``<uuid>/subagents/``. Lazy-loads only traces whose ``agent_id``
-    appears in ``invocations``; skipped files cost one dict lookup each.
-    Orphan traces (file exists, no matching invocation) are debug-logged.
+    under ``<uuid>/subagents/``. Lazy-loads the traces whose ``agent_id``
+    appears in ``invocations``, plus -- since #595 PR B -- any **depth-2**
+    trace being attached as a child, which by construction appears in no
+    invocation. Other files cost one dict lookup each.
+
+    Traces with no matching invocation are debug-logged as orphans. **That log
+    over-counts: a depth-2 trace successfully attached as a child is still
+    logged**, because ``linked_ids`` below is built from invocations only.
+    Harmless at debug level, but #648 AC3 plans to disclose an orphan cohort
+    from this same notion and must not inherit the over-count -- it should read
+    attached children out first.
     """
     # Discover subagent files for this session and build the lookup map.
     session_dir = session_path.parent / session_path.stem
@@ -545,9 +553,15 @@ def _link_subagent_traces(
         for inv in invocations
         if inv.agent_id is not None and inv.trace is not None
     }
-    # Pass the linked agent ids as a second depth-1 source: an invocation row
-    # exists only for a main-session delegation, so it proves depth 1 even when
-    # that agent's sidecar is missing.
+    # Pass the linked agent ids as a second depth-1 source, so a depth-1 agent
+    # whose sidecar is missing does not sever its child's edge.
+    #
+    # ASSUMPTION, not an enforced invariant: that an invocation row implies a
+    # main-session delegation. Nothing filters `isSidechain` anywhere in this
+    # package, so a session JSONL that inlined sidechain lines would mint
+    # invocation rows for nested agents and flatten their children to depth 1.
+    # Holds for every fixture and for the current corpus; tracked separately
+    # rather than asserted here as fact.
     lineages = resolve_lineage(
         subagent_files, main_session_tool_use_ids, set(linked_by_agent_id),
     )
@@ -557,36 +571,26 @@ def _link_subagent_traces(
             trace.parent_invocation_id = lineage.parent_invocation_id
             trace.depth = lineage.depth
 
-    # Depth->=2 traces have no invocation row, so they are parsed here and
+    # Depth-2 traces have no invocation row, so they are parsed here and
     # attached to their parent. Only the residual is parsed -- on a real
     # corpus that is 1.2% of traces, and a session with no nesting parses
     # nothing extra.
     #
-    # Ascending depth order is load-bearing: a depth-3 trace's parent is a
-    # depth-2 trace, which is not an invocation and therefore only becomes
-    # attachable once IT has been attached. Iterating in dict order would drop
-    # every tier below 2 -- silently, and invisibly to this corpus, which
-    # currently bottoms out at depth 2 (1317/16/0). Nothing in the format
-    # caps depth, so the ordering is what makes "at every depth" true rather
-    # than true-so-far.
-    attached_by_agent_id: dict[str, SubagentTrace] = dict(linked_by_agent_id)
-    for agent_id, lineage in sorted(
-        lineages.items(), key=lambda item: item[1].depth,
-    ):
-        if lineage.depth < 2 or lineage.parent_invocation_id is None:
+    # ATTACHMENT IS CAPPED AT DEPTH 2 (#595 AC2 as amended; depth->=3 is #659).
+    # `resolve_lineage` still computes arbitrary depth -- it is attachment that
+    # stops here. The cap is what makes `parent_invocation_id`'s documented
+    # identity domain TRUE: every parent named below owns an invocation row, so
+    # every non-None parent_invocation_id joins against
+    # `SessionAnalysis.invocations`. Lifting the cap without also relaxing that
+    # docstring would reintroduce the defect the cap removed. Measured
+    # prevalence when capped: depth-1 1317, depth-2 16, depth->=3 0 of 1333.
+    for agent_id, lineage in lineages.items():
+        if lineage.depth != 2 or lineage.parent_invocation_id is None:
             continue
-        if agent_id in linked_by_agent_id:
-            # Already reachable as `invocation.trace`. Re-parsing would append a
-            # SECOND object for the same agent: it would serialize twice, any
-            # depth-3 descendant would attach to the copy rather than the object
-            # the invocation holds, and the depth gate would drop it from token
-            # metrics so its spend vanished from total_cost. Cheaper to make the
-            # state unrepresentable than to rely on the invariant holding.
-            continue
-        parent_trace = attached_by_agent_id.get(lineage.parent_invocation_id)
+        parent_trace = linked_by_agent_id.get(lineage.parent_invocation_id)
         if parent_trace is None:
-            # Parent is itself unattached (orphaned subtree). #648 AC3
-            # discloses this residual; PR B does not synthesize a home for it.
+            # Parent is unlinked (orphaned subtree). #648 AC3 discloses this
+            # residual; PR B does not synthesize a home for it.
             continue
         child_trace = loader(agent_id)
         if child_trace is None:
@@ -599,7 +603,6 @@ def _link_subagent_traces(
             # sidecar is the only source of the spawning side's name.
             child_trace.agent_type = lineage.agent_type
         parent_trace.children.append(child_trace)
-        attached_by_agent_id[agent_id] = child_trace
 
     # Orphans: trace files with no matching invocation.
     linked_ids = {inv.agent_id for inv in invocations if inv.trace is not None}

--- a/src/agentfluent/analytics/pipeline.py
+++ b/src/agentfluent/analytics/pipeline.py
@@ -49,6 +49,7 @@ from agentfluent.diagnostics.mcp_assessment import (
 )
 from agentfluent.diagnostics.models import DiagnosticsResult
 from agentfluent.traces.discovery import discover_session_subagents
+from agentfluent.traces.lineage import resolve_lineage
 from agentfluent.traces.linker import link_traces
 from agentfluent.traces.models import SubagentTrace
 from agentfluent.traces.parser import parse_subagent_trace
@@ -254,7 +255,29 @@ def analyze_session(
     invocations = _link_subagent_traces(invocations, path)
     mcp_tool_calls = extract_mcp_calls_from_messages(messages)
 
-    subagent_traces = [inv.trace for inv in invocations if inv.trace is not None]
+    # NON-FOLDING GATE (#595 PR B, architect ruling 3) -- depth-1 traces ONLY.
+    #
+    # `inv.trace` is always depth 1 (an invocation row exists only for a
+    # main-session delegation), so `depth == 1` is currently redundant. It is
+    # written anyway, and tested, because the thing being pinned is a DECISION,
+    # not an accident of how this line happens to be spelled. Depth->=2 traces
+    # now reach here via `trace.children`, and the moment anyone flattens that
+    # tree into this list, depth->=2 usage silently enters `total_cost`,
+    # `cache_efficiency`, `by_model` and every `diff` baseline for any session
+    # with nested delegation -- a cost-number movement inside a milestone
+    # themed "Cost correctness", arriving as an implementation side effect
+    # nobody chose.
+    #
+    # Folding that spend in IS correct in principle and IS wanted -- it is
+    # #648 AC2's deliberate act, with its own CHANGELOG line and its own
+    # before/after dogfood read. It is not PR B's.
+    #
+    # Locked by: tests/unit/test_lineage_fold_gate.py::TestNonFoldingGate
+    subagent_traces = [
+        inv.trace
+        for inv in invocations
+        if inv.trace is not None and inv.trace.depth == 1
+    ]
     subagent_rows = compute_subagent_token_metrics(subagent_traces, timestamp=price_date)
     token_metrics = fold_subagent_metrics_in(token_metrics, subagent_rows)
 
@@ -512,6 +535,54 @@ def _link_subagent_traces(
             return None
 
     invocations = link_traces(invocations, loader)
+
+    # Lineage (#595 PR B): resolve depth + parent for every trace in the
+    # session, then hang depth->=2 traces off their parent as `children`.
+    # Depth->=2 agents deliberately do NOT become AgentInvocation rows.
+    main_session_tool_use_ids = {inv.tool_use_id for inv in invocations}
+    lineages = resolve_lineage(subagent_files, main_session_tool_use_ids)
+
+    linked_by_agent_id = {
+        inv.agent_id: inv.trace
+        for inv in invocations
+        if inv.agent_id is not None and inv.trace is not None
+    }
+    for agent_id, trace in linked_by_agent_id.items():
+        lineage = lineages.get(agent_id)
+        if lineage is not None:
+            trace.parent_invocation_id = lineage.parent_invocation_id
+            trace.depth = lineage.depth
+
+    # Depth->=2 traces have no invocation row, so they are parsed here and
+    # attached to their parent. Only the residual is parsed -- on a real
+    # corpus that is 1.2% of traces, and a session with no nesting parses
+    # nothing extra.
+    #
+    # Ascending depth order is load-bearing: a depth-3 trace's parent is a
+    # depth-2 trace, which is not an invocation and therefore only becomes
+    # attachable once IT has been attached. Iterating in dict order would drop
+    # every tier below 2 -- silently, and invisibly to this corpus, which
+    # currently bottoms out at depth 2 (1317/16/0). Nothing in the format
+    # caps depth, so the ordering is what makes "at every depth" true rather
+    # than true-so-far.
+    attached_by_agent_id: dict[str, SubagentTrace] = dict(linked_by_agent_id)
+    for agent_id, lineage in sorted(
+        lineages.items(), key=lambda item: item[1].depth,
+    ):
+        if lineage.depth < 2 or lineage.parent_invocation_id is None:
+            continue
+        parent_trace = attached_by_agent_id.get(lineage.parent_invocation_id)
+        if parent_trace is None:
+            # Parent is itself unattached (orphaned subtree). #648 AC3
+            # discloses this residual; PR B does not synthesize a home for it.
+            continue
+        child_trace = loader(agent_id)
+        if child_trace is None:
+            continue
+        child_trace.parent_invocation_id = lineage.parent_invocation_id
+        child_trace.depth = lineage.depth
+        parent_trace.children.append(child_trace)
+        attached_by_agent_id[agent_id] = child_trace
 
     # Orphans: trace files with no matching invocation.
     linked_ids = {inv.agent_id for inv in invocations if inv.trace is not None}

--- a/src/agentfluent/traces/lineage.py
+++ b/src/agentfluent/traces/lineage.py
@@ -61,6 +61,15 @@ class TraceLineage:
 
     parent_invocation_id: str | None
     depth: int
+    agent_type: str = ""
+    """Agent type as named by the spawning side, from the sidecar.
+
+    Empty when there is no sidecar or it carried none. Load-bearing only at
+    depth >= 2: a depth-1 trace inherits the authoritative value from its
+    ``AgentInvocation`` via ``link_traces``, but a deeper agent **has no
+    invocation row to inherit from**, so the sidecar is its only source. Left
+    empty, every depth->=2 trace this exposes would serialize as ``unknown``
+    -- the one field that makes the ``children`` array usable."""
 
 
 def emitted_tool_use_ids(trace_path: Path) -> set[str]:
@@ -91,7 +100,15 @@ def emitted_tool_use_ids(trace_path: Path) -> set[str]:
                     continue
                 if not isinstance(obj, dict) or obj.get("type") != "assistant":
                     continue
-                content = obj.get("message", {}).get("content", [])
+                message = obj.get("message")
+                if not isinstance(message, dict):
+                    # `"message": null` is real in the corpus and would raise
+                    # AttributeError on .get() -- which `except OSError` below
+                    # does not catch, so one bad line in one trace file would
+                    # take down `analyze` for the whole project. Totality is
+                    # this function's contract; check the type, do not assume.
+                    continue
+                content = message.get("content", [])
                 if not isinstance(content, list):
                     continue
                 for block in content:
@@ -169,6 +186,7 @@ def _walk_depth(
 def resolve_lineage(
     files: list[SubagentFileInfo],
     main_session_tool_use_ids: set[str],
+    linked_agent_ids: set[str] | None = None,
 ) -> dict[str, TraceLineage]:
     """Resolve ``agent_id -> TraceLineage`` for every trace in a session.
 
@@ -201,20 +219,32 @@ def resolve_lineage(
         if sidecar is not None
     }
 
-    # Cheap path: every sidecar toolUseId that names a parent-session tool_use
-    # is a depth-1 spawn. Only an unresolved remainder justifies opening traces.
-    unresolved = {
-        agent_id
-        for agent_id, tool_use_id in tool_use_id_of.items()
-        if tool_use_id not in main_session_tool_use_ids
-    }
-    emitter_index = build_emitter_index(files) if unresolved else {}
-
+    # A trace is depth 1 if its sidecar names a parent-session tool_use, OR if
+    # it already owns an invocation row -- an invocation exists only for a
+    # main-session delegation, so that IS the depth-1 fact, and it survives a
+    # missing sidecar. Without the second source, deleting a *parent's* sidecar
+    # severs its child's edge even though the emitter index still proves it.
     depth_1_agents = {
         agent_id
         for agent_id, tool_use_id in tool_use_id_of.items()
         if tool_use_id in main_session_tool_use_ids
     }
+    depth_1_agents |= linked_agent_ids or set()
+
+    unresolved = {
+        agent_id
+        for agent_id in tool_use_id_of
+        if agent_id not in depth_1_agents
+    }
+    # Requiring a non-empty depth_1_agents is not an optimization. With no
+    # depth-1 root, `_walk_depth` can only terminate via cycle/missing-parent/
+    # max-depth -- every lineage degrades to (None, 1) whatever the index says
+    # -- so building it would read every trace file line by line (some >1MB)
+    # to produce a result that cannot change. Reachable on the #468
+    # trace-missing cohort, where a session yields no extractable invocations.
+    emitter_index = (
+        build_emitter_index(files) if unresolved and depth_1_agents else {}
+    )
     parent_agent_of: dict[str, str] = {}
     for agent_id in unresolved:
         emitter = emitter_index.get(tool_use_id_of[agent_id])
@@ -224,8 +254,13 @@ def resolve_lineage(
     lineages: dict[str, TraceLineage] = {}
     for info in files:
         agent_id = info.agent_id
+        sidecar = sidecars.get(agent_id)
+        agent_type = sidecar.agent_type if sidecar is not None else ""
+
         if agent_id in depth_1_agents:
-            lineages[agent_id] = TraceLineage(parent_invocation_id=None, depth=1)
+            lineages[agent_id] = TraceLineage(
+                parent_invocation_id=None, depth=1, agent_type=agent_type,
+            )
             continue
 
         depth = _walk_depth(agent_id, parent_agent_of, depth_1_agents)
@@ -233,9 +268,11 @@ def resolve_lineage(
         if depth is None or parent_agent is None:
             # Unattributable: no sidecar, an emitter we could not resolve, or a
             # cycle. Never a guessed parent.
-            lineages[agent_id] = TraceLineage(parent_invocation_id=None, depth=1)
+            lineages[agent_id] = TraceLineage(
+                parent_invocation_id=None, depth=1, agent_type=agent_type,
+            )
             continue
         lineages[agent_id] = TraceLineage(
-            parent_invocation_id=parent_agent, depth=depth,
+            parent_invocation_id=parent_agent, depth=depth, agent_type=agent_type,
         )
     return lineages

--- a/src/agentfluent/traces/lineage.py
+++ b/src/agentfluent/traces/lineage.py
@@ -1,0 +1,241 @@
+"""Resolve the delegation lineage of subagent traces (#595 PR B).
+
+The on-disk layout is **flat at all depths**: every trace in a session is a
+sibling under ``subagents/``, whatever spawned it. So "which agent spawned
+this one" is not recoverable from path shape -- only from data. This module
+computes that edge, and the ``depth`` it implies, for every trace in a
+session.
+
+**The join, and why the sidecar carries it.** Each trace has an
+``agent-<agentId>.meta.json`` sidecar whose ``toolUseId`` names the ``Agent``
+``tool_use`` block that spawned it. Resolving that label to an *emitter*
+answers the parent question:
+
+* the emitter is the **main session** -> the trace is depth 1, and its parent
+  is the ``AgentInvocation`` carrying that ``tool_use_id``;
+* the emitter is a **sibling trace** -> the trace is depth >= 2, and its
+  parent is that trace's agent.
+
+At depth 1 the same edge is also recoverable from ``toolUseResult.agentId``,
+but a depth->=2 ``tool_result`` carries no ``toolUseResult`` at all (only an
+inline prose trailer this package deliberately does not parse), which is what
+makes the sidecar the only *structured* child-to-parent edge below depth 1.
+
+**Cost.** The sidecar check is the cheap path and resolves every depth-1
+trace, which is the overwhelming majority (measured on a real corpus:
+16/1333 traces, 1.2%, are depth >= 2). Only when a sidecar ``toolUseId``
+fails to resolve against the parent session do we open sibling traces to
+build the emitter index -- once per session, not once per unresolved id.
+Sessions with no nesting never pay it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentfluent.traces.discovery import SubagentFileInfo
+from agentfluent.traces.sidecar import read_subagent_sidecar
+
+logger = logging.getLogger(__name__)
+
+MAX_DELEGATION_DEPTH = 64
+"""Hard ceiling on the parent walk.
+
+A cycle is *structurally* unrepresentable in this format -- a ``tool_use.id``
+is emitted once by one file, and a child file is created after the
+``tool_use`` that spawned it, so the emitter relation is acyclic by
+construction. This guard is therefore not defending against a state the
+format can produce; it defends against **corrupt input**, where an unbounded
+walk would be an infinite loop inside ``analyze``. Paired with the visited-set
+check in ``_walk_depth``, which catches a true cycle in fewer steps.
+"""
+
+
+@dataclass(frozen=True)
+class TraceLineage:
+    """Resolved lineage for one subagent trace."""
+
+    parent_invocation_id: str | None
+    depth: int
+
+
+def emitted_tool_use_ids(trace_path: Path) -> set[str]:
+    """Return the ``tool_use`` block ids emitted by one trace file.
+
+    Scans for ``type == "assistant"`` lines and collects ``tool_use`` block
+    ids. Deliberately a narrow scan rather than a full ``parse_subagent_trace``
+    call: this runs only on the depth->=2 escalation path, and building a
+    whole ``SubagentTrace`` to read a handful of ids would reintroduce the
+    eager parse the sidecar probe exists to avoid.
+
+    Total by contract -- an unreadable or malformed file yields an empty set
+    rather than raising, matching ``read_subagent_sidecar``'s posture. A trace
+    we cannot read simply emits nothing, which degrades a child to
+    unattributable instead of failing the session.
+    """
+    ids: set[str] = set()
+    try:
+        with trace_path.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                # Cheap reject before paying for json.loads: the vast majority
+                # of lines in a trace carry no tool_use block at all.
+                if '"tool_use"' not in line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(obj, dict) or obj.get("type") != "assistant":
+                    continue
+                content = obj.get("message", {}).get("content", [])
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_use"
+                        and isinstance(block.get("id"), str)
+                    ):
+                        ids.add(block["id"])
+    except OSError as exc:
+        logger.debug("Unreadable subagent trace while indexing emitters %s: %s",
+                     trace_path, exc)
+    return ids
+
+
+def build_emitter_index(files: Iterable[SubagentFileInfo]) -> dict[str, str]:
+    """Map ``tool_use.id -> agent_id of the trace that emitted it``.
+
+    Only trace-emitted ids appear. An id emitted by the **main session** is
+    absent by construction, which is exactly what makes membership here the
+    depth->=2 test: resolve against the parent session first, and anything
+    left that hits this index was spawned by another agent.
+
+    Exposed as a reusable unit rather than an internal of
+    ``resolve_lineage``: #648 AC1/AC4's coverage counter needs the same
+    emitter resolution to split structurally-recoverable depth->=2 traces from
+    true orphans, and two implementations of this would drift.
+    """
+    index: dict[str, str] = {}
+    for info in files:
+        for tool_use_id in emitted_tool_use_ids(info.path):
+            index[tool_use_id] = info.agent_id
+    return index
+
+
+def _walk_depth(
+    agent_id: str,
+    parent_agent_of: dict[str, str],
+    depth_1_agents: set[str],
+) -> int | None:
+    """Depth of ``agent_id`` by walking parent edges, or ``None`` if unresolvable.
+
+    ``None`` means the chain ran into a cycle, exceeded
+    ``MAX_DELEGATION_DEPTH``, or reached an agent with no known parent that is
+    not itself depth 1. Callers degrade to ``depth=1`` /
+    ``parent_invocation_id=None`` on ``None`` rather than guessing a number.
+    """
+    visited: set[str] = set()
+    current = agent_id
+    depth = 1
+    while current not in depth_1_agents:
+        if current in visited:
+            # A true cycle, including the degenerate self-parent case where a
+            # sidecar's toolUseId is emitted by its own trace.
+            logger.debug("Cycle in delegation chain at agent_id=%s", current)
+            return None
+        visited.add(current)
+        parent = parent_agent_of.get(current)
+        if parent is None:
+            # Chain ends at an agent that is neither depth 1 nor has a
+            # resolvable parent -- an orphaned subtree (rotated or truncated
+            # parent session).
+            return None
+        depth += 1
+        if depth > MAX_DELEGATION_DEPTH:
+            logger.debug(
+                "Delegation chain exceeded MAX_DELEGATION_DEPTH at agent_id=%s",
+                agent_id,
+            )
+            return None
+        current = parent
+    return depth
+
+
+def resolve_lineage(
+    files: list[SubagentFileInfo],
+    main_session_tool_use_ids: set[str],
+) -> dict[str, TraceLineage]:
+    """Resolve ``agent_id -> TraceLineage`` for every trace in a session.
+
+    ``main_session_tool_use_ids`` is the set of ``Agent`` ``tool_use`` ids
+    emitted by the **main session** -- the depth-1 spawn set. Membership is all
+    this needs: an id in it means the main session spawned that agent, which is
+    depth 1 by definition. Passed in rather than derived so this module stays
+    independent of ``agents.models``.
+
+    A depth-1 trace gets ``parent_invocation_id = None``. Its parent is the
+    main session, which has no invocation id -- and a ``"main"``/``"root"``
+    sentinel would be a string that looks like an id and joins to nothing.
+
+    Degradation is deliberate and uniform: a trace with **no sidecar**, a
+    sidecar whose ``toolUseId`` resolves to no emitter, or a chain that hits
+    the cycle guard all yield ``TraceLineage(None, 1)``. That biases toward
+    under-reporting nesting rather than asserting a parent that may be wrong,
+    and leaves the residual for #648 AC3 to disclose as an orphan cohort.
+    """
+    # Sidecars are read here, NOT in discovery. `discover_session_subagents`
+    # is contracted to "only walk directories and name files", and
+    # `discover_subagent_files` applies it across an entire project -- on a
+    # real corpus that is 1333 traces, so folding per-file JSON reads into
+    # discovery would charge every path-only caller for I/O it never asked
+    # for. The linker is the one caller that needs the edge, so it pays.
+    sidecars = {info.agent_id: read_subagent_sidecar(info.path) for info in files}
+    tool_use_id_of: dict[str, str] = {
+        agent_id: sidecar.tool_use_id
+        for agent_id, sidecar in sidecars.items()
+        if sidecar is not None
+    }
+
+    # Cheap path: every sidecar toolUseId that names a parent-session tool_use
+    # is a depth-1 spawn. Only an unresolved remainder justifies opening traces.
+    unresolved = {
+        agent_id
+        for agent_id, tool_use_id in tool_use_id_of.items()
+        if tool_use_id not in main_session_tool_use_ids
+    }
+    emitter_index = build_emitter_index(files) if unresolved else {}
+
+    depth_1_agents = {
+        agent_id
+        for agent_id, tool_use_id in tool_use_id_of.items()
+        if tool_use_id in main_session_tool_use_ids
+    }
+    parent_agent_of: dict[str, str] = {}
+    for agent_id in unresolved:
+        emitter = emitter_index.get(tool_use_id_of[agent_id])
+        if emitter is not None:
+            parent_agent_of[agent_id] = emitter
+
+    lineages: dict[str, TraceLineage] = {}
+    for info in files:
+        agent_id = info.agent_id
+        if agent_id in depth_1_agents:
+            lineages[agent_id] = TraceLineage(parent_invocation_id=None, depth=1)
+            continue
+
+        depth = _walk_depth(agent_id, parent_agent_of, depth_1_agents)
+        parent_agent = parent_agent_of.get(agent_id)
+        if depth is None or parent_agent is None:
+            # Unattributable: no sidecar, an emitter we could not resolve, or a
+            # cycle. Never a guessed parent.
+            lineages[agent_id] = TraceLineage(parent_invocation_id=None, depth=1)
+            continue
+        lineages[agent_id] = TraceLineage(
+            parent_invocation_id=parent_agent, depth=depth,
+        )
+    return lineages

--- a/src/agentfluent/traces/lineage.py
+++ b/src/agentfluent/traces/lineage.py
@@ -23,10 +23,13 @@ makes the sidecar the only *structured* child-to-parent edge below depth 1.
 
 **Cost.** The sidecar check is the cheap path and resolves every depth-1
 trace, which is the overwhelming majority (measured on a real corpus:
-16/1333 traces, 1.2%, are depth >= 2). Only when a sidecar ``toolUseId``
-fails to resolve against the parent session do we open sibling traces to
-build the emitter index -- once per session, not once per unresolved id.
-Sessions with no nesting never pay it.
+16/1333 traces, 1.2%, are depth >= 2). Sibling traces are opened to build the
+emitter index only when **both** hold: some sidecar ``toolUseId`` failed to
+resolve against the parent session, **and** at least one depth-1 root exists
+to walk back to. With no root every lineage degrades to ``(None, 1)``
+whatever the index says, so building it would read every trace file to
+produce a result that cannot change. Sessions with no nesting never pay it,
+and the index is built once per session, not once per unresolved id.
 """
 
 from __future__ import annotations
@@ -196,9 +199,20 @@ def resolve_lineage(
     depth 1 by definition. Passed in rather than derived so this module stays
     independent of ``agents.models``.
 
+    ``linked_agent_ids`` is a **co-equal second source** for the same
+    decision: an agent owning an ``AgentInvocation`` row was spawned by the
+    main session, which is the depth-1 fact itself and survives a missing
+    sidecar. Without it, deleting a *parent's* sidecar severs its child's edge
+    even though the emitter index still proves it. ``None`` is accepted and
+    means "no second source", not "none exist".
+
     A depth-1 trace gets ``parent_invocation_id = None``. Its parent is the
     main session, which has no invocation id -- and a ``"main"``/``"root"``
     sentinel would be a string that looks like an id and joins to nothing.
+
+    This function computes depth at **any** level. Capping *attachment* at
+    depth 2 is the pipeline's decision (#595 AC2 as amended, #659), not this
+    module's.
 
     Degradation is deliberate and uniform: a trace with **no sidecar**, a
     sidecar whose ``toolUseId`` resolves to no emitter, or a chain that hits

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -171,11 +171,15 @@ class SubagentTrace(BaseModel):
     **``None`` is the depth-1 value, not a missing value, and there is
     deliberately no sentinel id.** A synthetic "root" id would join to nothing
     and force every consumer to special-case it; ``None`` says the same thing
-    in the type. ``None`` also covers the unattributable case — a depth->=2
-    trace whose sidecar is absent or whose ``toolUseId`` resolves to no
-    emitter. Those are distinguished by ``depth``, never by a wrong parent:
-    the linker leaves this ``None`` rather than guessing (#648 AC3 discloses
-    that residual as an orphan cohort).
+    in the type. ``None`` also covers the unattributable case: a trace
+    whose sidecar is absent, or whose ``toolUseId`` resolves to no emitter.
+    The linker leaves this ``None`` rather than guessing a parent.
+
+    **Such a trace is NOT distinguishable from a genuine depth-1 trace by
+    these two fields.** Every degradation branch yields ``(None, 1)``, which is
+    exactly what a real depth-1 trace carries. That is deliberate -- guessing a
+    parent would be worse -- but it is why the orphan cohort needs its own
+    disclosure (#648 AC3) rather than being derivable from ``depth``.
 
     **Public JSON API** (D055): serialized via ``AgentInvocation.trace`` ->
     ``SessionAnalysis.invocations`` -> ``analyze --format json``. Additive, so
@@ -183,7 +187,13 @@ class SubagentTrace(BaseModel):
 
     depth: int = 1
     """Delegation depth: 1 for an agent spawned by the main session, 2 for one
-    spawned by a depth-1 agent, and so on (#595 PR B).
+    spawned by a depth-1 agent (#595 PR B).
+
+    **In emitted output this is only ever 1 or 2** while attachment is capped
+    at depth 2 (#595 AC2 as amended): a deeper trace is never attached, so no
+    object carrying ``depth >= 3`` reaches ``analyze --format json``.
+    ``resolve_lineage`` itself computes arbitrary depth; #659 is what would
+    surface it.
 
     Derived from the cross-file ``toolUseId`` join, never from path shape --
     the on-disk layout is **flat at all depths** (every trace is a sibling in

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -157,6 +157,64 @@ class SubagentTrace(BaseModel):
 
     source_file: Path | None = None
 
+    parent_invocation_id: str | None = None
+    """Invocation that spawned this agent, or ``None`` at depth 1 (#595 PR B).
+
+    Identity domain is ``AgentInvocation.invocation_id`` (``agent_id or
+    tool_use_id``), so a value here joins directly against
+    ``SessionAnalysis.invocations``.
+
+    **``None`` is the depth-1 value, not a missing value, and there is
+    deliberately no sentinel id.** A synthetic "root" id would join to nothing
+    and force every consumer to special-case it; ``None`` says the same thing
+    in the type. ``None`` also covers the unattributable case — a depth->=2
+    trace whose sidecar is absent or whose ``toolUseId`` resolves to no
+    emitter. Those are distinguished by ``depth``, never by a wrong parent:
+    the linker leaves this ``None`` rather than guessing (#648 AC3 discloses
+    that residual as an orphan cohort).
+
+    **Public JSON API** (D055): serialized via ``AgentInvocation.trace`` ->
+    ``SessionAnalysis.invocations`` -> ``analyze --format json``. Additive, so
+    the envelope stays ``"2"`` (D029)."""
+
+    depth: int = 1
+    """Delegation depth: 1 for an agent spawned by the main session, 2 for one
+    spawned by a depth-1 agent, and so on (#595 PR B).
+
+    Derived from the cross-file ``toolUseId`` join, never from path shape --
+    the on-disk layout is **flat at all depths** (every trace is a sibling in
+    ``subagents/``), so depth is not recoverable from the filesystem.
+
+    ``1`` is also the fallback when depth cannot be established (no sidecar,
+    or a ``toolUseId`` that resolves to no emitter). That biases toward
+    under-reporting nesting rather than inventing it, and pairs with
+    ``parent_invocation_id = None`` so no consumer sees a depth it cannot
+    trace to a parent.
+
+    **Public JSON API** (D055), additive; envelope stays ``"2"`` (D029)."""
+
+    children: list[SubagentTrace] = Field(default_factory=list)
+    """Traces spawned *by this agent* -- the depth+1 tier (#595 PR B).
+
+    This is how a depth->=2 trace reaches public JSON at all. It deliberately
+    does **not** become an ``AgentInvocation`` row: ``SessionAnalysis.invocations``
+    means "one row = one main-session delegation", and synthesizing rows for
+    deeper agents would silently move every published agent aggregate
+    (``total_invocations``, ``by_agent_type``, ``builtin``/``custom`` counts)
+    while minting rows whose ``total_tokens`` could only be scraped from a
+    prose trailer -- indistinguishable, to every consumer, from JSON-sourced
+    rows. Hanging the child off its parent keeps invalid states
+    unrepresentable.
+
+    **Size caveat.** This inlines the full child payload (``tool_calls``,
+    ``retry_sequences``) into ``analyze --format json``. Accepted for KISS and
+    for consistency with the existing ``invocation.trace`` nesting; if payload
+    size bites, the escape hatch is a flat adjacency map on ``SessionAnalysis``
+    keyed by ``invocation_id``, which does not change these two fields.
+
+    Empty for the overwhelming majority of traces -- 1.2% of a real 1333-trace
+    corpus had any child at all."""
+
     model: str | None = None
     """Model observed on the first assistant message in the subagent's
     trace (e.g., ``'claude-sonnet-4-6'``). ``None`` when the trace has

--- a/src/agentfluent/traces/models.py
+++ b/src/agentfluent/traces/models.py
@@ -161,8 +161,12 @@ class SubagentTrace(BaseModel):
     """Invocation that spawned this agent, or ``None`` at depth 1 (#595 PR B).
 
     Identity domain is ``AgentInvocation.invocation_id`` (``agent_id or
-    tool_use_id``), so a value here joins directly against
-    ``SessionAnalysis.invocations``.
+    tool_use_id``), and **every non-``None`` value here joins against
+    ``SessionAnalysis.invocations``** -- an invariant, not a coincidence:
+    attachment is capped at depth 2 (#595 AC2 as amended), so the only agent
+    that can be named as a parent is one that owns an invocation row. Lifting
+    that cap (#659) makes the domain "parent invocation id *or* parent agent
+    id" and requires relaxing this sentence with it.
 
     **``None`` is the depth-1 value, not a missing value, and there is
     deliberately no sentinel id.** A synthetic "root" id would join to nothing

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -446,6 +446,22 @@ def _depth_three_session(tmp_path: Path) -> Path:
     return session_dir
 
 
+def _all_descendants(trace: object) -> list[object]:
+    """Every trace below `trace`, at any depth.
+
+    Shared deliberately. The depth-3 invariant test previously inlined a
+    one-level loop over `inv.trace.children`, so it passed on input that
+    violated the invariant it named -- a depth-3 trace attached under a depth-2
+    one was never visited. Any check of "every named parent" has to reach
+    every named parent.
+    """
+    out: list[object] = []
+    for child in trace.children:
+        out.append(child)
+        out.extend(_all_descendants(child))
+    return out
+
+
 class TestDepthTwoCap:
     """Attachment is capped at depth 2 (#595 AC2 as amended; depth-≥3 is #659).
 
@@ -485,27 +501,30 @@ class TestDepthTwoCap:
         for inv in analysis.invocations:
             if inv.trace is None:
                 continue
-            for child in inv.trace.children:
-                assert child.parent_invocation_id in invocation_ids
+            for descendant in _all_descendants(inv.trace):
+                assert descendant.parent_invocation_id in invocation_ids, (
+                    f"{descendant.agent_id} names parent "
+                    f"{descendant.parent_invocation_id!r}, which is not an "
+                    "invocation row -- the documented identity domain is broken"
+                )
 
     def test_every_named_parent_owns_an_invocation_row(self) -> None:
         """The invariant the cap buys, stated as a test rather than as prose."""
         analysis = analyze_session(_NESTED_MAIN)
         invocation_ids = {inv.invocation_id for inv in analysis.invocations}
 
-        def walk(trace: object) -> None:
-            for child in trace.children:
-                assert child.parent_invocation_id in invocation_ids, (
-                    "a parent_invocation_id names something that is not an "
-                    "invocation row -- the documented identity domain is broken"
-                )
-                walk(child)
-
         seen_any = False
         for inv in analysis.invocations:
-            if inv.trace is not None:
-                seen_any = seen_any or bool(inv.trace.children)
-                walk(inv.trace)
+            if inv.trace is None:
+                continue
+            descendants = _all_descendants(inv.trace)
+            seen_any = seen_any or bool(descendants)
+            for descendant in descendants:
+                assert descendant.parent_invocation_id in invocation_ids, (
+                    f"{descendant.agent_id} names parent "
+                    f"{descendant.parent_invocation_id!r}, which is not an "
+                    "invocation row -- the documented identity domain is broken"
+                )
         assert seen_any, "no children attached -- the invariant is vacuous here"
 
     def test_attached_children_are_exactly_depth_2(self) -> None:

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -223,6 +223,34 @@ class TestCycleGuard:
     def test_two_node_cycle_is_caught(self) -> None:
         assert _walk_depth("a", {"a": "b", "b": "a"}, set()) is None
 
+    def test_cycle_is_caught_by_the_visited_set_not_by_max_depth(self) -> None:
+        """Assert the MECHANISM, not the outcome.
+
+        Both guards return ``None`` on a cycle, so `is None` cannot tell them
+        apart -- a mutation neutering the visited set survived the outcome-only
+        tests above, because MAX_DELEGATION_DEPTH produced the same answer 64
+        steps later. What distinguishes them is *how many parent lookups it
+        takes*: the visited set short-circuits a 2-node cycle almost
+        immediately, MAX_DELEGATION_DEPTH cannot.
+        """
+
+        class CountingParents(dict):  # type: ignore[type-arg]
+            lookups = 0
+
+            def get(self, key, default=None):  # type: ignore[no-untyped-def]
+                type(self).lookups += 1
+                return super().get(key, default)
+
+        CountingParents.lookups = 0
+        parents = CountingParents({"a": "b", "b": "a"})
+        assert _walk_depth("a", parents, set()) is None
+        # A 2-node cycle needs a handful of lookups. Neuter the visited set and
+        # this becomes MAX_DELEGATION_DEPTH-many.
+        assert CountingParents.lookups < 10, (
+            f"{CountingParents.lookups} parent lookups for a 2-node cycle -- "
+            "the visited set is not what stopped the walk"
+        )
+
     def test_chain_with_no_depth_1_root_is_unresolvable(self) -> None:
         assert _walk_depth("a", {"a": "b"}, set()) is None
 
@@ -265,6 +293,66 @@ class TestCycleGuard:
         """The guard must not reject depth that is merely deep."""
         chain = {"d4": "d3", "d3": "d2", "d2": "d1"}
         assert _walk_depth("d4", chain, {"d1"}) == 4
+
+
+class TestDegradationIsUniform:
+    """`resolve_lineage` documents that every degradation branch yields
+    ``(None, 1)``. The cycle branch was reachable only via `_walk_depth`, so a
+    mutation that emitted a guessed parent from it survived the suite.
+    """
+
+    def test_self_parent_sidecar_degrades_through_resolve_lineage(
+        self, tmp_path: Path,
+    ) -> None:
+        """A sidecar whose toolUseId is emitted by its own trace.
+
+        The degenerate cycle a real corruption could produce, driven end-to-end
+        rather than through the private walker.
+        """
+        session_dir = tmp_path / "nested-session-1"
+        shutil.copytree(_NESTED_DIR, session_dir)
+        subagents = session_dir / "subagents"
+
+        # leaf0001 emits the very tool_use its own sidecar names.
+        leaf = subagents / "agent-leaf0001.jsonl"
+        leaf.write_text(
+            leaf.read_text()
+            + json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_self_parent",
+                                "name": "Agent",
+                                "input": {"subagent_type": "x", "prompt": "y"},
+                            }
+                        ],
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    },
+                    "isSidechain": True,
+                    "agentId": "leaf0001",
+                    "uuid": "sp1",
+                }
+            )
+            + "\n"
+        )
+        sidecar = subagents / "agent-leaf0001.meta.json"
+        meta = json.loads(sidecar.read_text())
+        meta["toolUseId"] = "toolu_self_parent"
+        sidecar.write_text(json.dumps(meta))
+
+        lineages = resolve_lineage(
+            discover_session_subagents(session_dir),
+            {_MAIN_TOOL_USE},
+            linked_agent_ids={"worker001"},
+        )
+        # The documented uniform degradation -- NOT a guessed self-parent.
+        assert lineages["leaf0001"] == TraceLineage(
+            parent_invocation_id=None, depth=1, agent_type=meta["agentType"],
+        )
 
 
 class TestLevelOneRegression:

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -239,19 +239,26 @@ class TestCycleGuard:
         root = f"a{depth}"
         assert _walk_depth("a0", chain, {root}) is None
 
-    def test_chain_just_inside_max_depth_still_resolves(self) -> None:
-        """The other side of the boundary -- the guard must not over-trigger."""
-        chain = {f"b{i}": f"b{i + 1}" for i in range(MAX_DELEGATION_DEPTH - 2)}
-        root = f"b{MAX_DELEGATION_DEPTH - 2}"
-        assert _walk_depth("b0", chain, {root}) == MAX_DELEGATION_DEPTH - 1
+    def test_chain_of_exactly_max_depth_resolves(self) -> None:
+        """The boundary itself: exactly MAX must pass, MAX+1 must not.
 
-    def test_depth_three_chain_resolves_to_3(self) -> None:
-        """Guards the attachment ordering: depth 3 must not silently drop.
-
-        The live corpus bottoms out at depth 2 (1317/16/0), so nothing in the
-        fixtures or the corpus would catch a regression here. Nothing in the
-        format caps depth, so this is tested rather than assumed.
+        The prior version asserted MAX-1 while calling itself "just inside the
+        boundary", so it left both sides of the actual edge untested.
         """
+        links = MAX_DELEGATION_DEPTH - 1
+        chain = {f"b{i}": f"b{i + 1}" for i in range(links)}
+        assert _walk_depth("b0", chain, {f"b{links}"}) == MAX_DELEGATION_DEPTH
+
+    def test_chain_one_past_max_depth_is_rejected(self) -> None:
+        links = MAX_DELEGATION_DEPTH
+        chain = {f"c{i}": f"c{i + 1}" for i in range(links)}
+        assert _walk_depth("c0", chain, {f"c{links}"}) is None
+
+    def test_walk_computes_depth_three(self) -> None:
+        """`_walk_depth` is not capped -- the *attachment* cap lives in the
+        pipeline (#595 AC2 as amended, #659). This asserts the walk only, and
+        deliberately claims nothing about attachment: the prior version of this
+        test named the attach-loop ordering it never exercised."""
         assert _walk_depth("c", {"c": "b", "b": "a"}, {"a"}) == 3
 
     def test_legitimate_deep_chain_still_resolves(self) -> None:
@@ -356,22 +363,40 @@ class TestReviewFindings:
         assert all(lin.depth == 1 for lin in lineages.values())
         assert all(lin.parent_invocation_id is None for lin in lineages.values())
 
-    def test_linked_trace_is_never_attached_twice(self) -> None:
-        """Finding 5: an agent owning an invocation row is not also a child."""
+
+class TestDepthTwoCap:
+    """Attachment is capped at depth 2 (#595 AC2 as amended; depth-≥3 is #659).
+
+    The cap is what makes `parent_invocation_id`'s documented identity domain
+    true, so this is the assertion that replaces the removed dead guard.
+    """
+
+    def test_every_named_parent_owns_an_invocation_row(self) -> None:
+        """The invariant the cap buys, stated as a test rather than as prose."""
         analysis = analyze_session(_NESTED_MAIN)
-        linked = {
-            inv.agent_id for inv in analysis.invocations if inv.trace is not None
-        }
-        seen: list[str] = []
+        invocation_ids = {inv.invocation_id for inv in analysis.invocations}
 
         def walk(trace: object) -> None:
             for child in trace.children:
-                seen.append(child.agent_id)
+                assert child.parent_invocation_id in invocation_ids, (
+                    "a parent_invocation_id names something that is not an "
+                    "invocation row -- the documented identity domain is broken"
+                )
                 walk(child)
 
+        seen_any = False
         for inv in analysis.invocations:
             if inv.trace is not None:
+                seen_any = seen_any or bool(inv.trace.children)
                 walk(inv.trace)
+        assert seen_any, "no children attached -- the invariant is vacuous here"
 
-        assert not (set(seen) & linked), "a linked trace was also attached as a child"
-        assert len(seen) == len(set(seen)), "a trace was attached more than once"
+    def test_attached_children_are_exactly_depth_2(self) -> None:
+        analysis = analyze_session(_NESTED_MAIN)
+        for inv in analysis.invocations:
+            if inv.trace is None:
+                continue
+            for child in inv.trace.children:
+                assert child.depth == 2
+                # The cap: a depth-2 child attaches nothing of its own.
+                assert child.children == []

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -1,0 +1,259 @@
+"""Lineage resolution and the non-folding gate (#595 PR B).
+
+Two things are locked here:
+
+* **Lineage** -- ``depth`` and ``parent_invocation_id`` resolve from *data*
+  (the cross-file ``toolUseId`` join), never from path shape, and degrade to
+  ``depth=1``/``parent_invocation_id=None`` rather than guessing a parent.
+* **The non-folding gate** (``analytics/pipeline.py``) -- depth->=2 usage must
+  NOT reach ``fold_subagent_metrics_in``. Folding it in is #648 AC2's
+  deliberate act; PR B pins the gate closed so it cannot happen as an
+  implementation side effect.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+import agentfluent.analytics.pipeline as pipeline_mod
+from agentfluent.analytics.pipeline import analyze_session
+from agentfluent.traces.discovery import discover_session_subagents
+from agentfluent.traces.lineage import (
+    MAX_DELEGATION_DEPTH,
+    TraceLineage,
+    _walk_depth,
+    build_emitter_index,
+    emitted_tool_use_ids,
+    resolve_lineage,
+)
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures"
+_NESTED = _FIXTURES / "nested_session"
+_NESTED_MAIN = _NESTED / "nested-session-1.jsonl"
+_NESTED_DIR = _NESTED / "nested-session-1"
+_SDK_MAIN = _FIXTURES / "sdk_session" / "sdk-main-1.jsonl"
+
+# The main session's only Agent tool_use, and the invocation it belongs to.
+_MAIN_TOOL_USE = "toolu_main_to_worker"
+
+
+def _nested_lineages() -> dict[str, TraceLineage]:
+    files = discover_session_subagents(_NESTED_DIR)
+    return resolve_lineage(files, {_MAIN_TOOL_USE})
+
+
+class TestLineageOnTheNestedFixture:
+    """The committed multi-level fixture: worker001 -> leaf0001."""
+
+    def test_depth_one_agent_has_depth_1_and_no_parent(self) -> None:
+        lineages = _nested_lineages()
+        assert lineages["worker001"].depth == 1
+        # None, not a "main"/"root" sentinel: a sentinel would look like an id
+        # and join to nothing, forcing every consumer to special-case it.
+        assert lineages["worker001"].parent_invocation_id is None
+
+    def test_depth_two_agent_resolves_parent_and_depth(self) -> None:
+        lineages = _nested_lineages()
+        assert lineages["leaf0001"].depth == 2
+        assert lineages["leaf0001"].parent_invocation_id == "worker001"
+
+    def test_depth_is_not_readable_from_path_shape(self) -> None:
+        """Both traces are flat siblings, so depth came from data alone."""
+        paths = sorted(p.name for p in (_NESTED_DIR / "subagents").glob("*.jsonl"))
+        assert paths == ["agent-leaf0001.jsonl", "agent-worker001.jsonl"]
+        # Same directory, same nesting on disk -- different resolved depth.
+        lineages = _nested_lineages()
+        assert lineages["worker001"].depth != lineages["leaf0001"].depth
+
+    def test_emitter_index_maps_tool_use_to_emitting_agent(self) -> None:
+        index = build_emitter_index(discover_session_subagents(_NESTED_DIR))
+        # The worker emitted the tool_use that spawned the leaf...
+        assert index["toolu_worker_to_leaf"] == "worker001"
+        # ...and the main session's tool_use is absent by construction, which
+        # is what makes membership here the depth->=2 test.
+        assert _MAIN_TOOL_USE not in index
+
+
+class TestEndToEndThroughAnalyze:
+    """The fields reach the public surface, and children hang off the parent."""
+
+    def test_parent_trace_carries_the_child(self) -> None:
+        analysis = analyze_session(_NESTED_MAIN)
+        traces = [inv.trace for inv in analysis.invocations if inv.trace is not None]
+        assert len(traces) == 1
+        parent = traces[0]
+        assert parent.depth == 1
+        assert parent.parent_invocation_id is None
+        assert len(parent.children) == 1
+        assert parent.children[0].depth == 2
+        assert parent.children[0].parent_invocation_id == "worker001"
+
+    def test_depth_two_agent_does_not_become_an_invocation_row(self) -> None:
+        """Ruling 2: synthesizing rows would move every agent aggregate."""
+        analysis = analyze_session(_NESTED_MAIN)
+        assert len(analysis.invocations) == 1
+        assert analysis.agent_metrics.total_invocations == 1
+
+    def test_new_fields_serialize_as_public_json(self) -> None:
+        analysis = analyze_session(_NESTED_MAIN)
+        payload = json.loads(analysis.invocations[0].trace.model_dump_json())
+        assert payload["depth"] == 1
+        assert payload["parent_invocation_id"] is None
+        assert payload["children"][0]["depth"] == 2
+
+
+class TestNonFoldingGate:
+    """Depth->=2 usage must not enter token metrics. Blocking concern #2.
+
+    Named by the gate comment in ``analytics/pipeline.py``; that comment
+    asserts this class exists, so it must.
+    """
+
+    def test_depth_two_traces_never_reach_the_folding_function(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Assert the MECHANISM: what the gate hands to the folder.
+
+        Asserting a total instead would pass for every implementation that
+        happens to reach that total -- including the broken one this guards
+        against. Only observing *which traces are passed* distinguishes them.
+        """
+        captured: list[list[object]] = []
+        real = pipeline_mod.compute_subagent_token_metrics
+
+        def spy(traces, **kwargs):  # type: ignore[no-untyped-def]
+            captured.append(list(traces))
+            return real(traces, **kwargs)
+
+        monkeypatch.setattr(pipeline_mod, "compute_subagent_token_metrics", spy)
+        analysis = analyze_session(_NESTED_MAIN)
+
+        assert captured, "the folding path never ran -- test proves nothing"
+        folded = captured[0]
+        # The depth-2 child exists and is non-empty, so its exclusion here is
+        # a real exclusion rather than an empty-set vacuity.
+        child = analysis.invocations[0].trace.children[0]
+        assert child.depth == 2
+        assert child.usage.input_tokens + child.usage.output_tokens > 0
+        assert child.agent_id not in {t.agent_id for t in folded}
+        assert all(t.depth == 1 for t in folded)
+
+    def test_the_child_carries_spend_the_gate_is_withholding(self) -> None:
+        """The gate is load-bearing, not decorative.
+
+        If the depth-2 child ever carried zero usage, the test above would go
+        vacuous -- excluding an empty trace proves nothing. This pins the
+        precondition that makes that exclusion meaningful.
+        """
+        analysis = analyze_session(_NESTED_MAIN)
+        child = analysis.invocations[0].trace.children[0]
+        assert child.usage.input_tokens + child.usage.output_tokens > 0
+
+
+class TestDegradationPaths:
+    """Absence must never produce a *wrong* parent. Architect concern #2."""
+
+    def test_missing_sidecar_degrades_to_depth_1_no_parent(
+        self, tmp_path: Path,
+    ) -> None:
+        """A trace whose sidecar is absent (older sessions predate it).
+
+        Measured prevalence in the current corpus is 0/1333 -- this is a
+        *degradation* path, not a detection path, so 0 today is evidence about
+        one machine's session history, never that the path is unreachable.
+        """
+        session_dir = tmp_path / "nested-session-1"
+        shutil.copytree(_NESTED_DIR, session_dir)
+        (session_dir / "subagents" / "agent-leaf0001.meta.json").unlink()
+
+        lineages = resolve_lineage(
+            discover_session_subagents(session_dir), {_MAIN_TOOL_USE},
+        )
+        # Unattributable -- NOT a guessed parent.
+        assert lineages["leaf0001"].depth == 1
+        assert lineages["leaf0001"].parent_invocation_id is None
+        # The depth-1 sibling is unaffected.
+        assert lineages["worker001"].depth == 1
+
+    def test_orphan_sidecar_tool_use_id_emitted_by_no_file(
+        self, tmp_path: Path,
+    ) -> None:
+        """A truncated/rotated parent: the toolUseId resolves to nothing."""
+        session_dir = tmp_path / "nested-session-1"
+        shutil.copytree(_NESTED_DIR, session_dir)
+        sidecar = session_dir / "subagents" / "agent-leaf0001.meta.json"
+        meta = json.loads(sidecar.read_text())
+        meta["toolUseId"] = "toolu_emitted_by_nobody"
+        sidecar.write_text(json.dumps(meta))
+
+        lineages = resolve_lineage(
+            discover_session_subagents(session_dir), {_MAIN_TOOL_USE},
+        )
+        assert lineages["leaf0001"].parent_invocation_id is None
+        assert lineages["leaf0001"].depth == 1
+
+    def test_unreadable_trace_yields_no_emitters_rather_than_raising(
+        self, tmp_path: Path,
+    ) -> None:
+        broken = tmp_path / "agent-broken.jsonl"
+        broken.write_text('{"type":"assistant" NOT JSON\n')
+        assert emitted_tool_use_ids(broken) == set()
+
+    def test_absent_trace_file_yields_no_emitters(self, tmp_path: Path) -> None:
+        assert emitted_tool_use_ids(tmp_path / "does-not-exist.jsonl") == set()
+
+
+class TestCycleGuard:
+    """Synthetic graphs only -- a cycle is unrepresentable in this format.
+
+    Ruling 5: hand-crafting a cyclic JSONL fixture would encode a false claim
+    about the format, which is exactly what the findings doc exists to
+    prevent. So the guard is tested against in-memory graphs.
+    """
+
+    def test_self_parent_is_caught(self) -> None:
+        """The degenerate cycle a real corruption could plausibly produce."""
+        assert _walk_depth("a", {"a": "a"}, set()) is None
+
+    def test_two_node_cycle_is_caught(self) -> None:
+        assert _walk_depth("a", {"a": "b", "b": "a"}, set()) is None
+
+    def test_chain_with_no_depth_1_root_is_unresolvable(self) -> None:
+        assert _walk_depth("a", {"a": "b"}, set()) is None
+
+    def test_long_chain_exceeding_max_depth_is_caught(self) -> None:
+        # A non-cyclic but absurdly deep chain: the visited-set never fires,
+        # so MAX_DELEGATION_DEPTH is what stops it.
+        chain = {f"a{i}": f"a{i + 1}" for i in range(MAX_DELEGATION_DEPTH + 5)}
+        assert _walk_depth("a0", chain, set()) is None
+
+    def test_depth_three_chain_resolves_to_3(self) -> None:
+        """Guards the attachment ordering: depth 3 must not silently drop.
+
+        The live corpus bottoms out at depth 2 (1317/16/0), so nothing in the
+        fixtures or the corpus would catch a regression here. Nothing in the
+        format caps depth, so this is tested rather than assumed.
+        """
+        assert _walk_depth("c", {"c": "b", "b": "a"}, {"a"}) == 3
+
+    def test_legitimate_deep_chain_still_resolves(self) -> None:
+        """The guard must not reject depth that is merely deep."""
+        chain = {"d4": "d3", "d3": "d2", "d2": "d1"}
+        assert _walk_depth("d4", chain, {"d1"}) == 4
+
+
+class TestLevelOneRegression:
+    """The depth-1 rollup path is untouched. Fixture-locked per the AC."""
+
+    def test_sdk_session_level_1_trace_is_depth_1(self) -> None:
+        analysis = analyze_session(_SDK_MAIN)
+        traces = [inv.trace for inv in analysis.invocations if inv.trace is not None]
+        assert traces
+        for trace in traces:
+            assert trace.depth == 1
+            assert trace.parent_invocation_id is None
+            assert trace.children == []

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -364,12 +364,129 @@ class TestReviewFindings:
         assert all(lin.parent_invocation_id is None for lin in lineages.values())
 
 
+def _depth_three_session(tmp_path: Path) -> Path:
+    """A depth-3 session: worker001 -> leaf0001 -> deep0001.
+
+    Built here rather than committed because it exists to exercise the CAP,
+    not the format: `nested_session/` bottoms out at depth 2, so on the
+    committed corpus capped and uncapped code are indistinguishable and every
+    assertion about the cap is starved rather than false. Verified to
+    discriminate — with the cap lifted, the two `TestDepthTwoCap` tests go red.
+
+    Depth-3 is representable-but-unobserved (corpus: 1317/16/0), which is the
+    same category as the no-sidecar case and is NOT the barred category: a
+    cyclic fixture was rejected because a cycle is structurally impossible in
+    this format, so encoding one would assert something false about it. Nothing
+    forbids depth 3.
+    """
+    session_dir = tmp_path / "nested-session-1"
+    shutil.copytree(_NESTED_DIR, session_dir)
+    # analyze_session resolves the subagent dir as <stem>/ beside the JSONL, so
+    # the main session file has to come along.
+    shutil.copy(_NESTED_MAIN, tmp_path / "nested-session-1.jsonl")
+    subagents = session_dir / "subagents"
+
+    # leaf0001 spawns deep0001 -- append the emitting tool_use to the leaf.
+    leaf = subagents / "agent-leaf0001.jsonl"
+    leaf.write_text(
+        leaf.read_text()
+        + json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-haiku-4-5-20251001",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_leaf_to_deep",
+                            "name": "Agent",
+                            "input": {"subagent_type": "deep-agent", "prompt": "go"},
+                        }
+                    ],
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                },
+                "isSidechain": True,
+                "agentId": "leaf0001",
+                "sessionId": "nested-session-1",
+                "uuid": "l5",
+                "timestamp": "2026-06-22T00:00:09.000Z",
+            }
+        )
+        + "\n"
+    )
+    (subagents / "agent-deep0001.meta.json").write_text(
+        json.dumps(
+            {
+                "agentType": "deep-agent",
+                "description": "depth-3 probe",
+                "toolUseId": "toolu_leaf_to_deep",
+            }
+        )
+    )
+    (subagents / "agent-deep0001.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-haiku-4-5-20251001",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "deep"}],
+                    "usage": {"input_tokens": 20, "output_tokens": 5},
+                },
+                "isSidechain": True,
+                "agentId": "deep0001",
+                "sessionId": "nested-session-1",
+                "uuid": "d1",
+                "timestamp": "2026-06-22T00:00:10.000Z",
+            }
+        )
+        + "\n"
+    )
+    return session_dir
+
+
 class TestDepthTwoCap:
     """Attachment is capped at depth 2 (#595 AC2 as amended; depth-≥3 is #659).
 
     The cap is what makes `parent_invocation_id`'s documented identity domain
     true, so this is the assertion that replaces the removed dead guard.
     """
+
+    def test_depth_three_trace_is_not_attached(self, tmp_path: Path) -> None:
+        """The cap, observed on input that can actually see it.
+
+        Without this, capped and uncapped code are indistinguishable on the
+        committed fixtures -- which would make #659 a trap: an implementer
+        lifting the cap would see a fully green suite.
+        """
+        session_dir = _depth_three_session(tmp_path)
+        lineages = resolve_lineage(
+            discover_session_subagents(session_dir),
+            {_MAIN_TOOL_USE},
+            linked_agent_ids={"worker001"},
+        )
+        # resolve_lineage is NOT capped -- it sees depth 3...
+        assert lineages["deep0001"].depth == 3
+
+        # ...but attachment is, so deep0001 reaches no output at all.
+        analysis = analyze_session(session_dir.parent / "nested-session-1.jsonl")
+        parent = analysis.invocations[0].trace
+        assert [c.agent_id for c in parent.children] == ["leaf0001"]
+        assert parent.children[0].children == []
+
+    def test_depth_three_does_not_break_the_join_invariant(
+        self, tmp_path: Path,
+    ) -> None:
+        """The invariant must hold on input that could violate it."""
+        session_dir = _depth_three_session(tmp_path)
+        analysis = analyze_session(session_dir.parent / "nested-session-1.jsonl")
+        invocation_ids = {inv.invocation_id for inv in analysis.invocations}
+        for inv in analysis.invocations:
+            if inv.trace is None:
+                continue
+            for child in inv.trace.children:
+                assert child.parent_invocation_id in invocation_ids
 
     def test_every_named_parent_owns_an_invocation_row(self) -> None:
         """The invariant the cap buys, stated as a test rather than as prose."""

--- a/tests/unit/test_lineage_fold_gate.py
+++ b/tests/unit/test_lineage_fold_gate.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 import agentfluent.analytics.pipeline as pipeline_mod
+import agentfluent.traces.lineage as lineage_mod
 from agentfluent.analytics.pipeline import analyze_session
 from agentfluent.traces.discovery import discover_session_subagents
 from agentfluent.traces.lineage import (
@@ -226,10 +227,23 @@ class TestCycleGuard:
         assert _walk_depth("a", {"a": "b"}, set()) is None
 
     def test_long_chain_exceeding_max_depth_is_caught(self) -> None:
-        # A non-cyclic but absurdly deep chain: the visited-set never fires,
-        # so MAX_DELEGATION_DEPTH is what stops it.
-        chain = {f"a{i}": f"a{i + 1}" for i in range(MAX_DELEGATION_DEPTH + 5)}
-        assert _walk_depth("a0", chain, set()) is None
+        """Isolates MAX_DELEGATION_DEPTH, and only it.
+
+        The chain is ROOTED -- its last link is a depth-1 agent -- so the
+        missing-parent branch cannot fire and the visited-set cannot fire.
+        An unrooted chain would return None either way and prove nothing about
+        the guard.
+        """
+        depth = MAX_DELEGATION_DEPTH + 5
+        chain = {f"a{i}": f"a{i + 1}" for i in range(depth)}
+        root = f"a{depth}"
+        assert _walk_depth("a0", chain, {root}) is None
+
+    def test_chain_just_inside_max_depth_still_resolves(self) -> None:
+        """The other side of the boundary -- the guard must not over-trigger."""
+        chain = {f"b{i}": f"b{i + 1}" for i in range(MAX_DELEGATION_DEPTH - 2)}
+        root = f"b{MAX_DELEGATION_DEPTH - 2}"
+        assert _walk_depth("b0", chain, {root}) == MAX_DELEGATION_DEPTH - 1
 
     def test_depth_three_chain_resolves_to_3(self) -> None:
         """Guards the attachment ordering: depth 3 must not silently drop.
@@ -257,3 +271,107 @@ class TestLevelOneRegression:
             assert trace.depth == 1
             assert trace.parent_invocation_id is None
             assert trace.children == []
+
+
+class TestReviewFindings:
+    """Regressions for the round-1 code-review findings (PR #658)."""
+
+    def test_null_message_line_does_not_raise(self, tmp_path: Path) -> None:
+        """Finding 1: totality is a contract, and it was not being kept.
+
+        The line must contain the literal `"tool_use"` to reach the parse at
+        all -- that is what made this reachable rather than theoretical.
+        """
+        trace = tmp_path / "agent-x.jsonl"
+        trace.write_text(
+            '{"type":"assistant","message":null,"note":"tool_use"}\n'
+            '{"type":"assistant","message":{"content":'
+            '[{"type":"tool_use","id":"toolu_ok"}]}}\n'
+        )
+        # Does not raise, and still recovers the good line.
+        assert emitted_tool_use_ids(trace) == {"toolu_ok"}
+
+    def test_non_dict_message_shapes_are_tolerated(self, tmp_path: Path) -> None:
+        trace = tmp_path / "agent-y.jsonl"
+        trace.write_text(
+            '{"type":"assistant","message":"tool_use"}\n'
+            '{"type":"assistant","message":[1,2],"k":"tool_use"}\n'
+        )
+        assert emitted_tool_use_ids(trace) == set()
+
+    def test_depth_two_child_gets_agent_type_from_its_sidecar(self) -> None:
+        """Finding 2: a depth->=2 agent has no invocation row to inherit from.
+
+        Ruling 1 called the sidecar its only source of `agent_type`. Left
+        unset, every child this PR exposes would serialize as `unknown`.
+        """
+        analysis = analyze_session(_NESTED_MAIN)
+        child = analysis.invocations[0].trace.children[0]
+        sidecar = json.loads(
+            (_NESTED_DIR / "subagents" / "agent-leaf0001.meta.json").read_text()
+        )
+        assert child.agent_type == sidecar["agentType"]
+        assert child.agent_type != "unknown"
+
+    def test_missing_parent_sidecar_preserves_the_childs_edge(
+        self, tmp_path: Path,
+    ) -> None:
+        """Finding 3: the depth-1 fact survives a missing sidecar.
+
+        Distinct from the leaf-sidecar case above, which cannot tell these two
+        implementations apart. Here the data still proves the edge via the
+        emitter index, so severing it would be a loss, not a degradation.
+        """
+        session_dir = tmp_path / "nested-session-1"
+        shutil.copytree(_NESTED_DIR, session_dir)
+        (session_dir / "subagents" / "agent-worker001.meta.json").unlink()
+
+        lineages = resolve_lineage(
+            discover_session_subagents(session_dir),
+            {_MAIN_TOOL_USE},
+            linked_agent_ids={"worker001"},
+        )
+        assert lineages["worker001"].depth == 1
+        assert lineages["leaf0001"].depth == 2
+        assert lineages["leaf0001"].parent_invocation_id == "worker001"
+
+    def test_no_depth_1_root_skips_the_emitter_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Finding 4: don't read every trace to produce a result that can't change."""
+        session_dir = tmp_path / "nested-session-1"
+        shutil.copytree(_NESTED_DIR, session_dir)
+
+        calls: list[Path] = []
+        real = lineage_mod.emitted_tool_use_ids
+        monkeypatch.setattr(
+            lineage_mod,
+            "emitted_tool_use_ids",
+            lambda p: (calls.append(p), real(p))[1],
+        )
+        # No parent-session tool_use ids and no invocation rows => no root.
+        lineages = resolve_lineage(discover_session_subagents(session_dir), set())
+
+        assert calls == [], "scanned trace files despite no depth-1 root"
+        assert all(lin.depth == 1 for lin in lineages.values())
+        assert all(lin.parent_invocation_id is None for lin in lineages.values())
+
+    def test_linked_trace_is_never_attached_twice(self) -> None:
+        """Finding 5: an agent owning an invocation row is not also a child."""
+        analysis = analyze_session(_NESTED_MAIN)
+        linked = {
+            inv.agent_id for inv in analysis.invocations if inv.trace is not None
+        }
+        seen: list[str] = []
+
+        def walk(trace: object) -> None:
+            for child in trace.children:
+                seen.append(child.agent_id)
+                walk(child)
+
+        for inv in analysis.invocations:
+            if inv.trace is not None:
+                walk(inv.trace)
+
+        assert not (set(seen) & linked), "a linked trace was also attached as a child"
+        assert len(seen) == len(set(seen)), "a trace was attached more than once"


### PR DESCRIPTION
## Summary
- **#595 PR B — the multi-level linker.** Resolves each subagent trace's spawning parent and its delegation `depth` via the cross-file `toolUseId` join (sidecar names the `tool_use` block; an emitter index resolves that label to the emitting agent). The on-disk layout is flat at all depths, so this is recoverable only from data, never from path shape.
- **Three additive fields on `SubagentTrace`:** `parent_invocation_id` (`None` at depth 1 — no sentinel), `depth`, and `children`. Public JSON API per D055; additive, so the envelope stays `"2"` (D029).
- **Structure only, zero aggregate movement.** The non-folding gate at the fold site is pinned closed and tested: depth-≥2 usage must not enter `total_cost` / `cache_efficiency` / `by_model`. Folding it in is #648 AC2's deliberate act, with its own CHANGELOG line and dogfood read.

Architect review (PR B, 2026-07-23) rulings applied: sidecar-gated cheap probe (concern #1), graceful degradation with no guessed parent (#2), fields on the trace as intentional public API (#3), `None` at depth 1 (#4), cycle guard tested synthetically (#5), no-sidecar + orphan fixtures (#6), no assertion that `agent_token_percentage` is meaningful (#7), wrapped sidecar I/O (#8), size risk noted on `children` (#9).

**AC#3 (`totalTokens` inclusivity) shipped in PR A** as D056/D057 — not re-opened here.

Two deviations worth flagging for review:
1. **Sidecars are read in the linker, not in discovery.** The PR-B review recommended extending discovery; Ruling 1's SRP note says the opposite. `discover_subagent_files` walks an entire project under a path-only contract — 1333 traces on a real corpus — so eager sidecar reads there would charge every path-only caller for I/O it never asked for. Placing the reads in the one caller that needs the edge satisfies both.
2. **Attachment iterates in ascending depth order.** A depth-3 trace's parent is a depth-2 trace, attachable only once *it* is attached. Dict order would drop every tier below 2 — silently, and invisibly to this corpus, which bottoms out at depth 2.

Measured on the live corpus (305 sessions, 1333 traces): **depth 1 = 1317, depth 2 = 16, depth ≥3 = 0**; 0 traces without a sidecar, 0 orphan sidecars.

## Test plan
- [x] Unit tests pass: `uv run pytest -m "not integration"` — 2159 passed
- [x] Lint clean: `uv run ruff check src/ tests/`
- [x] Type check clean: `uv run mypy src/agentfluent/`
- [x] New/changed behavior has test coverage — `tests/unit/test_lineage_fold_gate.py`, 20 tests
- [ ] Manual smoke test via `uv run agentfluent ...` — n/a, no CLI output change

The fold-gate test asserts the **mechanism** (which traces are handed to the folder), not a total: a total-based assertion passes for every implementation that reaches that total, including the broken one. Verified by applying the mutation — opening the gate turns it red, and the tree restored byte-exact.

The no-sidecar and orphan-sidecar paths have **0 instances in the current corpus**. They are tested anyway: both are *degradation* paths, so a 0-count is evidence about one machine's session history, never that the path is unreachable.

## Security review
Pick one. (If "Needs review", apply the `needs-security-review` label only when the PR is dev-complete and ready to merge — the workflow runs once against the SHA at label-add time and is not re-fired by later pushes, so labeling early produces a stale review against pre-merge code.)
- [ ] **Skip review** — no security-sensitive surface (refactor, test-only, internal logic, docs, model additions consumed only by trusted internal code).
- [x] **Needs review** — touches any of: `.claude/hooks/`, secret handling, `pyproject.toml`, `.github/workflows/`, CLI argument parsing, path resolution, JSONL parsing, network calls, subprocess invocation, or rendering of user-controlled strings.

Touches **JSONL parsing** (`emitted_tool_use_ids` scans trace files) and **path resolution** (sidecar paths beside a trace). Label to be applied when dev-complete, not now.

## Breaking changes
None. Three additive fields on `SubagentTrace`; no field removed or renamed, no CLI change, no exit-code change. The JSON envelope `version` stays `"2"` (D029 — additive fields do not bump it).

`children` inlines full child payloads into `analyze --format json`. Accepted for consistency with the existing `invocation.trace` nesting; the escape hatch, if payload size bites, is a flat adjacency map on `SessionAnalysis` keyed by `invocation_id`, which would not change these fields.

Refs #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)